### PR TITLE
Ingest micropayments_adjustments Littlepay data

### DIFF
--- a/airflow/dags/payments_loader/calitp_included_payments_tables.py
+++ b/airflow/dags/payments_loader/calitp_included_payments_tables.py
@@ -3,6 +3,7 @@
 # dependencies:
 #   - customer_funding_source
 #   - device_transactions
+#   - micropayment_adjustments
 #   - micropayment_device_transactions
 #   - micropayments
 # ---
@@ -18,6 +19,7 @@ def main():
             # required tables ----
             ("customer_funding_source", ".psv"),
             ("device_transactions", ".psv"),
+            ("micropayment_adjustments", ".psv"),
             ("micropayment_device_transactions", ".psv"),
             ("micropayments", ".psv"),
         ],

--- a/airflow/dags/payments_loader/micropayment_adjustments.yml
+++ b/airflow/dags/payments_loader/micropayment_adjustments.yml
@@ -26,3 +26,5 @@ schema_fields:
     type: BOOL
   - name: zone_ids_us
     type: STRING
+  - name: calitp_extracted_at
+    type: DATE

--- a/airflow/dags/payments_loader/micropayment_adjustments.yml
+++ b/airflow/dags/payments_loader/micropayment_adjustments.yml
@@ -1,0 +1,28 @@
+operator: operators.ExternalTable
+source_objects:
+  - "mst/processed/micropayment_adjustments/*"
+destination_project_dataset_table: "payments.micropayment_adjustments"
+skip_leading_rows: 1
+schema_fields:
+  - name: micropayment_id
+    type: STRING
+  - name: adjustment_id
+    type: STRING
+  - name: participant_id
+    type: STRING
+  - name: customer_id
+    type: STRING
+  - name: product_id
+    type: STRING
+  - name: type
+    type: STRING  # Daily_Cap, Weekly_Cap
+  - name: description
+    type: STRING
+  - name: amount
+    type: NUMERIC  # SHOULD WE CAP THE PRECISION/SCALE?
+  - name: time_period_type
+    type: STRING  # Peak, Off Peak
+  - name: applied
+    type: BOOL
+  - name: zone_ids_us
+    type: STRING

--- a/airflow/dags/payments_loader/micropayment_adjustments.yml
+++ b/airflow/dags/payments_loader/micropayment_adjustments.yml
@@ -19,7 +19,7 @@ schema_fields:
   - name: description
     type: STRING
   - name: amount
-    type: NUMERIC  # SHOULD WE CAP THE PRECISION/SCALE?
+    type: NUMERIC
   - name: time_period_type
     type: STRING  # Peak, Off Peak
   - name: applied

--- a/docs/datasets/mst_payments.md
+++ b/docs/datasets/mst_payments.md
@@ -9,6 +9,7 @@ Currently, Payments data is hosted by Littlepay, who exposes the "Littlepay Data
 | device_transactions | A list of every tap on the devices | * Cannot use for ridership stats because tap on / offs |
 | micropayments | A list of every charge to a card | * T-2 delays because of charing rules |
 | micropayments_devices_transactions | Join tables for two prior tables | |
+| micropayment_adjustments | A list of amounts deducted from the `nominal_amount` to arrive at the `charge_amount` for a micropayment | A micropayment can include multiple adjustments candidates, but only one should have `applied=true`. |
 
 ## Views
 

--- a/docs/datasets/mst_payments.md
+++ b/docs/datasets/mst_payments.md
@@ -43,6 +43,7 @@ The payments_views is made of SQL queries that transform the loaded tables above
 * In the `calitp_included_payments_data` task,
     * add a row for this new table.
     * add a depedency in yaml header to this new table.
+* In the `docs/datasets/mst_payments.md` file, add an entry into the `Tables` table describing the new data set.
 
 ### Adding a new table to payments_views
 

--- a/docs/datasets/mst_payments.md
+++ b/docs/datasets/mst_payments.md
@@ -40,6 +40,7 @@ The payments_views is made of SQL queries that transform the loaded tables above
 * Alter `destination_project_dataset_table` and `source_objects` to match the new table name.
 * Edit `schema_fields` to be the columns in the new table. If you are unsure of a column type,
   specify it as "STRING".
+    * Keep a `calitp_extracted_at` column at the end of the table. This column contains the execution date of the load task, and is added automatically by the `preprocess_columns` task.
 * In the `calitp_included_payments_data` task,
     * add a row for this new table.
     * add a depedency in yaml header to this new table.


### PR DESCRIPTION
The miropayments_adjustments data has fare cap values, which will be used in reporting metrics. This work is in relation to:
* #361 
* #372 

Ran the `payments_loader` DAG locally to check that everything flows correctly. New table is loaded into staging.