### PR TITLE
fix(airflow): add missing validation schema fields

### DIFF
--- a/airflow/dags/gtfs_schedule_history/validation_report.yml
+++ b/airflow/dags/gtfs_schedule_history/validation_report.yml
@@ -155,3 +155,7 @@ schema_fields:
           type: STRING
         - name: parentStopName
           type: STRING
+        - name: entityCount
+          type: INTEGER
+        - name: fieldType
+          type: STRING


### PR DESCRIPTION
Small and classic fix to add missing validation report fields to schema. Going to merge, so I can make sure we can pull all the data needed for reports.