### PR TITLE
Fix gh cloud push

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1317,7 +1317,7 @@ trinity-transit:
 tulare-county-area-transit:
   agency_name: Tulare County Area Transit
   feeds:
-    - gtfs_schedule_url:  http://data.trilliumtransit.com/gtfs/tcat-flex-ca-us/tcat-ca-us.zip
+    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/tcat-flex-ca-us/tcat-ca-us.zip
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null


### PR DESCRIPTION
@evansiroky I think GITHUB_ACTOR may get set to the person who opens a PR / does a commit (but am not quite sure). It appears we are not pushing up DAG changes to the bucket anymore, so this PR is a quick fix to re-implement. Do you mind if we merge, so I can check some of @mjumbewu's payments changes?

I searched around for the "right way" to detect actions being run from a forked PR, but couldn't find a lot of info :/. So I hard-coded our repo in the checks for now....

It looks like the actions are working again (since this job runs "Push agencies to preprod service")

https://github.com/cal-itp/data-infra/runs/4025629267?check_suite_focus=true