### PR TITLE
Feat staging project

### DIFF
--- a/airflow/dags/catalogs/catalog.yml
+++ b/airflow/dags/catalogs/catalog.yml
@@ -1,9 +1,0 @@
-
-metadata:
-  version: 1
-sources:
-  official_list:
-    driver: csv
-    description: description of url for each active GTFS feed
-    args:
-      urlpath: https://docs.google.com/spreadsheets/d/1qr49azk6p30mp96_7myKoO-Bb_bXMMn5ZzgbL-uPiPw/gviz/tq?tqx=out:csv&sheet=Data

--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -12,23 +12,12 @@ from calitp.templates import user_defined_macros, user_defined_filters
 # point to your dags directory (the one this file lives in)
 dag_parent_dir = Path(__file__).parent
 
-# TODO: catalogs directory is not a dag, which screws up auto loading folders
 # assumes any subdirectories in the dags directory are Gusty DAGs (with METADATA.yml)
 # (excludes subdirectories like __pycache__)
-# dag_directories = []
-# for child in dag_parent_dir.iterdir():
-#     if child.is_dir() and not str(child).endswith('__'):
-#         dag_directories.append(str(child))
-
-dag_directories = [
-    dag_parent_dir / "gtfs_downloader",
-    dag_parent_dir / "gtfs_loader",
-    dag_parent_dir / "gtfs_views",
-    dag_parent_dir / "gtfs_schedule_history",
-    dag_parent_dir / "gtfs_schedule_history2",
-    dag_parent_dir / "transitstacks_loader",
-]
-
+dag_directories = []
+for child in dag_parent_dir.iterdir():
+    if child.is_dir() and not str(child).endswith("__"):
+        dag_directories.append(str(child))
 
 # DAG Generation ==============================================================
 

--- a/airflow/dags/gtfs_loader/calitp_files_process.py
+++ b/airflow/dags/gtfs_loader/calitp_files_process.py
@@ -13,13 +13,14 @@ This is for the files downloaded for an agency, as well as validator results.
 
 from calitp import read_gcfs, save_to_gcfs
 from calitp.config import get_bucket
+from calitp.storage import get_fs
+
 import pandas as pd
-import gcsfs
 
 
 def main(execution_date, **kwargs):
     # TODO: remove hard-coded project string
-    fs = gcsfs.GCSFileSystem(project="cal-itp-data-infra")
+    fs = get_fs()
 
     bucket = get_bucket()
 

--- a/airflow/dags/gtfs_schedule_history/stops.yml
+++ b/airflow/dags/gtfs_schedule_history/stops.yml
@@ -15,9 +15,9 @@ schema_fields:
   - name: tts_stop_name
     type: STRING
   - name: stop_lat
-    type: FLOAT
+    type: NUMERIC
   - name: stop_lon
-    type: FLOAT
+    type: NUMERIC
 
   - name: zone_id
     type: STRING

--- a/airflow/dags/gtfs_schedule_history/validation_report.yml
+++ b/airflow/dags/gtfs_schedule_history/validation_report.yml
@@ -3,6 +3,7 @@ source_objects:
   - "schedule/processed/*/validation_report.json"
 destination_project_dataset_table: "gtfs_schedule_history.validation_report"
 source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
 schema_fields:
   - name: calitp_itp_id
     type: INTEGER

--- a/airflow/dags/sandbox/METADATA.yml
+++ b/airflow/dags/sandbox/METADATA.yml
@@ -1,0 +1,18 @@
+description: "DAG for testing operators"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "hunter.owens@dot.ca.gov"
+      - "michael.c@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: True

--- a/airflow/dags/sandbox/create_dataset.py
+++ b/airflow/dags/sandbox/create_dataset.py
@@ -1,0 +1,5 @@
+from calitp import get_engine
+
+engine = get_engine()
+
+engine.execute("""CREATE SCHEMA IF NOT EXISTS sandbox""")

