### PR TITLE
Add adjustment and product information to payments_rides

### DIFF
--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -44,6 +44,11 @@ SELECT
     m.charge_amount,
     m.nominal_amount,
     m.charge_type,
+    a.adjustment_id,
+    a.type AS adjustment_type,
+    a.time_period_type AS adjustment_time_period_type,
+    a.description AS adjustment_description,
+    a.amount AS adjustment_amount,
 
     -- Common transaction info
     t1.route_id,
@@ -80,3 +85,5 @@ FROM `payments.stg_cleaned_micropayments` AS m
 JOIN initial_transactions AS t1 USING (participant_id, micropayment_id)
 LEFT JOIN gtfs_routes_with_participant AS r USING (participant_id, route_id)
 LEFT JOIN second_transactions AS t2 USING (participant_id, micropayment_id)
+LEFT JOIN `payments.stg_cleaned_micropayment_adjustments` AS a USING (participant_id, micropayment_id)
+WHERE a.applied = True

--- a/airflow/dags/payments_views/validate_payments_ride_adjustments.sql
+++ b/airflow/dags/payments_views/validate_payments_ride_adjustments.sql
@@ -1,0 +1,26 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.invalid_payments_ride_adjustments"
+
+description: >
+  Make sure that all rides where the amount paid is not equal to the nominal
+  amount have adjustments, and rides where the amount paid is equal to the
+  nominal amount do not have adjustments.
+
+dependencies:
+  - payments_rides
+
+tests:
+  check_empty:
+    - "*"
+---
+
+SELECT * FROM views.payments_rides
+WHERE charge_amount <> nominal_amount
+AND adjustment_id IS NULL
+
+UNION ALL
+
+SELECT * FROM views.payments_rides
+WHERE charge_amount = nominal_amount
+AND adjustment_id IS NOT NULL

--- a/airflow/dags/payments_views/validate_payments_ride_counts.sql
+++ b/airflow/dags/payments_views/validate_payments_ride_counts.sql
@@ -1,0 +1,39 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.invalid_payments_ride_counts"
+
+description: >
+  Make sure that we did not lose any transactions while joining for the rides
+  table.
+
+dependencies:
+  - payments_rides
+
+tests:
+  check_empty:
+    - "*"
+---
+
+WITH
+
+payments_rides_counts AS (
+    SELECT 'on' AS type, COUNTIF(charge_type = 'complete_variable_fare') AS val FROM views.payments_rides UNION ALL
+    SELECT 'off' AS type, COUNTIF(charge_type = 'complete_variable_fare') AS val FROM views.payments_rides UNION ALL
+    SELECT 'pending' AS type, COUNTIF(charge_type = 'pending_charge_fare') AS val FROM views.payments_rides UNION ALL
+    SELECT 'single' AS type, COUNTIF(charge_type = 'flat_fare') AS val FROM views.payments_rides
+),
+
+device_transaction_types_counts AS (
+    SELECT 'on' AS type, COUNTIF(transaction_type = 'on' AND NOT pending) AS val FROM payments.stg_cleaned_device_transaction_types UNION ALL
+    SELECT 'off' AS type, COUNTIF(transaction_type = 'off') AS val FROM payments.stg_cleaned_device_transaction_types UNION ALL
+    SELECT 'pending' AS type, COUNTIF(transaction_type = 'on' AND pending) AS val FROM payments.stg_cleaned_device_transaction_types UNION ALL
+    SELECT 'single' AS type, COUNTIF(transaction_type = 'single') AS val FROM payments.stg_cleaned_device_transaction_types
+)
+
+SELECT
+    type AS transaction_type,
+    p.val AS payments_rides_count,
+    t.val AS device_transaction_types_count
+FROM payments_rides_counts AS p
+JOIN device_transaction_types_counts AS t USING (type)
+WHERE p.val <> t.val

--- a/airflow/dags/payments_views_staging/stg_cleaned_device_transaction_types.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_device_transaction_types.sql
@@ -17,7 +17,8 @@ WITH
 single_device_transaction_ids AS (
     SELECT littlepay_transaction_id
     FROM `payments.stg_cleaned_micropayments` AS m
-    JOIN `payments.stg_cleaned_micropayment_device_transactions` AS t USING (micropayment_id)
+    JOIN `payments.stg_cleaned_micropayment_device_transactions` AS mt USING (micropayment_id)
+    JOIN `payments.stg_cleaned_device_transactions` AS t USING (littlepay_transaction_id)
     WHERE m.charge_type = 'flat_fare'
 ),
 
