### PR TITLE
fix(reports): reports index was filtering those without feed info

### DIFF
--- a/airflow/dags/gtfs_views/reports_gtfs_schedule_index.sql
+++ b/airflow/dags/gtfs_views/reports_gtfs_schedule_index.sql
@@ -62,9 +62,13 @@ agency_feeds_on_end_date AS (
         , S.itp_id AS calitp_itp_id
         , S.url_number AS calitp_url_number
         , S.agency_name
+        , COALESCE(FI.has_feed_info, FALSE)
+            AS has_feed_info
     FROM `gtfs_schedule_history.calitp_status` S
     JOIN publish_dates_crnt PD ON
         S.calitp_extracted_at = PD.date_end
+    LEFT JOIN has_feed_info_end_date FI
+      USING(calitp_itp_id, calitp_url_number, publish_date)      
 )
 
 SELECT
@@ -75,9 +79,7 @@ SELECT
     , PD.date_start
     , PD.date_end
     , FI.has_feed_info
-    , (calitp_url_number = 0 AND FI.has_feed_info) AS use_for_report
+    , (calitp_url_number = 0 AND has_feed_info) AS use_for_report
 FROM agency_feeds_on_end_date AF
-JOIN has_feed_info_end_date FI
-    USING(calitp_itp_id, calitp_url_number, publish_date)
 JOIN publish_dates_crnt PD
   USING (publish_date)

--- a/airflow/dags/gtfs_views/reports_gtfs_schedule_index.sql
+++ b/airflow/dags/gtfs_views/reports_gtfs_schedule_index.sql
@@ -68,7 +68,9 @@ agency_feeds_on_end_date AS (
     JOIN publish_dates_crnt PD ON
         S.calitp_extracted_at = PD.date_end
     LEFT JOIN has_feed_info_end_date FI
-      USING(calitp_itp_id, calitp_url_number, publish_date)      
+      ON S.itp_id = FI.calitp_itp_id
+         AND S.url_number = FI.calitp_url_number
+         AND PD.publish_date = FI.publish_date
 )
 
 SELECT
@@ -78,7 +80,7 @@ SELECT
     , AF.agency_name
     , PD.date_start
     , PD.date_end
-    , FI.has_feed_info
+    , has_feed_info
     , (calitp_url_number = 0 AND has_feed_info) AS use_for_report
 FROM agency_feeds_on_end_date AF
 JOIN publish_dates_crnt PD


### PR DESCRIPTION
cc @holly-g . This PR fixes a minor issue in reports_gtfs_schedule_index. This table should record one row per agency gtfs feed that *could* be reported on in reports.calitp.org.

In addition it has the following columns:

* has_feed_info - does the feed have a feed_info.txt for the last day of the month being reported?
* use_for_report - should it be used to generate a report? This is true when a feed has url number = 0 and has feed info. (note that reports currently break if an agency does not have feed_info.txt, https://github.com/cal-itp/reports/issues/26#issuecomment-883630244)

Note that use_for_reports is referenced in this line of the reports repo: https://github.com/cal-itp/reports/blob/main/reports/1_generate_ids.py#L7

The issue is that this table was accidentally filtering out rows where not has_feed_info (by accidentally using a JOIN, rather than a LEFT JOIN). This means that reports were being generated as intended, but internal users could not tell why a potential report was marked as "should not generate".