### PR TITLE
feat(airflow): require all agencies.yml fields

### DIFF
--- a/airflow/data/schema_agencies_entry.yml
+++ b/airflow/data/schema_agencies_entry.yml
@@ -19,3 +19,6 @@ properties:
           type: ["string", "null"]
         gtfs_rt_trip_updates_url:
           type: ["string", "null"]
+      additionalProperties: false
+      minProperties: 4
+required: ["agency_name", "itp_id", "feeds"]


### PR DESCRIPTION
cc @hunterowens this is a quick addition. Based on the discussion on having valid `agencies.yml`, I added quick validation with jsonschema to #172. However, it also needed to fail when properties were misnamed / omitted, which is added here!

(Whenever someone pushes a change to the airflow subdirectory it will run the validation)