### PR TITLE
fix(airflow): xcom values too big for mysql

### DIFF
--- a/airflow/dags/gtfs_downloader/generate_provider_list.py
+++ b/airflow/dags/gtfs_downloader/generate_provider_list.py
@@ -36,7 +36,14 @@ def make_gtfs_list(fname=None):
     assert df_feeds.index.equals(df_long.index)
 
     # append columns for feed urls
-    df_final = df_long.join(df_feeds).drop(columns=["feeds"])
+    df_final = df_long.join(df_feeds).drop(
+        columns=[
+            "feeds",
+            "gtfs_rt_vehicle_positions",
+            "gtfs_rt_service_alerts_url",
+            "gtfs_rt_trip_updates_url",
+        ]
+    )
     df_final["url_number"] = df_final.groupby("itp_id").cumcount()
 
     return df_final


### PR DESCRIPTION
This PR fixes an error caused by a task returning xcom values that are too big (byte-wise) for airflow's mysql setup.
I cut out the RT url columns for now, since the values are just used to download static schedule data. Going to merge and re-run task, so we can get save today's feed data.

```
sqlalchemy.exc.DataError: (_mysql_exceptions.DataError) (1406, "Data too long for column 'value' at row 1"
[SQL: INSERT INTO xcom (`key`, value, timestamp, execution_date, task_id, dag_id) VALUES (%s, %s, %s, %s, %s, %s)
[parameters: ('return_value', b'[{"agency_handle": "ac-transit", "agency_name": "AC Transit", "itp_id": 4, "gtfs_schedule_url": "https://api.actransit.org/transit/gtfs/download?tok ... (66677 characters truncated) ... reaferries-ca-us.zip", "gtfs_rt_vehicle_positions_url": null, "gtfs_rt_service_alerts_url": null, "gtfs_rt_trip_updates_url": null, "url_number": 0}]', datetime.datetime(2021, 6, 15, 0, 3, 52, 100234), datetime.datetime(2021, 6, 14, 0, 0), 'generate_provider_list', 'gtfs_downloader')
(Background on this error at: http://sqlalche.me/e/13/9h9h
```