--- a/airflow/dags/sandbox/op_csv_to_warehouse.yml
+++ b/airflow/dags/sandbox/op_csv_to_warehouse.yml
@@ -1,0 +1,9 @@
+operator: operators.CsvToWarehouseOperator
+table_name: "{{ 'sandbox.csv_to_warehouse' | table }}"
+src_uri: "https://docs.google.com/spreadsheets/d/1Ed62uU-SJYoV7ecEQ61aT-9FzF1R5W2w-V1D7Bd_Ib4/export?gid=0&format=csv"
+fields:
+  g: The g field
+  x: The x field
+
+dependencies:
+  - create_dataset

--- a/airflow/dags/sandbox/op_external_table.yml
+++ b/airflow/dags/sandbox/op_external_table.yml
@@ -1,0 +1,13 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'sandbox/external_table.csv'
+destination_project_dataset_table: "sandbox.external_table"
+skip_leading_rows: 1
+schema_fields:
+  - name: g
+    type: STRING
+  - name: x
+    type: INTEGER
+dependencies:
+  - save_external_table_data
+  - create_dataset

--- a/airflow/dags/sandbox/op_python_to_warehouse.py
+++ b/airflow/dags/sandbox/op_python_to_warehouse.py
@@ -1,0 +1,16 @@
+# ---
+# operator: operators.PythonToWarehouseOperator
+# table_name: "sandbox.python_to_warehouse"
+# fields:
+#   g: The g field
+#   x: The x field
+# dependencies:
+#   - create_dataset
+# ---
+
+import pandas as pd
+from calitp import write_table
+
+df = pd.DataFrame({"g": ["a", "b"], "x": [1, 2]})
+
+write_table(df, "sandbox.python_to_warehouse")

--- a/airflow/dags/sandbox/op_sql_query.sql
+++ b/airflow/dags/sandbox/op_sql_query.sql
@@ -1,0 +1,12 @@
+---
+operator: operators.SqlQueryOperator
+dependencies:
+  - create_dataset
+---
+
+CREATE OR REPLACE TABLE `sandbox.sql_query` AS (
+    SELECT g, x
+    FROM
+        UNNEST(["a", "b"]) g
+        , UNNEST([1, 2]) x
+)

--- a/airflow/dags/sandbox/op_sql_to_warehouse.sql
+++ b/airflow/dags/sandbox/op_sql_to_warehouse.sql
@@ -1,0 +1,15 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "sandbox.sql_to_warehouse"
+fields:
+  g: The g field
+  x: The x field
+
+dependencies:
+  - create_dataset
+---
+
+SELECT g, x
+FROM
+    UNNEST(["a", "b"]) g
+    , UNNEST([1, 2]) x

--- a/airflow/dags/sandbox/query_external.py
+++ b/airflow/dags/sandbox/query_external.py
@@ -1,0 +1,8 @@
+# ---
+# dependencies:
+#   - op_external_table
+# ---
+
+from calitp import get_table
+
+get_table("sandbox.external_table", as_df=True)

--- a/airflow/dags/sandbox/save_external_table_data.py
+++ b/airflow/dags/sandbox/save_external_table_data.py
@@ -1,0 +1,12 @@
+# ---
+# ---
+
+from calitp import save_to_gcfs
+
+import pandas as pd
+
+df = pd.DataFrame({"g": ["a", "b"], "x": [1, 2]})
+
+save_to_gcfs(
+    df.to_csv(index=False).encode(), "sandbox/external_table.csv", use_pipe=True
+)

--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -6,3 +6,4 @@ from .python_taskflow_operator import PythonTaskflowOperator
 from .sql_to_warehouse_operator import SqlToWarehouseOperator
 from .csv_to_warehouse_operator import CsvToWarehouseOperator
 from .python_to_warehouse_operator import PythonToWarehouseOperator
+from .sql_query_operator import SqlQueryOperator

--- a/airflow/plugins/operators/csv_to_warehouse_operator.py
+++ b/airflow/plugins/operators/csv_to_warehouse_operator.py
@@ -58,6 +58,7 @@ class CsvToWarehouseOperator(BaseOperator):
         self.fields = fields if fields is not None else {}
 
     def execute(self, context):
