### PR TITLE
fix(gtfs-rt): lower task concurrency to 1

### DIFF
--- a/airflow/dags/rt_loader/parse_rt_vehicle_positions.py
+++ b/airflow/dags/rt_loader/parse_rt_vehicle_positions.py
@@ -2,7 +2,7 @@
 # python_callable: main
 # provide_context: true
 #
-# task_concurrency: 4
+# task_concurrency: 1
 #
 # dependencies:
 #   - load_vehicle_positions


### PR DESCRIPTION
Noticed tasks still fail intermittently, going very conservative and only allow 1 of these tasks to run at a time