### PR TITLE
feat(airflow): support invalid_row_length validation error

### DIFF
--- a/airflow/dags/gtfs_schedule_history/validation_report.yml
+++ b/airflow/dags/gtfs_schedule_history/validation_report.yml
@@ -36,6 +36,10 @@ schema_fields:
           type: INTEGER
         - name: csvRowNumberB
           type: INTEGER
+        - name: rowLength
+          type: INTEGER
+        - name: headerCount
+          type: INTEGER
         - name: fareId
           type: STRING
         - name: previousCsvRowNumber


### PR DESCRIPTION
This PR adds fields for a previously unseen validator error. Tested on dev. Details below...

Looks like [Santa Clara Valley Transportation Authority](https://github.com/cal-itp/data-infra/blob/main/airflow/data/agencies.yml#L793) triggered a new validator error: invalid_row_length. This is because they did not correctly quote entries with commas in them (see North,South and East,West at the far right of data).

```
route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color,route_sort_order,ext_route_type
500,VTA,Rapid 500,San Jose Diridon Station - Berryessa BART,"Rapid buses may depart up to five minutes earlier than the time shown, if traffic allows.",3,https://www.vta.org/go/routes/rapid-500,e4002b,FFFFFF,4,North,South,702
522,VTA,Rapid 522,Palo Alto Transit Center - Eastridge,"Rapid buses may depart up to five minutes earlier than the time shown, if traffic allows.",3,https://www.vta.org/go/routes/rapid-522,e4002b,FFFFFF,5,East,West,702
```

Note that while pandas is able to open these files, it does not get the column names right. It thinks the first two columns are actually (unnamed) indexes. As a result, when we load into bigquery, the data is put in the wrong columns :/.

Notice below that for the first 3 rows, the route_short_name is in the route_id column..

![image](https://user-images.githubusercontent.com/2574498/121376769-c9aa3680-c90f-11eb-8e36-375d2efd2c84.png)
