### PR TITLE
Add a payments_rides view

### DIFF
--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -1,0 +1,82 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.payments_rides"
+
+dependencies:
+  - payments_feeds
+
+external_dependencies:
+  - payments_views_staging: all
+
+tests:
+  check_unique:
+    - micropayment_id
+    - littlepay_transaction_id
+---
+
+WITH
+
+gtfs_routes_with_participant AS (
+    SELECT participant_id, route_id, route_short_name, route_long_name
+    FROM `gtfs_schedule.routes`
+    JOIN `views.payments_feeds` USING (calitp_itp_id, calitp_url_number)
+),
+
+initial_transactions AS (
+    SELECT *
+    FROM `payments.stg_cleaned_micropayment_device_transactions`
+    JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
+    JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)
+    WHERE transaction_type IN ('single', 'on')
+),
+
+second_transactions AS (
+    SELECT *
+    FROM `payments.stg_cleaned_micropayment_device_transactions`
+    JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
+    JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)
+    WHERE transaction_type = 'off'
+)
+
+SELECT
+    m.participant_id,
+    m.micropayment_id,
+    m.charge_type,
+    m.charge_amount,
+    m.nominal_amount,
+
+    -- Common transaction info
+    r.route_id,
+    r.route_long_name,
+    r.route_short_name,
+    t1.direction,
+    t1.vehicle_id,
+
+    -- Tap on or single transaction info
+    t1.littlepay_transaction_id,
+    t1.device_id,
+    t1.transaction_type,
+    t1.transaction_outcome,
+    t1.transaction_date_time_utc,
+    t1.transaction_date_time_pacific,
+    t1.location_id,
+    t1.location_name,
+    t1.latitude,
+    t1.longitude,
+
+    -- Tap off transaction info
+    t2.littlepay_transaction_id AS off_littlepay_transaction_id,
+    t2.device_id AS off_device_id,
+    t2.transaction_type AS off_transaction_type,
+    t2.transaction_outcome AS off_transaction_outcome,
+    t2.transaction_date_time_utc AS off_transaction_date_time_utc,
+    t2.transaction_date_time_pacific AS off_transaction_date_time_pacific,
+    t2.location_id AS off_location_id,
+    t2.location_name AS off_location_name,
+    t2.latitude AS off_latitude,
+    t2.longitude AS off_longitude
+
+FROM `payments.stg_cleaned_micropayments` AS m
+JOIN initial_transactions AS t1 USING (participant_id, micropayment_id)
+JOIN gtfs_routes_with_participant AS r USING (participant_id, route_id)
+LEFT JOIN second_transactions AS t2 USING (participant_id, micropayment_id)

--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -41,9 +41,9 @@ second_transactions AS (
 SELECT
     m.participant_id,
     m.micropayment_id,
-    m.charge_type,
     m.charge_amount,
     m.nominal_amount,
+    m.charge_type,
 
     -- Common transaction info
     t1.route_id,

--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -46,7 +46,7 @@ SELECT
     m.nominal_amount,
 
     -- Common transaction info
-    r.route_id,
+    t1.route_id,
     r.route_long_name,
     r.route_short_name,
     t1.direction,
@@ -78,5 +78,5 @@ SELECT
 
 FROM `payments.stg_cleaned_micropayments` AS m
 JOIN initial_transactions AS t1 USING (participant_id, micropayment_id)
-JOIN gtfs_routes_with_participant AS r USING (participant_id, route_id)
+LEFT JOIN gtfs_routes_with_participant AS r USING (participant_id, route_id)
 LEFT JOIN second_transactions AS t2 USING (participant_id, micropayment_id)

--- a/airflow/dags/payments_views_staging/stg_cleaned_device_transaction_types.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_device_transaction_types.sql
@@ -1,0 +1,73 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.stg_cleaned_device_transaction_types"
+
+dependencies:
+  - stg_cleaned_device_transactions
+  - stg_cleaned_micropayments
+  - stg_cleaned_micropayment_device_transactions
+
+tests:
+  check_unique:
+    - littlepay_transaction_id
+---
+
+WITH
+
+single_device_transaction_ids AS (
+    SELECT littlepay_transaction_id
+    FROM `payments.stg_cleaned_micropayments` AS m
+    JOIN `payments.stg_cleaned_micropayment_device_transactions` AS t USING (micropayment_id)
+    WHERE m.charge_type = 'flat_fare'
+),
+
+pending_device_transaction_ids AS (
+    SELECT littlepay_transaction_id
+    FROM `payments.stg_cleaned_micropayments` AS m
+    JOIN `payments.stg_cleaned_micropayment_device_transactions` AS mt USING (micropayment_id)
+    WHERE m.charge_type = 'pending_charge_fare'
+),
+
+potential_tap_on_or_off_micropayment_device_transaction_ids AS (
+    SELECT micropayment_id,
+           littlepay_transaction_id,
+           transaction_date_time_utc
+    FROM `payments.stg_cleaned_micropayments` m
+    JOIN `payments.stg_cleaned_micropayment_device_transactions` AS mt USING (micropayment_id)
+    JOIN `payments.stg_cleaned_device_transactions` AS t USING (littlepay_transaction_id)
+    WHERE m.charge_type = 'complete_variable_fare'
+),
+
+paired_device_transaction_ids AS (
+    SELECT t1.littlepay_transaction_id AS tap_on_littlepay_transaction_id,
+           t2.littlepay_transaction_id AS tap_off_littlepay_transaction_id
+    FROM potential_tap_on_or_off_micropayment_device_transaction_ids AS t1
+    JOIN potential_tap_on_or_off_micropayment_device_transaction_ids AS t2 USING (micropayment_id)
+    WHERE t1.transaction_date_time_utc < t2.transaction_date_time_utc
+)
+
+SELECT littlepay_transaction_id,
+       'single' AS transaction_type,
+       False AS pending
+FROM single_device_transaction_ids
+
+UNION ALL
+
+SELECT littlepay_transaction_id,
+       'on' AS transaction_type,
+       True AS pending
+FROM pending_device_transaction_ids
+
+UNION ALL
+
+SELECT tap_on_littlepay_transaction_id AS littlepay_transaction_id,
+       'on' AS transaction_type,
+       False AS pending
+FROM paired_device_transaction_ids
+
+UNION ALL
+
+SELECT tap_off_littlepay_transaction_id AS littlepay_transaction_id,
+       'off' AS transaction_type,
+       False AS pending
+FROM paired_device_transaction_ids

--- a/airflow/dags/payments_views_staging/stg_enriched_device_transactions.sql
+++ b/airflow/dags/payments_views_staging/stg_enriched_device_transactions.sql
@@ -7,12 +7,20 @@ external_dependencies:
   - payments_loader: all
 ---
 
-{{
+WITH
 
-  sql_enrich_duplicates(
-    "payments.device_transactions",
-    ["littlepay_transaction_id"],
-    ["calitp_file_name desc", "transaction_date_time_utc desc"]
-  )
+enriched AS (
+    {{
 
-}}
+      sql_enrich_duplicates(
+        "payments.device_transactions",
+        ["littlepay_transaction_id"],
+        ["calitp_file_name desc", "transaction_date_time_utc desc"]
+      )
+
+    }}
+)
+
+SELECT *,
+       DATETIME(TIMESTAMP(transaction_date_time_utc), "America/Los_Angeles") AS transaction_date_time_pacific,
+FROM enriched


### PR DESCRIPTION
This view is in service of #312. It consolidates information about each ride taken. Variable fare rides have information about the first tap as well as the second tap in separate fields prefixed with `off_`, whereas rides with a single tap simple have `null` values in all of the `off_` fields.