### PR TITLE
fix(content): gtfs schedule dim routes missing when no agency.txt

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_routes.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_routes.sql
@@ -14,23 +14,27 @@ dependencies:
 
 WITH
 
+-- combine route and agency information. note that agency may be missing from
+-- a feed's gtfs data, so we need to take care that the route data makes it
+-- into the table no matter what
 route_agencies AS (
     SELECT
         T1.* EXCEPT(continuous_pickup, continuous_drop_off, calitp_extracted_at, calitp_deleted_at, calitp_hash)
         , continuous_pickup AS route_continuous_pickup
         , continuous_drop_off AS route_continuous_drop_off
         , T2.* EXCEPT(calitp_itp_id, calitp_url_number, agency_id, calitp_extracted_at, calitp_deleted_at, calitp_hash)
-        , GREATEST(T1.calitp_extracted_at, T2.calitp_extracted_at) AS calitp_extracted_at
-        , LEAST(T1.calitp_deleted_at, T2.calitp_deleted_at) AS calitp_deleted_at
+        , COALESCE(GREATEST(T1.calitp_extracted_at, T2.calitp_extracted_at), T1.calitp_extracted_at) AS calitp_extracted_at
+        , COALESCE(LEAST(T1.calitp_deleted_at, T2.calitp_deleted_at), T1.calitp_deleted_at) AS calitp_deleted_at
     FROM `gtfs_schedule_type2.routes_clean` T1
     LEFT JOIN `gtfs_schedule_type2.agency_clean` T2
-        USING (calitp_itp_id, calitp_url_number, agency_id)
-    WHERE
-        T1.calitp_extracted_at < T2.calitp_deleted_at
+        ON T1.calitp_itp_id = T2.calitp_itp_id
+        AND T1.calitp_url_number = T2.calitp_url_number
+        AND T1.agency_id = T2.agency_id
+        AND T1.calitp_extracted_at < T2.calitp_deleted_at
         AND T2.calitp_extracted_at < T1.calitp_deleted_at
 )
 
 SELECT
-    FARM_FINGERPRINT(CONCAT(route_key, "___", CAST(agency_key AS STRING))) AS route_key
+    FARM_FINGERPRINT(CONCAT(route_key, "___", COALESCE(CAST(agency_key AS STRING), "MISSING"))) AS route_key
     , * EXCEPT (route_key, agency_key)
 FROM route_agencies

--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_routes.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_routes.sql
@@ -5,6 +5,8 @@ dst_table_name: "views.gtfs_schedule_dim_routes"
 tests:
   check_null:
     - route_key
+    - calitp_extracted_at
+    - calitp_deleted_at
   check_unique:
     - route_key
 


### PR DESCRIPTION
This PR fixes an error in modeling our routes dimensional table, that caused route_keys with no agency.txt to be omitted from `gtfs_schedule_fact_daily_feed_routes`. Basically, dim routes denormalizes in agency data, but needed more coalescing to ensure extracted at, deleted at, and keys were not NULL.

Added fixes to code and checks for inappropriate nulls in columns above.

(Note: this dynamic of GTFS Schedule data discussed a bit here: https://github.com/cal-itp/data-infra/issues/70#issuecomment-832089250)