### PR TITLE
feature(payments): Add ID dupe order for each ID in funding sources

### DIFF
--- a/airflow/dags/payments_views_staging/stg_enriched_customer_funding_source.sql
+++ b/airflow/dags/payments_views_staging/stg_enriched_customer_funding_source.sql
@@ -6,12 +6,44 @@ external_dependencies:
   - payments_loader: all
 ---
 
-{{
+WITH
 
-  sql_enrich_duplicates(
-    "payments.customer_funding_source",
-    ["funding_source_id"],
-    ["calitp_file_name desc"]
-  )
+core_enrichments AS (
+    {{
 
-}}
+      sql_enrich_duplicates(
+        "payments.customer_funding_source",
+        ["funding_source_id"],
+        ["calitp_file_name desc"]
+      )
+
+    }}
+),
+
+enrichments_with_ordered_ids AS (
+    SELECT
+        *,
+
+        COUNT(DISTINCT calitp_hash) OVER (
+            PARTITION BY funding_source_id, calitp_export_datetime) AS calitp_funding_source_id_ranking_size,
+        DENSE_RANK() OVER (
+            PARTITION BY funding_source_id
+            ORDER BY calitp_export_datetime DESC) AS calitp_funding_source_id_rank,
+
+        COUNT(DISTINCT calitp_hash) OVER (
+            PARTITION BY funding_source_vault_id, calitp_export_datetime) AS calitp_funding_source_vault_id_ranking_size,
+        DENSE_RANK() OVER (
+            PARTITION BY funding_source_vault_id
+            ORDER BY calitp_export_datetime DESC) AS calitp_funding_source_vault_id_rank,
+
+        COUNT(DISTINCT calitp_hash) OVER (
+            PARTITION BY customer_id, calitp_export_datetime) AS calitp_customer_id_ranking_size,
+        DENSE_RANK() OVER (
+            PARTITION BY customer_id
+            ORDER BY calitp_export_datetime DESC) AS calitp_customer_id_rank
+
+    FROM core_enrichments
+)
+
+SELECT *
+FROM enrichments_with_ordered_ids


### PR DESCRIPTION
This adds **6** fields to the enriched `customer_funding_source` table:
* calitp_funding_source_id_ranking_size
* calitp_funding_source_id_rank
* calitp_funding_source_vault_id_ranking_size
* calitp_funding_source_vault_id_rank
* calitp_customer_id_ranking_size
* calitp_customer_id_rank

For each of the `..._rank` fields, if the value is `1` then it is the latest occurrence of the corresponding ID. Instances are arranged in desc order by the export datetime.