### PR TITLE
Feat snapshots

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,5 @@ repos:
     rev: 1.7.0
     hooks:
       - id: bandit
-        args: ["-ll", "--skip", "B108", "--skip", "B608"]
+        args: ["-ll", "--skip=B108,B608"]
         files: .py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,5 @@ repos:
     rev: 1.7.0
     hooks:
       - id: bandit
-        args: ["-ll", "--skip", "B108"]
+        args: ["-ll", "--skip", "B108", "--skip", "B608"]
         files: .py$

--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -25,6 +25,7 @@ dag_directories = [
     dag_parent_dir / "gtfs_loader",
     dag_parent_dir / "gtfs_views",
     dag_parent_dir / "gtfs_schedule_history",
+    dag_parent_dir / "gtfs_schedule_history2",
 ]
 
 

--- a/airflow/dags/gtfs_loader/METADATA.yml
+++ b/airflow/dags/gtfs_loader/METADATA.yml
@@ -16,4 +16,6 @@ default_args:
     retry_delay: !timedelta 'minutes: 2'
     concurrency: 50
     #sla: !timedelta 'hours: 2'
+wait_for_defaults:
+    timeout: 3600
 latest_only: False

--- a/airflow/dags/gtfs_schedule_history2/METADATA.yml
+++ b/airflow/dags/gtfs_schedule_history2/METADATA.yml
@@ -1,0 +1,18 @@
+description: "Create type 2 history tables for gtfs schedules"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: True
+    start_date: "2021-04-15"
+    email:
+      - "hunter.owens@dot.ca.gov"
+      - "michael.c@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: False

--- a/airflow/dags/gtfs_schedule_history2/merge_updates.py
+++ b/airflow/dags/gtfs_schedule_history2/merge_updates.py
@@ -132,4 +132,8 @@ def main(**kwargs):
     table_names = create_tables()
 
     for table_name in table_names:
+        # TODO: remove validation report from included tables
+        if table_name == "validation_report":
+            continue
+
         merge_updates(table_name, **kwargs)

