### PR TITLE
fix: agency data had misnamed calitp_url_number col

### DIFF
--- a/airflow/dags/gtfs_loader/agency_staging.yml
+++ b/airflow/dags/gtfs_loader/agency_staging.yml
@@ -9,6 +9,10 @@ dependencies:
 filename: agency.txt
 table_name: "gtfs_schedule.agency"
 schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
   - name: agency_id
     type: STRING
   - name: agency_name
@@ -25,8 +29,4 @@ schema_fields:
     type: STRING
   - name: agency_email
     type: STRING
-  - name: calitp_itp_id
-    type: INTEGER
-  - name: url_number
-    type: INTEGER
 ---


### PR DESCRIPTION
quick fix to correct warehouse data: agency.url_number should be agency.calitp_url_number. This also fixes it to not be null.