### PR TITLE
Load gtfs schedule data into bigquery

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -34,6 +34,19 @@ Finally, run the initial database migration and create an `airflow / airflow` us
 docker-compose run airflow db init
 ```
 
+
+Note that in order to get bigquery credentials working, you'll need to [download a service account token](https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account),
+and manually add it to airflow:
+
+```console
+docker-compose exec airflow-scheduler /bin/bash
+
+# run this inside container, and replace json key name in last line
+airflow connections -d --conn_id bigquery_default
+airflow connections -a --conn_id bigquery_default --conn_uri 'google-cloud-platform://:@:?extra__google_cloud_platform__project=cal-itp-data-infra&extra__google_cloud_platform__key_path=/home/airflow/.config/gcloud/cal-itp-data-infra-dcde6f46af07.json'
+```
+
+
 Start all services with:
 
 ```console

--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -18,7 +18,7 @@ dag_parent_dir = Path(__file__).parent
 #     if child.is_dir() and not str(child).endswith('__'):
 #         dag_directories.append(str(child))
 
-dag_directories = [dag_parent_dir / "gtfs_downloader"]
+dag_directories = [dag_parent_dir / "gtfs_downloader", dag_parent_dir / "gtfs_loader"]
 
 
 # DAG Generation ==============================================================

--- a/airflow/dags/gtfs_downloader/download_data.py
+++ b/airflow/dags/gtfs_downloader/download_data.py
@@ -111,7 +111,7 @@ def downloader(task_instance, execution_date, **kwargs):
     src_path = Path(SRC_DIR) / f"{execution_date}/status.csv"
     dst_path = Path(DST_DIR) / f"{execution_date}/status.csv"
 
-    df_status.convert_dtypes().to_csv(src_path)
+    df_status.convert_dtypes().to_csv(src_path, index=False)
     save_to_gcfs(src_path, dst_path)
 
     error_agencies = df_status[lambda d: d.status != "success"].agency_name.tolist()

--- a/airflow/dags/gtfs_downloader/download_data.py
+++ b/airflow/dags/gtfs_downloader/download_data.py
@@ -61,7 +61,7 @@ def download_url(url, itp_id, url_number, execution_date):
     try:
         z = zipfile.ZipFile(io.BytesIO(r.content))
         # replace here with s3fs
-        rel_path = Path(f"{execution_date}/{int(itp_id)}/{int(url_number)}")
+        rel_path = Path(f"{execution_date}/{int(itp_id)}_{int(url_number)}")
         src_path = SRC_DIR / rel_path
         dst_path = DST_DIR / rel_path
 

--- a/airflow/dags/gtfs_loader/METADATA.yml
+++ b/airflow/dags/gtfs_loader/METADATA.yml
@@ -1,0 +1,17 @@
+description: "Download the state of CA GTFS files, async version"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "hunter.owens@dot.ca.gov"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: False

--- a/airflow/dags/gtfs_loader/agency_staging.yml
+++ b/airflow/dags/gtfs_loader/agency_staging.yml
@@ -1,0 +1,32 @@
+---
+operator: operators.stage_on_bigquery
+parent_id: gtfs_loader
+dst_dir: "processed"
+gcs_dirs_xcom: valid_agency_paths
+dependencies:
+  - valid_agency_paths
+
+filename: agency.txt
+table_name: "gtfs_schedule.agency"
+schema_fields:
+  - name: agency_id
+    type: STRING
+  - name: agency_name
+    type: STRING
+  - name: agency_url
+    type: STRING
+  - name: agency_timezone
+    type: STRING
+  - name: agency_lang
+    type: STRING
+  - name: agency_phone
+    type: STRING
+  - name: agency_fare_url
+    type: STRING
+  - name: agency_email
+    type: STRING
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: url_number
+    type: INTEGER
+---

