### PR TITLE
fix(content): remove redundant entries from calendar_dates for daily service

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
@@ -30,7 +30,11 @@ WITH
     SELECT
       * EXCEPT (date)
       , date AS service_date
-    FROM `gtfs_schedule_type2.calendar_dates_clean`
+    FROM (
+        -- deduplicate calendar_dates, which does not have a unique id column
+        -- and has identical entries in rare cases
+        SELECT DISTINCT * FROM `gtfs_schedule_type2.calendar_dates_clean`
+    )
   ),
 
   # for each day in our date calendar, get service entries that existed


### PR DESCRIPTION
This PR addresses https://github.com/cal-itp/data-infra/issues/382 by removing duplicate entries from calendar_dates in the relevant CTE. Tests appear to be passing locally.