### PR TITLE
Update agencies.yml: Norwalk, GTrans, Duarte

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -382,14 +382,6 @@ downeylink:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 95
-duarte-transit:
-  agency_name: Duarte Transit
-  feeds:
-    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/duartetransit-ca-us/duartetransit-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
-  itp_id: 97
 east-los-angeles-shuttle:
   agency_name: East Los Angeles Shuttle
   feeds:
@@ -553,7 +545,7 @@ grapeline:
 gtrans:
   agency_name: GTrans
   feeds:
-    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/gtrans-ca-us/gtrans-ca-us.zip
+    - gtfs_schedule_url: http://ridegtrans.com/gtfs.zip
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
@@ -837,7 +829,7 @@ north-county-transit-district:
 norwalk-transit-system:
   agency_name: Norwalk Transit System
   feeds:
-    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/nts-ca-us/nts-ca-us.zip
+    - gtfs_schedule_url: https://www.norwalktransit.com/s/GTFS_Data.zip
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null


### PR DESCRIPTION
Updated Norwalk Transit's and GTrans' GTFS Schedule links.
Removed Duarte as a distinct provider (now part of Foothill's service).