### PR TITLE
views: fix service_daily related tables

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily.yml
@@ -67,9 +67,16 @@ sql: |
         , t2.full_date AS service_date
       FROM  `{{ "views.gtfs_schedule_history_calendar_long" | table }}` t1
       JOIN `{{ "views.dim_date" | table }}` t2
-        ON t1.calitp_extracted_at <= t2.full_date
+        ON
+          # use full_date to get active schedule on that date, and ensure
+          # that entries have same day_name
+          t1.calitp_extracted_at <= t2.full_date
           AND COALESCE(t1.calitp_deleted_at, DATE("2099-01-01")) > t2.full_date
           AND t1.day_name = t2.day_name
+      WHERE
+          # Service date (full_date) must be between service start and end dates
+          t1.start_date <= t2.full_date
+          AND COALESCE(t1.end_date, DATE("2099-01-01")) >= t2.full_date
     )
   SELECT
     *

--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily_metrics.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily_metrics.yml
@@ -4,11 +4,23 @@ dependencies:
   - warehouse_loaded
 
 sql: |
+  WITH service_agg AS (
+    SELECT
+      calitp_itp_id
+      , calitp_url_number
+      , service_date
+      , service_id
+      , SUM(service_hours) AS ttl_service_hours
+      , COUNT(DISTINCT trip_id) AS n_trips
+      , COUNT(DISTINCT route_id) AS n_routes
+      , MIN(trip_first_departure_ts) AS first_departure_ts
+      , MAX(trip_last_arrival_ts) AS last_arrival_ts
+    FROM `{{ "views.gtfs_schedule_service_daily_trips" | table }}`
+    WHERE is_in_service
+    GROUP BY 1, 2, 3, 4
+  )
+
   SELECT
-    calitp_itp_id
-    , calitp_url_number
-    , service_date
-    , service_id
-    , SUM(service_hours) AS ttl_service_hours
-  FROM `{{ "views.gtfs_schedule_service_daily_trips" | table }}`
-  GROUP BY 1, 2, 3, 4
+    *
+    , (last_arrival_ts - first_departure_ts) / 3600 AS service_window
+  FROM service_agg

--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily_trips.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily_trips.yml
@@ -9,6 +9,9 @@ sql: |
   #
   WITH
   daily_service_trips AS (
+    # Daily service for each trip. Note that scheduled service in the calendar
+    # can have multiple trips associated with it, via the service_id key.
+    # (i.e. calendar service to trips is 1-to-many)
     SELECT
       t1.*
       , t2.trip_id
@@ -20,15 +23,13 @@ sql: |
       t2.calitp_extracted_at <= t1.service_date
       AND COALESCE(t2.calitp_deleted_at, DATE("2099-01-01")) > t1.service_date
   ),
-  stop_time_update_dates AS (
-    SELECT calitp_extracted_at AS updated_at FROM `{{ "views.gtfs_schedule_stop_times" | table }}`
-    UNION DISTINCT
-    SELECT calitp_deleted_at FROM `{{ "views.gtfs_schedule_stop_times" | table }}`
-  ),
   service_dates AS (
+    # Each unique value for service_date
     (SELECT DISTINCT service_date FROM `{{ "views.gtfs_schedule_service_daily" | table }}`)
   ),
   trip_summary AS (
+    # Trip metrics for each possible service date (e.g. for a given trip that existed
+    # on this day, when was its last arrival? how many stops did it have?)
     SELECT
       t1.calitp_itp_id
       , t1.calitp_url_number


### PR DESCRIPTION
Main issues were..

* gtfs_schedule_service_daily needed to take into account calendar start_date and end_date
* service hours calculation for report is the service window available on a given day (ie. 24 hours or less); named service_window for now in data, since previous calculations are still in there.

(added some extra comments)