### PR TITLE
Pin pydata-sphinx-theme in publish-docs GitHub Action Workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,6 +23,9 @@ jobs:
         pip install -r airflow/requirements.txt
         pip install git+https://github.com/machow/siuba.git@stable
         pip install jupyter-book==0.12.0
+        # Temporary pinning of pydata-sphinx-theme to workaround Sphinx 4.3.0 error
+        # https://github.com/pydata/pydata-sphinx-theme/issues/508
+        pip install pydata-sphinx-theme==0.7.2
     - uses: google-github-actions/setup-gcloud@master
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
The previous version was having some problems with Sphinx 4.3.0 (see CI run here). The package depending on pydata-sphinx-theme hasn't updated their requirement of pydata-sphinx-theme to be above 0.6.x, so this pins the version to 0.7.2 (one that is compatible with Sphinx 4.3.0).