### PR TITLE
feat: daily extract unpacked agencies.yml as feeds.csv, feeds_raw.csv

### DIFF
--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -46,4 +46,5 @@ jobs:
         gsutil -m rsync -d -c -r airflow/plugins gs://us-west2-calitp-airflow-pro-332827a9-bucket/plugins
         gsutil -m rsync -d -c -r airflow/data gs://us-west2-calitp-airflow-pro-332827a9-bucket/data
         # replace agencies.yml with filled in template
+        gsutil -m cp airflow/data/agencies.yml gs://us-west2-calitp-airflow-pro-332827a9-bucket/data/agencies_raw.yml
         gsutil -m cp airflow/data/agencies.filled.yml gs://us-west2-calitp-airflow-pro-332827a9-bucket/data/agencies.yml

--- a/airflow/dags/gtfs_downloader/generate_provider_list.py
+++ b/airflow/dags/gtfs_downloader/generate_provider_list.py
@@ -1,12 +1,13 @@
 # ---
 # python_callable: gen_list
+# provide_context: true
 # ---
 
 
 import yaml
 import pandas as pd
 
-from calitp import pipe_file_name
+from calitp import pipe_file_name, save_to_gcfs
 
 
 def make_gtfs_list(fname=None):
@@ -36,32 +37,46 @@ def make_gtfs_list(fname=None):
     assert df_feeds.index.equals(df_long.index)
 
     # append columns for feed urls
-    df_final = df_long.join(df_feeds).drop(
+    df_feed_urls = df_long.join(df_feeds).drop(columns=["feeds"])
+    df_feed_urls["url_number"] = df_feed_urls.groupby("itp_id").cumcount()
+
+    all_cols = list(df_feed_urls.columns)
+    front_cols = ["itp_id", "url_number"]
+    other_cols = [name for name in all_cols if name not in front_cols]
+    return df_feed_urls[[*front_cols, *other_cols]]
+
+
+def gen_list(execution_date, **kwargs):
+    """
+    task callable to generate the list and push into
+    xcom
+    """
+
+    # get a table of feed urls from agencies.yml
+    # we fetch both the raw and filled w/ API key versions to save
+    feeds_raw = make_gtfs_list(pipe_file_name("data/agencies_raw.yml"))
+    feeds = make_gtfs_list(pipe_file_name("data/agencies.yml"))
+
+    path_metadata = f"schedule/{execution_date}/metadata"
+
+    save_to_gcfs(
+        feeds_raw.to_csv(index=False).encode(),
+        f"{path_metadata}/feeds_raw.csv",
+        use_pipe=True,
+    )
+    save_to_gcfs(
+        feeds.to_csv(index=False).encode(), f"{path_metadata}/feeds.csv", use_pipe=True
+    )
+
+    # note that right now we useairflow's xcom functionality in this dag.
+    # because xcom can only store a small amount of data, we have to drop some
+    # columns. this is the only dag that uses xcom, and we should remove it!
+    df_subset = feeds.drop(
         columns=[
-            "feeds",
             "gtfs_rt_vehicle_positions_url",
             "gtfs_rt_service_alerts_url",
             "gtfs_rt_trip_updates_url",
         ]
     )
-    df_final["url_number"] = df_final.groupby("itp_id").cumcount()
 
-    return df_final
-
-
-def clean_url(url):
-    """
-    take the list of urls, clean as needed.
-    used as a pd.apply, so singleton.
-    """
-    # LA Metro split requires lstrip
-    return url
-
-
-def gen_list(**kwargs):
-    """
-    task callable to generate the list and push into
-    xcom
-    """
-    provider_set = make_gtfs_list().apply(clean_url)
-    return provider_set.to_dict("records")
+    return df_subset.to_dict("records")

--- a/airflow/dags/gtfs_schedule_history/calitp_feeds.yml
+++ b/airflow/dags/gtfs_schedule_history/calitp_feeds.yml
@@ -1,0 +1,22 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/*/metadata/feeds.csv'
+destination_project_dataset_table: "gtfs_schedule_history.calitp_feeds"
+skip_leading_rows: 1
+schema_fields:
+  - name: itp_id
+    type: INTEGER
+  - name: url_number
+    type: INTEGER
+  - name: agency_handle
+    type: STRING
+  - name: agency_name
+    type: STRING
+  - name: gtfs_schedule_url
+    type: STRING
+  - name: gtfs_rt_vehicle_positions_url
+    type: STRING
+  - name: gtfs_rt_service_alerts_url
+    type: STRING
+  - name: gtfs_rt_trip_updates_url
+    type: STRING

--- a/airflow/dags/gtfs_schedule_history/calitp_feeds_raw.yml
+++ b/airflow/dags/gtfs_schedule_history/calitp_feeds_raw.yml
@@ -1,0 +1,22 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/*/metadata/feeds_raw.csv'
+destination_project_dataset_table: "gtfs_schedule_history.calitp_feeds_raw"
+skip_leading_rows: 1
+schema_fields:
+  - name: itp_id
+    type: INTEGER
+  - name: url_number
+    type: INTEGER
+  - name: agency_handle
+    type: STRING
+  - name: agency_name
+    type: STRING
+  - name: gtfs_schedule_url
+    type: STRING
+  - name: gtfs_rt_vehicle_positions_url
+    type: STRING
+  - name: gtfs_rt_service_alerts_url
+    type: STRING
+  - name: gtfs_rt_trip_updates_url
+    type: STRING


### PR DESCRIPTION
Tested by running airflow locally. Saves the DataFramed version of agencies.yml as feeds_raw.csv, and feeds.csv (where API token is filled in).

e.g. to cloud storage:

 * gs://gtfs-data-test/schedule/2021-06-30T00:00:00+00:00/metadata/feeds_raw.csv
 * gs://gtfs-data-test/schedule/2021-06-30T00:00:00+00:00/metadata/feeds.csv

Also creates external tables for feeds, so they can be queried from `gtfs_schedule_history.calitp_feeds` (and feeds_raw)!