--- a/airflow/dags/gtfs_loader/calitp_files_process.py
+++ b/airflow/dags/gtfs_loader/calitp_files_process.py
@@ -1,0 +1,42 @@
+# ---
+# python_callable: main
+# provide_context: true
+# external_dependencies:
+#   - gtfs_downloader: download_data
+# ---
+
+from calitp import read_gcfs, get_bucket, save_to_gcfs
+import pandas as pd
+import gcsfs
+
+
+def main(execution_date, **kwargs):
+    # TODO: remove hard-coded project string
+    fs = gcsfs.GCSFileSystem(project="cal-itp-data-infra")
+
+    bucket = get_bucket()
+
+    f = read_gcfs(f"schedule/{execution_date}/status.csv")
+    status = pd.read_csv(f)
+
+    success = status[lambda d: d.status == "success"]
+
+    gtfs_files = []
+    for ii, row in success.iterrows():
+        agency_folder = f"{row.itp_id}_{row.url_number}"
+        gtfs_url = f"{bucket}/schedule/{execution_date}/{agency_folder}/*"
+
+        gtfs_files.append(fs.glob(gtfs_url))
+
+    res = (
+        success[["itp_id", "url_number"]]
+        .assign(gtfs_file=gtfs_files)
+        .explode("gtfs_file")
+        .loc[lambda d: d.gtfs_file != "processed"]
+    )
+
+    save_to_gcfs(
+        res.to_csv(index=False).encode(),
+        f"schedule/{execution_date}/processed/files.csv",
+        use_pipe=True,
+    )

--- a/airflow/dags/gtfs_loader/calitp_files_staging.yml
+++ b/airflow/dags/gtfs_loader/calitp_files_staging.yml
@@ -1,0 +1,8 @@
+---
+operator: operators.CreateStagingTable
+src_uris: "schedule/{{execution_date}}/processed/files.csv"
+dst_table_name: "gtfs_schedule.calitp_files"
+autodetect: true
+dependencies:
+  - calitp_files_process
+---

--- a/airflow/dags/gtfs_loader/calitp_load_errors_staging.yml
+++ b/airflow/dags/gtfs_loader/calitp_load_errors_staging.yml
@@ -1,0 +1,8 @@
+---
+operator: operators.CreateStagingTable
+src_uris: "schedule/{{execution_date}}/processed/agency_load_errors.csv"
+dst_table_name: "gtfs_schedule.calitp_load_errors"
+autodetect: true
+dependencies:
+  - valid_agency_paths
+---

--- a/airflow/dags/gtfs_loader/calitp_status_staging.yml
+++ b/airflow/dags/gtfs_loader/calitp_status_staging.yml
@@ -1,0 +1,8 @@
+---
+operator: operators.CreateStagingTable
+src_uris: "schedule/{{execution_date}}/status.csv"
+dst_table_name: "gtfs_schedule.calitp_status"
+autodetect: true
+external_dependencies:
+  - gtfs_downloader: validate_gcs_bucket
+---

--- a/airflow/dags/gtfs_loader/move_to_destination.yml
+++ b/airflow/dags/gtfs_loader/move_to_destination.yml
@@ -1,0 +1,22 @@
+---
+operator: operators.MoveStagingTablesOperator
+dataset: gtfs_schedule
+dst_table_names:
+  - agency
+  - stop_times
+  - trips
+  - stops
+  - routes
+  - calitp_status
+  - calitp_load_errors
+  - calitp_files
+dependencies:
+  - agency_staging
+  - stop_times_staging
+  - trips_staging
+  - stops_staging
+  - routes_staging
+  - calitp_status_staging
+  - calitp_load_errors_staging
+  - calitp_files_staging
+---

--- a/airflow/dags/gtfs_loader/routes_staging.yml
+++ b/airflow/dags/gtfs_loader/routes_staging.yml
@@ -9,6 +9,10 @@ dependencies:
 filename: routes.txt
 table_name: "gtfs_schedule.routes"
 schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
   - name: route_id
     type: STRING
   - name: route_type

