### PR TITLE
charts/metabase: inject default MB_SITE_URL from ingress

### DIFF
--- a/kubernetes/apps/charts/metabase/templates/metabase.yaml
+++ b/kubernetes/apps/charts/metabase/templates/metabase.yaml
@@ -88,5 +88,8 @@ metadata:
   name: metabase-config
   namespace: {{ .Release.Namespace }}
 data:
-  {{- toYaml .Values.configs.metabase | nindent 2 }}
+  {{- $defaultHost := get (index (default (list (dict "host" "")) .Values.ingress.hosts) 0) "host" }}
+  {{- $emptyDict := dict }}
+  {{- $siteUrlDict := dict "MB_SITE_URL" (print "https://" $defaultHost) }}
+  {{- ne $defaultHost "" | ternary $siteUrlDict $emptyDict | merge .Values.configs.metabase | toYaml | nindent 2 }}
 {{- end }}

--- a/kubernetes/apps/charts/metabase/templates/metabase.yaml
+++ b/kubernetes/apps/charts/metabase/templates/metabase.yaml
@@ -88,6 +88,8 @@ metadata:
   name: metabase-config
   namespace: {{ .Release.Namespace }}
 data:
+  {{- /* select first hostname from the ingress hosts list (if it exists; empty string otherwise) */}}
+  {{- /* to use as the default value of the MB_SITE_URL environment variable                      */}}
   {{- $defaultHost := get (index (default (list (dict "host" "")) .Values.ingress.hosts) 0) "host" }}
   {{- $emptyDict := dict }}
   {{- $siteUrlDict := dict "MB_SITE_URL" (print "https://" $defaultHost) }}

--- a/kubernetes/apps/values/metabase.yaml
+++ b/kubernetes/apps/values/metabase.yaml
@@ -23,9 +23,9 @@ ingress:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
   hosts:
-    - host: metabase.k8s.calitp.jarv.us
-      paths: [ '/' ]
     - host: dashboards.calitp.org
+      paths: [ '/' ]
+    - host: metabase.k8s.calitp.jarv.us
       paths: [ '/' ]
   tls:
     - secretName: metabase-tls


### PR DESCRIPTION
Metabase will use the internal container IP by default to form its
configured site url. This causes issues such as users receiving broken
links in account activation emails. This changeset adds the capability
to the chart to set the site url to whatever hostname is configured in
the ingress configuration.