### PR TITLE
Fix download data failing due to http retries

### DIFF
--- a/airflow/dags/gtfs_downloader/download_data.py
+++ b/airflow/dags/gtfs_downloader/download_data.py
@@ -57,6 +57,8 @@ def download_url(url, itp_id, url_number, execution_date):
     except UnicodeError:
         # this occurs when a misformatted url is given
         raise NoFeedError("error: UnicodeError")
+    except Exception as e:
+        raise NoFeedError(f"error: {e}")
 
     try:
         z = zipfile.ZipFile(io.BytesIO(r.content))


### PR DESCRIPTION
Addresses #56, in the sense that the task now succeeds. I'm not sure what's going on with the urls. I tried one on my laptop, and it worked okay--but they may be blocking our pipeline's IP / user-agent?