### PR TITLE
feat: load validation report, and unnest

### DIFF
--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -4,6 +4,8 @@ import airflow  # noqa
 from pathlib import Path
 from gusty import create_dag
 
+from calitp import user_defined_macros, user_defined_filters
+
 
 # DAG Directories =============================================================
 
@@ -18,7 +20,11 @@ dag_parent_dir = Path(__file__).parent
 #     if child.is_dir() and not str(child).endswith('__'):
 #         dag_directories.append(str(child))
 
-dag_directories = [dag_parent_dir / "gtfs_downloader", dag_parent_dir / "gtfs_loader"]
+dag_directories = [
+    dag_parent_dir / "gtfs_downloader",
+    dag_parent_dir / "gtfs_loader",
+    dag_parent_dir / "gtfs_views",
+]
 
 
 # DAG Generation ==============================================================
@@ -31,4 +37,6 @@ for dag_directory in dag_directories:
         task_group_defaults={"tooltip": "this is a default tooltip"},
         wait_for_defaults={"retries": 10, "check_existence": True},
         latest_only=False,
+        user_defined_macros=user_defined_macros,
+        user_defined_filters=user_defined_filters,
     )

--- a/airflow/dags/gtfs_loader/METADATA.yml
+++ b/airflow/dags/gtfs_loader/METADATA.yml
@@ -8,6 +8,7 @@ default_args:
     start_date: !days_ago 1
     email:
       - "hunter.owens@dot.ca.gov"
+      - "michael.c@jarv.us"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/gtfs_loader/move_to_destination.yml
+++ b/airflow/dags/gtfs_loader/move_to_destination.yml
@@ -10,6 +10,7 @@ dst_table_names:
   - calitp_status
   - calitp_load_errors
   - calitp_files
+  - validation_report
 dependencies:
   - agency_staging
   - stop_times_staging
@@ -19,4 +20,5 @@ dependencies:
   - calitp_status_staging
   - calitp_load_errors_staging
   - calitp_files_staging
+  - validation_report_staging
 ---

--- a/airflow/dags/gtfs_loader/validation_report_process.py
+++ b/airflow/dags/gtfs_loader/validation_report_process.py
@@ -1,0 +1,69 @@
+# ---
+# python_callable: validator_process
+# provide_context: true
+# external_dependencies:
+#   - gtfs_downloader: validate_gcs_bucket
+# ---
+
+import pandas as pd
+import json
+
+from calitp import save_to_gcfs, read_gcfs
+
+PANDAS_TYPES_TO_BIGQUERY = {"O": "STRING", "i": "INTEGER", "f": "NUMERIC"}
+
+
+def process_notices(itp_id, url_number, validation):
+    raw_codes = validation["data"]["report"]["notices"]
+
+    # one row per code. includes a notices column with nested details
+    df_codes = pd.DataFrame(raw_codes)
+    df_codes.insert(0, "calitp_itp_id", itp_id)
+    df_codes.insert(1, "calitp_url_number", url_number)
+
+    return df_codes
+
+    return df_codes.explode("notices")
+
+
+def infer_notice_schema(notice_entries):
+    # note that convert_dtypes enables integer cols w/ missing values
+    wide = pd.DataFrame(notice_entries).convert_dtypes()
+    schema = []
+    for k in wide:
+        schema.append(dict(name=k, type=PANDAS_TYPES_TO_BIGQUERY[wide[k].dtype.kind]))
+
+    return schema
+
+
+def validator_process(execution_date, **kwargs):
+    base_path = f"schedule/{execution_date}"
+
+    status = pd.read_csv(read_gcfs(f"{base_path}/status.csv"))
+    success = status[lambda d: d.status == "success"]
+
+    # hold on to notices, so we can infer schema after
+    # notice_entries = []
+    for k, row in success.iterrows():
+        agency_path = f"{base_path}/{row['itp_id']}_{row['url_number']}"
+        url = f"{agency_path}/validation.json"
+        dst_path = f"{agency_path}/processed/validation_report.json"
+
+        validation = json.load(read_gcfs(url))
+
+        # copy code-level notices, and add internal ids
+        raw_codes = {**validation["data"]["report"]}
+        raw_codes["calitp_itp_id"] = row["itp_id"]
+        raw_codes["calitp_url_number"] = row["url_number"]
+
+        json_codes = json.dumps(raw_codes).encode()
+        # df_notices = process_notices(row["itp_id"], row["url_number"], validation)
+        # csv_string = df_notices.to_csv(index=None).encode()
+        # notice_entries.extend(df_notices.notices.tolist())
+
+        save_to_gcfs(json_codes, dst_path, use_pipe=True)
+
+    # schema = infer_notice_schema(notice_entries)
+
+
+# infer schema

