### PR TITLE
fix(content): fix gtfs schedule merge missing re-added entries

### DIFF
--- a/airflow/dags/gtfs_schedule_history2/merge_updates.py
+++ b/airflow/dags/gtfs_schedule_history2/merge_updates.py
@@ -17,6 +17,8 @@
 # one task per table.
 # TODO: split out operators.py into submodules and move logic into there.
 
+from merge_sql import SQL_TEMPLATE
+
 SRC_SCHEMA = "gtfs_schedule_history"
 DST_SCHEMA = "gtfs_schedule_type2"
 
@@ -55,60 +57,6 @@ def create_tables(names=None):
 
 
 # Task 2: Daily type 2 merge ==================================================
-
-# This MERGE statement uses a hash of all of the columns of the table, except for
-# extracted_at. But because this requires TO_JSON_STRING on a table, I had to
-# remove calitp_extracted_at, and then re-insert it as execution date. An
-# alternative (used by DBT) is to create a surrogate key by coercing the columns
-# of interest to a string and then concatenating them.
-SQL_TEMPLATE = """
-MERGE `{target}` T
-USING (
-  WITH
-    tbl_files_today AS (
-      SELECT * EXCEPT(calitp_extracted_at) FROM `{source}`
-      WHERE _FILE_NAME LIKE "{bucket_like_str}"
-    ),
-    tbl_hash AS (
-      SELECT
-        *
-        , DATE("{execution_date}") as calitp_extracted_at
-        , DATE(NULL) as calitp_deleted_at
-        , TO_BASE64(MD5(TO_JSON_STRING(tbl_files_today))) AS calitp_hash
-      FROM
-        tbl_files_today
-    ),
-    feed_ids_today AS (
-      SELECT DISTINCT calitp_itp_id, calitp_url_number
-      FROM tbl_hash
-    ),
-    missing_entries AS (
-      SELECT t1.calitp_hash AS calitp_hash
-      FROM `{target}` t1
-      FULL JOIN feed_ids_today t2
-        ON
-            t1.calitp_itp_id=t2.calitp_itp_id
-            AND t1.calitp_url_number=t2.calitp_url_number
-      WHERE
-        t1.calitp_deleted_at IS NULL
-        AND t2.calitp_itp_id IS NULL
-    )
-  SELECT
-    t1.* EXCEPT(calitp_hash)
-    , COALESCE(t1.calitp_hash, t2.calitp_hash) AS calitp_hash
-  FROM tbl_hash t1
-  FULL JOIN missing_entries t2
-    USING(calitp_hash)
-) S
-ON
-  T.calitp_hash = S.calitp_hash
-WHEN NOT MATCHED BY TARGET THEN
-    INSERT ROW
-WHEN NOT MATCHED BY SOURCE AND T.calitp_deleted_at IS NULL THEN
-    UPDATE
-        SET calitp_deleted_at = DATE("{execution_date}")
-
-"""
 
 
 def merge_updates(table_name, execution_date, **kwargs):

--- a/airflow/dags/sandbox/merge_create_merge_target.sql
+++ b/airflow/dags/sandbox/merge_create_merge_target.sql
@@ -1,0 +1,12 @@
+---
+operator: operators.SqlQueryOperator
+---
+
+CREATE OR REPLACE TABLE `sandbox.merge_target` (
+    calitp_itp_id INT64,
+    calitp_url_number INT64,
+    x INT64,
+    calitp_extracted_at DATE,
+    calitp_deleted_at DATE,
+    calitp_hash STRING
+)

--- a/airflow/dags/sandbox/merge_query_table.py
+++ b/airflow/dags/sandbox/merge_query_table.py
@@ -1,0 +1,15 @@
+# ---
+# dependencies:
+#   - merge_run
+# ---
+
+import pprint
+
+from calitp import get_table
+
+df = get_table("sandbox.merge_target", as_df=True)
+pprint.pprint(
+    df.sort_values(["calitp_extracted_at", "calitp_deleted_at"]).to_dict(
+        orient="records"
+    )
+)

--- a/airflow/dags/sandbox/merge_run.py
+++ b/airflow/dags/sandbox/merge_run.py
@@ -1,0 +1,37 @@
+# ---
+# dependencies:
+#   - op_external_table
+#   - merge_create_merge_target
+# ---
+
+from calitp import get_engine
+from calitp.config import get_bucket
+
+from merge_sql import SQL_TEMPLATE
+
+merges = [
+    {
+        "target": "sandbox.merge_target",
+        "source": "sandbox.external_table",
+        "bucket_like_str": f"{get_bucket()}/sandbox/external_table_1.csv",
+        "execution_date": "2021-01-01",
+    },
+    {
+        "target": "sandbox.merge_target",
+        "source": "sandbox.external_table",
+        "bucket_like_str": f"{get_bucket()}/sandbox/external_table_2.csv",
+        "execution_date": "2021-01-02",
+    },
+    {
+        "target": "sandbox.merge_target",
+        "source": "sandbox.external_table",
+        "bucket_like_str": f"{get_bucket()}/sandbox/external_table_3.csv",
+        "execution_date": "2021-01-03",
+    },
+]
+
+engine = get_engine()
+
+for entry in merges:
+    sql_code = SQL_TEMPLATE.format(**entry)
+    engine.execute(sql_code)