+        print(self.table_name)
         csv_to_warehouse(
             self.src_uri, self.table_name, self.fields, self.dst_bucket_dir
         )

--- a/airflow/plugins/operators/external_table.py
+++ b/airflow/plugins/operators/external_table.py
@@ -1,24 +1,41 @@
 from calitp.config import (
+    CALITP_BQ_LOCATION,
     get_bucket,
+    get_project_id,
     format_table_name,
 )
-from calitp.sql import get_engine
 
-# from google.cloud import bigquery
+from calitp.sql import get_engine
+from google.cloud import bigquery
 
 from airflow.models import BaseOperator
+
 
 # This operator originally ran using airflow's bigquery hooks. However, for the
 # version we had to use (airflow v1.14) they used an outdated form of authentication.
 # Now, the pipeline aims to use bigquery's sqlalchemy client where possible.
 # However, it's cumbersome to convert the http api style schema fields to SQL, so
 # we provide a fallback for these old-style tasks.
-# def _hook_params_to_bq_client(
-#     table_name, skip_leading_rows, schema_fields, source_objects, format
-#    ):
-#    bigquery.Table(table_name, schema=)
-#
-#
+def _bq_client_create_external_table(
+    table_name, schema_fields, source_objects, source_format
+):
+    # TODO: must be fully qualified table name
+    ext = bigquery.ExternalConfig(source_format)
+    ext.source_uris = source_objects
+
+    client = bigquery.Client(project=get_project_id(), location=CALITP_BQ_LOCATION)
+
+    # for some reason, you can set the project name in the bigquery client, and
+    # it doesn't need to be in the SQL code, but this bigquery API still requires
+    # the fully qualified table name when initializing a Table..
+    full_table_name = f"{get_project_id()}.{table_name}"
+
+    print(f"Creating external table: {full_table_name}")
+
+    tbl = bigquery.Table(full_table_name, schema_fields)
+    tbl.external_data_configuration = ext
+
+    return client.create_table(tbl, timeout=300, exists_ok=True)
 
 
 class ExternalTable(BaseOperator):
@@ -30,7 +47,7 @@ class ExternalTable(BaseOperator):
         skip_leading_rows=1,
         schema_fields=None,
         source_objects=[],
-        format="csv",
+        source_format="CSV",
         use_bq_client=False,
         **kwargs,
     ):
@@ -41,33 +58,46 @@ class ExternalTable(BaseOperator):
         self.skip_leading_rows = skip_leading_rows
         self.schema_fields = schema_fields
         self.source_objects = list(map(self.fix_prefix, source_objects))
-        self.format = format
+        self.source_format = source_format
         self.use_bq_client = use_bq_client
 
         super().__init__(**kwargs)
 
     def execute(self, context):
-        field_strings = [
-            f'{entry["name"]} {entry["type"]}' for entry in self.schema_fields
-        ]
-        fields_spec = ",\n".join(field_strings)
+        # Basically for backwards support of tasks that have nested fields and
+        # were created when we were using airflow bigquery hooks.
+        # e.g. dags/gtfs_schedule_history/validation_report.yml
+        # These tables should be defined using SqlQueryOperator and raw SQL now.
+        if self.use_bq_client:
+            _bq_client_create_external_table(
+                self.destination_project_dataset_table,
+                self.schema_fields,
+                self.source_objects,
+                self.source_format,
+            )
 
-        query = f"""
-        CREATE OR REPLACE EXTERNAL TABLE `{self.destination_project_dataset_table}` (
-            {fields_spec}
-        )
-        OPTIONS (
-            format = "{self.format}",
-            skip_leading_rows = {self.skip_leading_rows},
-            uris = {repr(self.source_objects)}
-        )
-        """
+        else:
+            field_strings = [
+                f'{entry["name"]} {entry["type"]}' for entry in self.schema_fields
+            ]
+            fields_spec = ",\n".join(field_strings)
 