--- a/airflow/dags/gtfs_loader/routes_staging.yml
+++ b/airflow/dags/gtfs_loader/routes_staging.yml
@@ -1,0 +1,40 @@
+---
+operator: operators.stage_on_bigquery
+parent_id: gtfs_loader
+dst_dir: "processed"
+gcs_dirs_xcom: valid_agency_paths
+dependencies:
+  - valid_agency_paths
+
+filename: routes.txt
+table_name: "gtfs_schedule.routes"
+schema_fields:
+  - name: route_id
+    type: STRING
+  - name: route_type
+    type: STRING
+
+    # conditional
+  - name: agency_id
+    type: STRING
+  - name: route_short_name
+    type: STRING
+  - name: route_long_name
+    type: STRING
+  - name: route_desc
+    type: STRING
+
+    # optional
+  - name: route_url
+    type: STRING
+  - name: route_color
+    type: STRING
+  - name: route_text_color
+    type: STRING
+  - name: route_sort_order
+    type: STRING
+  - name: continuous_pickup
+    type: STRING
+  - name: continuous_drop_off
+    type: STRING
+---

--- a/airflow/dags/gtfs_loader/stop_times_staging.yml
+++ b/airflow/dags/gtfs_loader/stop_times_staging.yml
@@ -9,6 +9,10 @@ dependencies:
 filename: stop_times.txt
 table_name: "gtfs_schedule.stop_times"
 schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
   - name: trip_id
     type: STRING
   - name: stop_id

--- a/airflow/dags/gtfs_loader/stop_times_staging.yml
+++ b/airflow/dags/gtfs_loader/stop_times_staging.yml
@@ -1,0 +1,40 @@
+---
+operator: operators.stage_on_bigquery
+parent_id: gtfs_loader
+dst_dir: "processed"
+gcs_dirs_xcom: valid_agency_paths
+dependencies:
+  - valid_agency_paths
+
+filename: stop_times.txt
+table_name: "gtfs_schedule.stop_times"
+schema_fields:
+  - name: trip_id
+    type: STRING
+  - name: stop_id
+    type: STRING
+  - name: stop_sequence
+    type: STRING
+
+    # conditional
+  - name: arrival_time
+    type: STRING
+  - name: departure_time
+    type: STRING
+
+    # optional
+  - name: stop_headsign
+    type: STRING
+  - name: pickup_type
+    type: STRING
+  - name: drop_off_type
+    type: STRING
+  - name: continuous_pickup
+    type: STRING
+  - name: continuous_drop_off
+    type: STRING
+  - name: shape_dist_traveled
+    type: STRING
+  - name: timepoint
+    type: STRING
+---

--- a/airflow/dags/gtfs_loader/stops_staging.yml
+++ b/airflow/dags/gtfs_loader/stops_staging.yml
@@ -9,6 +9,10 @@ dependencies:
 filename: stops.txt
 table_name: "gtfs_schedule.stops"
 schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
   - name: stop_id
     type: STRING
 

--- a/airflow/dags/gtfs_loader/stops_staging.yml
+++ b/airflow/dags/gtfs_loader/stops_staging.yml
@@ -1,0 +1,47 @@
+---
+operator: operators.stage_on_bigquery
+parent_id: gtfs_loader
+dst_dir: "processed"
+gcs_dirs_xcom: valid_agency_paths
+dependencies:
+  - valid_agency_paths
+
+filename: stops.txt
+table_name: "gtfs_schedule.stops"
+schema_fields:
+  - name: stop_id
+    type: STRING
+
+    # conditional
+  - name: tts_stop_name
+    type: STRING
+  - name: stop_lat
+    type: FLOAT
+  - name: stop_lon
+    type: FLOAT
+
+  - name: zone_id
+    type: STRING
+  - name: parent_station
+    type: STRING
+
+    # optional
+  - name: stop_code
+    type: STRING
+  - name: stop_name
+    type: STRING
+  - name: stop_desc
+    type: STRING
+  - name: stop_url
+    type: STRING
+  - name: location_type
+    type: STRING
+  - name: stop_timezone
+    type: STRING
+  - name: wheelchair_boarding
+    type: STRING
+  - name: level_id
+    type: STRING
+  - name: platform_code
+    type: STRING
+---

--- a/airflow/dags/gtfs_loader/trips_staging.yml
+++ b/airflow/dags/gtfs_loader/trips_staging.yml
@@ -9,6 +9,10 @@ dependencies:
 filename: trips.txt
 table_name: "gtfs_schedule.trips"
 schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
   - name: route_id
     type: STRING
   - name: service_id

