### PR TITLE
Docs: add Google ID

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,3 +28,4 @@ html:
   use_issues_button: true
   use_repository_button: true
   use_edit_page_button: true
+  google_analytics_id: G-SZB618VNBZ


### PR DESCRIPTION
Porting the same ID from the `mkdocs` site