### PR TITLE
'How to Open Issues' screencast

### DIFF
--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -1,11 +1,11 @@
 (technical-onboarding)=
 # Technical Onboarding (WIP)
-:::{admonition} How to use this page
-:class: tip
 This page serves as a beginning entry-point into our Cal-ITP analytics resources for both new analysts and non-analyst team members.
 
 Below you can find links to the resources themselves, as well as relevant support documents.
 
+:::{admonition} How to use this page
+:class: tip
 **Analysts**
 * See below for an introduction to team meetings as well as our collaboration and analysis tools.
 * Privileges have already been created for you to access the resources below.
@@ -17,9 +17,11 @@ Below you can find links to the resources themselves, as well as relevant suppor
 :::
 
 **Meetings to Expect - Analysts:**
-Look out for these meetings to be added to your calendar. More information on them can be found [in the 'How We Work' section](meetings).
+Look out for these meetings to be added to your calendar.
 
-- [ ]  Week 1:  Analytics Introduction + Technical Onboarding
+More information on them can be found in the  ['How We Work' section](meetings).
+
+- [ ]  Week One:  Analytics Introduction + Technical Onboarding
 - [ ]  Weekly Data Services All-Hands
 - [ ]  Daily Stand-Ups
 - [ ]  Lunch & Learn

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -19,13 +19,14 @@ Below you can find links to the resources themselves, as well as relevant suppor
 **Meetings to Expect - Analysts:**
 Look out for these meetings to be added to your calendar.
 
-- [ ]  Week 1:  Technical Onboarding - Analytics Tools Introduction ([Docs](week-one-meeting))
+- [ ]  Week 1:  Analytics Introduction + Technical Onboarding ([Docs](week-one-meeting))
 - [ ]  Weekly Data Services All-Hands ([Docs](weekly-data-services))
 - [ ]  Daily Stand-Ups ([Docs](daily-stand-ups))
+- [ ]  Lunch & Learn | ([Docs](lunch-and-learn))
 
 **Collaboration Tools:**
 
