### PR TITLE
fix(gtfs-rt): remove return statement that was triggering xcom

### DIFF
--- a/airflow/dags/rt_loader_files/calitp_files_process.py
+++ b/airflow/dags/rt_loader_files/calitp_files_process.py
@@ -70,5 +70,3 @@ def main(execution_date, **kwargs):
         f"rt-processed/calitp_files/{date_string}.csv",
         use_pipe=True,
     )
-
-    return res


### PR DESCRIPTION
I used a return statement in a task for debugging locally. For some reason, while everything worked in airflow local dev, this caused errors on prod.