### PR TITLE
Tolerate corrupted feeds

### DIFF
--- a/airflow/dags/gtfs_loader/calitp_files_process.py
+++ b/airflow/dags/gtfs_loader/calitp_files_process.py
@@ -11,26 +11,23 @@ Process and dump files for gtfs_schedule_history.calitp_files external table.
 This is for the files downloaded for an agency, as well as validator results.
 """
 
-from calitp import read_gcfs, save_to_gcfs
+import pandas as pd
+
+from calitp import save_to_gcfs
 from calitp.config import get_bucket
 from calitp.storage import get_fs
 
-import pandas as pd
+from utils import get_successfully_downloaded_feeds
 
 
 def main(execution_date, **kwargs):
-    # TODO: remove hard-coded project string
     fs = get_fs()
-
     bucket = get_bucket()
 
-    f = read_gcfs(f"schedule/{execution_date}/status.csv")
-    status = pd.read_csv(f)
-
-    success = status[lambda d: d.status == "success"]
+    successes = get_successfully_downloaded_feeds(execution_date)
 
     gtfs_file = []
-    for ii, row in success.iterrows():
+    for ii, row in successes.iterrows():
         agency_folder = f"{row.itp_id}_{row.url_number}"
         agency_url = f"{bucket}/schedule/{execution_date}/{agency_folder}"
 

--- a/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
+++ b/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
@@ -7,7 +7,7 @@
 
 import pandas as pd
 
-from calitp import get_table
+from calitp import get_table, save_to_gcfs
 from calitp.config import get_bucket
 from calitp.storage import get_fs
 
@@ -48,7 +48,14 @@ def main(execution_date, ti, **kwargs):
     print(f"Number of feeds being loaded: {df_latest_updates.shape[0]}")
 
     ttl_feeds_copied = 0
+    feed_tables_process_results = []
+    feed_process_resuls = []
     for k, row in df_latest_updates.iterrows():
+        # initialize variable to track whether a parsing error occurred and which tables
+        # were loaded so far
+        parse_error_encountered_in_this_feed = False
+        id_and_url = f"{row['itp_id']}_{row['url_number']}"
+
         # process and copy over tables into external table folder ----
         for table_file, is_required, colnames in table_details:
             # validation report handled in a separate task, since it is in a subfolder
@@ -56,7 +63,6 @@ def main(execution_date, ti, **kwargs):
             if table_file == constants.VALIDATION_REPORT:
                 continue
 
-            id_and_url = f"{row['itp_id']}_{row['url_number']}"
             src_path = "/".join(
                 ["schedule", str(execution_date), id_and_url, table_file]
             )
@@ -69,7 +75,7 @@ def main(execution_date, ti, **kwargs):
             if not is_required and not fs.exists(f"{bucket}/{src_path}"):
                 print(f"Skipping missing optional file: {src_path}")
             else:
-                _keep_columns(
+                parse_error_encountered = _keep_columns(
                     src_path,
                     dst_path,
                     colnames,
@@ -77,7 +83,45 @@ def main(execution_date, ti, **kwargs):
                     row["url_number"],
                     date_string,
                 )
+                if parse_error_encountered:
+                    print(
+                        f"Fatal parsing error encountered in {table_file} for id and "
+                        "URL: {id_and_url}."
+                    )
+                    parse_error_encountered_in_this_feed = True
+
+                feed_tables_process_results.append(
+                    {
+                        "calitp_itp_id": row["itp_id"],
+                        "calitp_url_number": row["url_number"],
+                        "calitp_extracted_at": execution_date.to_date_string(),
+                        "filename": table_file,
+                        "parse_error_encountered": parse_error_encountered,
+                    }
+                )
+
+        # note the parse result for this feed
+        feed_process_resuls.append(
+            {
+                "calitp_itp_id": row["itp_id"],
+                "calitp_url_number": row["url_number"],
+                "calitp_extracted_at": execution_date.to_date_string(),
+                "parse_error_encountered": parse_error_encountered_in_this_feed,
+            }
+        )
 
         ttl_feeds_copied += 1
 
         print("total feeds copied:", ttl_feeds_copied)
+
+    # save feed and feed table process results
+    save_to_gcfs(
+        pd.DataFrame(feed_process_resuls).to_csv(index=False).encode(),
+        f"schedule/{execution_date}/processed/feed_parse_result.csv",
+        use_pipe=True,
+    )
+    save_to_gcfs(
+        pd.DataFrame(feed_tables_process_results).to_csv(index=False).encode(),
+        f"schedule/{execution_date}/processed/feed_tables_parse_result.csv",
+        use_pipe=True,
+    )

--- a/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
+++ b/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
@@ -6,10 +6,10 @@
 # ---
 
 import pandas as pd
-
 from calitp import get_table, save_to_gcfs
 from calitp.config import get_bucket
 from calitp.storage import get_fs
+from pandas.errors import ParserError
 
 import constants
 from utils import _keep_columns
@@ -75,19 +75,22 @@ def main(execution_date, ti, **kwargs):
             if not is_required and not fs.exists(f"{bucket}/{src_path}"):
                 print(f"Skipping missing optional file: {src_path}")
             else:
-                parse_error_encountered = _keep_columns(
-                    src_path,
-                    dst_path,
-                    colnames,
-                    row["itp_id"],
-                    row["url_number"],
-                    date_string,
-                )
-                if parse_error_encountered:
+                parse_error_encountered = False
+                try:
+                    _keep_columns(
+                        src_path,
+                        dst_path,
+                        colnames,
+                        row["itp_id"],
+                        row["url_number"],
+                        date_string,
+                    )
+                except ParserError:
                     print(
                         f"Fatal parsing error encountered in {table_file} for id and "
                         "URL: {id_and_url}."
                     )
+                    parse_error_encountered = True
                     parse_error_encountered_in_this_feed = True
 
                 feed_tables_process_results.append(

--- a/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
+++ b/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
@@ -114,7 +114,7 @@ def main(execution_date, ti, **kwargs):
 
         print("total feeds copied:", ttl_feeds_copied)
 
-    # save feed and feed table process results
+    # save feed and feed table process results to external tables
     save_to_gcfs(
         pd.DataFrame(feed_process_resuls).to_csv(index=False).encode(),
         f"schedule/{execution_date}/processed/feed_parse_result.csv",

--- a/airflow/dags/gtfs_loader/gtfs_validation_history_load.py
+++ b/airflow/dags/gtfs_loader/gtfs_validation_history_load.py
@@ -1,0 +1,54 @@
+# ---
+# python_callable: main
+# provide_context: true
+# dependencies:
+#   - validation_report_process
+# ---
+
+from calitp.config import get_bucket
+from calitp.storage import get_fs
+
+import constants
+from utils import get_successfully_downloaded_feeds
+
+
+def main(execution_date, ti, **kwargs):
+    fs = get_fs()
+    bucket = get_bucket()
+    successes = get_successfully_downloaded_feeds(execution_date)
+
+    ttl_feeds_copied = 0
+    for k, row in successes.iterrows():
+        date_string = execution_date.to_date_string()
+
+        # only handle today's updated data (backfill dag to run all) ----
+
+        # copy processed validator results ----
+        id_and_url = f"{row['itp_id']}_{row['url_number']}"
+        src_validator = "/".join(
+            [
+                bucket,
+                "schedule",
+                str(execution_date),
+                id_and_url,
+                "processed",
+                constants.VALIDATION_REPORT,
+            ]
+        )
+        dst_validator = "/".join(
+            [
+                bucket,
+                "schedule",
+                "processed",
+                f"{date_string}_{id_and_url}",
+                constants.VALIDATION_REPORT,
+            ]
+        )
+
+        print(f"Copying from {src_validator} to {dst_validator}")
+
+        fs.copy(src_validator, dst_validator)
+
+        ttl_feeds_copied += 1
+
+    print("total feeds copied:", ttl_feeds_copied)

--- a/airflow/dags/gtfs_loader/valid_agency_paths.py
+++ b/airflow/dags/gtfs_loader/valid_agency_paths.py
@@ -9,6 +9,8 @@ from calitp import read_gcfs, save_to_gcfs
 import json
 import pandas as pd
 
+from utils import get_successfully_downloaded_feeds
+
 ERROR_MISSING_FILE = "missing_required_file"
 VALIDATION_FILE = "validation.json"
 
@@ -22,12 +24,11 @@ def main(execution_date, **kwargs):
     in_path = f"schedule/{execution_date}"
     print(in_path)
 
-    status = pd.read_csv(read_gcfs(f"{in_path}/status.csv"))
-    success = status[status.status == "success"]
+    successes = get_successfully_downloaded_feeds(execution_date)
 
     agency_errors = []
     loadable_agencies = []
-    for ii, row in success.iterrows():
+    for ii, row in successes.iterrows():
         path_agency = f"{in_path}/{row['itp_id']}_{row['url_number']}"
         path_validation = f"{path_agency}/{VALIDATION_FILE}"
 

--- a/airflow/dags/gtfs_loader/validation_report_process.py
+++ b/airflow/dags/gtfs_loader/validation_report_process.py
@@ -10,6 +10,8 @@ import json
 
 from calitp import save_to_gcfs, read_gcfs
 
+from utils import get_successfully_downloaded_feeds
+
 PANDAS_TYPES_TO_BIGQUERY = {"O": "STRING", "i": "INTEGER", "f": "NUMERIC"}
 
 COERCE_TO_STRING = {
@@ -50,16 +52,14 @@ def coerce_notice_values_to_str(raw_codes, str_fields):
 
 def validator_process(execution_date, **kwargs):
     base_path = f"schedule/{execution_date}"
-
-    status = pd.read_csv(read_gcfs(f"{base_path}/status.csv"))
-    success = status[lambda d: d.status == "success"]
+    successes = get_successfully_downloaded_feeds(execution_date)
 
     # hold on to notices, so we can infer schema after
     # note that I've commented out the code for inferring schema below,
     # but it was usefule for generating, then hand-tweaking to load
     # into bigquery
     # notice_entries = []
-    for k, row in success.iterrows():
+    for k, row in successes.iterrows():
         agency_path = f"{base_path}/{row['itp_id']}_{row['url_number']}"
         url = f"{agency_path}/validation.json"
         dst_path = f"{agency_path}/processed/validation_report.json"

--- a/airflow/dags/gtfs_schedule_history/calitp_feed_parse_result.yml
+++ b/airflow/dags/gtfs_schedule_history/calitp_feed_parse_result.yml
@@ -1,0 +1,14 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/*/processed/feed_parse_result.csv'
+destination_project_dataset_table: "gtfs_schedule_history.calitp_feed_parse_result"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+  - name: calitp_extracted_at
+    type: DATE
+  - name: parse_error_encountered
+    type: BOOL

--- a/airflow/dags/gtfs_schedule_history/calitp_feed_tables_parse_result.yml
+++ b/airflow/dags/gtfs_schedule_history/calitp_feed_tables_parse_result.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+source_objects:
+  - 'schedule/*/processed/feed_tables_parse_result.csv'
+destination_project_dataset_table: "gtfs_schedule_history.calitp_feed_tables_parse_result"
+skip_leading_rows: 1
+schema_fields:
+  - name: calitp_itp_id
+    type: INTEGER
+  - name: calitp_url_number
+    type: INTEGER
+  - name: calitp_extracted_at
+    type: DATE
+  - name: filename
+    type: STRING
+  - name: parse_error_encountered
+    type: BOOL

--- a/airflow/plugins/constants.py
+++ b/airflow/plugins/constants.py
@@ -1,0 +1,1 @@
+VALIDATION_REPORT = "validation_report.json"

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-from pandas.errors import EmptyDataError
 from calitp import read_gcfs, save_to_gcfs
+from pandas.errors import EmptyDataError
 
 
 def _keep_columns(
@@ -11,7 +11,7 @@ def _keep_columns(
     itp_id=None,
     url_number=None,
     extracted_at=None,
-    **kwargs
+    **kwargs,
 ):
 
     # read csv using object dtype, so pandas does not coerce data
@@ -48,3 +48,13 @@ def _keep_columns(
     csv_result = df_select.to_csv(index=False).encode()
 
     save_to_gcfs(csv_result, dst_path, use_pipe=True)
+
+
+def get_successfully_downloaded_feeds(execution_date):
+    """Get a list of feeds that were successfully downloaded (as noted in a
+    `schedule/{execution_date}/status.csv/` file) for a given execution date.
+    """
+    f = read_gcfs(f"schedule/{execution_date}/status.csv")
+    status = pd.read_csv(f)
+
+    return status[lambda d: d.status == "success"]


### PR DESCRIPTION
This PR works on the items mentioned in #694 and #695 by doing the following:

- Extracting the validation loading (copying to bucket acting as external table) out of gtfs_schedule_history_load
- Tolerating and tracking CSV parse errors that occur when loading a CSV file.

This PR hasn't yet percolated the parse error information into dim and fact tables (as recommended in #695) as it seeks to first resolve the matter of a DAG task failing completely due to a CSV parse error.