### PR TITLE
Pin docker compose file version

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -36,7 +36,7 @@
 #
 # Feel free to modify this file to suit your needs.
 ---
-version: '3'
+version: '3.8'
 x-airflow-common:
   &airflow-common
   build: .

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
   redis:
     image: redis:latest
     ports:
-      - 6379:6379
+      - 6379
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
Two changes here:
* Pin the docker-compose file version to 3.8 to require a minimum docker-compose version of [1.25.5](https://docs.docker.com/compose/release-notes/#1255) and minimum docker version of [19.03.0](https://docs.docker.com/compose/compose-file/compose-versioning/#compatibility-matrix)
* Remove the fixed external port for `redis` service, as it may collide with any Redis servers already locally installed.