### PR TITLE
feat(content): interpolate daily feed files

### DIFF
--- a/airflow/dags/gtfs_views/dim_date.yml
+++ b/airflow/dags/gtfs_views/dim_date.yml
@@ -19,7 +19,8 @@ sql: |
     DATETIME_TRUNC(d, DAY) = DATETIME_TRUNC(d, QUARTER) AS is_quarter_start,
     d < CURRENT_DATE() AS is_in_past,
     d <= CURRENT_DATE() AS is_in_past_or_present,
-    d > CURRENT_DATE() AS is_in_future
+    d > CURRENT_DATE() AS is_in_future,
+    (d > "2021-04-15" AND d <= CURRENT_DATE()) AS is_gtfs_schedule_range
   FROM (
     SELECT
       *

--- a/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
@@ -5,23 +5,52 @@ dependencies:
   - gtfs_schedule_dim_feeds
 ---
 
+WITH
+
 -- calitp_files_updates tracks daily each file downloaded from a gtfs schedule
 -- zip file. It has 1 entry feed downloaded, per file, per day
-SELECT
-    T2.feed_key
-    , T1.name AS file_key
-    , T1.calitp_extracted_at AS date
-    , T1.size
-    , T1.md5_hash
-    , T1.is_loadable_file
-    , T1.is_changed
-    , T1.is_first_extraction
-    , T1.is_validation
-    , T1.is_agency_changed
-    , T1.full_path
-FROM `gtfs_schedule_history.calitp_files_updates` T1
-JOIN `views.gtfs_schedule_dim_feeds` T2
-    USING (calitp_itp_id, calitp_url_number)
-WHERE
-    T1.calitp_extracted_at >= T2.calitp_extracted_at
-    AND T1.calitp_extracted_at < T2.calitp_deleted_at
+raw_daily_files AS (
+    SELECT
+        T2.feed_key
+        , T1.name AS file_key
+        , T1.calitp_extracted_at AS date
+        , T1.size
+        , T1.md5_hash
+        , T1.is_loadable_file
+        , T1.is_changed
+        , T1.is_first_extraction
+        , T1.is_validation
+        , T1.is_agency_changed
+        , T1.full_path
+
+        -- calculate the leading date, so we can fill in missing rows, where
+        -- extraction failed to run.
+        , LEAD(T1.calitp_extracted_at)
+            OVER (PARTITION BY calitp_itp_id, calitp_url_number ORDER BY T1.calitp_extracted_at)
+            AS tmp_next_date
+
+    FROM `gtfs_schedule_history.calitp_files_updates` T1
+    JOIN `views.gtfs_schedule_dim_feeds` T2
+        USING (calitp_itp_id, calitp_url_number)
+    WHERE
+        T1.calitp_extracted_at >= T2.calitp_extracted_at
+        AND T1.calitp_extracted_at < T2.calitp_deleted_at
+),
+
+date_range AS (
+    SELECT full_date
+    FROM `views.dim_date`
+    WHERE is_gtfs_schedule_range
+),
+
+interp_daily_files AS (
+    SELECT
+        * EXCEPT(tmp_next_date)
+        , Files.date != D.full_date AS is_interpolated
+    FROM raw_daily_files Files
+    JOIN date_range D
+        ON Files.date <= D.full_date
+            AND COALESCE(Files.tmp_next_date, "2099-01-01") > D.full_date
+)
+
+SELECT * FROM interp_daily_files


### PR DESCRIPTION
Interpolates files over days where did not do any extraction. This will allow us to fill in metrics for missing days. I flagged these dates using the `is_interpolated` column.

This is important because we are using a fixed date (first day of quarter) for quarterly metrics