### PR TITLE
fix: use AIRFLOW_ENV to flag dev now

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -57,7 +57,7 @@ x-airflow-common:
     # Corresponds to GCP_PROJECT on composer, but gauth looks for this name.
     # see https://googleapis.dev/python/google-auth/latest/user-guide.html#using-external-identities
     GOOGLE_CLOUD_PROJECT: cal-itp-data-infra
-    COMPOSER_ENVIRONMENT: "development"
+    AIRFLOW_ENV: "development"
 
   volumes:
     # Note that in cloud composer, folders like dags are not in AIRFLOW_HOME

--- a/airflow/plugins/calitp.py
+++ b/airflow/plugins/calitp.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 def is_development():
-    return os.environ["COMPOSER_ENVIRONMENT"] == "development"
+    return os.environ["AIRFLOW_ENV"] == "development"
 
 
 def pipe_file_name(path):


### PR DESCRIPTION
I have no idea why this is happening, but after..

* setting airflow to reload whenever a plugin changes
* restarting the server

I'm seeing in the logs that the scheduler [can't find the environment variable `COMPOSER_ENVIRONMENT`](https://console.cloud.google.com/logs/query;pinnedLogId=2021-04-05T18:53:33.973701836Z%2F19sc6eog8rzlfaq;query=resource.type%3D%22cloud_composer_environment%22%0Aresource.labels.location%3D%22us-west2%22%0Aresource.labels.environment_name%3D%22calitp-airflow-prod%22%0Atimestamp%3D%222021-04-05T18:53:33.975978126Z%22%0AinsertId%3D%2219sc6eog8rzlfaw%22;timeRange=PT1H?project=cal-itp-data-infra). This is weird, since it's listed as one of the [variables composer uses](https://cloud.google.com/composer/docs/how-to/managing/environment-variables#reserved_names), and I can see it when shelling into the scheduler container. I'm just going to use a new variable name and add it to composer...

Going to merge so I can verify it works.