### PR TITLE
feat(push_to_gcloud): push agencies.yml changes to kubernetes cluster apps

### DIFF
--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -32,14 +32,20 @@ jobs:
           './airflow/data/agencies.filled.yml' \
           './airflow/data/schema_agencies_entry.yml'
 
-    # The following only runs on the main branch ----
-
     - uses: google-github-actions/setup-gcloud@master
-      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
-    - name: Push to google cloud
+
+    - name: Setup kubeconfig
+      env:
+        CLOUDSDK_CORE_PROJECT: cal-itp-data-infra
+      run: |
+        source "$GITHUB_WORKSPACE/kubernetes/gke/config-cluster.sh"
+        gcloud container clusters get-credentials "$GKE_NAME" --region "$GKE_REGION"
+
+    # push to prod services when merging into main branch
+    - name: Push agencies data to google cloud and prod services
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
         gsutil -m rsync -d -c -r airflow/dags gs://us-west2-calitp-airflow-pro-332827a9-bucket/dags
@@ -48,3 +54,28 @@ jobs:
         # replace agencies.yml with filled in template
         gsutil -m cp airflow/data/agencies.yml gs://us-west2-calitp-airflow-pro-332827a9-bucket/data/agencies_raw.yml
         gsutil -m cp airflow/data/agencies.filled.yml gs://us-west2-calitp-airflow-pro-332827a9-bucket/data/agencies.yml
+        kubectl apply -f - <<EOF
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: agencies-data
+          namespace: gtfs-rt
+        data:
+          data_agencies.yaml: $(base64 -w0 airflow/data/agencies.filled.yml)
+        EOF
+        kubectl -n gtfs-rt rollout restart deployments/gtfs-rt-archive
+
+    # push to preprod services when merging to other branches
+    - name: Push agencies data to preprod services
+      if: ${{ github.ref != 'refs/heads/main' }}
+      run: |
+        kubectl apply -f - <<EOF
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: agencies-data
+          namespace: gtfs-rt-preprod
+        data:
+          data_agencies.yaml: $(base64 -w0 airflow/data/agencies.filled.yml)
+        EOF
+        kubectl -n gtfs-rt-preprod rollout restart deployments/gtfs-rt-archive


### PR DESCRIPTION
This changeset automates the rollout of any changes to the agencies.yml file into the apps cluster and restarts the gtfs-rt-archive service upon such changes being pushed. Any future services deployed into the apps cluster which are dependent on the agencies.yml file will need to have lines added to the workflow to ensure they are also restarted after a change is pushed.