### PR TITLE
fix: use correct country code in validator

### DIFF
--- a/airflow/dags/gtfs_downloader/validate_gcs_bucket.yml
+++ b/airflow/dags/gtfs_downloader/validate_gcs_bucket.yml
@@ -1,6 +1,6 @@
 operator: 'operators.pod_operator'
 name: 'pod-ex-minimum2'
-image: 'ghcr.io/cal-itp/gtfs-validator-api:v0.0.4'
+image: 'ghcr.io/cal-itp/gtfs-validator-api:v0.0.5'
 cmds: ["sh", "-c"]
 arguments:
   - >-
@@ -9,7 +9,7 @@ arguments:
     -v
     -o validation.json
     cal-itp-data-infra cloud {{ ti.xcom_pull(task_ids='download_data')['gtfs_paths'] | join(" ") }}
-is_delete_operator_pod: false
+is_delete_operator_pod: true
 get_logs: true
 provide_context: true
 templates_dict:


### PR DESCRIPTION
see https://github.com/MobilityData/gtfs-validator/issues/858. The validator takes a feed name argument of form "{iso_country_code}-{agency_name}". The gtfs-validator-api wrapper was passing in "na-na", but the first piece affects validation behavior (I originally thought it was just being stored somewhere in the results).

After running this, I'll double check the phone numbers that @mcplanner flagged as false positives (https://github.com/MobilityData/gtfs-validator/issues/856), in case this corrects it.

edit: here is the call made by the validator: https://github.com/cal-itp/gtfs-validator-api/blob/v0.0.5/gtfs_validator_api.py#L33-L39