--- a/airflow/dags/gtfs_schedule_history2/merge_updates.py
+++ b/airflow/dags/gtfs_schedule_history2/merge_updates.py
@@ -1,0 +1,135 @@
+# ---
+# python_callable: main
+# provide_context: true
+# ---
+
+# This task looks up all included gtfs tables, then..
+#   * Creates an empty copy of each in DST_SCHEMA
+#   * Runs daily snapshots (type 2)
+# It can be re-run for the current day, but depends on past tasks.
+
+# TODO: Normally this task would be split into one task per table being updated.
+# However, because airflow v1 doesn't have task groups, it's probably easier
+# to keep as one big task for now. Once we upgrade to airflow v2, we can create
+# a special task group operator, that takes the names of each table, and generates
+# one task per table.
+# TODO: split out operators.py into submodules and move logic into there.
+
+SRC_SCHEMA = "gtfs_schedule_history"
+DST_SCHEMA = "gtfs_schedule_type2"
+
+
+# Task 1: Create tables =======================================================
+
+
+def create_tables():
+    """Fetch included gtfs tables. If they don't exist, then create them."""
+
+    from calitp import get_table, write_table
+
+    names = get_table(
+        f"{SRC_SCHEMA}.calitp_included_gtfs_tables", as_df=True
+    ).table_name.tolist()
+
+    for src_name in names:
+        sql_query = f"""
+        SELECT
+          *
+          , DATE(NULL) AS calitp_deleted_at
+          , "" AS calitp_hash
+        FROM `{SRC_SCHEMA}.{src_name}`
+        LIMIT 0
+        """
+        write_table(
+            sql_query,
+            f"{DST_SCHEMA}.{src_name}",
+            replace=False,
+            if_not_exists=True,
+            partition_by="calitp_deleted_at",
+        )
+
+    return names
+
+
+# Task 2: Daily type 2 merge ==================================================
+
+# This MERGE statement uses a hash of all of the columns of the table, except for
+# extracted_at. But because this requires TO_JSON_STRING on a table, I had to
+# remove calitp_extracted_at, and then re-insert it as execution date. An
+# alternative (used by DBT) is to create a surrogate key by coercing the columns
+# of interest to a string and then concatenating them.
+SQL_TEMPLATE = """
+MERGE `{target}` T
+USING (
+  WITH
+    tbl_files_today AS (
+      SELECT * EXCEPT(calitp_extracted_at) FROM `{source}`
+      WHERE _FILE_NAME LIKE "{bucket_like_str}"
+    ),
+    tbl_hash AS (
+      SELECT
+        *
+        , DATE("{execution_date}") as calitp_extracted_at
+        , DATE(NULL) as calitp_deleted_at
+        , TO_BASE64(MD5(TO_JSON_STRING(tbl_files_today))) AS calitp_hash
+      FROM
+        tbl_files_today
+    ),
+    feed_ids_today AS (
+      SELECT DISTINCT calitp_itp_id, calitp_url_number
+      FROM `{table_feed_updates}`
+      WHERE calitp_extracted_at="{execution_date}"
+    ),
+    missing_entries AS (
+      SELECT t1.calitp_hash AS calitp_hash
+      FROM `{target}` t1
+      JOIN feed_ids_today t2
+        ON
+            t1.calitp_itp_id=t2.calitp_itp_id
+            AND t1.calitp_url_number=t2.calitp_url_number
+      WHERE
+        t1.calitp_deleted_at IS NULL
+        AND t2.calitp_itp_id IS NULL
+    )
+  SELECT t1.*
+  FROM tbl_hash t1
+  FULL JOIN missing_entries t2
+    USING(calitp_hash)
+) S
+ON
+  T.calitp_hash = S.calitp_hash
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT ROW
+WHEN NOT MATCHED BY SOURCE AND T.calitp_deleted_at IS NULL THEN
+    UPDATE
+        SET calitp_deleted_at = DATE("{execution_date}"),
+            calitp_hash = NULL
+
+"""
+
+
+def merge_updates(table_name, execution_date, **kwargs):
+    from calitp import get_engine, get_bucket, format_table_name
+    from sqlalchemy import sql
+
+    bucket_like_str = (
+        f"{get_bucket()}/schedule/processed/{execution_date}_%/{table_name}.txt"
+    )
+
+    sql_code = SQL_TEMPLATE.format(
+        target=format_table_name(f"{DST_SCHEMA}.{table_name}"),
+        source=format_table_name(f"{SRC_SCHEMA}.{table_name}"),
+        table_feed_updates=format_table_name(f"{SRC_SCHEMA}.calitp_feed_updates"),
+        bucket_like_str=bucket_like_str,
+        execution_date=execution_date,
+    )
+
+    engine = get_engine()
+    engine.execute(sql.text(sql_code))
+
+
+def main(**kwargs):
+    table_names = create_tables()
+
+    for table_name in table_names:
+        merge_updates(table_name, **kwargs)

--- a/airflow/dags/gtfs_views/METADATA.yml
+++ b/airflow/dags/gtfs_views/METADATA.yml
@@ -15,4 +15,6 @@ default_args:
     retry_delay: !timedelta 'minutes: 2'
     concurrency: 50
     #sla: !timedelta 'hours: 2'
+wait_for_defaults:
+    timeout: 3600
 latest_only: False

