### PR TITLE
Update validation schema

### DIFF
--- a/airflow/dags/gtfs_loader/validation_report_process.py
+++ b/airflow/dags/gtfs_loader/validation_report_process.py
@@ -58,6 +58,7 @@ def validator_process(execution_date, **kwargs):
         raw_codes = {**validation["data"]["report"]}
         raw_codes["calitp_itp_id"] = row["itp_id"]
         raw_codes["calitp_url_number"] = row["url_number"]
+        raw_codes["calitp_extracted_at"] = execution_date.to_date_string()
         raw_codes["calitp_gtfs_validated_by"] = validation["version"]
 
         json_codes = json.dumps(raw_codes).encode()

--- a/airflow/dags/gtfs_schedule_history/validation_report.yml
+++ b/airflow/dags/gtfs_schedule_history/validation_report.yml
@@ -8,6 +8,8 @@ schema_fields:
     type: INTEGER
   - name: calitp_url_number
     type: INTEGER
+  - name: calitp_extracted_at
+    type: DATE
   - name: calitp_gtfs_validated_by
     type: STRING
   - name: notices
@@ -53,7 +55,7 @@ schema_fields:
         - name: fieldValue1
           type: STRING
         - name: fieldValue2
-          type: STRING
+          type: INTEGER
         - name: index
           type: INTEGER
         - name: shapeId
@@ -131,4 +133,8 @@ schema_fields:
         - name: blockId
           type: STRING
         - name: intersection
+          type: STRING
+        - name: departureTime
+          type: STRING
+        - name: arrivalTime
           type: STRING

--- a/airflow/dags/gtfs_schedule_history/validation_report.yml
+++ b/airflow/dags/gtfs_schedule_history/validation_report.yml
@@ -26,6 +26,10 @@ schema_fields:
       fields:
         - name: csvRowNumber
           type: INTEGER
+        - name: oldCsvRowNumber
+          type: INTEGER
+        - name: newCsvRowNumber
+          type: INTEGER
         - name: csvRowNumberA
           type: INTEGER
         - name: csvRowNumberB
@@ -40,7 +44,15 @@ schema_fields:
           type: STRING
         - name: fieldName
           type: STRING
+        - name: fieldName1
+          type: STRING
+        - name: fieldName2
+          type: STRING
         - name: fieldValue
+          type: STRING
+        - name: fieldValue1
+          type: STRING
+        - name: fieldValue2
           type: STRING
         - name: index
           type: INTEGER

--- a/airflow/dags/gtfs_views/dim_date.yml
+++ b/airflow/dags/gtfs_views/dim_date.yml
@@ -4,6 +4,7 @@ dependencies:
   - warehouse_loaded
 
 sql: |
+  # from https://gist.github.com/ewhauser/d7dd635ad2d4b20331c7f18038f04817
   SELECT
     FORMAT_DATE('%F', d) as id,
     d AS full_date,

--- a/airflow/dags/gtfs_views/dim_date.yml
+++ b/airflow/dags/gtfs_views/dim_date.yml
@@ -1,0 +1,24 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.dim_date"
+dependencies:
+  - warehouse_loaded
+
+sql: |
+  SELECT
+    FORMAT_DATE('%F', d) as id,
+    d AS full_date,
+    EXTRACT(YEAR FROM d) AS year,
+    EXTRACT(WEEK FROM d) AS year_week,
+    EXTRACT(DAY FROM d) AS year_day,
+    EXTRACT(YEAR FROM d) AS fiscal_year,
+    FORMAT_DATE('%Q', d) as fiscal_qtr,
+    EXTRACT(MONTH FROM d) AS month,
+    FORMAT_DATE('%B', d) as month_name,
+    FORMAT_DATE('%w', d) AS week_day,
+    FORMAT_DATE('%A', d) AS day_name,
+    (CASE WHEN FORMAT_DATE('%A', d) IN ('Sunday', 'Saturday') THEN 0 ELSE 1 END) AS day_is_weekday,
+  FROM (
+    SELECT
+      *
+    FROM
+      UNNEST(GENERATE_DATE_ARRAY('2001-01-01', '2050-01-01', INTERVAL 1 DAY)) AS d )

