### PR TITLE
feat: add remaining tables from gtfs spec

### DIFF
--- a/airflow/dags/gtfs_schedule_history/calendar.yml
+++ b/airflow/dags/gtfs_schedule_history/calendar.yml
@@ -1,0 +1,35 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/processed/*/calendar.txt'
+destination_project_dataset_table: "gtfs_schedule_history.calendar"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+
+  - name: service_id
+    type: STRING
+  - name: monday
+    type: STRING
+  - name: tuesday
+    type: STRING
+  - name: wednesday
+    type: STRING
+  - name: thursday
+    type: STRING
+  - name: friday
+    type: STRING
+  - name: saturday
+    type: STRING
+  - name: sunday
+    type: STRING
+
+  - name: start_date
+    type: STRING
+  - name: end_date
+    type: STRING
+
+  - name: calitp_extracted_at
+    type: DATE

--- a/airflow/dags/gtfs_schedule_history/calendar_dates.yml
+++ b/airflow/dags/gtfs_schedule_history/calendar_dates.yml
@@ -1,0 +1,20 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/processed/*/calendar_dates.txt'
+destination_project_dataset_table: "gtfs_schedule_history.calendar_dates"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+
+  - name: service_id
+    type: STRING
+  - name: date
+    type: STRING
+  - name: exception_type
+    type: STRING
+
+  - name: calitp_extracted_at
+    type: DATE

--- a/airflow/dags/gtfs_schedule_history/calitp_included_gtfs_tables.py
+++ b/airflow/dags/gtfs_schedule_history/calitp_included_gtfs_tables.py
@@ -20,6 +20,13 @@ def main():
             # optional tables ----
             ("transfers", ".txt", False),
             ("feed_info", ".txt", False),
+            ("calendar", ".txt", False),
+            ("calendar_dates", ".txt", False),
+            ("frequencies", ".txt", False),
+            ("fare_rules", ".txt", False),
+            ("fare_attributes", ".txt", False),
+            ("frequencies", ".txt", False),
+            ("shapes", ".txt", False),
         ],
         columns=["table_name", "ext", "is_required"],
     )

--- a/airflow/dags/gtfs_schedule_history/fare_attributes.yml
+++ b/airflow/dags/gtfs_schedule_history/fare_attributes.yml
@@ -1,0 +1,28 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/processed/*/fare_attributes.txt'
+destination_project_dataset_table: "gtfs_schedule_history.fare_attributes"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+
+  - name: fare_id
+    type: STRING
+  - name: price
+    type: STRING
+  - name: currency_type
+    type: STRING
+  - name: payment_method
+    type: STRING
+  - name: transfers
+    type: STRING
+  - name: agency_id
+    type: STRING
+  - name: transfer_duration
+    type: STRING
+
+  - name: calitp_extracted_at
+    type: DATE

--- a/airflow/dags/gtfs_schedule_history/fare_rules.yml
+++ b/airflow/dags/gtfs_schedule_history/fare_rules.yml
@@ -1,0 +1,24 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/processed/*/fare_rules.txt'
+destination_project_dataset_table: "gtfs_schedule_history.fare_rules"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+
+  - name: fare_id
+    type: STRING
+  - name: route_id
+    type: STRING
+  - name: origin_id
+    type: STRING
+  - name: destination_id
+    type: STRING
+  - name: contains_id
+    type: STRING
+
+  - name: calitp_extracted_at
+    type: DATE

--- a/airflow/dags/gtfs_schedule_history/frequencies.yml
+++ b/airflow/dags/gtfs_schedule_history/frequencies.yml
@@ -1,0 +1,24 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/processed/*/frequencies.txt'
+destination_project_dataset_table: "gtfs_schedule_history.frequencies"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+
+  - name: trip_id
+    type: STRING
+  - name: start_time
+    type: STRING
+  - name: end_time
+    type: STRING
+  - name: headway_secs
+    type: STRING
+  - name: exact_times
+    type: STRING
+
+  - name: calitp_extracted_at
+    type: DATE

--- a/airflow/dags/gtfs_schedule_history/shapes.yml
+++ b/airflow/dags/gtfs_schedule_history/shapes.yml
@@ -1,0 +1,24 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/processed/*/shapes.txt'
+destination_project_dataset_table: "gtfs_schedule_history.shapes"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+
+  - name: shape_id
+    type: STRING
+  - name: shape_pt_lat
+    type: STRING
+  - name: shape_pt_lon
+    type: STRING
+  - name: shape_pt_sequence
+    type: STRING
+  - name: shape_dist_traveled
+    type: STRING
+
+  - name: calitp_extracted_at
+    type: DATE


### PR DESCRIPTION
This PR adds these remaining tables from the GTFS schedule spec:

* calendar
* calendar_dates
* fare_attributes
* fare_rules
* frequencies
* shapes

I think more are necessary for the GTFS report in #75. Data is currently up on the dev schemas!