--- a/airflow/dags/gtfs_views/gtfs_schedule_history_calendar_long.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_history_calendar_long.yml
@@ -1,0 +1,26 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_schedule_history_calendar_long"
+dependencies:
+  - warehouse_loaded
+
+sql: |
+  # Note that you can unnest values easily in SQL, but getting the column names
+  # is weirdly hard. To work around this, we just UNION ALL.
+  {% for dow in ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"] %}
+
+  {% if not loop.first %}
+  UNION ALL
+  {% endif %}
+
+  SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , service_id
+    , PARSE_DATE("%Y%m%d", start_date) AS start_date
+    , PARSE_DATE("%Y%m%d", end_date) AS end_date
+    , calitp_extracted_at
+    , calitp_deleted_at
+    , "{{dow | title}}" AS day_name
+    , {{dow}} AS service_indicator
+  FROM `{{ "gtfs_schedule_type2.calendar" | table }}`
+  {% endfor %}

--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily.yml
@@ -1,0 +1,81 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_schedule_service_daily"
+dependencies:
+  - gtfs_schedule_history_calendar_long
+  - dim_date
+
+sql: |
+  # For a given service_date, find the latest feed describing whether that date
+  # is in service or not. For example, for 2021-04-10, the latest active feed
+  # might be from 2021-04-09 (or even earlier, if it has not been updated recently).
+  # Key features:
+  #   * There should be one entry per feed x service_date
+  #   * service_date may extend far into the future (depending on service_date_end)
+  #   * is_in_service for service_date(s) past today are not stable. They reflect
+  #     what the most recent feed thinks will be in service in e.g. 2050-01-01.
+  WITH
+    # preprocess calendar dates
+    cal_dates AS (
+      SELECT
+        *
+        , PARSE_DATE("%Y%m%d", date) AS service_date
+      FROM `{{ "gtfs_schedule_type2.calendar_dates" | table }}`
+    ),
+
+    # for each day in our date calendar, get service entries that existed
+    # in the feed on that day (for that day).
+    cal_dates_daily AS (
+      SELECT
+        t1.*
+      FROM cal_dates t1
+      JOIN `{{ "views.dim_date" | table }}` t2
+        ON t1.calitp_extracted_at <= t2.full_date
+          AND COALESCE(t1.calitp_deleted_at, DATE("2099-01-01")) > t2.full_date
+          AND t1.service_date = t2.full_date
+    ),
+
+    # inclusions from calendar_dates
+    date_include AS (
+      SELECT
+        calitp_itp_id
+        , calitp_url_number
+        , service_id
+        , service_date
+        , TRUE AS service_inclusion
+      FROM cal_dates
+      WHERE cal_dates.exception_type = "1"
+    ),
+
+    # exclusions from calendar_dates
+    date_exclude AS (
+      SELECT
+        calitp_itp_id
+        , calitp_url_number
+        , service_id
+        , service_date
+        , TRUE AS service_exclusion
+      FROM cal_dates
+      WHERE cal_dates.exception_type = "2"
+    ),
+    # for the active calendar entries on a each date (e.g. from the latest feed
+    # on that date), get the service indicator (0 for out of service, 1 for in).
+    calendar_daily AS (
+      SELECT
+        t1.* EXCEPT(start_date, end_date, day_name)
+        , t1.start_date AS service_start_date
+        , t1.end_date AS service_end_date
+        , t2.full_date AS service_date
+      FROM  `{{ "views.gtfs_schedule_history_calendar_long" | table }}` t1
+      JOIN `{{ "views.dim_date" | table }}` t2
+        ON t1.calitp_extracted_at <= t2.full_date
+          AND COALESCE(t1.calitp_deleted_at, DATE("2099-01-01")) > t2.full_date
+          AND t1.day_name = t2.day_name
+    )
+  SELECT
+    *
+    , (service_indicator="1" AND NOT COALESCE(service_exclusion, FALSE))
+        OR COALESCE(service_inclusion, FALSE)
+        AS is_in_service
+  FROM calendar_daily
+  FULL JOIN date_include USING(calitp_itp_id, calitp_url_number, service_id, service_date)
+  FULL JOIN date_exclude USING(calitp_itp_id, calitp_url_number, service_id, service_date)

--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily.yml
@@ -79,3 +79,5 @@ sql: |
   FROM calendar_daily
   FULL JOIN date_include USING(calitp_itp_id, calitp_url_number, service_id, service_date)
   FULL JOIN date_exclude USING(calitp_itp_id, calitp_url_number, service_id, service_date)
+  # TODO: remove hardcoding--set this to be 1 month in the future, etc..
+  WHERE service_date < "2022-01-01"

--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily_metrics.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily_metrics.yml
@@ -1,0 +1,14 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_schedule_service_daily_metrics"
+dependencies:
+  - warehouse_loaded
+
+sql: |
+  SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , service_date
+    , service_id
+    , SUM(service_hours) AS ttl_service_hours
+  FROM `{{ "views.gtfs_schedule_service_daily_trips" | table }}`
+  GROUP BY 1, 2, 3, 4

--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily_trips.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily_trips.yml
@@ -1,0 +1,54 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_schedule_service_daily_trips"
+dependencies:
+  - gtfs_schedule_service_daily
+
+sql: |
+  # Each trip with scheduled service on a date, augmented with route_id, first departure,
+  # and last arrival timestamps.
+  #
+  WITH
+  daily_service_trips AS (
+    SELECT
+      t1.*
+      , t2.trip_id
+      , t2.route_id
+    FROM `{{ "views.gtfs_schedule_service_daily" | table }}` t1
+    JOIN `{{ "gtfs_schedule_type2.trips" | table }}` t2
+      USING (calitp_itp_id, calitp_url_number, service_id)
+    WHERE
+      t2.calitp_extracted_at <= t1.service_date
+      AND COALESCE(t2.calitp_deleted_at, DATE("2099-01-01")) > t1.service_date
+  ),
+  stop_time_update_dates AS (
+    SELECT calitp_extracted_at AS updated_at FROM `{{ "views.gtfs_schedule_stop_times" | table }}`
+    UNION DISTINCT
+    SELECT calitp_deleted_at FROM `{{ "views.gtfs_schedule_stop_times" | table }}`
+  ),
+  service_dates AS (
+    (SELECT DISTINCT service_date FROM `{{ "views.gtfs_schedule_service_daily" | table }}`)
+  ),
+  trip_summary AS (
+    SELECT
+      t1.calitp_itp_id
+      , t1.calitp_url_number
+      , t1.trip_id
+      , t2.service_date
+      , COUNT(DISTINCT t1.stop_id) AS n_stops
+      , COUNT(*) AS n_stop_times
+      , MIN(t1.departure_ts) AS trip_first_departure_ts
+      , MAX(t1.arrival_ts) AS trip_last_arrival_ts
+    FROM `{{ "views.gtfs_schedule_stop_times" | table }}` t1
+    JOIN  service_dates t2
+    ON t1.calitp_extracted_at <= t2.service_date
+      AND COALESCE(t1.calitp_deleted_at, DATE("2099-01-01")) > t2.service_date
+    GROUP BY 1, 2, 3, 4
+  )
+
+  SELECT
+    t1.*
+    , t2.* EXCEPT(calitp_itp_id, calitp_url_number, trip_id, service_date)
+    , (t2.trip_last_arrival_ts - t2.trip_first_departure_ts) / 3600 AS service_hours
+  FROM daily_service_trips t1
+  JOIN trip_summary t2
+    USING(calitp_itp_id, calitp_url_number, trip_id, service_date)

--- a/airflow/dags/gtfs_views/gtfs_schedule_stop_times.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_stop_times.yml
@@ -1,0 +1,37 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_schedule_stop_times"
+dependencies:
+  - warehouse_loaded
+
+sql: |
+     WITH
+     raw_time_parts AS (
+          SELECT *
+            , REGEXP_EXTRACT_ALL(arrival_time, "([0-9]+)") AS part_arr
+            , REGEXP_EXTRACT_ALL(departure_time, "([0-9]+)") AS part_dep
+            FROM `{{ "gtfs_schedule_type2.stop_times" | table }}`
+     ),
+     int_time_parts AS (
+          SELECT
+            * EXCEPT (part_arr, part_dep, stop_sequence)
+            , ARRAY(SELECT CAST(num AS INT64) FROM UNNEST(raw_time_parts.part_arr) num) AS part_arr
+            , ARRAY(SELECT CAST(num AS INT64) FROM UNNEST(raw_time_parts.part_dep) num) AS part_dep
+            , CAST(stop_sequence AS INT64) AS stop_sequence
+          FROM raw_time_parts
+     ),
+     array_len_fix AS (
+          SELECT
+            * EXCEPT(part_arr, part_dep)
+            , CASE WHEN ARRAY_LENGTH(part_arr) = 0 THEN [NULL, NULL, NULL] ELSE part_arr END AS part_arr
+            , CASE WHEN ARRAY_LENGTH(part_dep) = 0 THEN [NULL, NULL, NULL] ELSE part_arr END AS part_dep
+          FROM int_time_parts
+     )
+
+     SELECT
+       * EXCEPT(part_arr, part_dep)
+       , DENSE_RANK()
+            OVER (PARTITION BY calitp_itp_id, calitp_url_number, trip_id ORDER BY stop_sequence)
+          AS stop_sequence_rank
+       , part_arr[OFFSET(0)] * 3600 + part_arr[OFFSET(1)] * 60 + part_arr[OFFSET(2)] AS arrival_ts
+       , part_dep[OFFSET(0)] * 3600 + part_dep[OFFSET(1)] * 60 + part_dep[OFFSET(2)] AS departure_ts
+     FROM array_len_fix

--- a/airflow/debug.py
+++ b/airflow/debug.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+import dotenv
+
+dotenv.load_dotenv()
+
+sys.path.append(os.path.abspath("plugins"))

--- a/airflow/plugins/calitp.py
+++ b/airflow/plugins/calitp.py
@@ -144,6 +144,27 @@ def _write_table_df(sql_stmt, table_name, engine=None, replace=True):
     )
 
 
