### PR TITLE
fix(airflow): wait longer for external dependencies

### DIFF
--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -37,7 +37,7 @@ for dag_directory in dag_directories:
         dag_directory,
         tags=["default", "tags"],
         task_group_defaults={"tooltip": "this is a default tooltip"},
-        wait_for_defaults={"retries": 12, "check_existence": True, "timeout": 10 * 60},
+        wait_for_defaults={"retries": 24, "check_existence": True, "timeout": 10 * 60},
         latest_only=False,
         user_defined_macros=user_defined_macros,
         user_defined_filters=user_defined_filters,


### PR DESCRIPTION
This should hopefully fix #133 the `wait_for` tasks failing once and for all. I recently lengthened their wait time to 2.5 hours, but the validator took a bit longer than that this morning. Going to try waiting for 4 hours.

For context, waiting for other DAGs to finish is set on a short timer in gusty by default, in order to prevent extraction tasks from rolling over to the following day (i.e. they need to complete somewhat quickly or fail!). But our loading tasks can wait longer..

edit: note that once we upgrade to airflow 2, I can create a "task group" operator that splits validation into several batches running in parallel (not urgent).