### PR TITLE
Use Named Keys for API keys

### DIFF
--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -17,6 +17,15 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+    - name: Install python packages
+      run: |
+        pip install jinja2==2.11.3 PyYAML==5.4.1
+    - name: Fill in agencies.yml API keys
+      run: |
+        python script/agencies_convert.py \
+          './airflow/data/agencies.yml' \
+          './airflow/data/agencies.filled.yml' \
+          'https://docs.google.com/spreadsheets/d/1Fp7sesSMS6VOIndTLTKcyyN2qHj6najKAaN-I9_3SFo/export?gid=0&format=csv'
     - uses: google-github-actions/setup-gcloud@master
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -25,3 +34,5 @@ jobs:
         gsutil -m rsync -d -c -r airflow/dags gs://us-west2-calitp-airflow-pro-332827a9-bucket/dags
         gsutil -m rsync -d -c -r airflow/plugins gs://us-west2-calitp-airflow-pro-332827a9-bucket/plugins
         gsutil -m rsync -d -c -r airflow/data gs://us-west2-calitp-airflow-pro-332827a9-bucket/data
+        # replace agencies.yml with filled in template
+        gsutil -m cp airflow/data/agencies.filled.yml gs://us-west2-calitp-airflow-pro-332827a9-bucket/data/agencies.yml

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'airflow/data/agencies.yml'
 
 jobs:
   deploy:
@@ -26,11 +28,17 @@ jobs:
           './airflow/data/agencies.yml' \
           './airflow/data/agencies.filled.yml' \
           'https://docs.google.com/spreadsheets/d/1Fp7sesSMS6VOIndTLTKcyyN2qHj6najKAaN-I9_3SFo/export?gid=0&format=csv'
+
+    # The following only runs on the main branch ----
+
     - uses: google-github-actions/setup-gcloud@master
+      if: github.ref == "refs/head/main"
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
-    - run: |
+    - name: Push to google cloud
+      if: github.ref == "refs/head/main"
+      run: |
         gsutil -m rsync -d -c -r airflow/dags gs://us-west2-calitp-airflow-pro-332827a9-bucket/dags
         gsutil -m rsync -d -c -r airflow/plugins gs://us-west2-calitp-airflow-pro-332827a9-bucket/plugins
         gsutil -m rsync -d -c -r airflow/data gs://us-west2-calitp-airflow-pro-332827a9-bucket/data

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -21,13 +21,18 @@ jobs:
         python-version: 3.8
     - name: Install python packages
       run: |
-        pip install jinja2==2.11.3 PyYAML==5.4.1
+        pip install jinja2==2.11.3 PyYAML==5.4.1 jsonschema==3.2.0
     - name: Fill in agencies.yml API keys
       run: |
         python script/agencies_convert.py \
           './airflow/data/agencies.yml' \
           './airflow/data/agencies.filled.yml' \
           'https://docs.google.com/spreadsheets/d/1Fp7sesSMS6VOIndTLTKcyyN2qHj6najKAaN-I9_3SFo/export?gid=0&format=csv'
+    - name: Validate agencies.yml
+      run: |
+        python script/agencies_validate.py \
+          './airflow/data/agencies.filled.yml' \
+          './airflow/data/schema_agencies_entry.yml'
 
     # The following only runs on the main branch ----
 

--- a/airflow/data/.gitignore
+++ b/airflow/data/.gitignore
@@ -1,0 +1,1 @@
+agencies.filled.yml

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1,10 +1,10 @@
 ac-transit:
   agency_name: AC Transit
   feeds:
-    - gtfs_schedule_url: https://api.actransit.org/transit/gtfs/download?token=2512B81107A09D2DC44895CDDC650D47
-      gtfs_rt_vehicle_positions_url: https://api.actransit.org/gtfsrt/vehicles?token=2512B81107A09D2DC44895CDDC650D47
-      gtfs_rt_service_alerts_url: https://api.actransit.org/gtfsrt/alerts?token=2512B81107A09D2DC44895CDDC650D47
-      gtfs_rt_trip_updates_url: https://api.actransit.org/gtfsrt/tripupdates?token=2512B81107A09D2DC44895CDDC650D47
+    - gtfs_schedule_url: https://api.actransit.org/transit/gtfs/download?token={{ AC_TRANSIT_API_KEY }}
+      gtfs_rt_vehicle_positions_url: https://api.actransit.org/gtfsrt/vehicles?token={{ AC_TRANSIT_API_KEY }}
+      gtfs_rt_service_alerts_url: https://api.actransit.org/gtfsrt/alerts?token={{ AC_TRANSIT_API_KEY }}
+      gtfs_rt_trip_updates_url: https://api.actransit.org/gtfsrt/tripupdates?token={{ AC_TRANSIT_API_KEY }}
   itp_id: 4
 alhambra-community-transit:
   agency_name: Alhambra Community Transit