+def query_yaml(fname, write_as=None, replace=False):
+    import yaml
+    from jinja2 import Environment, select_autoescape
+
+    config = yaml.safe_load(open(fname))
+
+    sql_template_raw = config["sql"]
+    env = Environment(autoescape=select_autoescape())
+    env.filters = {**env.filters, **user_defined_filters}
+
+    template = env.from_string(sql_template_raw)
+
+    sql_code = template.render({**user_defined_macros})
+
+    if write_as is not None:
+        return write_table(sql_code, write_as, replace=replace)
+    else:
+        engine = get_engine()
+        return engine.execute(sql_code)
+
+
 # Bucket related --------------------------------------------------------------
 
 

--- a/airflow/plugins/calitp.py
+++ b/airflow/plugins/calitp.py
@@ -144,7 +144,7 @@ def _write_table_df(sql_stmt, table_name, engine=None, replace=True):
     )
 
 
-def query_yaml(fname, write_as=None, replace=False):
+def query_yaml(fname, write_as=None, replace=False, dry_run=False):
     import yaml
     from jinja2 import Environment, select_autoescape
 
@@ -158,7 +158,9 @@ def query_yaml(fname, write_as=None, replace=False):
 
     sql_code = template.render({**user_defined_macros})
 
-    if write_as is not None:
+    if dry_run:
+        print(sql_code)
+    elif write_as is not None:
         return write_table(sql_code, write_as, replace=replace)
     else:
         engine = get_engine()
