### PR TITLE
Point to vanity docs site URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This website provides technical documentation for the Juniper codebase.
 
-Documentation for the `main` branch is available online at: <https://cal-itp.github.io/data-infra/>
+Documentation for the `main` branch is available online at: <https://docs.calitp.org/data-infra>
 
 ## Editing documentation
 


### PR DESCRIPTION
Minor change, but we can use the `docs.calitp.org` domain now.