### PR TITLE
Fix schedule merge

### DIFF
--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -37,7 +37,7 @@ for dag_directory in dag_directories:
         dag_directory,
         tags=["default", "tags"],
         task_group_defaults={"tooltip": "this is a default tooltip"},
-        wait_for_defaults={"retries": 10, "check_existence": True},
+        wait_for_defaults={"retries": 12, "check_existence": True, "timeout": 10 * 60},
         latest_only=False,
         user_defined_macros=user_defined_macros,
         user_defined_filters=user_defined_filters,

--- a/airflow/dags/gtfs_schedule_history2/merge_updates.py
+++ b/airflow/dags/gtfs_schedule_history2/merge_updates.py
@@ -122,7 +122,7 @@ def merge_updates(table_name, execution_date, **kwargs):
         source=format_table_name(f"{SRC_SCHEMA}.{table_name}"),
         table_feed_updates=format_table_name(f"{SRC_SCHEMA}.calitp_feed_updates"),
         bucket_like_str=bucket_like_str,
-        execution_date=execution_date,
+        execution_date=execution_date.to_date_string(),
     )
 
     engine = get_engine()


### PR DESCRIPTION
Going to merge, so I can get prod up to date for #137. I needed to use the shortened version of execution date in a SQL merge, so need to convert the execution_date airflow passes in to operators (it shows up like `2021-01-01T00:00:00+00:00`, but we need `2021-01-01`).