@@ -442,10 +442,10 @@ emery-go-round:
   agency_name: Emery Go-Round
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/emerygoround-ca-us/emerygoround-ca-us.zip
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff4&agency=EM
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff4&agency=EM
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=EM
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=EM
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=EM
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=EM
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -462,10 +462,10 @@ fairfield-and-suisun-transit:
   agency_name: Fairfield and Suisun Transit
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/fairfield-ca-us/fairfield-ca-us.zip
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff5&agency=FS
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff5&agency=FS
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=FS
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=FS
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=FS
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=FS
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -1014,10 +1014,10 @@ samtrans:
   agency_name: SamTrans
   feeds:
     - gtfs_schedule_url: http://www.samtrans.com/Assets/GTFS/samtrans/ST-GTFS.zip?v=1114
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff8&agency=SM
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff8&agency=SM
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=SM
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=SM
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=SM
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=SM
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -1034,10 +1034,10 @@ san-francisco-bay-ferry:
   agency_name: San Francisco Bay Ferry
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/sfbayferry-ca-us/sfbayferry-ca-us.zip
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff6&agency=SB
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff6&agency=SB
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=SB
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=SB
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=SB
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=SB
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -1078,9 +1078,9 @@ santa-clara-valley-transportation-authority:
   agency_name: Santa Clara Valley Transportation Authority
   feeds:
     - gtfs_schedule_url: https://gtfs.vta.org/gtfs_vta.zip
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff5&agency=SC
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff5&agency=SC
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=SC
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=SC
   itp_id: 294
 santa-clarita-transit:
   agency_name: Santa Clarita Transit
@@ -1150,10 +1150,10 @@ soltrans:
   agency_name: SolTrans
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/soltrans-ca-us/soltrans-ca-us.zip
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff10&agency=ST
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff10&agency=ST
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=ST
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=ST
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=ST
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=ST
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -1322,10 +1322,10 @@ tri-delta-transit:
   agency_name: Tri Delta Transit
   feeds:
     - gtfs_schedule_url: http://.232.147.132/rtt/public/utility/gtfs.aspx
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&agency=3D
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&agency=3D
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=3D
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=3D
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=3D
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=3D
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -1334,10 +1334,10 @@ tri-valley-wheels:
   agency_name: Tri-Valley Wheels
   feeds:
     - gtfs_schedule_url: https://www.wheelsbus.com/wp-content/uploads/2020/06/google_transit1.zip?read_comply=
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff12&agency=WH
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff12&agency=WH
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=WH
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=WH
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=WH
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=WH
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -1370,10 +1370,10 @@ union-city-transit:
   agency_name: Union City Transit
   feeds:
     - gtfs_schedule_url: https://data.trilliumtransit.com/gtfs/unioncity-ca-us/unioncity-ca-us.zip
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff11&agency=UC
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff11&agency=UC
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=UC
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=UC
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=UC
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=UC
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -1469,26 +1469,26 @@ yuma-county-area-transit:
 dumbarton-express:
   agency_name: Dumbarton Express
   feeds:
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=DE
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff3&agency=DE
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff3&agency=DE
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=DE
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}g3&agency=DE
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}g3&agency=DE
   itp_id: 98
 san-fransisco-international-airport:
   agency_name: San Francisco International Airport
   feeds:
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=SI
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff7&agency=SI
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff7&agency=SI
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=SI
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=SI
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=SI
   itp_id: 281
 santa-rosa-citybus:
   agency_name: Santa Rosa CityBus
   feeds:
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2&operator_id=SR
-      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff9&agency=SR
-      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff2
-      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key=0eefcd07-b7d7-4a16-b454-bc7424dd0ff9&agency=SR
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=SR
+      gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=SR
+      gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
+      gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=SR
   itp_id: 301
 angel-island-tiburon-ferry-company:
   agency_name: Angel Island-Tiburon Ferry Company

--- a/airflow/data/schema_agencies_entry.yml
+++ b/airflow/data/schema_agencies_entry.yml
@@ -1,0 +1,21 @@
+title: Agency
+description: "An agency with GTFS feeds for the calitp warehouse"
+type: object
+properties:
+  agency_name:
+    type: string
+  itp_id:
+    type: integer
+  feeds:
+    type: array
+    items:
+      type: object
+      properties:
+        gtfs_schedule_url:
+          type: ["string", "null"]
+        gtfs_rt_vehicle_positions_url:
+          type: ["string", "null"]
+        gtfs_rt_service_alerts_url:
+          type: ["string", "null"]
+        gtfs_rt_trip_updates_url:
+          type: ["string", "null"]

--- a/docs/warehouse/01_agencies.md
+++ b/docs/warehouse/01_agencies.md
@@ -41,4 +41,5 @@ ac-transit:
 Every time the main branch of cal-itp/data-infra is updated on github,
 [this github action][action] swaps in the API keys and pushes to our Cloud Composer's data bucket.
 
