### PR TITLE
fields_from implementation

### DIFF
--- a/airflow/dags/sandbox/op_csv_to_warehouse.sql
+++ b/airflow/dags/sandbox/op_csv_to_warehouse.sql
@@ -3,8 +3,8 @@ operator: operators.CsvToWarehouseOperator
 table_name: "sandbox.csv_to_warehouse"
 src_uri: "https://docs.google.com/spreadsheets/d/1Ed62uU-SJYoV7ecEQ61aT-9FzF1R5W2w-V1D7Bd_Ib4/export?gid=0&format=csv"
 fields:
-  g: The g field
-  x: The x field
+  g: The g field csv
+  x: The x field csv
 
 dependencies:
   - create_dataset

--- a/airflow/dags/sandbox/op_python_to_warehouse.py
+++ b/airflow/dags/sandbox/op_python_to_warehouse.py
@@ -2,8 +2,8 @@
 # operator: operators.PythonToWarehouseOperator
 # table_name: "sandbox.python_to_warehouse"
 # fields:
-#   g: The g field is excellent
-#   x: The x field is awesome
+#   g: The g field python
+#   x: The x field python
 # dependencies:
 #   - create_dataset
 # ---

--- a/airflow/dags/sandbox/op_python_to_warehouse.py
+++ b/airflow/dags/sandbox/op_python_to_warehouse.py
@@ -2,8 +2,8 @@
 # operator: operators.PythonToWarehouseOperator
 # table_name: "sandbox.python_to_warehouse"
 # fields:
-#   g: The g field
-#   x: The x field
+#   g: The g field is excellent
+#   x: The x field is awesome
 # dependencies:
 #   - create_dataset
 # ---

--- a/airflow/dags/sandbox/op_sql_to_warehouse.sql
+++ b/airflow/dags/sandbox/op_sql_to_warehouse.sql
@@ -1,12 +1,15 @@
 ---
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "sandbox.sql_to_warehouse"
-fields:
-  g: The g field
-  x: The x field
 
 dependencies:
-  - create_dataset
+  - op_python_to_warehouse
+  - op_csv_to_warehouse
+
+fields_from:
+  sandbox.python_to_warehouse:
+    - g
+  sandbox.csv_to_warehouse: any
 
 tests:
   check_null:

--- a/airflow/plugins/operators/sql_to_warehouse_operator.py
+++ b/airflow/plugins/operators/sql_to_warehouse_operator.py
@@ -59,8 +59,6 @@ class SqlToWarehouseOperator(BaseOperator):
                 parent_table = get_table(format_table_name(table))
                 parent_fields = set(parent_table.columns.keys())
 
-                print("parent fields: %s" % parent_fields)
-                print("dst_table_fields: %s" % dst_table_fields)
                 shared_cols = dst_table_fields & parent_fields
 
                 if isinstance(contents, list):


### PR DESCRIPTION
Fixes #325

Adds functionality for a `fields_from` block in the `SqlToWarehouseOperator`, and includes usage example in sandbox DAG task `op_sql_to_warehouse.sql`.

Two ways designate fields from:

```
fields_from:
    table_a:
        -  individual
        -  fields
        -  here
    table_b: any
```

Where "any" is a special keyword.

`fields_from` checks that fields listed exist in the destination table and prioritizes fields listed from top to bottom. So if there are two tables that feature "any", the one listed first will get preference. Fields listed in the operator's `fields` blocked are prioritized over any fields listed in `fields_from`.