### PR TITLE
Fix dep pybigquery

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -4,4 +4,4 @@ ipdb==0.13.4
 pandas==1.1.4
 gusty==0.5.1
 pandas-gbq==0.14.1
-git+https://github.com/googleapis/python-bigquery-sqlalchemy.git@0a3151b
+pybigquery==0.7.0


### PR DESCRIPTION
Includes pybigquery pypi dependency (see #111). I've been keeping an eye on the extraction DAG (gtfs_download), which has been running, so thought I had merged this already..! Going to merge, since gtfs_loader needs this to run