### PR TITLE
Technical onboarding tweaks

### DIFF
--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -16,21 +16,11 @@ Below you can find links to the resources themselves, as well as relevant suppor
 **If you still need help with access**, use the information at the bottom of this page to [get help](get-help).
 :::
 
-**Meetings to Expect - Analysts:**
-Look out for these meetings to be added to your calendar.
-
-More information on them can be found in the  ['How We Work' section](meetings).
-
-- [ ]  Week One:  Analytics Introduction & Technical Onboarding
-- [ ]  Weekly Data Services All-Hands
-- [ ]  Daily Stand-Ups
-- [ ]  Lunch & Learn
-
 **Collaboration Tools:**
 
-- [ ]  [Cal-ITP Slack](https://cal-itp.slack.com) | ([Docs](slack-intro))
-- [ ]  [GitHub Analytics Repo](https://github.com/cal-itp/data-analyses) | ([Docs](analytics-repo))
-- [ ]  [GitHub Analyst Project Board](https://github.com/cal-itp/data-infra/projects/6) | ([Docs](analytics-project-board))
+- [ ]  Cal-ITP [Slack](https://cal-itp.slack.com) | ([Docs](slack-intro))
+- [ ]  GitHub [Analytics Repo](https://github.com/cal-itp/data-analyses) | ([Docs](analytics-repo))
+- [ ]  GitHub [Analyst Project Board](https://github.com/cal-itp/data-infra/projects/6) | ([Docs](analytics-project-board))
 
 **Querying & Dashboards:**
 

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -18,13 +18,13 @@ Below you can find links to the resources themselves, as well as relevant suppor
 
 **Collaboration Tools:**
 
-- [ ]  Cal-ITP [Slack](https://cal-itp.slack.com) | ([Docs](slack-intro))
-- [ ]  GitHub [Analytics Repo](https://github.com/cal-itp/data-analyses) | ([Docs](analytics-repo))
-- [ ]  GitHub [Analyst Project Board](https://github.com/cal-itp/data-infra/projects/6) | ([Docs](analytics-project-board))
+- [ ]  [Slack](https://cal-itp.slack.com) | ([Docs](slack-intro))
+- [ ]  [Analytics Repo](https://github.com/cal-itp/data-analyses) | ([Docs](analytics-repo))
+- [ ]  [Analyst Project Board](https://github.com/cal-itp/data-infra/projects/6) | ([Docs](analytics-project-board))
 
 **Querying & Dashboards:**
 
-- [ ]  [Big Query](https://console.cloud.google.com/bigquery/): Querying the warehouse with SQL | ([Docs](big-query))
+- [ ]  [BigQuery](https://console.cloud.google.com/bigquery/): Querying the warehouse with SQL | ([Docs](big-query))
 - [ ]  [Metabase](https://dashboards.calitp.org/): Dashboards and Business Insights | ([Docs](metabase))
 
 **Python Users:**

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -31,7 +31,7 @@ Below you can find links to the resources themselves, as well as relevant suppor
 
 - [ ]  [JupyterHub](https://hubtest.k8s.calitp.jarv.us/): Cloud-based notebooks | ([Docs](jupyterhub))
 - [ ]  calitp-py: Cal-ITP's internal Python library | ([Docs](calitp))
-- [ ]  siuba: Cal-ITP recommended data analysis library | ([Docs](siuba))
+- [ ]  siuba: Recommended data analysis library | ([Docs](siuba))
 
 
 (get-help)=

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -1,22 +1,16 @@
 # How We Work (WIP)
-
 ## Team Meetings
-
 The section below outlines our team's primary meetings and their purposes, as well as our our team's shared meeting standards.
-
+(current-meetings)=
 ### Current Meetings
 **New analysts**, look out for these meetings to be added to your calendar.
-(meetings)=
 | Name | Cadence | Description |
 | -------- | -------- | -------- |
-| Analytics Introduction & Technical Onboarding | Week One  <br/> One Hour | To ensure access to tools and go over best practices. |
+| Technical Onboarding | Week One  <br/> 1 Hour | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
-| Analyst Stand-ups | Tues-Fri <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
-
+| Analyst Stand-ups | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
 ### Meeting Standards
-
 #### Agendas
-
 #### Daily Stand-ups
 
 (slack-intro)=

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -1,13 +1,13 @@
 # How We Work (WIP)
 
 ## Meetings
-
+New analysts - look out for these meetings to be added to your calendar.
 (meetings)=
-| Meeting | Cadence | Description |
+| Name | Cadence | Description |
 | -------- | -------- | -------- |
 | Analytics Introduction & Technical Onboarding | Week One  <br/> One Hour | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Every Monday <br/> 1 Hour | A team-wide data services sync. |
-| Analyst Stand-ups | Every Tuesday - Friday <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
+| Analyst Stand-ups | Every Tues - Fri <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
 | Lunch & Learn | Weekly <br/> TBD | An opportunity to ask questions and share information with the team. |
 
 ### Meeting Standards

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -1,6 +1,10 @@
 # How We Work (WIP)
 
-## Meetings
+## Team Meetings
+
+The section below outlines our team's primary meetings and their purposes, as well as our our team's shared meeting standards.
+
+### Current Meetings
 **New analysts**, look out for these meetings to be added to your calendar.
 (meetings)=
 | Name | Cadence | Description |
@@ -8,7 +12,6 @@
 | Analytics Introduction & Technical Onboarding | Week One  <br/> One Hour | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
 | Analyst Stand-ups | Tues-Fri <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
-| Lunch & Learn | Weekly <br/> TBD | An opportunity to ask questions and share information with the team. |
 
 ### Meeting Standards
 

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -1,13 +1,13 @@
 # How We Work (WIP)
 
 ## Meetings
-New analysts - look out for these meetings to be added to your calendar.
+**New analysts** - look out for these meetings to be added to your calendar.
 (meetings)=
 | Name | Cadence | Description |
 | -------- | -------- | -------- |
 | Analytics Introduction & Technical Onboarding | Week One  <br/> One Hour | To ensure access to tools and go over best practices. |
-| Data Services All-Hands | Every Monday <br/> 1 Hour | A team-wide data services sync. |
-| Analyst Stand-ups | Every Tues - Fri <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
+| Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
+| Analyst Stand-ups | Tues - Fri <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
 | Lunch & Learn | Weekly <br/> TBD | An opportunity to ask questions and share information with the team. |
 
 ### Meeting Standards

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -6,7 +6,7 @@ The section below outlines our team's primary meetings and their purposes, as we
 **New analysts**, look out for these meetings to be added to your calendar.
 | Name | Cadence | Description |
 | -------- | -------- | -------- |
-| Technical Onboarding | Week One  <br/> 1 Hour | To ensure access to tools and go over best practices. |
+| Technical Onboarding | Week 1 <br/> 1 Hour | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
 | Analyst Stand-ups | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
 ### Meeting Standards

--- a/docs/analytics_welcome/03_how_we_work.md
+++ b/docs/analytics_welcome/03_how_we_work.md
@@ -1,13 +1,13 @@
 # How We Work (WIP)
 
 ## Meetings
-**New analysts** - look out for these meetings to be added to your calendar.
+**New analysts**, look out for these meetings to be added to your calendar.
 (meetings)=
 | Name | Cadence | Description |
 | -------- | -------- | -------- |
 | Analytics Introduction & Technical Onboarding | Week One  <br/> One Hour | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
-| Analyst Stand-ups | Tues - Fri <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
+| Analyst Stand-ups | Tues-Fri <br/> 15 Minutes | A short sync to share yesterdays work, today's work, and any blockers. |
 | Lunch & Learn | Weekly <br/> TBD | An opportunity to ask questions and share information with the team. |
 
 ### Meeting Standards


### PR DESCRIPTION
* Removed meetings information from the technical onboarding overview page as it wasn't very technical, is covered in the page before, and made the page less concise
* Also tweaked how urls display in collaboration section
* Moved a message related to meetings from technical onboarding to the how we work page, tweaked wording of the meetings table