@@ -25,6 +26,7 @@ pending_device_transaction_ids AS (
     SELECT littlepay_transaction_id
     FROM `payments.stg_cleaned_micropayments` AS m
     JOIN `payments.stg_cleaned_micropayment_device_transactions` AS mt USING (micropayment_id)
+    JOIN `payments.stg_cleaned_device_transactions` AS t USING (littlepay_transaction_id)
     WHERE m.charge_type = 'pending_charge_fare'
 ),
 

--- a/airflow/dags/payments_views_staging/stg_cleaned_micropayment_adjustments.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_micropayment_adjustments.sql
@@ -6,7 +6,7 @@ dependencies:
   - stg_enriched_micropayment_adjustments
 
 tests:
-  check_unique_together:
+  check_composite_unique:
     - micropayment_id
     - adjustment_id
 ---

--- a/airflow/dags/payments_views_staging/stg_cleaned_micropayment_adjustments.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_micropayment_adjustments.sql
@@ -1,0 +1,20 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.stg_cleaned_micropayment_adjustments"
+
+dependencies:
+  - stg_enriched_micropayment_adjustments
+
+tests:
+  check_unique_together:
+    - micropayment_id
+    - adjustment_id
+---
+
+select distinct * except (
+    calitp_file_name,
+    calitp_n_dupes,
+    calitp_n_dupe_ids,
+    calitp_dupe_number)
+from payments.stg_enriched_micropayment_adjustments
+where calitp_dupe_number = 1

--- a/airflow/dags/payments_views_staging/stg_cleaned_product_data.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_product_data.sql
@@ -1,0 +1,19 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.stg_cleaned_product_data"
+
+dependencies:
+  - stg_enriched_product_data
+
+tests:
+  check_unique:
+    - product_id
+---
+
+select distinct * except (
+    calitp_file_name,
+    calitp_n_dupes,
+    calitp_n_dupe_ids,
+    calitp_dupe_number)
+from payments.stg_enriched_product_data
+where calitp_dupe_number = 1

--- a/airflow/dags/payments_views_staging/stg_enriched_micropayment_adjustments.sql
+++ b/airflow/dags/payments_views_staging/stg_enriched_micropayment_adjustments.sql
@@ -10,7 +10,7 @@ external_dependencies:
 
   sql_enrich_duplicates(
     "payments.micropayment_adjustments",
-    ["adjustment_id"],
+    ["calitp_hash"],
     ["calitp_file_name desc"]
   )
 

--- a/airflow/dags/payments_views_staging/stg_enriched_product_data.sql
+++ b/airflow/dags/payments_views_staging/stg_enriched_product_data.sql
@@ -10,7 +10,7 @@ external_dependencies:
 
   sql_enrich_duplicates(
     "payments.product_data",
-    ["calitp_hash"],
+    ["product_id"],
     ["calitp_file_name desc"]
   )
 

