### PR TITLE
fix(payments): error in littlepay model docs, number_of_transfer is a float

### DIFF
--- a/airflow/dags/payments_loader/product_data.yml
+++ b/airflow/dags/payments_loader/product_data.yml
@@ -47,7 +47,7 @@ schema_fields:
   - name: capping_duration
     type: FLOAT64
   - name: number_of_transfer
-    type: INTEGER
+    type: FLOAT64
   - name: capping_time_zone
     type: STRING
   - name: capping_overlap


### PR DESCRIPTION
This PR makes a small fix to the payments data model, which was mis-described in the littlepay docs