### PR TITLE
Enrich with payments export account and datetime info

### DIFF
--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -83,7 +83,15 @@ def sql_enrich_duplicates(schema_tbl, key_columns, order_by_columns):
             SELECT
                 *,
                 TO_BASE64(MD5(TO_JSON_STRING(T))) AS calitp_hash,
-                _FILE_NAME AS calitp_file_name
+                _FILE_NAME AS calitp_file_name,
+                REGEXP_EXTRACT(
+                    _FILE_NAME,
+                    '.*/[0-9]{4}-[0-9]{2}-[0-9]{2}_(.*)_[0-9]{12}_.*'
+                ) AS calitp_export_account,
+                PARSE_DATETIME(
+                    '%Y%m%d%H%M',
+                    REGEXP_EXTRACT(_FILE_NAME, '.*_([0-9]{12})_.*')
+                ) AS calitp_export_datetime
             FROM {schema_tbl} T
         ),
 


### PR DESCRIPTION
This will be helpful (and necessary) for deduplicating the `customer_funding_source` data, and is generally useful. It allows us to see the source of each record even downstream of the raw ingested tables.