### PR TITLE
style(ci): rename lint workflow to match  filename

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `lint.yml` workflow is named `build` -- seems like maybe some copy-pasta. I renamed it to `lint` which shows while the lint workflow is initializing and is the name used to require the check. Looks like github repo branch settings will need to be updated when this gets merged to make `lint` the required check instead of `build`