@@ -253,7 +255,11 @@ def read_gcfs(
 
 # Macros ----
 
-user_defined_macros = dict(get_project_id=get_project_id, get_bucket=get_bucket)
+user_defined_macros = dict(
+    get_project_id=get_project_id,
+    get_bucket=get_bucket,
+    THE_FUTURE=lambda: 'DATE("2099-01-01")',
+)
 
 user_defined_filters = dict(
     table=lambda x: format_table_name(x, is_staging=False, full_name=True),


### PR DESCRIPTION
This PR builds out the tables needed for #75, and also fixed a few small things along the way. Main features:

* daily snapshots of gtfs schedule data (merge_updates.py)
* added views for describing daily service schedules (e.g. on a specific date, what does the most recent feed before that date say service is like in the calendar)
* fixed an issue with gusty configuration that was causing wait_for tasks to fail everyday #133 
* added a `query_yaml` function, which can take the name of a task file
* add a debug.py file that makes it easy to import from airflow plugins, dag tasks

TODO (but likely not urgent): 

* Change loading in `gtfs_loader/gtfs_schedule_tables_load.py` to load the latest data from the snapshots, move to history2 dags
* I'd go for renaming the current gtfs_schedule_history dataset to gtfs_schedule_external or something.

### Debugging example


e.g.

```python
import debug
from calitp import query_yaml

# these can be uncommented if you need to test a query against the production tables
# which is maybe not ideal, but useful until we put in a quick way to copy the prod
# bigquery tables to dev
# os.environ["AIRFLOW_ENV"] = "cal-itp-data-infra"
# os.environ["AIRFLOW_VAR_EXTRACT_BUCKET"] = "gs://gtfs-data"

query_yaml("dags/gtfs_views/gtfs_schedule_service_daily_metrics.yml", write_as="views.gtfs_schedule_servce_daily_metrics", replace=True)
```

Note that I run the new SQL views over production, so I could punt on figuring out easy ways to copy datasets to dev. Once I get back, it's probably about a good time to add in functionality for creating SQL table / column comments, and having them generate docs. There's also nice SQL testing functionality via https://github.com/sodadata/soda-sql!