--- a/airflow/dags/gtfs_loader/validation_report_process.py
+++ b/airflow/dags/gtfs_loader/validation_report_process.py
@@ -43,6 +43,9 @@ def validator_process(execution_date, **kwargs):
     success = status[lambda d: d.status == "success"]
 
     # hold on to notices, so we can infer schema after
+    # note that I've commented out the code for inferring schema below,
+    # but it was usefule for generating, then hand-tweaking to load
+    # into bigquery
     # notice_entries = []
     for k, row in success.iterrows():
         agency_path = f"{base_path}/{row['itp_id']}_{row['url_number']}"

--- a/airflow/dags/gtfs_loader/validation_report_process.py
+++ b/airflow/dags/gtfs_loader/validation_report_process.py
@@ -58,6 +58,7 @@ def validator_process(execution_date, **kwargs):
         raw_codes = {**validation["data"]["report"]}
         raw_codes["calitp_itp_id"] = row["itp_id"]
         raw_codes["calitp_url_number"] = row["url_number"]
+        raw_codes["calitp_gtfs_validated_by"] = validation["version"]
 
         json_codes = json.dumps(raw_codes).encode()
         # df_notices = process_notices(row["itp_id"], row["url_number"], validation)

--- a/airflow/dags/gtfs_loader/validation_report_staging.yml
+++ b/airflow/dags/gtfs_loader/validation_report_staging.yml
@@ -12,6 +12,8 @@ schema_fields:
     type: INTEGER
   - name: calitp_url_number
     type: INTEGER
+  - name: calitp_gtfs_validated_by
+    type: STRING
   - name: notices
     type: RECORD
     mode: REPEATED

--- a/airflow/dags/gtfs_loader/validation_report_staging.yml
+++ b/airflow/dags/gtfs_loader/validation_report_staging.yml
@@ -1,0 +1,109 @@
+---
+operator: operators.CreateStagingTable
+src_uris: "schedule/{{execution_date}}/*/processed/validation_report.json"
+dst_table_name: "gtfs_schedule.validation_report"
+source_format: NEWLINE_DELIMITED_JSON
+
+dependencies:
+  - validation_report_process
+
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+  - name: notices
+    type: RECORD
+    mode: REPEATED
+    fields:
+    - name: code
+      type: STRING
+    - name: severity
+      type: STRING
+    - name: totalNotices
+      type: INTEGER
+    - name: notices
+      type: RECORD
+      mode: REPEATED
+      fields:
+        - name: csvRowNumber
+          type: INTEGER
+        - name: fareId
+          type: STRING
+        - name: previousCsvRowNumber
+          type: INTEGER
+        - name: previousFareId
+          type: STRING
+        - name: filename
+          type: STRING
+        - name: fieldName
+          type: STRING
+        - name: fieldValue
+          type: STRING
+        - name: index
+          type: INTEGER
+        - name: shapeId
+          type: STRING
+        - name: shapeDistTraveled
+          type: BIGNUMERIC
+        - name: shapePtSequence
+          type: INTEGER
+        - name: prevCsvRowNumber
+          type: INTEGER
+        - name: prevShapeDistTraveled
+          type: BIGNUMERIC
+        - name: prevShapePtSequence
+          type: INTEGER
+        - name: duplicatedField
+          type: STRING
+        - name: routeId
+          type: STRING
+        - name: currentDate
+          type: STRING
+        - name: feedEndDate
+          type: STRING
+        - name: suggestedExpirationDate
+          type: RECORD
+          fields:
+            - name: localDate
+              type: RECORD
+              fields:
+                - name: year
+                  type: INTEGER
+                - name: month
+                  type: INTEGER
+                - name: day
+                  type: INTEGER
+        - name: routeColor
+          type: STRING
+        - name: routeTextColor
+          type: STRING
+        - name: tripId
+          type: STRING
+        - name: stopSequence
+          type: INTEGER
+        - name: specifiedField
+          type: STRING
+        - name: routeShortName
+          type: STRING
+        - name: routeLongName
+          type: STRING
+        - name: prevStopTimeDistTraveled
+          type: BIGNUMERIC
+        - name: prevStopSequence
+          type: INTEGER
+        - name: routeDesc
+          type: STRING
+        - name: speedkmh
+          type: BIGNUMERIC
+        - name: firstStopSequence
+          type: INTEGER
+        - name: lastStopSequence
+          type: INTEGER
+        - name: stopId
+          type: STRING
+        - name: stopName
+          type: STRING
+        - name: stopShapeThresholdMeters
+          type: NUMERIC
+---

