### PR TITLE
feat: add table of urls, errors to email

### DIFF
--- a/airflow/dags/gtfs_downloader/download_data.py
+++ b/airflow/dags/gtfs_downloader/download_data.py
@@ -116,7 +116,10 @@ def downloader(task_instance, execution_date, **kwargs):
     df_status.convert_dtypes().to_csv(src_path)
     save_to_gcfs(src_path, dst_path)
 
-    error_agencies = df_status[lambda d: d.status != "success"].agency_name.tolist()
-    logging.info(f"error agencies: {error_agencies}")
+    df_errors = df_status[lambda d: d.status != "success"]
+    error_agencies = df_errors[["agency_name", "gtfs_schedule_url", "status"]]
+    error_records = error_agencies.to_dict(orient="record")
 
-    return {"gtfs_paths": gtfs_paths, "errors": error_agencies}
+    logging.info(f"error agencies: {error_agencies.agency_name.tolist()}")
+
+    return {"gtfs_paths": gtfs_paths, "errors": error_records}

--- a/airflow/dags/gtfs_downloader/email_failures.py
+++ b/airflow/dags/gtfs_downloader/email_failures.py
@@ -7,23 +7,25 @@
 
 import datetime
 from airflow.utils.email import send_email
+import pandas as pd
 
 
-def email_failures(task_instance, **kwargs):
+def email_failures(task_instance, ds, **kwargs):
     status = task_instance.xcom_pull(task_ids="download_data")
     error_agencies = status["errors"]
 
-    # email out error agencies
-    email_template = (
-        "The follow agencies failed to have GTFS a GTFS feed at"
-        "the URL or the Zip File Failed to extract:"
-        f"{error_agencies}"
-        "{{ ds }}"
-    )
+    html_report = pd.DataFrame(error_agencies).to_html(border=False)
+
+    html_content = f"""\
+The following agency GTFS feeds could not be extracted on {ds}:
+
+{html_report}
+"""
+
     send_email(
         to=["ruth.miller@dot.ca.gov", "hunter.owens@dot.ca.gov", "michael.c@jarv.us"],
-        html_content=email_template,
+        html_content=html_content,
         subject=(
-            "Operator GTFS Errors for" f"{datetime.datetime.now().strftime('%Y-%m-%d')}"
+            f"Operator GTFS Errors for {datetime.datetime.now().strftime('%Y-%m-%d')}"
         ),
     )


### PR DESCRIPTION
addresses #48, and adds an html table of results. Note that sendgrid isn't configured in the container, so I have tested that it attempts to send (and viewed the contents). Since this is the only email we're sending, I'd vote for merging, and wait to get things set up on dev if/when we start sending more emails.