--- a/airflow/dags/payments_views_staging/validate_cleaned_device_transaction_pairs_common_fields.sql
+++ b/airflow/dags/payments_views_staging/validate_cleaned_device_transaction_pairs_common_fields.sql
@@ -1,0 +1,72 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.invalid_cleaned_device_transaction_common_fields"
+
+description: >
+  Ensure that fields that are expected to be consistent across tap on/off
+  transactions are actually consistent. Invalid records are any that differ on
+  the device_id, device_id_issuer, route_id, mode, direction, of vehicle_id
+  fields.
+
+dependencies:
+  - stg_cleaned_device_transactions
+  - stg_cleaned_device_transaction_types
+  - stg_cleaned_micropayment_device_transactions
+
+tests:
+  check_empty:
+    - "*"
+---
+
+WITH
+
+initial_transactions AS (
+    SELECT *
+    FROM `payments.stg_cleaned_micropayment_device_transactions`
+    JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
+    JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)
+    WHERE transaction_type = 'on'
+),
+
+second_transactions AS (
+    SELECT *
+    FROM `payments.stg_cleaned_micropayment_device_transactions`
+    JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
+    JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)
+    WHERE transaction_type = 'off'
+)
+
+SELECT participant_id,
+       micropayment_id,
+       t1.littlepay_transaction_id AS littlepay_transaction_id_1,
+       t2.littlepay_transaction_id AS littlepay_transaction_id_2,
+       t1.customer_id AS customer_id_1,
+       t2.customer_id AS customer_id_2,
+       t1.device_id AS device_id_1,
+       t2.device_id AS device_id_2,
+       t1.device_id_issuer AS device_id_issuer_1,
+       t2.device_id_issuer AS device_id_issuer_2,
+       t1.route_id AS route_id_1,
+       t2.route_id AS route_id_2,
+       t1.mode AS mode_1,
+       t2.mode AS mode_2,
+       t1.direction AS direction_1,
+       t2.direction AS direction_2,
+       t1.vehicle_id AS vehicle_id_1,
+       t2.vehicle_id AS vehicle_id_2
+FROM initial_transactions AS t1
+JOIN second_transactions AS t2 USING (participant_id, micropayment_id)
+WHERE
+    -- (t1.customer_id <> t2.customer_id AND (t1.customer_id IS NOT NULL OR t2.customer_id IS NOT NULL))
+    -- OR
+    (t1.device_id <> t2.device_id AND (t1.device_id IS NOT NULL OR t2.device_id IS NOT NULL))
+    OR
+    (t1.device_id_issuer <> t2.device_id_issuer AND (t1.device_id_issuer IS NOT NULL OR t2.device_id_issuer IS NOT NULL))
+    OR
+    (t1.route_id <> t2.route_id AND (t1.route_id IS NOT NULL OR t2.route_id IS NOT NULL))
+    OR
+    (t1.mode <> t2.mode AND (t1.mode IS NOT NULL OR t2.mode IS NOT NULL))
+    OR
+    (t1.direction <> t2.direction AND (t1.direction IS NOT NULL OR t2.direction IS NOT NULL))
+    OR
+    (t1.vehicle_id <> t2.vehicle_id AND (t1.vehicle_id IS NOT NULL OR t2.vehicle_id IS NOT NULL))

--- a/airflow/dags/payments_views_staging/validate_cleaned_micropayment_adjustments_applied.sql
+++ b/airflow/dags/payments_views_staging/validate_cleaned_micropayment_adjustments_applied.sql
@@ -14,7 +14,7 @@ tests:
     - "*"
 ---
 
-SELECT micropayment_id, count(*)
+SELECT micropayment_id, count(*) AS num_applied_adjustments
 FROM payments.stg_cleaned_micropayment_adjustments
 WHERE applied IS True
 GROUP BY micropayment_id

--- a/airflow/dags/payments_views_staging/validate_cleaned_micropayment_adjustments_applied.sql
+++ b/airflow/dags/payments_views_staging/validate_cleaned_micropayment_adjustments_applied.sql
@@ -1,0 +1,22 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.invalid_cleaned_micropayment_adjustments_applied"
+
+description: >
+  Ensure that there is only one micropayment_adjustments record with applied
+  set to True for each micropayment.
+
+dependencies:
+  - stg_cleaned_micropayment_adjustments
+
+tests:
+  check_empty:
+    - "*"
+---
+
+SELECT micropayment_id, count(*)
+FROM payments.stg_cleaned_micropayment_adjustments
+WHERE applied IS True
+GROUP BY micropayment_id
+HAVING COUNT(*) > 1
+ORDER BY COUNT(*) desc


### PR DESCRIPTION
This would allow us to add to the [payments dashboard](https://metabase.k8s.calitp.jarv.us/dashboard/29) metrics such as number of riders hitting fare caps (#372).

Includes the following validations which should be added to the [payments validation dashboard](https://metabase.k8s.calitp.jarv.us/dashboard/28):
* **Ride adjustments:** Make sure that all rides where the amount paid is not equal to the nominal amount have adjustments, and rides where the amount paid is equal to the nominal amount do not have adjustments.
* **Ride counts:** Make sure that we did not lose any transactions while joining for the rides table.
* **Paired device transaction (tap on/off) common fields:** Ensure that fields that are expected to be consistent across tap on/off transactions are actually consistent. Invalid records are any that differ on the `device_id`, `device_id_issuer`, `route_id`, `mode`, `direction`, or `vehicle_id` fields.
  
  _NOTE: I'm not sure that `device_id` is appropriate in this set, as you could have a bus with a device in the front and back, or a train system where you tap on/off at the station rather than on the vehicle. Would those be different devices?_
* **Applied micropayment adjustments:** Ensure that there is only one micropayment_adjustments record with `applied` set to `True` for each micropayment.