### PR TITLE
Update agencies.yml

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1051,7 +1051,7 @@ santa-rosa-citybus:
     - trip_updates: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff9&agency=SR
     - vehicle_positions: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff9&agency=SR
 angel-island-tiburon-ferry-company:
-  Agency Name: Angel Island-Tiburon Ferry Company
+  agency_name: Angel Island-Tiburon Ferry Company
   itp_id: 15
   gtfs_schedule_url:
     - http://data.trilliumtransit.com/gtfs/bayareaferries-ca-us/bayareaferries-ca-us.zip


### PR DESCRIPTION
An entry was named `Agency Name`, rather than `agency_name`. Normally this would cause the pipe to fail, only to create a new column of data, but a sort of complex set of events happened...

* it created an `Agency Name` column of data in status.csv, in addition to `agency_name`
* BigQuery automatically wanted to rename it to `agency_name`
* BigQuery complained that there were two `agency_name` columns, causing an error

(merging so I can re-run airflow)