--- a/airflow/dags/gtfs_views/gtfs_agency_names.yml
+++ b/airflow/dags/gtfs_views/gtfs_agency_names.yml
@@ -1,0 +1,13 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_agency_names"
+dependencies:
+  - gtfs_status_latest
+
+sql: |
+  # Note that these entries should be distinct already, but since they're entered
+  # by hand, we guarantee it by using DISTINCT below.
+  SELECT DISTINCT
+    itp_id as calitp_itp_id
+    , url_number as calitp_url_number
+    , agency_name
+  FROM `{{ "views.gtfs_status_latest" | table }}`

--- a/airflow/dags/gtfs_views/gtfs_status_latest.yml
+++ b/airflow/dags/gtfs_views/gtfs_status_latest.yml
@@ -1,0 +1,12 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_status_latest"
+dependencies:
+  - warehouse_loaded
+
+sql: |
+  WITH tbl_max AS (
+    SELECT *, MAX(calitp_extracted_at) OVER () AS max_date
+    FROM `{{ "gtfs_schedule_history.calitp_status" | table }}`
+  )
+  SELECT * EXCEPT(max_date) FROM tbl_max
+  WHERE calitp_extracted_at=max_date

--- a/airflow/dags/gtfs_views/validation_codes.yml
+++ b/airflow/dags/gtfs_views/validation_codes.yml
@@ -6,6 +6,8 @@ dependencies:
 sql: |
   SELECT
     calitp_itp_id
+    , calitp_url_number
+    , calitp_extracted_at
     , code.code
     , code.severity
     , code.totalNotices

--- a/airflow/dags/gtfs_views/validation_notice_fields.py
+++ b/airflow/dags/gtfs_views/validation_notice_fields.py
@@ -1,0 +1,47 @@
+# ---
+# python_callable: validation_notice_fields
+# dependencies:
+#   - warehouse_loaded
+# ---
+
+# Note that in theory we could use a SQL query (maybe with a js UDF), but it
+# looks kind of crazy: https://stackoverflow.com/q/34890339/1144523
+# instead, just loop over the bucket of validation reports
+import gcsfs
+import json
+import pandas as pd
+
+from calitp import get_bucket, get_project_id, write_table
+from collections import defaultdict
+
+
+# note that if we upgrade gusty, we don't need to wrap this in a function
+def validation_notice_fields():
+    bucket = get_bucket()
+
+    fs = gcsfs.GCSFileSystem(project=get_project_id())
+    reports = fs.glob(f"{bucket}/schedule/processed/*/validation_report.json")
+    reports_json = [json.load(fs.open(fname)) for fname in reports]
+
+    code_fields = defaultdict(lambda: set())
+    for report in reports_json:
+        # one entry per code (e.g. the code: invalid phone number)
+        for notice in report["notices"]:
+            # one entry per specific code violation (e.g. each invalid phone number)
+            for entry in notice["notices"]:
+                # map each code to the fields in its notice
+                # (e.g. duplicate_route_name has a duplicatedField field
+                for field_name, value in entry.items():
+                    if isinstance(value, dict):
+                        # handle the few cases where there's one level of nesting
+                        sub_fields = [field_name + "." + v for v in value]
+                        code_fields[notice["code"]].update(sub_fields)
+                    else:
+                        # handle the common case of no sub-objects
+                        code_fields[notice["code"]].update(entry.keys())
+
+    validation_json_fields = pd.DataFrame(
+        {"code": code_fields.keys(), "field": list(map(list, code_fields.values()))}
+    ).explode("field")
+
+    write_table(validation_json_fields, "views.validation_notice_fields")

--- a/airflow/dags/gtfs_views/validation_notices.yml
+++ b/airflow/dags/gtfs_views/validation_notices.yml
@@ -7,6 +7,7 @@ sql: |
   SELECT
     calitp_itp_id
     , calitp_url_number
+    , calitp_extracted_at
     , code.code AS code
     , code.severity AS severity
     , notices.*


### PR DESCRIPTION
Addresses #128 #90, and adds additional view tables:

* `views.gtfs_status_latest` - data from the last ingested agencies.yml
* `views.gtfs_agency_names` - has itp id, url number, and agency name (derived from table above)
* `views.validation_notice_fields` - has a row for each error code x validation field, so you can look up what fields belong to which codes
* `dim_date` - a calendar table, to make it easier to do date stuff

Also makes `calitp.write_table` a singledispatch function, so that it can write DataFrames to bigquery.