### PR TITLE
fix: add missing codes to validator schema

### DIFF
--- a/airflow/dags/gtfs_loader/validation_report_staging.yml
+++ b/airflow/dags/gtfs_loader/validation_report_staging.yml
@@ -30,6 +30,10 @@ schema_fields:
       fields:
         - name: csvRowNumber
           type: INTEGER
+        - name: csvRowNumberA
+          type: INTEGER
+        - name: csvRowNumberB
+          type: INTEGER
         - name: fareId
           type: STRING
         - name: previousCsvRowNumber
@@ -82,6 +86,8 @@ schema_fields:
           type: STRING
         - name: tripId
           type: STRING
+        - name: tripIdA
+          type: STRING
         - name: stopSequence
           type: INTEGER
         - name: specifiedField
@@ -108,4 +114,12 @@ schema_fields:
           type: STRING
         - name: stopShapeThresholdMeters
           type: NUMERIC
+        - name: serviceIdA
+          type: STRING
+        - name: serviceIdB
+          type: STRING
+        - name: blockId
+          type: STRING
+        - name: intersection
+          type: STRING
 ---


### PR DESCRIPTION
Currently, the validator schema is based on codes I was able to observe in our data. However, today's validator produced a new code, so I've updated the schema.

(@hunterowens going to merge, since missing these breaks the task, and it takes a while for the dev airflow to get caught up. Down the road, may be a quick way to pull these out of the gtfs-validator java app?)