### PR TITLE
remove old files from dags folder on gcloud

### DIFF
--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -21,9 +21,4 @@ jobs:
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
-    - id: upload-files
-      uses: google-github-actions/upload-cloud-storage@main
-      name: upload-the-file
-      with:
-        path: airflow/dags
-        destination: us-west2-calitp-airflow-pro-332827a9-bucket
+      run: gsutil -m rsync -d -c -r airflow/dags gs://us-west2-calitp-airflow-pro-332827a9-bucket


### PR DESCRIPTION
addresses #35. Will double check in the morning. Pulled the sync command out of [this article](https://www.mickaelvieira.com/blog/2020/01/29/deploying-a-static-website-to-google-cloud-storage-with-github-actions.html
):

## Notes

* the bucket the dag dir is being uploaded to also has the whole data-infra repo in it (from some point in time?)
* tested by creating a new bucket `gtfs-data-test` and syncing a folder to it, deleting file, re-syncing.
* the dag bucket currently has a task called `airflow_monitoring.py`. Looks like it is [automatically added](https://stackoverflow.com/questions/56496779/why-is-there-a-dag-named-airflow-monitoring-automatically-generated-in-cloud-c) for health checks.
* for some reason on the 19th a job used the full datetime-stamp when saving data, rather than only the date (see image below). Guessing it's related to having two files in the dags generating dags with the same ID or something? Will be easier to diagnose once this is merged, and hopefully merging fixes.

![image](https://user-images.githubusercontent.com/2574498/112177939-5d008500-8bc7-11eb-8c98-382754160d23.png)
