### PR TITLE
fix: Use correct time info for departure time

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_stop_times.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_stop_times.sql
@@ -31,7 +31,7 @@ array_len_fix AS (
     SELECT
       * EXCEPT(part_arr, part_dep)
       , CASE WHEN ARRAY_LENGTH(part_arr) = 0 THEN [NULL, NULL, NULL] ELSE part_arr END AS part_arr
-      , CASE WHEN ARRAY_LENGTH(part_dep) = 0 THEN [NULL, NULL, NULL] ELSE part_arr END AS part_dep
+      , CASE WHEN ARRAY_LENGTH(part_dep) = 0 THEN [NULL, NULL, NULL] ELSE part_dep END AS part_dep
     FROM int_time_parts
 )
 


### PR DESCRIPTION
While exploring for cal-itp/data-analyses#180, I found that we were using arrival time information when calculating the numeric departure time. This commit fixes that sneaky little bug.