-        print(query)
+            query = f"""
+CREATE OR REPLACE EXTERNAL TABLE `{self.destination_project_dataset_table}` (
+    {fields_spec}
+)
+OPTIONS (
+    format = "{self.source_format}",
+    skip_leading_rows = {self.skip_leading_rows},
+    uris = {repr(self.source_objects)}
+)
+            """
 
-        # delete the external table, if it already exists
-        engine = get_engine()
-        engine.execute(query)
+            print(query)
+
+            # delete the external table, if it already exists
+            engine = get_engine()
+            engine.execute(query)
 
         return self.schema_fields
 

--- a/airflow/plugins/operators/external_table.py
+++ b/airflow/plugins/operators/external_table.py
@@ -1,34 +1,78 @@
-from airflow.contrib.operators.bigquery_operator import (
-    BigQueryCreateExternalTableOperator,
-)
-from functools import wraps
-from google.cloud import bigquery
-
 from calitp.config import (
     get_bucket,
     format_table_name,
 )
+from calitp.sql import get_engine
+
+# from google.cloud import bigquery
+
+from airflow.models import BaseOperator
+
+# This operator originally ran using airflow's bigquery hooks. However, for the
+# version we had to use (airflow v1.14) they used an outdated form of authentication.
+# Now, the pipeline aims to use bigquery's sqlalchemy client where possible.
+# However, it's cumbersome to convert the http api style schema fields to SQL, so
+# we provide a fallback for these old-style tasks.
+# def _hook_params_to_bq_client(
+#     table_name, skip_leading_rows, schema_fields, source_objects, format
+#    ):
+#    bigquery.Table(table_name, schema=)
+#
+#
 
 
-class ExternalTable(BigQueryCreateExternalTableOperator):
-    @wraps(BigQueryCreateExternalTableOperator.__init__)
+class ExternalTable(BaseOperator):
     def __init__(
-        self, *args, bucket=None, destination_project_dataset_table=None, **kwargs
+        self,
+        *args,
+        bucket=None,
+        destination_project_dataset_table=None,
+        skip_leading_rows=1,
+        schema_fields=None,
+        source_objects=[],
+        format="csv",
+        use_bq_client=False,
+        **kwargs,
     ):
