### PR TITLE
fix(kubernetes/gtfs-rt-archive): use recreate strategy to deploy changes

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -7,6 +7,8 @@ metadata:
     name: gtfs-rt-archive
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: gtfs-rt-archive


### PR DESCRIPTION
By default, when updating deployments kubernetes will create new
containers before terminating old ones. This behavior is undesirable
for the archiver since we want to ensure there is never more than one
instance running at a time.