### PR TITLE
fix(content): revert daily feed files

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
@@ -53,4 +53,5 @@ interp_daily_files AS (
             AND COALESCE(Files.tmp_next_date, "2099-01-01") > D.full_date
 )
 
-SELECT * FROM interp_daily_files
+#SELECT * FROM interp_daily_files
+SELECT * FROM raw_daily_files


### PR DESCRIPTION
interpolating files for missing days requires a bit more finessing. I grouped by agency, which was the wrong action. Going to revert.