--- a/airflow/dags/gtfs_loader/trips_staging.yml
+++ b/airflow/dags/gtfs_loader/trips_staging.yml
@@ -1,0 +1,36 @@
+---
+operator: operators.stage_on_bigquery
+parent_id: gtfs_loader
+dst_dir: "processed"
+gcs_dirs_xcom: valid_agency_paths
+dependencies:
+  - valid_agency_paths
+
+filename: trips.txt
+table_name: "gtfs_schedule.trips"
+schema_fields:
+  - name: route_id
+    type: STRING
+  - name: service_id
+    type: STRING
+  - name: trip_id
+    type: STRING
+
+    # conditional
+  - name: shape_id
+    type: STRING
+
+    # optional
+  - name: trip_headsign
+    type: STRING
+  - name: trip_short_name
+    type: STRING
+  - name: direction_id
+    type: STRING
+  - name: block_id
+    type: STRING
+  - name: wheelchair_accessible
+    type: STRING
+  - name: bikes_allowed
+    type: STRING
+---

--- a/airflow/dags/gtfs_loader/valid_agency_paths.py
+++ b/airflow/dags/gtfs_loader/valid_agency_paths.py
@@ -1,0 +1,41 @@
+# ---
+# python_callable: main
+# provide_context: true
+# external_dependencies:
+#   - gtfs_downloader: validate_gcs_bucket
+# ---
+
+from calitp import read_gcfs
+import json
+import pandas
+
+ERROR_MISSING_FILE = "missing_required_file"
+VALIDATION_FILE = "validation.json"
+
+
+def get_notice_codes(validation):
+    code_entries = validation["data"]["report"]["notices"]
+    return set([entry["code"] for entry in code_entries])
+
+
+def main(execution_date, **kwargs):
+    in_path = f"schedule/{execution_date}"
+    print(in_path)
+
+    status = pandas.read_csv(read_gcfs(f"{in_path}/status.csv"))
+    success = status[status.status == "success"]
+
+    loadable_agencies = []
+    for ii, row in success.iterrows():
+        path_agency = f"{in_path}/{row['itp_id']}_{row['url_number']}"
+        path_validation = f"{path_agency}/{VALIDATION_FILE}"
+
+        print(f"reading validation file: {path_validation}")
+        validation = json.load(read_gcfs(path_validation))
+
+        unique_codes = get_notice_codes(validation)
+
+        if ERROR_MISSING_FILE not in unique_codes:
+            loadable_agencies.append(path_agency)
+
+    return loadable_agencies

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -52,6 +52,9 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_FOLDER: /opt/airflow/gcs/dags
     AIRFLOW__CORE__BASE_LOG_FOLDER: /opt/airflow/gcs/logs
     AIRFLOW__CORE__PLUGINS_FOLDER: /opt/airflow/gcs/plugins
+    # connections
+    # see https://stackoverflow.com/a/55064944/1144523
+    AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: "google-cloud-platform://:@:?extra__google_cloud_platform__project=cal-itp-data-infra"
     # bucket for holding results of extraction tasks
     AIRFLOW_VAR_EXTRACT_BUCKET: "gs://gtfs-data-test"
     # Corresponds to GCP_PROJECT on composer, but gauth looks for this name.

--- a/airflow/plugins/calitp.py
+++ b/airflow/plugins/calitp.py
@@ -23,6 +23,15 @@ def get_bucket():
     return os.environ["AIRFLOW_VAR_EXTRACT_BUCKET"]
 
 
