### PR TITLE
fix(payments): Escape regex parameters in formatted string

### DIFF
--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -86,11 +86,11 @@ def sql_enrich_duplicates(schema_tbl, key_columns, order_by_columns):
                 _FILE_NAME AS calitp_file_name,
                 REGEXP_EXTRACT(
                     _FILE_NAME,
-                    '.*/[0-9]{4}-[0-9]{2}-[0-9]{2}_(.*)_[0-9]{12}_.*'
+                    '.*/[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}_(.*)_[0-9]{{12}}_.*'
                 ) AS calitp_export_account,
                 PARSE_DATETIME(
                     '%Y%m%d%H%M',
-                    REGEXP_EXTRACT(_FILE_NAME, '.*_([0-9]{12})_.*')
+                    REGEXP_EXTRACT(_FILE_NAME, '.*_([0-9]{{12}})_.*')
                 ) AS calitp_export_datetime
             FROM {schema_tbl} T
         ),


### PR DESCRIPTION
It took me a while to figure out why the `calitp_export_account` and `calitp_export_datetime` fields were empty. Then I realized we were using curly braces inside of the regex, and the regex string was inside of a format string.

This issue is relevant to #617, as we need to know the export file for resolving the funding source IDs.