-        bucket = get_bucket().replace("gs://", "", 1) if bucket is None else bucket
-        dst_table = format_table_name(destination_project_dataset_table)
-
-        super().__init__(
-            *args, bucket=bucket, destination_project_dataset_table=dst_table, **kwargs
+        self.bucket = bucket
+        self.destination_project_dataset_table = format_table_name(
+            destination_project_dataset_table
         )
+        self.skip_leading_rows = skip_leading_rows
+        self.schema_fields = schema_fields
+        self.source_objects = list(map(self.fix_prefix, source_objects))
+        self.format = format
+        self.use_bq_client = use_bq_client
+
+        super().__init__(**kwargs)
 
     def execute(self, context):
-        # delete the external table, if it already exists
-        bq_client = bigquery.Client()
-        bq_client.delete_table(
-            self.destination_project_dataset_table, not_found_ok=True
-        )
+        field_strings = [
+            f'{entry["name"]} {entry["type"]}' for entry in self.schema_fields
+        ]
+        fields_spec = ",\n".join(field_strings)
 
-        super().execute(context)
+        query = f"""
+        CREATE OR REPLACE EXTERNAL TABLE `{self.destination_project_dataset_table}` (
+            {fields_spec}
+        )
+        OPTIONS (
+            format = "{self.format}",
+            skip_leading_rows = {self.skip_leading_rows},
+            uris = {repr(self.source_objects)}
+        )
+        """
+
+        print(query)
+
+        # delete the external table, if it already exists
+        engine = get_engine()
+        engine.execute(query)
 
         return self.schema_fields
+
+    def fix_prefix(self, entry):
+        bucket = get_bucket() if not self.bucket else self.bucket
+        entry = entry.replace("gs://", "") if entry.startswith("gs://") else entry
+
+        return f"{bucket}/{entry}"

--- a/airflow/plugins/operators/sql_query_operator.py
+++ b/airflow/plugins/operators/sql_query_operator.py
@@ -11,6 +11,8 @@ from sqlalchemy import sql
 class SqlQueryOperator(BaseOperator):
     @apply_defaults
     def __init__(self, sql, **kwargs):
+        super().__init__(**kwargs)
+
         self.sql = sql
 
     def execute(self, context):

--- a/airflow/plugins/operators/sql_to_warehouse_operator.py
+++ b/airflow/plugins/operators/sql_to_warehouse_operator.py
@@ -1,68 +1,32 @@
 from airflow.models import BaseOperator
-from airflow.contrib.hooks.bigquery_hook import BigQueryHook
-from googleapiclient.errors import HttpError
-from airflow import AirflowException
 
 from calitp.config import format_table_name
-from calitp.sql import sql_patch_comments
+from calitp.sql import sql_patch_comments, write_table
 
 
 class SqlToWarehouseOperator(BaseOperator):
     template_fields = ("sql",)
 
     def __init__(
-        self,
-        sql,
-        dst_table_name,
-        bigquery_conn_id="bigquery_default",
-        create_disposition="CREATE_IF_NEEDED",
-        fields=None,
-        **kwargs,
+        self, sql, dst_table_name, create_disposition=None, fields=None, **kwargs,
     ):
+
         self.sql = sql
         self.dst_table_name = dst_table_name
-        self.bigquery_conn_id = bigquery_conn_id
-        self.create_disposition = create_disposition
         self.fields = fields if fields is not None else {}
         super().__init__(**kwargs)
 
     def execute(self, context):
         """Create a table based on a sql query, then patch in column descriptions."""
 
+        table_name = self.dst_table_name
+
         # create table from sql query -----------------------------------------
 
-        full_table_name = format_table_name(self.dst_table_name)
-        print(full_table_name)
+        write_table(self.sql, table_name=table_name, verbose=True)
 
-        # TODO: replace bq_hook with google.cloud.bigquery (or pybigquery)
-        bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
-        conn = bq_hook.get_conn()
-        cursor = conn.cursor()
-
-        print(self.sql)
-
-        # table_resource = {
-        #    "tableReference": {"table_id": table_id},
-        #    "materializedView": {"query": self.sql}
-        # }
-
-        # bigquery.Table.from_api_repr(table_resource)
-
-        try:
-            cursor.run_query(
-                sql=self.sql,
-                destination_dataset_table=full_table_name,
-                write_disposition="WRITE_TRUNCATE",
-                create_disposition=self.create_disposition,
-                use_legacy_sql=False,
-            )
-
-            self.log.info(
-                "Query table as created successfully: {}".format(full_table_name)
-            )
-        except HttpError as err:
-            raise AirflowException("BigQuery error: %s" % err.content)
+        self.log.info("Query table as created successfully")
 
         # patch in comments ---------------------------------------------------
 
-        sql_patch_comments(full_table_name, self.fields)
+        sql_patch_comments(format_table_name(table_name), self.fields)

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,5 +6,5 @@ gusty==0.6.0
 pandas-gbq==0.14.1
 pybigquery==0.7.0
 google-cloud-bigquery==2.16.1
-git+https://github.com/cal-itp/calitp-py.git@feat-sql-staging
+calitp==0.0.2
 google-auth==1.32.1

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,4 +6,5 @@ gusty==0.6.0
 pandas-gbq==0.14.1
 pybigquery==0.7.0
 google-cloud-bigquery==2.16.1
-calitp==0.0.1
+git+https://github.com/cal-itp/calitp-py.git@feat-sql-staging
+google-auth==1.32.1


### PR DESCRIPTION
This PR moves the pipeline development environment to use the `cal-itp-data-infra-staging` project, and pays down longstanding tech debt.

* old airflow bigquery hooks removed (only uses python-bigquery or sqlalchemy dialect)
* removed old catalog folder from DAGs
* DAGs automatically discovered for gusty
* added sandbox DAG, to test and demo each custom operator we use
* upgrade calitp to v0.0.2, as part of the move to a staging project 


 
TODO: release version and update requirements.