### PR TITLE
Update the proprocess_columns task to support multiple providers

### DIFF
--- a/airflow/dags/payments_loader/METADATA.yml
+++ b/airflow/dags/payments_loader/METADATA.yml
@@ -1,4 +1,4 @@
-description: "Update the MST Materialized View"
+description: "Update the Littlepay Ridership Materialized View"
 schedule_interval: "0 0 * * *"
 tags:
   - all_gusty_features

--- a/airflow/dags/payments_loader/customer_funding_source.yml
+++ b/airflow/dags/payments_loader/customer_funding_source.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "mst/processed/customer_funding_source/*"
+  - "processed/customer_funding_source/*"
 destination_project_dataset_table: "payments.customer_funding_source"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/customer_funding_source.yml
+++ b/airflow/dags/payments_loader/customer_funding_source.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "processed/customer_funding_source/*"
+  - "payments-processed/customer_funding_source/*"
 destination_project_dataset_table: "payments.customer_funding_source"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/device_transactions.yml
+++ b/airflow/dags/payments_loader/device_transactions.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "processed/device_transactions/*"
+  - "payments-processed/device_transactions/*"
 destination_project_dataset_table: "payments.device_transactions"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/device_transactions.yml
+++ b/airflow/dags/payments_loader/device_transactions.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "mst/processed/device_transactions/*"
+  - "processed/device_transactions/*"
 destination_project_dataset_table: "payments.device_transactions"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/micropayment_adjustments.yml
+++ b/airflow/dags/payments_loader/micropayment_adjustments.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "processed/micropayment_adjustments/*"
+  - "payments-processed/micropayment_adjustments/*"
 destination_project_dataset_table: "payments.micropayment_adjustments"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/micropayment_adjustments.yml
+++ b/airflow/dags/payments_loader/micropayment_adjustments.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "mst/processed/micropayment_adjustments/*"
+  - "processed/micropayment_adjustments/*"
 destination_project_dataset_table: "payments.micropayment_adjustments"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/micropayment_device_transactions.yml
+++ b/airflow/dags/payments_loader/micropayment_device_transactions.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "mst/processed/micropayment_device_transactions/*"
+  - "processed/micropayment_device_transactions/*"
 destination_project_dataset_table: "payments.micropayment_device_transactions"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/micropayment_device_transactions.yml
+++ b/airflow/dags/payments_loader/micropayment_device_transactions.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "processed/micropayment_device_transactions/*"
+  - "payments-processed/micropayment_device_transactions/*"
 destination_project_dataset_table: "payments.micropayment_device_transactions"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/micropayments.yml
+++ b/airflow/dags/payments_loader/micropayments.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "processed/micropayments/*"
+  - "payments-processed/micropayments/*"
 destination_project_dataset_table: "payments.micropayments"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/micropayments.yml
+++ b/airflow/dags/payments_loader/micropayments.yml
@@ -1,6 +1,6 @@
 operator: operators.ExternalTable
 source_objects:
-  - "mst/processed/micropayments/*"
+  - "processed/micropayments/*"
 destination_project_dataset_table: "payments.micropayments"
 skip_leading_rows: 1
 schema_fields:

