### PR TITLE
feat(gtfs-rt): stub out loading DAGs

### DIFF
--- a/airflow/dags/rt_loader/METADATA.yml
+++ b/airflow/dags/rt_loader/METADATA.yml
@@ -1,0 +1,21 @@
+description: "Download the state of CA GTFS files, async version"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: "2021-07-09"
+    email:
+      - "hunter.owens@dot.ca.gov"
+      - "michael.c@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    max_active_dag_runs: 6
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+wait_for_defaults:
+    timeout: 3600
+latest_only: False

--- a/airflow/dags/rt_loader/dummy_task.yml
+++ b/airflow/dags/rt_loader/dummy_task.yml
@@ -1,0 +1,1 @@
+operator: airflow.operators.dummy_operator.DummyOperator

--- a/airflow/dags/rt_loader_files/METADATA.yml
+++ b/airflow/dags/rt_loader_files/METADATA.yml
@@ -1,0 +1,21 @@
+description: "Download the state of CA GTFS files, async version"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: "2021-07-09"
+    email:
+      - "hunter.owens@dot.ca.gov"
+      - "michael.c@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    max_active_dag_runs: 6
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+wait_for_defaults:
+    timeout: 3600
+latest_only: False

--- a/airflow/dags/rt_loader_files/dummy_task.yml
+++ b/airflow/dags/rt_loader_files/dummy_task.yml
@@ -1,0 +1,1 @@
+operator: airflow.operators.dummy_operator.DummyOperator

--- a/airflow/dags/rt_views/METADATA.yml
+++ b/airflow/dags/rt_views/METADATA.yml
@@ -1,0 +1,20 @@
+description: "Download the state of CA GTFS files, async version"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "hunter.owens@dot.ca.gov"
+      - "michael.c@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+wait_for_defaults:
+    timeout: 3600
+latest_only: True

--- a/airflow/dags/rt_views/dummy_task.yml
+++ b/airflow/dags/rt_views/dummy_task.yml
@@ -1,0 +1,1 @@
+operator: airflow.operators.dummy_operator.DummyOperator


### PR DESCRIPTION
From pairing w/ @ccjarvus, this PR creates two DAGs for GTFS RT work:

* rt_loader_files: for creating a big table of all our RT files extracted (and their md5 hash)
* rt_loader: other loading tasks (e.g. parquet for external tables; validation)
* rt_views: views for transforming loaded data

Note that I would have used `gtfs_rt` as a prefix, but we have some dags named `gtfs_loader` and `gtfs_downloader` that should have used `gtfs_schedule_*`, and it's helpful to see all the `gifs_schedule_*` dags together.