### PR TITLE
Fix SLORTA GTFS URL

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1037,7 +1037,7 @@ san-juan-capistrano-free-weekend-trolley:
 san-luis-obispo-regional-transit-authority:
   agency_name: San Luis Obispo Regional Transit Authority
   feeds:
-    - gtfs_schedule_url: http://app.mecatran.com/urb/ws/feed/c2ZT1zbGcmFuc2O2NsaWVudD1zZWxmO2V4cGlyZ7dHlwZT1ndGZzO2tlezZTMwMzM1OTRiMTE2NzN2IxNjQwNjZjQwMGMzMzdiM2E1MT
+    - gtfs_schedule_url: http://slo.connexionz.net/rtt/public/resource/gtfs.zip
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null


### PR DESCRIPTION
The previous URL has been having download errors for multiple days. This new URL should be the correct one.