+def format_table_name(name, is_staging=False):
+    dataset, table_name = name.split(".")
+    staging = "__staging" if is_staging else ""
+    test_prefix = "test_" if is_development() else ""
+
+    # e.g. test_gtfs_schedule__staging.agency
+    return f"{test_prefix}{dataset}.{table_name}{staging}"
+
+
 def pipe_file_name(path):
     """Returns absolute path for a file in the pipeline (e.g. the data folder).
 
@@ -41,7 +50,6 @@ def pipe_file_name(path):
 
 def get_fs(gcs_project="cal-itp-data-infra"):
     if is_development():
-        # Note: project on dev is set w/ GOOGLE_CLOUD_PROJECT environment var
         return gcsfs.GCSFileSystem(project=gcs_project, token="google_default")
     else:
         return gcsfs.GCSFileSystem(project=gcs_project, token="cloud")

--- a/airflow/plugins/calitp.py
+++ b/airflow/plugins/calitp.py
@@ -10,7 +10,17 @@ from pathlib import Path
 
 
 def is_development():
+    options = {"development", "cal-itp-data-infra"}
+
+    if os.environ["AIRFLOW_ENV"] not in options:
+        raise ValueError("AIRFLOW_ENV variable must be one of %s" % options)
+
     return os.environ["AIRFLOW_ENV"] == "development"
+
+
+def get_bucket():
+    # TODO: can probably pull some of these behaviors into a config class
+    return os.environ["AIRFLOW_VAR_EXTRACT_BUCKET"]
 
 
 def pipe_file_name(path):
@@ -29,8 +39,22 @@ def pipe_file_name(path):
     return str(root / path)
 
 
+def get_fs(gcs_project="cal-itp-data-infra"):
+    if is_development():
+        # Note: project on dev is set w/ GOOGLE_CLOUD_PROJECT environment var
+        return gcsfs.GCSFileSystem(project=gcs_project, token="google_default")
+    else:
+        return gcsfs.GCSFileSystem(project=gcs_project, token="cloud")
+
+
 def save_to_gcfs(
-    src_path, dst_path, gcs_project="cal-itp-data-infra", bucket=None, **kwargs
+    src_path,
+    dst_path,
+    gcs_project="cal-itp-data-infra",
+    bucket=None,
+    use_pipe=False,
+    verbose=True,
+    **kwargs,
 ):
     """Convenience function for saving files from disk to google cloud storage.
 
