### PR TITLE
Corrected Commerce feeds

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -200,7 +200,14 @@ clovis-transit-system:
 commerce-municipal-bus-lines:
   agency_name: Commerce Municipal Bus Lines
   gtfs_schedule_url:
-    - http://data.trilliumtransit.com/gtfs/cmbl-ca-us/cmbl-ca-us.zip
+    - https://citycommbus.com/gtfs
+  gtfs_rt_urls:
+    vehicle_positions:
+      - https://citycommbus.com/gtfs-rt/vehiclepositions
+    trip_updates:
+      - https://citycommbus.com/gtfs-rt/tripupdates
+    service_alerts:
+      - https://citycommbus.com/gtfs-rt/alerts
   itp_id: 75
 commuter-express:
   agency_name: Commuter Express


### PR DESCRIPTION
Per discussion with Commerce today, they prefer their GMV data over Trillium.