### PR TITLE
fix: update LADOT GTFS url, remove commuter express

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -338,9 +338,9 @@ ladot:
   agency_name: Los Angeles Department of Transportation
   feeds:
     - gtfs_schedule_url: https://ladotbus.com/gtfshttps://ladotbus.com/gtfs
-      gtfs_rt_vehicle_positions_url:
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://ladotbus.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://ladotbus.com/gtfs-rt/tripupdates
+      gtfs_rt_trip_updates_url: https://ladotbus.com/gtfs-rt/alerts
   itp_id: 183
 delano-area-rapid-transit:
   agency_name: Delano Area Rapid Transit

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -337,7 +337,7 @@ culver-citybus:
 ladot:
   agency_name: Los Angeles Department of Transportation
   feeds:
-    - gtfs_schedule_url: https://ladotbus.com/gtfshttps://ladotbus.com/gtfs
+    - gtfs_schedule_url: https://ladotbus.com/gtfs
       gtfs_rt_vehicle_positions_url: https://ladotbus.com/gtfs-rt/vehiclepositions
       gtfs_rt_service_alerts_url: https://ladotbus.com/gtfs-rt/tripupdates
       gtfs_rt_trip_updates_url: https://ladotbus.com/gtfs-rt/alerts

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -286,14 +286,6 @@ commerce-municipal-bus-lines:
       gtfs_rt_service_alerts_url: https://citycommbus.com/gtfs-rt/alerts
       gtfs_rt_trip_updates_url: https://citycommbus.com/gtfs-rt/tripupdates
   itp_id: 75
-commuter-express:
-  agency_name: Commuter Express
-  feeds:
-    - gtfs_schedule_url: http://lacitydot.com/gtfs/administrator/gtfszip/ladotgtfs.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
-  itp_id: 390
 compton-renaissance-transit-service:
   agency_name: Compton Renaissance Transit Service
   feeds:
@@ -345,8 +337,8 @@ culver-citybus:
 ladot:
   agency_name: Los Angeles Department of Transportation
   feeds:
-    - gtfs_schedule_url: http://lacitydot.com/gtfs/administrator/gtfszip/ladotgtfs.zip
-      gtfs_rt_vehicle_positions_url: null
+    - gtfs_schedule_url: https://ladotbus.com/gtfshttps://ladotbus.com/gtfs
+      gtfs_rt_vehicle_positions_url:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 183


### PR DESCRIPTION
This updates the LADOT gtfs url to avoid us their feed. 