--- a/airflow/dags/gtfs_views/METADATA.yml
+++ b/airflow/dags/gtfs_views/METADATA.yml
@@ -1,0 +1,17 @@
+description: "Download the state of CA GTFS files, async version"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "hunter.owens@dot.ca.gov"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: False

--- a/airflow/dags/gtfs_views/METADATA.yml
+++ b/airflow/dags/gtfs_views/METADATA.yml
@@ -8,6 +8,7 @@ default_args:
     start_date: !days_ago 1
     email:
       - "hunter.owens@dot.ca.gov"
+      - "michael.c@jarv.us"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/gtfs_views/validation_codes.yml
+++ b/airflow/dags/gtfs_views/validation_codes.yml
@@ -1,0 +1,15 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.validation_codes"
+sql: |
+  SELECT
+    calitp_itp_id
+    , code.code
+    , code.severity
+    , code.totalNotices
+  FROM
+    `{{ "gtfs_schedule.validation_report" | table }}` AS t
+    , UNNEST(t.notices) as code
+external_dependencies:
+  - gtfs_loader: move_to_destination
+---

--- a/airflow/dags/gtfs_views/validation_notices.yml
+++ b/airflow/dags/gtfs_views/validation_notices.yml
@@ -1,0 +1,18 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.validation_notices"
+sql: |
+  SELECT
+    calitp_itp_id
+    , code.code
+    , code.severity
+    notices
+  FROM
+    `{{ "gtfs_schedule.validation_report" | table }}` AS t
+    , UNNEST(t.notices) as code
+    , UNNEST(code.notices) as notices
+external_dependencies:
+  - gtfs_loader: move_to_destination
+
+
+---

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -52,6 +52,7 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_FOLDER: /opt/airflow/gcs/dags
     AIRFLOW__CORE__BASE_LOG_FOLDER: /opt/airflow/gcs/logs
     AIRFLOW__CORE__PLUGINS_FOLDER: /opt/airflow/gcs/plugins
+    AIRFLOW__WEBSERVER__RELOAD_ON_PLUGIN_CHANGE: 'true'
     # connections
     # see https://stackoverflow.com/a/55064944/1144523
     AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: "google-cloud-platform://:@:?extra__google_cloud_platform__project=cal-itp-data-infra"

--- a/airflow/plugins/calitp.py
+++ b/airflow/plugins/calitp.py
@@ -23,13 +23,19 @@ def get_bucket():
     return os.environ["AIRFLOW_VAR_EXTRACT_BUCKET"]
 
 
-def format_table_name(name, is_staging=False):
+def get_project_id():
+    return "cal-itp-data-infra"
+
+
+def format_table_name(name, is_staging=False, full_name=False):
     dataset, table_name = name.split(".")
     staging = "__staging" if is_staging else ""
     test_prefix = "test_" if is_development() else ""
 
+    project_id = get_project_id() + "." if full_name else ""
     # e.g. test_gtfs_schedule__staging.agency
-    return f"{test_prefix}{dataset}.{table_name}{staging}"
+
+    return f"{project_id}{test_prefix}{dataset}.{table_name}{staging}"
 
 
 def pipe_file_name(path):
@@ -113,3 +119,12 @@ def read_gcfs(
         raise NotImplementedError()
 
     return full_src_path
+
+
+# Macros ----
+
+user_defined_macros = dict(get_project_id=get_project_id, get_bucket=get_bucket)
+
+user_defined_filters = dict(
+    table=lambda x: format_table_name(x, is_staging=False, full_name=True)
+)


### PR DESCRIPTION
Addresses #59:

### Features

* loads the validation reports into bigquery (1 row per itp_id)
* create a views dag, to handle transformation, and two convenient tables:
  - `views.validation_codes`: unnesting validation into 1 row per agency x code
  - `views.validation_details`: unnesting validation into 1 row per agency x code x individual code violation
 * creates custom airflow macros, so we can handle loading into our test datasets by...
   - writing `SELECT * FROM { "gtfs_schedule.agency" | table }`
   - generating `SELECT * FROM cal-itp-data-infra.test_gtfs_schedule.agency`.

### Notes

* bigquery requires an aggregation in its materialized views, so I've implemented a MaterializedViewOperator, but don't use it 😭.
* bigquery's api feels very low level, so I'm still leaning on the airflow bigquery hook
* I'm keen on knocking out the UPSERTING issue (#69), and creating a "golden" table or two in the views dag (#70), but once those are done it seems like maybe a good time to queue up some gentle refactoring of calitp.py and operators.py.