### PR TITLE
WIP: GTFS-Static Downloader

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint and style checks
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint and style checks
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
-    branches: master
+    branches: main
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: flake8
+        types:
+          - python
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # data-infra
-temporary repo / maybe permanent for CalITP data infrastructure 
+temporary repo / maybe permanent for CalITP data infrastructure
+
+## Repository Structure
+* `src` contains source code for ETLs, scripts, more
+* `catalogs` contains intake catalogs for semi-static / version data access.
+
+## pre-commit
+This repository uses black and pre-commit hooks to format code. To install locally, run
+
+`pip install pre-commit` & `pre-commit install` in the root of the repo.
+
+## Running Locally .

--- a/catalogs/catalog.yml
+++ b/catalogs/catalog.yml
@@ -1,0 +1,9 @@
+
+metadata:
+  version: 1
+sources:
+  repository:
+    driver: csv
+    description: description of url for each active GTFS feed
+    args:
+      urlpath: https://docs.google.com/spreadsheets/d/1OtPkq2uDuKa4mpNfTmkfcGZfm31ru8zQs2gaNHYgmwk/gviz/tq?tqx=out:csv&sheet=Sheet1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+# References:
+# http://flake8.readthedocs.org/en/latest/config.html
+# http://flake8.readthedocs.org/en/latest/warnings.html#error-codes
+max-line-length = 88
+ignore=E203, W503

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -1,0 +1,66 @@
+"""
+Download the state of CA GTFS files, async version
+"""
+import pandas as pd
+import intake
+import requests
+import logging
+from tqdm import tqdm
+import zipfile
+import io
+import pathlib
+import datetime
+
+catalog = intake.open_catalog("./catalog.yml")
+
+
+def make_gtfs_list():
+    """
+    Read in a list of GTFS urls
+    from the main db
+    """
+    df = catalog.repository.read()
+    urls = (
+        df[df.GTFS.str.startswith("http")].GTFS.str.split(",").apply(pd.Series).stack()
+    )
+    return urls
+
+
+def clean_urls(url):
+    """
+    take the list of urls, clean as needed
+    """
+    # LA Metro split requires lstrip
+    if (
+        url
+        == "http://www.vta.org/sfc/servlet.shepherd/document/download/069A0000001NUea"
+    ):
+        url = "https://gtfs.vta.org/gtfs_vta.zip"
+    return url.lstrip()
+
+
+if __name__ == "__main__":
+    run_time = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    urls = make_gtfs_list().apply(clean_urls).values
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4)"
+            "AppleWebKit/537.36 (KHTML, like Gecko)"
+            "Chrome/83.0.4103.97 Safari/537.36"
+        )
+    }
+    for url in tqdm(urls):
+        try:
+            r = requests.get(url, headers=headers)
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            logging.warning(f"No feed found for {url}, {err}")
+        try:
+            z = zipfile.ZipFile(io.BytesIO(r.content))
+            # replace here with s3fs
+            pathlib.Path(f"/tmp/gtfs-data/{run_time}/{url}").mkdir(
+                parents=True, exist_ok=True
+            )
+            z.extractall(f"/tmp/gtfs-data/{run_time}/{url}")
+        except zipfile.BadZipFile:
+            logging.warning(f"failed to zipfile {url}")

--- a/src/gtfs_static_downloader.py
+++ b/src/gtfs_static_downloader.py
@@ -11,7 +11,7 @@ import io
 import pathlib
 import datetime
 
-catalog = intake.open_catalog("./catalog.yml")
+catalog = intake.open_catalog("../catalogs/catalog.yml")
 
 
 def make_gtfs_list():


### PR DESCRIPTION
This PR adds a script and some structure for a static GTFS downloader. It also adds code formatting and linting as a pre-commit hook.

As of now, the deployment strategy isn't figured out. I see two routes 

1) [Kubernetes Cron](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/)
2) [Cloud Composer](https://cloud.google.com/composer) / Airflow 

Each of these have pro / cons that would be good to discuss as a team. 

TODOs

- [ ] Dockerfile / Requirements TXT 
- [ ] Deployment Strategy 
- [ ] Save to gcs or similar, not `/tmp` 
- [ ] notify when GTFS fails to parse / run and if the URL is down / down-ish 

Once w have this done, we need to pipe the collected data at the GTFS-Validator. 

Commits: 
- adding src folder
- adding catalogs folder
- Adding readme
- rename file, fix paths