-- [ ] [Cal-ITP Slack](https://cal-itp.slack.com)
+- [ ] [Cal-ITP Slack](https://cal-itp.slack.com) | ([Docs](slack-intro))
 - [ ] [GitHub Analytics Repo](https://github.com/cal-itp/data-analyses) ([Docs](analytics-repo))
 - [ ]  [GitHub Analyst Project Board](https://github.com/cal-itp/data-infra/projects/6) ([Docs](analytics-project-board))
 

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -19,10 +19,10 @@ Below you can find links to the resources themselves, as well as relevant suppor
 **Meetings to Expect - Analysts:**
 Look out for these meetings to be added to your calendar.
 
-- [ ]  Week 1:  Analytics Introduction + Technical Onboarding ([Docs](week-one-meeting))
-- [ ]  Weekly Data Services All-Hands ([Docs](weekly-data-services))
-- [ ]  Daily Stand-Ups ([Docs](daily-stand-ups))
-- [ ]  Lunch & Learn | ([Docs](lunch-and-learn))
+- [ ]  Week 1:  Analytics Introduction + Technical Onboarding ([Docs](meetings))
+- [ ]  Weekly Data Services All-Hands ([Docs](meetings))
+- [ ]  Daily Stand-Ups ([Docs](meetings))
+- [ ]  Lunch & Learn | ([Docs](meetings))
 
 **Collaboration Tools:**
 

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -17,12 +17,12 @@ Below you can find links to the resources themselves, as well as relevant suppor
 :::
 
 **Meetings to Expect - Analysts:**
-Look out for these meetings to be added to your calendar.
+Look out for these meetings to be added to your calendar. More information on them can be found [in the 'How We Work' section](meetings).
 
-- [ ]  Week 1:  Analytics Introduction + Technical Onboarding ([Docs](meetings))
-- [ ]  Weekly Data Services All-Hands ([Docs](meetings))
-- [ ]  Daily Stand-Ups ([Docs](meetings))
-- [ ]  Lunch & Learn | ([Docs](meetings))
+- [ ]  Week 1:  Analytics Introduction + Technical Onboarding
+- [ ]  Weekly Data Services All-Hands
+- [ ]  Daily Stand-Ups
+- [ ]  Lunch & Learn
 
 **Collaboration Tools:**
 

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -11,7 +11,7 @@ Below you can find links to the resources themselves, as well as relevant suppor
 * Privileges have already been created for you to access the resources below.
 
 **Non-Analyst Team Members**
-* You can access any of the tools below as well!
+* Any of the tools below are available to you as well!
 
 **If you still need help with access**, use the information at the bottom of this page to [get help](get-help).
 :::

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -1,21 +1,47 @@
 # How We Work (WIP)
+
 ## Meetings
-### Week 1
+
+### Existing Meetings
+
+#### Week 1
+
 (week-one-meeting)=
-#### Technical Onboarding - Analytics Tools Introduction
-### Recurring
+##### Analytics Introduction + Technical Onboarding (1 hour)
+
+#### Recurring
+
 (weekly-data-services)=
-#### Data Services All-Hands
+##### Data Services All-Hands (Weekly, 1 hour)
+
 (daily-stand-ups)=
-#### Daily Analyst Standups
+##### Analyst Standups (Tuesday - Friday, 15 minutes)
+
+(lunch-and-learn)=
+##### Lunch & Learn (Weekly, TBD)
+
+### Meeting Standards
+
+#### Meeting Preparation
+
+(slack-intro)=
 ## Communication Channels
+
 ### Discussion
+
 #### data-analysis
+
+#### data-office-hours
+
 ### Repo Notifications
+
 #### data-analysis-notify
+
 ## Collaboration Tools
+
 (analytics-repo)=
 ### Github Analytics Repo
+
 #### Using the data-analyses Repo
 A place for sharing quick reports, and works in progress
 * Clone the repository: `git clone https://github.com/cal-itp/[REPO_NAME].git`
@@ -30,13 +56,34 @@ This repository is for quick sharing of works in progress and simple analyses.
 For collaborative short-term tasks, create a new folder and work off a separate branch.
 
 For longer-term projects, consider making a new repository!
-## Introduction to Project Management
+
+## Introduction to Managing Work
+
 (analytics-project-board)=
 ### Analytics Project Board
-#### How to use
-#### Who should use?
-#### Stages
-#### Issue Templates
-#### What makes a good issue?
-#### Tags
-#### Assignees
+
+#### How to Use the Board
+
+##### Who should use it?
+
+##### Screencast - Navigating the Board
+The screencast below introduces:
+* Creating new GitHub issues to track your work
+* Adding your issues to our analytics project board
+* Viewing all of your issues on the board (e.g. clicking your avatar to filter)
+
+<div style="position: relative; padding-bottom: 62.5%; height: 0;"><iframe src="https://www.loom.com/embed/a7332ee2e1c040edbf2d11da70b4c3ea" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
+#### Writing Issues
+
+##### Issue Best Practices
+
+##### Issue Templates
+
+##### Assignees
+
+##### Tags
+
+##### Board Stages
+
+## Netiquette

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -39,32 +39,12 @@
 
 ## Collaboration Tools
 
-(analytics-repo)=
-### Github Analytics Repo
-
-#### Using the data-analyses Repo
-A place for sharing quick reports, and works in progress
-* Clone the repository: `git clone https://github.com/cal-itp/[REPO_NAME].git`
-* Make a new folder and code your analyses in it.
-* Make new branches or push directly to the main branch.
-    * Create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) (PAT) to successfully push to `origin/main`
-    * When pushing a commit to `origin`, use your PAT, instead of your password.
-    * To cache your token, use the [GitHub CLI or Git Credential Manager Core](https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git)
-
-This repository is for quick sharing of works in progress and simple analyses.
-
-For collaborative short-term tasks, create a new folder and work off a separate branch.
-
-For longer-term projects, consider making a new repository!
-
-## Introduction to Managing Work
-
 (analytics-project-board)=
-### Analytics Project Board
+### GitHub Analytics Project Board
 
-#### How to Use the Board
+#### How We Track Work
 
-##### Who should use it?
+##### Who should use the board?
 
 ##### Screencast - Navigating the Board
 The screencast below introduces:
@@ -85,5 +65,23 @@ The screencast below introduces:
 ##### Tags
 
 ##### Board Stages
+
+(analytics-repo)=
+### GitHub Analytics Repo
+
+#### Using the data-analyses Repo
+A place for sharing quick reports, and works in progress
+* Clone the repository: `git clone https://github.com/cal-itp/[REPO_NAME].git`
+* Make a new folder and code your analyses in it.
+* Make new branches or push directly to the main branch.
+    * Create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) (PAT) to successfully push to `origin/main`
+    * When pushing a commit to `origin`, use your PAT, instead of your password.
+    * To cache your token, use the [GitHub CLI or Git Credential Manager Core](https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git)
+
+This repository is for quick sharing of works in progress and simple analyses.
+
+For collaborative short-term tasks, create a new folder and work off a separate branch.
+
+For longer-term projects, consider making a new repository!
 
 ## Netiquette

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -5,10 +5,10 @@
 (meetings)=
 | Meeting | Cadence | Description |
 | -------- | -------- | -------- |
-| Analytics Introduction & Technical Onboarding | Once <br/> Week one, one hour | To ensure access to tools and go over best practices. |
-| Data Services All-Hands | Recurring <br/> Every Monday, 1 hour | A team-wide data services sync. |
-| Analyst Stand-ups | Recurring <br/> Tuesday - Friday, 15 minutes | A short sync to share yesterdays work, today's work, and any blockers. |
-| Lunch & Learn | Recurring <br/> Weekly, TBD | An opportunity to ask questions and share information with the team. |
+| Analytics Introduction & Technical Onboarding | Week One  <br/> One Hour | To ensure access to tools and go over best practices. |
+| Data Services All-Hands | Every Monday <br/> 1 Hour | A team-wide data services sync. |
+| Analyst Stand-ups | Recurring <br/> Every Tuesday - Friday <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
+| Lunch & Learn | Recurring <br/> Weekly <br/> TBD | An opportunity to ask questions and share information with the team. |
 
 ### Meeting Standards
 

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -2,32 +2,24 @@
 
 ## Meetings
 
-### Existing Meetings
-
-#### Week 1
-
 (meetings)=
-##### Analytics Introduction + Technical Onboarding (1 hour)
-
-#### Recurring
-
-(weekly-data-services)=
-##### Data Services All-Hands (Weekly, 1 hour)
-
-(daily-stand-ups)=
-##### Analyst Standups (Tuesday - Friday, 15 minutes)
-
-(lunch-and-learn)=
-##### Lunch & Learn (Weekly, TBD)
+| meeting | cadence | description |
+| -------- | -------- | -------- |
+| Analytics Introduction + Technical Onboarding | Once | Ensure access to tools, go over best practices. Week one, one hour. |
+| Data Services All-Hands | Recurring | Team-wide data services sync. Every Monday, 1 hour. |
+| Analyst Stand-ups | Recurring | A short sync to share yesterdays work, today's work, and any blockers. Tuesday - Friday, 15 minutes. |
+| Lunch & Learn | Recurring | An opportunity to ask questions and share information with the team. Weekly, TBD. |
 
 ### Meeting Standards
 
-#### Meeting Preparation
+#### Agendas
+
+#### Daily Stand-ups
 
 (slack-intro)=
 ## Communication Channels
 
-| channel | purpose | description
+| channel | purpose | description |
 | -------- | -------- | -------- |
 | #data-analysis | Discussion | For sharing and collaborating on Cal-ITP data analyses. |
 | #data-office-hours | Discussion | A place to bring questions, issues, and observations for team discussion. |

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -6,7 +6,7 @@
 
 #### Week 1
 
-(week-one-meeting)=
+(meetings)=
 ##### Analytics Introduction + Technical Onboarding (1 hour)
 
 #### Recurring
@@ -27,15 +27,11 @@
 (slack-intro)=
 ## Communication Channels
 
-### Discussion
-
-#### data-analysis
-
-#### data-office-hours
-
-### Repo Notifications
-
-#### data-analysis-notify
+| channel | purpose | description
+| -------- | -------- | -------- |
+| #data-analysis | Discussion | For sharing and collaborating on Cal-ITP data analyses. |
+| #data-office-hours | Discussion | A place to bring questions, issues, and observations for team discussion. |
+| #data-analysis-notify | Repo Notifications | A notifications channel for updates to the data-analyses repo. |
 
 ## Collaboration Tools
 

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -3,12 +3,12 @@
 ## Meetings
 
 (meetings)=
-| meeting | cadence | description |
+| Meeting | Cadence | Description |
 | -------- | -------- | -------- |
-| Analytics Introduction + Technical Onboarding | Once | Ensure access to tools, go over best practices. Week one, one hour. |
-| Data Services All-Hands | Recurring | Team-wide data services sync. Every Monday, 1 hour. |
-| Analyst Stand-ups | Recurring | A short sync to share yesterdays work, today's work, and any blockers. Tuesday - Friday, 15 minutes. |
-| Lunch & Learn | Recurring | An opportunity to ask questions and share information with the team. Weekly, TBD. |
+| Analytics Introduction & Technical Onboarding | Once <br/> Week one, one hour | To ensure access to tools and go over best practices. |
+| Data Services All-Hands | Recurring <br/> Every Monday, 1 hour | A team-wide data services sync. |
+| Analyst Stand-ups | Recurring <br/> Tuesday - Friday, 15 minutes | A short sync to share yesterdays work, today's work, and any blockers. |
+| Lunch & Learn | Recurring <br/> Weekly, TBD | An opportunity to ask questions and share information with the team. |
 
 ### Meeting Standards
 
@@ -19,11 +19,11 @@
 (slack-intro)=
 ## Communication Channels
 
-| channel | purpose | description |
+| Channel | Purpose | Description |
 | -------- | -------- | -------- |
 | #data-analysis | Discussion | For sharing and collaborating on Cal-ITP data analyses. |
 | #data-office-hours | Discussion | A place to bring questions, issues, and observations for team discussion. |
-| #data-analysis-notify | Repo Notifications | A notifications channel for updates to the data-analyses repo. |
+| #data-analysis-notify | Notifications | A notifications channel for updates to the data-analyses repo. |
 
 ## Collaboration Tools
 

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -7,8 +7,8 @@
 | -------- | -------- | -------- |
 | Analytics Introduction & Technical Onboarding | Week One  <br/> One Hour | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Every Monday <br/> 1 Hour | A team-wide data services sync. |
-| Analyst Stand-ups | Recurring <br/> Every Tuesday - Friday <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
-| Lunch & Learn | Recurring <br/> Weekly <br/> TBD | An opportunity to ask questions and share information with the team. |
+| Analyst Stand-ups | Every Tuesday - Friday <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
+| Lunch & Learn | Weekly <br/> TBD | An opportunity to ask questions and share information with the team. |
 
 ### Meeting Standards
 


### PR DESCRIPTION
**Added to 'How We Work' section:**
* Loom video on how to open issues in GitHub

_Other small changes in this PR in Docs_

**Added to:**
* 'How We Work' section:
  * Missing Slack channel: data-office-hours
  * Missing meeting: Lunch & Learn
  * 'Meeting standards' section (agendas, etc - can remove if not needed)
  * 'Netiquette' section (can remove if not needed)
* 'Technical Onboarding' Section:
  * Missing meeting: Lunch & Learn, w/ internal link
  * Missing Slack channel: data-office-hours, w/ internal link to Slack documentation

**Renamed (in both the above sections):**
* 'Week one meeting' name

**Edited for clarity:**
* H2s
* Headers within the GitHub section