### PR TITLE
fix(docs): pin mkdocs to v1.1.2

### DIFF
--- a/script/docs-server
+++ b/script/docs-server
@@ -18,7 +18,7 @@ echo "Installing mkdocs and plugins..."
 # lines after mkdocs and mkdocs-material are optional plugins,
 # must be matched in .holo/branches/docs-site.lenses/mkdocs.toml
 pip install \
-    mkdocs \
+    mkdocs==1.1.2 \
     mkdocs-material \
     mkdocs-awesome-pages-plugin \
     fontawesome_markdown \


### PR DESCRIPTION
v1.2.0 was released yesterday with broken livereload

See: https://github.com/mkdocs/mkdocs/issues/2448