### PR TITLE
clarify tools for writing geospatial data to GCS buckets by linking t…

### DIFF
--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -64,6 +64,8 @@ These are demonstrated in the screencast below.
 The code below shows how to copy a file from JupyterHub to the data bucket.
 Be sure to replace `<FILE NAME>` and `<ANALYSIS FOLDER>` with the appropriate names.
 
+For additional details, including options for reading/writing geospatial data using `geopandas`, see [](storing-new-data).
+
 ```python
 # Using the `calitp` package
 from calitp.storage import get_fs
@@ -84,10 +86,6 @@ df.to_csv("gs://calitp-analytics-data/data-analyses/<ANALYSIS FOLDER>/<FILE NAME
 # Parquet
 df = pd.read_parquet("gs://calitp-analytics-data/data-analyses/<ANALYSIS FOLDER>/<FILE NAME>")
 df.to_parquet("gs://calitp-analytics-data/data-analyses/<ANALYSIS FOLDER>/<FILE NAME>")
-
-# Geoparquet
-gdf = gpd.read_parquet("gs://calitp-analytics-data/data-analyses/<ANALYSIS FOLDER>/<FILE NAME>")
-gdf.to_parquet("gs://calitp-analytics-data/data-analyses/<ANALYSIS FOLDER>/<FILE NAME>")
 ```
 
 #### Uploading from google cloud storage


### PR DESCRIPTION
A small docs change to Introduction to Analytics Tools --> Notebooks to clarify that directly saving geoparquets to GCS buckets doesn't work for now, linking to the Storing New Data page which already has accurate and complete info for working with geospatial data.