### PR TITLE
Ensure no duplicate transaction ids in cleaned micropayment_device_transactions

### DIFF
--- a/airflow/dags/payments_views_staging/stg_cleaned_micropayment_device_transactions.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_micropayment_device_transactions.sql
@@ -9,7 +9,59 @@ tests:
   check_composite_unique:
     - micropayment_id
     - littlepay_transaction_id
+  check_unique:
+    - littlepay_transaction_id
 ---
+
+with
+
+deduped_micropayment_device_transaction_ids as (
+
+    select distinct
+        littlepay_transaction_id,
+        micropayment_id
+    from payments.stg_enriched_micropayment_device_transactions
+    where calitp_dupe_number = 1
+
+),
+
+-- Some transactions are associated with more than one micropayment. This should
+-- not happen. In the query below, we identify the micropayment_id of the
+-- pending micropayment records that are no longer valid because they've been
+-- superceded by a completed micropayment.
+--
+-- See https://github.com/cal-itp/data-infra/issues/647 for the explanation.
+invalid_micropayment_device_transaction_ids as (
+
+    select
+        littlepay_transaction_id,
+        m1.micropayment_id
+
+    from deduped_micropayment_device_transaction_ids as mdt1
+    join payments.stg_cleaned_micropayments as m1
+        on mdt1.micropayment_id = m1.micropayment_id
+
+    join deduped_micropayment_device_transaction_ids as mdt2 using (littlepay_transaction_id)
+    join payments.stg_cleaned_micropayments as m2
+        on mdt2.micropayment_id = m2.micropayment_id
+
+    where m1.micropayment_id <> m2.micropayment_id
+        and m1.charge_type = 'pending_charge_fare'
+        and m2.charge_type = 'complete_variable_fare'
+
+),
+
+cleaned_micropayment_device_transaction_ids as (
+
+    select
+        littlepay_transaction_id,
+        micropayment_id
+    from deduped_micropayment_device_transaction_ids as deduped
+    left join invalid_micropayment_device_transaction_ids as invalid
+        using (littlepay_transaction_id, micropayment_id)
+    where invalid.littlepay_transaction_id is null
+
+)
 
 select distinct * except (
     calitp_file_name,
@@ -17,4 +69,6 @@ select distinct * except (
     calitp_n_dupe_ids,
     calitp_dupe_number)
 from payments.stg_enriched_micropayment_device_transactions
+join cleaned_micropayment_device_transaction_ids
+    using (littlepay_transaction_id, micropayment_id)
 where calitp_dupe_number = 1

--- a/airflow/dags/payments_views_staging/validate_cleaned_micropayment_device_transactions.sql
+++ b/airflow/dags/payments_views_staging/validate_cleaned_micropayment_device_transactions.sql
@@ -1,0 +1,26 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.invalid_cleaned_micropayment_device_transactions"
+
+dependencies:
+  - stg_cleaned_micropayment_device_transactions
+
+tests:
+  check_empty:
+    - "*"
+---
+
+with
+
+multplied_transaction_ids as (
+    select littlepay_transaction_id
+    from `payments.stg_cleaned_micropayment_device_transactions`
+    group by 1
+    having count(*) > 1
+)
+
+select littlepay_transaction_id, m.*
+from `payments.stg_cleaned_micropayment_device_transactions`
+join `payments.stg_cleaned_micropayments` m using (micropayment_id)
+join multplied_transaction_ids using (littlepay_transaction_id)
+order by transaction_time desc, littlepay_transaction_id, charge_type desc

--- a/airflow/plugins/testing.py
+++ b/airflow/plugins/testing.py
@@ -55,6 +55,19 @@ FROM (
 )
 """
 
+# check_empty
+empty_query_template = """
+SELECT
+    '{field}' AS field,
+    '{test}' AS test,
+    n_rows = 0 AS passed
+FROM (
+    SELECT
+        COUNT(*) AS n_rows
+    FROM {table}
+)
+"""
+
 
 def run_test(test_name, engine, fields, table, query_template, composite=False):
 
@@ -120,6 +133,18 @@ class Tester:
         )
 
         self.test_results["check_composite_unique"] = res
+
+    def check_empty(self, fields):
+        res = run_test(
+            "check_empty",
+            engine=self.engine,
+            fields=fields,
+            table=self.table,
+            query_template=empty_query_template,
+            composite=False,
+        )
+
+        self.test_results["check_empty"] = res
 
     def all_passed(self):
         if self.test_results == {}:


### PR DESCRIPTION
This PR contains the following code. The first item is the meat of the PR, and the later two are new functionality allowing us to validate that the data was produced correctly:

* **Ensure no duplicate transaction ids in cleaned `micropayment_device_transactions`**
  
  This resolves #647

* **Add test for table emptiness**
  
  Creates a new table test. This test is useful for validation of a general query for invalid data. The way to use it is to create a view that selects some invalid records. If that view materializes to an empty table (i.e., there are no invalid records) then the test passes. If the view materializes some non-empty records (i.e., there are invalid records), then the test fails. This is based off of similar concepts like DBT's [bespoke tests](https://docs.getdbt.com/docs/building-a-dbt-project/tests#bespoke-tests)
  
  Since the testing framework expects a list of fields, use the `check_empty` test like:

  ```yaml
  tests:
    check_empty:
      - "*"
  ```

* **Add a check for invalid micropayment_device_transaction rows**
  
  Currently this view materializes to `payments.invalid_cleaned_micropayment_device_transaction`s. We should create a new schema in BigQuery (something like `qa`) so that these validation views don't pollute the `payments` and other production schemas.