### PR TITLE
fix(gtfs-rt): up concurrency to 3 on new cluster

### DIFF
--- a/airflow/dags/rt_loader/parse_rt_vehicle_positions.py
+++ b/airflow/dags/rt_loader/parse_rt_vehicle_positions.py
@@ -2,7 +2,7 @@
 # python_callable: main
 # provide_context: true
 #
-# task_concurrency: 1
+# task_concurrency: 3
 #
 # dependencies:
 #   - load_vehicle_positions


### PR DESCRIPTION
Now that the cluster is beefed up, it should be able to handle running a few more gtfs rt parsing tasks at a time