--- a/airflow/dags/payments_loader/preprocess_columns.py
+++ b/airflow/dags/payments_loader/preprocess_columns.py
@@ -99,10 +99,5 @@ def preprocess_littlepay_provider_bucket(
 
 
 def main(execution_date, **kwargs):
-    preprocess_littlepay_provider_bucket(
-        execution_date,
-        provider_name="mst",
-        src_url_template="gs://littlepay-data-extract-prod/mst/{table_name}/*.psv",
-    )
-
+    preprocess_littlepay_provider_bucket(execution_date, provider_name="mst")
     preprocess_littlepay_provider_bucket(execution_date, provider_name="sbmtd")

--- a/airflow/dags/payments_loader/preprocess_columns.py
+++ b/airflow/dags/payments_loader/preprocess_columns.py
@@ -20,22 +20,19 @@ DATASET = "payments"
 # However, if we move to processing only the data for a given day each task,
 # we should change the SRC_DIR glob to use a datetime
 
-SRC_DIR = "gs://littlepay-data-extract-prod/mst/{table_name}/*.psv"
-STAGE_DIR = "mst/{table_name}"
-DST_DIR = "mst/processed/{table_name}"
+DEFAULT_SRC_URL_TEMPLATE = "gs://littlepay-data-extract-prod/{provider_name}/{provider_name}/{table_name}/*.psv"
+DEFAULT_STG_DIR_TEMPLATE = "{table_name}"
+DEFAULT_DST_DIR_TEMPLATE = "processed/{table_name}"
 
 
-def main(execution_date, **kwargs):
-
+def preprocess_littlepay_provider_bucket(
+    execution_date,
+    provider_name,
+    src_url_template=DEFAULT_SRC_URL_TEMPLATE,
+    stg_dir_template=DEFAULT_STG_DIR_TEMPLATE,
+    dst_dir_template=DEFAULT_DST_DIR_TEMPLATE,
+):
     fs = get_fs()
-
-    # remove previously processed data, in case they remove any data files ---
-    dst_parent_dir = f"{get_bucket()}/mst/processed/"
-
-    if fs.exists(dst_parent_dir):
-        # sanity check that we are deleting something mst related
-        assert "/mst/" in dst_parent_dir
-        fs.rm(dst_parent_dir, recursive=True)
 
     # Get high level data on tables we are pre-processing ----
     tables = get_table("payments.calitp_included_payments_tables", as_df=True)
@@ -50,10 +47,11 @@ def main(execution_date, **kwargs):
     # process data for each table ----
 
     for table_name, columns in zip(tables.table_name, schemas):
-        stg_dir = STAGE_DIR.format(table_name=table_name)
-        dst_dir = DST_DIR.format(table_name=table_name)
+        stg_dir = stg_dir_template.format(provider_name=provider_name, table_name=table_name)
+        dst_dir = dst_dir_template.format(provider_name=provider_name, table_name=table_name)
         src_files = fs.glob(
-            SRC_DIR.format(
+            src_url_template.format(
+                provider_name=provider_name,
                 table_name=table_name.replace("_", "-"),
                 date_string_narrow=date_string_narrow,
             )
@@ -61,13 +59,22 @@ def main(execution_date, **kwargs):
 
         print(f"\n\nTable {table_name} has {len(src_files)} new files =========")
 
+        # remove previously processed data, in case they remove any data files ---
+
+        dst_old_url = f"{get_bucket()}/{dst_dir}/*_{provider_name}_*"
+        dst_old_files = fs.glob(dst_old_url)
+
+        if dst_old_files:
+            print(f'Deleting {len(dst_old_files)} old file(s) for {provider_name} {table_name}.')
+            fs.rm(dst_old_files)
+
         # copy and process each file ----
 
         for fname in src_files:
             basename = fname.split("/")[-1]
 
-            stg_fname = f"{stg_dir}/{basename}"
-            dst_fname = f"{dst_dir}/{date_string}_{basename}"
+            stg_fname = f"{stg_dir}/{provider_name}_{basename}"
+            dst_fname = f"{dst_dir}/{date_string}_{provider_name}_{basename}"
 
             print(f"copying from payments bucket: {stg_fname} -> {dst_fname}")
             fs.cp(fname, f"{get_bucket()}/{stg_fname}")
@@ -79,3 +86,16 @@ def main(execution_date, **kwargs):
                 extracted_at=date_string,
                 delimiter="|",
             )
+
+
+def main(execution_date, **kwargs):
+    preprocess_littlepay_provider_bucket(
+        execution_date,
+        provider_name="mst",
+        src_url_template="gs://littlepay-data-extract-prod/mst/{table_name}/*.psv",
+    )
+
+    preprocess_littlepay_provider_bucket(
+        execution_date,
+        provider_name="sbmtd",
+    )

--- a/airflow/dags/payments_loader/preprocess_columns.py
+++ b/airflow/dags/payments_loader/preprocess_columns.py
@@ -20,7 +20,10 @@ DATASET = "payments"
 # However, if we move to processing only the data for a given day each task,
 # we should change the SRC_DIR glob to use a datetime
 
-DEFAULT_SRC_URL_TEMPLATE = "gs://littlepay-data-extract-prod/{provider_name}/{provider_name}/{table_name}/*.psv"
+DEFAULT_SRC_URL_TEMPLATE = (
+    "gs://littlepay-data-extract-prod/{provider_name}/"
+    "{provider_name}/{table_name}/*.psv"
+)
 DEFAULT_STG_DIR_TEMPLATE = "{table_name}"
 DEFAULT_DST_DIR_TEMPLATE = "processed/{table_name}"
 
@@ -47,8 +50,12 @@ def preprocess_littlepay_provider_bucket(
     # process data for each table ----
 
     for table_name, columns in zip(tables.table_name, schemas):
-        stg_dir = stg_dir_template.format(provider_name=provider_name, table_name=table_name)
-        dst_dir = dst_dir_template.format(provider_name=provider_name, table_name=table_name)
+        stg_dir = stg_dir_template.format(
+            provider_name=provider_name, table_name=table_name
+        )
+        dst_dir = dst_dir_template.format(
+            provider_name=provider_name, table_name=table_name
+        )
         src_files = fs.glob(
             src_url_template.format(
                 provider_name=provider_name,
@@ -65,7 +72,10 @@ def preprocess_littlepay_provider_bucket(
         dst_old_files = fs.glob(dst_old_url)
 
         if dst_old_files:
-            print(f'Deleting {len(dst_old_files)} old file(s) for {provider_name} {table_name}.')
+            print(
+                f"Deleting {len(dst_old_files)} old file(s) for "
+                f"{provider_name} {table_name}."
+            )
             fs.rm(dst_old_files)
 
         # copy and process each file ----
@@ -95,7 +105,4 @@ def main(execution_date, **kwargs):
         src_url_template="gs://littlepay-data-extract-prod/mst/{table_name}/*.psv",
     )
 
-    preprocess_littlepay_provider_bucket(
-        execution_date,
-        provider_name="sbmtd",
-    )
+    preprocess_littlepay_provider_bucket(execution_date, provider_name="sbmtd")

--- a/airflow/dags/payments_loader/preprocess_columns.py
+++ b/airflow/dags/payments_loader/preprocess_columns.py
@@ -24,8 +24,8 @@ DEFAULT_SRC_URL_TEMPLATE = (
     "gs://littlepay-data-extract-prod/{provider_name}/"
     "{provider_name}/{table_name}/*.psv"
 )
-DEFAULT_STG_DIR_TEMPLATE = "{table_name}"
-DEFAULT_DST_DIR_TEMPLATE = "processed/{table_name}"
+DEFAULT_STG_DIR_TEMPLATE = "payments-staging/{table_name}"
+DEFAULT_DST_DIR_TEMPLATE = "payments-processed/{table_name}"
 
 
 def preprocess_littlepay_provider_bucket(


### PR DESCRIPTION
* Introduce a new function in the `preprocess_columns` task to handle preprocessing of a given littlepay data source. If need be, we can move this into a new operator in the future.
* Add SBMTD Littlepay data to be preprocessed. The SBMTD data is being synced to the same bucket as the MST data, but into a different folder. ~~The MST data is still being synced to the root, but should also be changed to use a different folder. We may have to create a new sync task to do so, as there doesn't appear to be a way to modify the bucket/folder being synced to. After merging this code, we should:~~
  1. ~~Delete the old transfer task for MST~~
  2. ~~Create a new transfer task for MST pointing to a subfolder of the Littlepay data bucket~~
  3. ~~Submit a new PR changing the `preprocess_columns` task to not override the default `src_url_template` for MST~~
  
  **A new MTS transfer task has been created and the old one has been disabled for now.**

This code has been run locally to ensure functionality. This PR addresses #210 