### PR TITLE
feat(content): tweak names used by metric_views, cleanup

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_fact_stop_id_changes.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_fact_stop_id_changes.sql
@@ -5,14 +5,14 @@ dst_table_name: "views.gtfs_schedule_fact_stop_id_changes"
 tests:
   check_null:
     - feed_key
-    - period
-    - period_date
+    - metric_period
+    - metric_date
     - change_status
 
   check_composite_unique:
     - feed_key
-    - period
-    - period_date
+    - metric_period
+    - metric_date
     - change_status
 
 
@@ -24,31 +24,31 @@ WITH
 
 date_range AS (
     SELECT
-      period
-      , period_date
+      metric_period
+      , metric_date
       , start_date
       , end_date
     FROM `views.dim_metric_date`
     WHERE
         is_gtfs_schedule_range
-        AND period_type != "daily"
+        AND metric_type != "daily"
 ),
 
 source_table AS (
 
-    SELECT * FROM `views.gtfs_schedule_dim_stops`
+    SELECT *, stop_id as source_id FROM `views.gtfs_schedule_dim_stops`
 
 ),
 
 table_start AS (
-    SELECT calitp_itp_id, calitp_url_number, period, period_date, source_id
+    SELECT calitp_itp_id, calitp_url_number, metric_period, metric_date, source_id
     FROM source_table
     JOIN date_range ON calitp_extracted_at <= start_date
     AND calitp_deleted_at > start_date
 ),
 
 table_end AS (
-    SELECT calitp_itp_id, calitp_url_number, period, period_date, source_id
+    SELECT calitp_itp_id, calitp_url_number, metric_period, metric_date, source_id
     FROM source_table
     JOIN date_range ON calitp_extracted_at <= end_date
     AND calitp_deleted_at > end_date
@@ -67,7 +67,7 @@ table_partial AS (
           END AS change_status
     FROM table_start t1
     FULL JOIN table_end t2
-      USING ( calitp_itp_id, calitp_url_number, period, period_date, source_id)
+      USING ( calitp_itp_id, calitp_url_number, metric_period, metric_date, source_id)
 
 ),
 
@@ -76,8 +76,8 @@ metric_counts AS (
     SELECT
         calitp_itp_id
         , calitp_url_number
-        , period
-        , period_date
+        , metric_period
+        , metric_date
         , change_status
         , COUNT(*) AS n
     FROM table_partial GROUP BY 1, 2, 3, 4, 5
@@ -91,5 +91,5 @@ FROM metric_counts T1
 JOIN `views.gtfs_schedule_dim_feeds` T2
     USING(calitp_itp_id, calitp_url_number)
 WHERE
-    T2.calitp_extracted_at <= T1.period_date
-    AND T2.calitp_deleted_at > T1.period_date
+    T2.calitp_extracted_at <= T1.metric_date
+    AND T2.calitp_deleted_at > T1.metric_date


### PR DESCRIPTION
This PR tweaks the metric calendar, to use names starting with `metric_*`. Going to push so I can replace the manual id change calculations in reports with these ones. The gist is that dim_metric_dates allows people to perform calculations across

* daily
* rolling windows
* calendar periods (e.g. monthly, quarterly)

This is especially important when calculations are non-additive (e.g. distinct ids in some period, changes between two discrete dates).