### PR TITLE
fix: dags accidentally syncing to root

### DIFF
--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
-    - run: gsutil -m rsync -d -c -r airflow/dags gs://us-west2-calitp-airflow-pro-332827a9-bucket
+    - run: gsutil -m rsync -d -c -r airflow/dags gs://us-west2-calitp-airflow-pro-332827a9-bucket/dags


### PR DESCRIPTION
@hunterowens I made an error with PR #36, and needed to specify we're syncing to the dags subfolder on gcloud. Going to merge, so I can make sure everything is syncing properly.