@@ -39,15 +63,45 @@ def save_to_gcfs(
         dst_path: path to bucket subdirectory (e.g. "path/to/dir").
     """
 
-    bucket = os.environ["AIRFLOW_VAR_EXTRACT_BUCKET"] if bucket is None else bucket
-
-    if is_development():
-        # Note: project on dev is set w/ GOOGLE_CLOUD_PROJECT environment var
-        fs = gcsfs.GCSFileSystem(project=gcs_project, token="google_default")
-    else:
-        fs = gcsfs.GCSFileSystem(project=gcs_project, token="cloud")
+    bucket = get_bucket() if bucket is None else bucket
 
     full_dst_path = bucket + "/" + str(dst_path)
-    fs.put(str(src_path), full_dst_path, **kwargs)
+
+    fs = get_fs(gcs_project)
+
+    if verbose:
+        print("Saving to:", full_dst_path)
+
+    if not use_pipe:
+        fs.put(str(src_path), full_dst_path, **kwargs)
+    else:
+        fs.pipe(str(full_dst_path), src_path, **kwargs)
 
     return full_dst_path
+
+
+def read_gcfs(
+    src_path, dst_path=None, gcs_project="cal-itp-data-infra", bucket=None, verbose=True
+):
+    """
+    Arguments:
+        src_path: path to file being read from google cloud.
+        dst_path: optional path to save file directly on disk.
+    """
+
+    bucket = get_bucket() if bucket is None else bucket
+
+    fs = get_fs(gcs_project)
+
+    full_src_path = bucket + "/" + str(src_path)
+
+    if verbose:
+        print(f"Reading file: {full_src_path}")
+
+    if dst_path is None:
+        return fs.open(full_src_path)
+    else:
+        # TODO: in this case, dump directly to disk, rather opening
+        raise NotImplementedError()
+
+    return full_src_path

--- a/airflow/plugins/operators.py
+++ b/airflow/plugins/operators.py
@@ -98,6 +98,9 @@ class PythonTaskflowOperator(PythonOperator):
 #       cal-itp package, so few operators are needed, and we don't have to
 #       worry about stiching them together.
 class stage_on_bigquery(SubDagOperator):
+    # TODO: this should be a function that returns an operator, but an issue
+    # in gusty requires using a class with an __init__ method.
+    # see: https://github.com/chriscardillo/gusty/issues/26
     def __new__(
         cls,
         parent_id,

--- a/airflow/plugins/operators.py
+++ b/airflow/plugins/operators.py
@@ -1,9 +1,16 @@
 import os
+import pandas as pd
+
 from functools import wraps
 
 from airflow.contrib.operators.gcp_container_operator import GKEPodOperator
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from calitp import is_development
+from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
+from airflow.operators import PythonOperator, SubDagOperator
+from airflow.utils.decorators import apply_defaults
+from airflow import DAG
+
+from calitp import is_development, get_bucket, save_to_gcfs, read_gcfs
 
 
 @wraps(KubernetesPodOperator)
@@ -19,8 +26,186 @@ def pod_operator(*args, **kwargs):
             location=os.environ["POD_LOCATION"],
             cluster_name=os.environ["POD_CLUSTER_NAME"],
             namespace=namespace,
-            **kwargs
+            **kwargs,
         )
 
     else:
         return KubernetesPodOperator(*args, namespace=namespace, **kwargs)
+
+
+class PythonTaskflowOperator(PythonOperator):
+    @apply_defaults
+    def __init__(
+        self,
+        python_callable,
+        op_args=None,
+        op_kwargs=None,
+        provide_context=False,
+        templates_dict=None,
+        templates_exts=None,
+        taskflow=None,
+        *args,
+        **kwargs,
+    ):
+        super(PythonOperator, self).__init__(*args, **kwargs)
+
+        # taskflow specific ----
+        self.taskflow = taskflow
+        if isinstance(python_callable, str):
+            # if python_callable is a string of form mod_name.func_name,
+            # try to import function
+            import importlib
+
+            *mod_path, func_name = python_callable.split(".")
+            python_callable = getattr(
+                importlib.import_module(".".join(mod_path)), func_name
+            )
+
+        # original PythonOperator init code
+        self.python_callable = python_callable
+        self.op_args = op_args or []
+        self.op_kwargs = op_kwargs or {}
+        self.provide_context = provide_context
+        self.templates_dict = templates_dict
+        if templates_exts:
+            self.template_ext = templates_exts
+
+    def execute(self, context):
+        if self.taskflow:
+            ti = context["task_instance"]
+
+            # update op_kwargs to include data pulled from xcom
+            for k, v in self.taskflow.items():
+                from collections.abc import Mapping
+
+                if isinstance(v, Mapping):
+                    dag_id = v.get("dag_id", None)
+                    task_ids = v["task_ids"]
+                else:
+                    dag_id = None
+                    task_ids = v
+
+                self.op_kwargs[k] = ti.xcom_pull(dag_id=dag_id, task_ids=task_ids)
+
+        return super().execute(context)
+
+
+# CsvColumnSelectOperator ----
+
+# Npte: airflow v1 doesn't have task groups, so trying out a SubDag as an
+# alternative. They are not as nice in the UI, and have some other limitations.
+# TODO: in the long run, should pull logic for uploading to bigquery into the
+#       cal-itp package, so few operators are needed, and we don't have to
+#       worry about stiching them together.
+class stage_on_bigquery(SubDagOperator):
+    def __new__(
+        cls,
+        parent_id,
+        gcs_dirs_xcom,
+        dst_dir,
+        filename,
+        schema_fields,
+        table_name,
+        task_id,
+        dag,
+    ):
+        from airflow.utils.dates import days_ago
+
+        args = {
+            "start_date": days_ago(2),
+        }
+
+        bucket = get_bucket().replace("gs://", "", 1)
+
+        subdag = DAG(dag_id=f"{parent_id}.{task_id}", default_args=args)
+
+        column_names = [schema["name"] for schema in schema_fields]
+
+        # by convention, preface task names with dag_id
+        op_col_select = PythonTaskflowOperator(
+            task_id="select_cols",
+            python_callable=_keep_columns,
+            # note that this input should have form schedule/{execution_date}/...
+            taskflow={"gcs_dirs": {"dag_id": parent_id, "task_ids": gcs_dirs_xcom}},
+            op_kwargs={
+                "dst_dir": dst_dir,
+                "filename": filename,
+                "required_cols": [],
+                "optional_cols": column_names,
+            },
+            dag=subdag,
+        )
+
+        op_stage_bq = GoogleCloudStorageToBigQueryOperator(
+            task_id="stage_bigquery",
+            bucket=bucket,
+            # note that we can't really pull a list out of xcom without subclassing
+            # operators, so we really on knowing that the task passing in
+            # gcs_dirs_xcom data is using schedule/{execution_date}
+            source_objects=[
+                "schedule/{{execution_date}}/*/%s/%s" % (dst_dir, filename)
+            ],
+            schema_fields=schema_fields,
+            destination_project_dataset_table=table_name,
+            create_disposition="CREATE_IF_NEEDED",
+            write_disposition="WRITE_TRUNCATE",
+            # _keep_columns function includes headers in output
+            skip_leading_rows=1,
+            dag=subdag,
+        )
+
+        op_col_select >> op_stage_bq
+
+        return SubDagOperator(subdag=subdag, dag=dag, task_id=task_id)
+
+    def __init__(
+        self,
+        parent_id,
+        gcs_dirs_xcom,
+        dst_dir,
+        filename,
+        schema_fields,
+        table_name,
+        *args,
+        **kwargs,
+    ):
+        pass
+
+
+def _keep_columns(
+    gcs_dirs, dst_dir, filename, required_cols, optional_cols, prepend_ids=True
+):
+    for path in gcs_dirs:
+        full_src_path = f"{path}/{filename}"
+        full_dst_path = f"{path}/{dst_dir}/{filename}"
+
+        final_header = [*required_cols, *optional_cols]
+
+        # read csv using object dtype, so pandas does not coerce data
+        df = pd.read_csv(read_gcfs(full_src_path), dtype="object")
+        df_cols = set(df.columns)
+
+        opt_cols_present = [x for x in optional_cols if x in df_cols]
+
+        # get specified columns, inserting NA columns where needed
+        df_select = df[[*required_cols, *opt_cols_present]]
+
+        for ii, colname in enumerate(final_header):
+            if colname not in df_select:
+                print("INSERTING MISSING COLUMN")
+                df_select.insert(ii, colname, pd.NA)
+            print("SHAPE: ", df_select.shape)
+
+        csv_result = df_select
+
+        if prepend_ids:
+            # hacky, but parse /path/.../{itp_id}/{url_number}
+            basename = path.split("/")[-1]
+            itp_id, url_number = map(int, basename.split("_"))
+
+            csv_result = csv_result.assign(
+                calitp_itp_id=itp_id, calitp_url_number=url_number
+            )
+
+        encoded = csv_result.to_csv(index=False).encode()
+        save_to_gcfs(encoded, full_dst_path, use_pipe=True)


### PR DESCRIPTION
This PR adds the loading of the 5 required GTFS static tables for agencies: agency, stops, stop_times, routes, trips. More can be added by adding simple yaml files to the `gtfs_loader` DAG.

Notes:

* data loaded to `gtfs_schedule` dataset at the moment (e.g. `gtfs_schedule.stops`, `gtfs_schedule.agency`)
* tables columns are loaded with mostly STRING types, so analysts can diagnose misspec'd agencies.
* wrangling airflow's BigQuery operators took a lot of work; we should move away from it down the road!
* changed the paths to be {itp_id}_{url_number}, instead of {itp_id}/{url_number}. This makes it easy to use with bigquery, which only allows a single wildcard in paths.

## TODO before merging

- [x] use environment variable to toggle bigquery dataset (its term for schema?) being loaded to.
- [x] quickly toss up `calitp_status`, `calitp_files`, and `calitp_load_errors` tables (using `calitp` here to prefix data that reports warehouse internals / details)

Going to punt loading validation data to https://github.com/cal-itp/data-infra/issues/59.

## Follow-up tasks

* prepare to package calitp.py. I would just package it in the root of this repo for now--will be possible to pip install. Lets us keep moving it quickly, but also share it outside the pipeline. Once things stabilize, seems useful to make its own package.
* add bigquery fuctionality to calitp.py (and break it into modules)
  * loading into bigquery
  * analysts querying bigquery