+<!-- markdown-link-check-disable-next-line -->
 [action]: (https://github.com/cal-itp/data-infra/blob/main/.github/workflows/update_gcloud_requirements.yml)

--- a/docs/warehouse/01_agencies.md
+++ b/docs/warehouse/01_agencies.md
@@ -35,7 +35,6 @@ ac-transit:
   itp_id: 4
 ```
 
-
 ## Deploying to Pipeline
 
 Every time the main branch of cal-itp/data-infra is updated on github,

--- a/docs/warehouse/01_agencies.md
+++ b/docs/warehouse/01_agencies.md
@@ -1,0 +1,44 @@
+# Agency GTFS Feeds
+
+Feed information is stored in [airflow/data/agencies.yml](https://github.com/cal-itp/data-infra/blob/main/airflow/data/agencies.yml).
+This file is then used by our Airflow data pipeline to download feeds, and load them into the warehouse.
+
+Each agency feed entry includes these fields:
+
+* `agency_name`: Human friendly name for the agency
+* `itp_id`: The California Integrated Travel Project ID
+* URLs such as `gtfs_schedule_url`, and those for realtime feeds.
+
+## Finding the ITP ID
+
+Entries must include the correct ITP ID for an agency.
+These can be found on the [Primary List of California Transit Providers](https://docs.google.com/spreadsheets/d/105oar4q_Z3yihDeUlP-VnYpJ0N9Mfs7-q4TnribqYLU/edit?usp=sharing).
+
+## Including API Keys
+
+If the URL for a GTFS feed requires an API key, you can include using these steps:
+
+* Add a unique name, and the key to [this private spreadsheet](https://docs.google.com/spreadsheets/d/1Fp7sesSMS6VOIndTLTKcyyN2qHj6najKAaN-I9_3SFo/edit?usp=sharing).
+* Include the API key in your url by using `{{ MY_KEY_NAME }}`, where `MY_KEY_NAME`
+  is the unique name used in the spreadsheet.
+
+Below is an example entry.
+
+```yaml
+ac-transit:
+  agency_name: AC Transit
+  feeds:
+    - gtfs_schedule_url: https://api.actransit.org/transit/gtfs/download?token={{ AC_TRANSIT_API_KEY }}
+      gtfs_rt_vehicle_positions_url: https://api.actransit.org/gtfsrt/vehicles?token={{ AC_TRANSIT_API_KEY }}
+      gtfs_rt_service_alerts_url: https://api.actransit.org/gtfsrt/alerts?token={{ AC_TRANSIT_API_KEY }}
+      gtfs_rt_trip_updates_url: https://api.actransit.org/gtfsrt/tripupdates?token={{ AC_TRANSIT_API_KEY }}
+  itp_id: 4
+```
+
+
+## Deploying to Pipeline
+
+Every time the main branch of cal-itp/data-infra is updated on github,
+[this github action][action] swaps in the API keys and pushes to our Cloud Composer's data bucket.
+
+[action]: (https://github.com/cal-itp/data-infra/blob/main/.github/workflows/update_gcloud_requirements.yml)

--- a/script/agencies_convert.py
+++ b/script/agencies_convert.py
@@ -1,0 +1,33 @@
+import yaml
+import pandas as pd
+import sys
+
+from pathlib import Path
+from jinja2 import Environment, select_autoescape, StrictUndefined
+from io import StringIO
+
+if len(sys.argv) < 4:
+    raise Exception(
+        "3 arguments required: input file, output file, and spreadsheet url"
+    )
+else:
+    FNAME_IN, FNAME_OUT, SPREADSHEET_URL = sys.argv[1:]
+
+api_key_df = pd.read_csv(SPREADSHEET_URL)
+api_keys = dict(zip(api_key_df["name"], api_key_df["api_key"]))
+
+agencies_path = Path(FNAME_IN)
+
+env = Environment(autoescape=select_autoescape(), undefined=StrictUndefined)
+template = env.from_string(agencies_path.read_text())
+
+new_agencies = template.render(**api_keys)
+
+try:
+    yaml.safe_load(StringIO(new_agencies))
+except yaml.ParserError:
+    raise Exception("Filled out agencies.yml is not valid yaml")
+
+print("Saving filled out agencies.yml to %s" % FNAME_OUT)
+
+Path(FNAME_OUT).write_text(new_agencies)

--- a/script/agencies_validate.py
+++ b/script/agencies_validate.py
@@ -1,0 +1,31 @@
+import yaml
+import sys
+
+from jsonschema import validate, ValidationError
+from collections import Counter
+
+if len(sys.argv) < 3:
+    raise Exception("2 arguments required: data file, schema file")
+else:
+    fname, schema_name = sys.argv[1:]
+
+agencies = yaml.safe_load(open(fname))
+schema = yaml.safe_load(open(schema_name))
+
+print(f"There are {len(agencies)} agencies")
+
+print("Checking agency entries formatted correctly")
+
+for k, entry in agencies.items():
+    try:
+        validate(instance=entry, schema=schema)
+    except ValidationError as err:
+        raise Exception(f"Error validating agency {k}: {str(err)}")
+
+print("Checking that they have unique itp_ids")
+
+id_counts = Counter([entry["itp_id"] for entry in agencies.values()])
+duplicates = {k: v for k, v in id_counts.items() if v > 1}
+
+if duplicates:
+    raise Exception(f"Duplicate itp_ids. {list(duplicates.values())}")


### PR DESCRIPTION
This PR supplants #144 basedon the new agencies.yml file, but uses named keys rather logic so it is easier to template.
