### PR TITLE
fix(airflow): do not split table name in CsvToWarehouse

### DIFF
--- a/airflow/plugins/operators/csv_to_warehouse_operator.py
+++ b/airflow/plugins/operators/csv_to_warehouse_operator.py
@@ -4,7 +4,7 @@ import pandas_gbq
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
-from calitp import save_to_gcfs, to_snakecase
+from calitp import save_to_gcfs, to_snakecase, get_project_id
 
 
 def sql_df_to_gbq_schema(df, fields=None):
@@ -24,7 +24,6 @@ def csv_to_warehouse(src_uri, table_name, fields=None, dst_bucket_dir="csv"):
     df = to_snakecase(pd.read_csv(src_uri))
 
     table_schema = sql_df_to_gbq_schema(df, fields)
-    project_id, table_name = table_name.split(".", 1)
 
     save_to_gcfs(
         df.to_csv(index=False).encode(),
@@ -35,7 +34,7 @@ def csv_to_warehouse(src_uri, table_name, fields=None, dst_bucket_dir="csv"):
     pandas_gbq.to_gbq(
         df,
         table_name,
-        project_id,
+        get_project_id(),
         table_schema=table_schema["fields"],
         if_exists="replace",
     )


### PR DESCRIPTION
This is a small fix, to stop pulling project_id out of the table name in one of the operators. I tested the sandbox locally before merging before, so not sure what happened....