--- a/airflow/dags/sandbox/op_external_table.yml
+++ b/airflow/dags/sandbox/op_external_table.yml
@@ -1,13 +1,17 @@
 operator: operators.ExternalTable
 source_objects:
-  - 'sandbox/external_table.csv'
+  - 'sandbox/external_table_*.csv'
 destination_project_dataset_table: "sandbox.external_table"
 skip_leading_rows: 1
 schema_fields:
-  - name: g
-    type: STRING
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
   - name: x
     type: INTEGER
+  - name: calitp_extracted_at
+    type: DATE
 dependencies:
   - save_external_table_data
   - create_dataset

--- a/airflow/dags/sandbox/save_external_table_data.py
+++ b/airflow/dags/sandbox/save_external_table_data.py
@@ -5,8 +5,39 @@ from calitp import save_to_gcfs
 
 import pandas as pd
 
-df = pd.DataFrame({"g": ["a", "b"], "x": [1, 2]})
-
-save_to_gcfs(
-    df.to_csv(index=False).encode(), "sandbox/external_table.csv", use_pipe=True
+df1 = pd.DataFrame(
+    {
+        "calitp_itp_id": [1, 1],
+        "calitp_url_number": [0, 0],
+        "x": [1, 2],
+        "calitp_extracted_at": "2021-01-01",
+    }
 )
+
+# second entry removed
+df2 = pd.DataFrame(
+    {
+        "calitp_itp_id": [1],
+        "calitp_url_number": [0],
+        "x": [1],
+        "calitp_extracted_at": "2021-01-02",
+    }
+)
+
+
+# new first entry, second entry returns
+df3 = pd.DataFrame(
+    {
+        "calitp_itp_id": [1, 1],
+        "calitp_url_number": [0, 0],
+        "x": [99, 2],
+        "calitp_extracted_at": "2021-01-03",
+    }
+)
+
+for ii, df in enumerate([df1, df2, df3]):
+    save_to_gcfs(
+        df.to_csv(index=False).encode(),
+        f"sandbox/external_table_{ii + 1}.csv",
+        use_pipe=True,
+    )

--- a/airflow/plugins/merge_sql.py
+++ b/airflow/plugins/merge_sql.py
@@ -1,0 +1,54 @@
+# This MERGE statement uses a hash of all of the columns of the table, except for
+# extracted_at. But because this requires TO_JSON_STRING on a table, I had to
+# remove calitp_extracted_at, and then re-insert it as execution date. An
+# alternative (used by DBT) is to create a surrogate key by coercing the columns
+# of interest to a string and then concatenating them.
+SQL_TEMPLATE = """
+MERGE `{target}` T
+USING (
+  WITH
+    tbl_files_today AS (
+      SELECT * EXCEPT(calitp_extracted_at) FROM `{source}`
+      WHERE _FILE_NAME LIKE "{bucket_like_str}"
+    ),
+    tbl_hash AS (
+      SELECT
+        *
+        , DATE("{execution_date}") as calitp_extracted_at
+        , DATE(NULL) as calitp_deleted_at
+        , TO_BASE64(MD5(TO_JSON_STRING(tbl_files_today))) AS calitp_hash
+      FROM
+        tbl_files_today
+    ),
+    feed_ids_today AS (
+      SELECT DISTINCT calitp_itp_id, calitp_url_number
+      FROM tbl_hash
+    ),
+    missing_entries AS (
+      SELECT t1.calitp_hash AS calitp_hash
+      FROM `{target}` t1
+      FULL JOIN feed_ids_today t2
+        ON
+            t1.calitp_itp_id=t2.calitp_itp_id
+            AND t1.calitp_url_number=t2.calitp_url_number
+      WHERE
+        t1.calitp_deleted_at IS NULL
+        AND t2.calitp_itp_id IS NULL
+    )
+  SELECT
+    t1.* EXCEPT(calitp_hash)
+    , COALESCE(t1.calitp_hash, t2.calitp_hash) AS calitp_hash
+  FROM tbl_hash t1
+  FULL JOIN missing_entries t2
+    USING(calitp_hash)
+) S
+ON
+  T.calitp_deleted_at IS NULL
+  AND T.calitp_hash = S.calitp_hash
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT ROW
+WHEN NOT MATCHED BY SOURCE AND T.calitp_deleted_at IS NULL THEN
+    UPDATE
+        SET calitp_deleted_at = DATE("{execution_date}")
+
+"""


### PR DESCRIPTION
Fixes #295. Going to run now, so that it can backfill the gtfs schedule type 2 tables for the next few hours. Saved a backup to the staging project, as the gtfs_schedule_type2_prod dataset.

This PR also adds a working version to the sandbox DAG with tests.