### PR TITLE
fix(airflow): fix task dependencies for a view; merges

### DIFF
--- a/airflow/dags/gtfs_loader/calitp_files_updates_load.yml
+++ b/airflow/dags/gtfs_loader/calitp_files_updates_load.yml
@@ -3,6 +3,7 @@ operator: airflow.contrib.operators.bigquery_operator.BigQueryOperator
 destination_dataset_table: "{{ 'gtfs_schedule_history.calitp_files_updates' | table }}"
 use_legacy_sql: false
 write_disposition: WRITE_TRUNCATE
+depends_on_past: true
 dependencies:
   - calitp_files_process
   - latest_only

--- a/airflow/dags/gtfs_schedule_history2/merge_updates.py
+++ b/airflow/dags/gtfs_schedule_history2/merge_updates.py
@@ -1,6 +1,8 @@
 # ---
 # python_callable: main
 # provide_context: true
+# external_dependencies:
+#   - gtfs_loader: gtfs_schedule_history_load
 # ---
 
 # This task looks up all included gtfs tables, then..

--- a/airflow/dags/gtfs_schedule_history2/validation_notices_load.yml
+++ b/airflow/dags/gtfs_schedule_history2/validation_notices_load.yml
@@ -1,0 +1,43 @@
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_schedule_type2.validation_notices"
+external_dependencies:
+  - gtfs_loader: gtfs_schedule_history_load
+sql: |
+     WITH
+     # TODO: For some reason some of the extracted_at values are null, so we should
+     # investigate / re-run the processing in gtfs_loader. As a work around, this
+     # query parses the extraction date out of our file names.
+     fixed_extracted AS (
+         SELECT
+           * EXCEPT(calitp_extracted_at)
+           , PARSE_DATE("%F", REGEXP_EXTRACT(_FILE_NAME, "processed/([0-9\\-]*)_.*/validation_report"))
+               AS calitp_extracted_at
+         FROM `{{ "gtfs_schedule_history.validation_report" | table }}`
+     ),
+     # adds a calitp_deleted_at column, similar to other tables in this DAG.
+     marked_deleted AS (
+         SELECT
+           *
+           , LEAD(calitp_extracted_at)
+               OVER (PARTITION BY calitp_itp_id ORDER BY calitp_extracted_at)
+               AS calitp_deleted_at
+         FROM fixed_extracted
+     ),
+     # unnests so each row is an individual notice (e.g. a specific instance of
+     # a code violation. If there are two rows with invalid phone numbers, each
+     # will be a row here.)
+     unnested AS (
+       SELECT
+         calitp_itp_id
+         , calitp_url_number
+         , calitp_extracted_at
+         , calitp_deleted_at
+         , code.code AS code
+         , code.severity AS severity
+         , notices.*
+       FROM
+         marked_deleted AS t
+         , UNNEST(t.notices) as code
+         , UNNEST(code.notices) as notices
+     )
+     SELECT * FROM unnested

--- a/airflow/dags/gtfs_views/gtfs_schedule_service_daily_metrics.yml
+++ b/airflow/dags/gtfs_views/gtfs_schedule_service_daily_metrics.yml
@@ -1,7 +1,7 @@
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "views.gtfs_schedule_service_daily_metrics"
 dependencies:
-  - warehouse_loaded
+  - gtfs_schedule_service_daily_trips
 
 sql: |
   WITH service_agg AS (


### PR DESCRIPTION
* Has the SQL merge statement that makes a big historical table of gtfs schedule data wait until the loading DAG is completed
* Correctly sets `views.gtfs_schedule_service_daily_trips` as the parent of `views.gtfs_schedule_service_daily_metrics`
* Fixes gtfs_loader to depend on the past when detecting whether files have updated (will make it easier to re-run history if we have to)
* Adds a `validator_notices` table with full history to `gtfs_schedule_type2`, so we can start on https://github.com/cal-itp/notebooks/issues/20