### PR TITLE
Remove failing device transaction data test in payments pipeline

### DIFF
--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -102,7 +102,7 @@ SELECT
     p.product_type,
 
     -- Common transaction info
-    t1.route_id,
+    CASE WHEN t1.route_id <> 'Route Z' THEN t1.route_id ELSE COALESCE(t2.route_id, 'Route Z') END AS route_id,
     r.route_long_name,
     r.route_short_name,
     t1.direction,
@@ -134,7 +134,9 @@ SELECT
 
 FROM `payments.stg_cleaned_micropayments` AS m
 JOIN initial_transactions AS t1 USING (participant_id, micropayment_id)
-LEFT JOIN gtfs_routes_with_participant AS r USING (participant_id, route_id)
 LEFT JOIN second_transactions AS t2 USING (participant_id, micropayment_id)
 LEFT JOIN applied_adjustments AS a USING (participant_id, micropayment_id)
 LEFT JOIN `payments.stg_cleaned_product_data` AS p USING (participant_id, product_id)
+LEFT JOIN gtfs_routes_with_participant AS r
+    ON r.participant_id = m.participant_id
+    AND r.route_id = (CASE WHEN t1.route_id <> 'Route Z' THEN t1.route_id ELSE COALESCE(t2.route_id, 'Route Z') END)

--- a/airflow/dags/payments_views_staging/validate_cleaned_device_transaction_pairs_common_fields.sql
+++ b/airflow/dags/payments_views_staging/validate_cleaned_device_transaction_pairs_common_fields.sql
@@ -12,10 +12,6 @@ dependencies:
   - stg_cleaned_device_transactions
   - stg_cleaned_device_transaction_types
   - stg_cleaned_micropayment_device_transactions
-
-tests:
-  check_empty:
-    - "*"
 ---
 
 WITH
@@ -34,39 +30,46 @@ second_transactions AS (
     JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
     JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)
     WHERE transaction_type = 'off'
+),
+
+joined_transactions AS (
+    SELECT participant_id,
+           micropayment_id,
+           t1.littlepay_transaction_id AS littlepay_transaction_id_1,
+           t2.littlepay_transaction_id AS littlepay_transaction_id_2,
+           t1.customer_id AS customer_id_1,
+           t2.customer_id AS customer_id_2,
+           t1.device_id AS device_id_1,
+           t2.device_id AS device_id_2,
+           t1.device_id_issuer AS device_id_issuer_1,
+           t2.device_id_issuer AS device_id_issuer_2,
+           t1.route_id AS route_id_1,
+           t2.route_id AS route_id_2,
+           t1.mode AS mode_1,
+           t2.mode AS mode_2,
+           t1.direction AS direction_1,
+           t2.direction AS direction_2,
+           t1.vehicle_id AS vehicle_id_1,
+           t2.vehicle_id AS vehicle_id_2,
+
+           (t1.customer_id <> t2.customer_id AND (t1.customer_id IS NOT NULL OR t2.customer_id IS NOT NULL)) AS has_mismatched_customer_id,
+           (t1.device_id <> t2.device_id AND (t1.device_id IS NOT NULL OR t2.device_id IS NOT NULL)) AS has_mismatched_device_id,
+           (t1.device_id_issuer <> t2.device_id_issuer AND (t1.device_id_issuer IS NOT NULL OR t2.device_id_issuer IS NOT NULL)) AS has_mismatched_device_id_issuer,
+           (t1.route_id <> t2.route_id AND (t1.route_id IS NOT NULL OR t2.route_id IS NOT NULL)) AS has_mismatched_route_id,
+           (t1.mode <> t2.mode AND (t1.mode IS NOT NULL OR t2.mode IS NOT NULL)) AS has_mismatched_mode,
+           (t1.direction <> t2.direction AND (t1.direction IS NOT NULL OR t2.direction IS NOT NULL)) AS has_mismatched_direction,
+           (t1.vehicle_id <> t2.vehicle_id AND (t1.vehicle_id IS NOT NULL OR t2.vehicle_id IS NOT NULL)) AS has_mismatched_vehicle_id
+
+    FROM initial_transactions AS t1
+    JOIN second_transactions AS t2 USING (participant_id, micropayment_id)
 )
 
-SELECT participant_id,
-       micropayment_id,
-       t1.littlepay_transaction_id AS littlepay_transaction_id_1,
-       t2.littlepay_transaction_id AS littlepay_transaction_id_2,
-       t1.customer_id AS customer_id_1,
-       t2.customer_id AS customer_id_2,
-       t1.device_id AS device_id_1,
-       t2.device_id AS device_id_2,
-       t1.device_id_issuer AS device_id_issuer_1,
-       t2.device_id_issuer AS device_id_issuer_2,
-       t1.route_id AS route_id_1,
-       t2.route_id AS route_id_2,
-       t1.mode AS mode_1,
-       t2.mode AS mode_2,
-       t1.direction AS direction_1,
-       t2.direction AS direction_2,
-       t1.vehicle_id AS vehicle_id_1,
-       t2.vehicle_id AS vehicle_id_2
-FROM initial_transactions AS t1
-JOIN second_transactions AS t2 USING (participant_id, micropayment_id)
-WHERE
-    -- (t1.customer_id <> t2.customer_id AND (t1.customer_id IS NOT NULL OR t2.customer_id IS NOT NULL))
-    -- OR
-    (t1.device_id <> t2.device_id AND (t1.device_id IS NOT NULL OR t2.device_id IS NOT NULL))
-    OR
-    (t1.device_id_issuer <> t2.device_id_issuer AND (t1.device_id_issuer IS NOT NULL OR t2.device_id_issuer IS NOT NULL))
-    OR
-    (t1.route_id <> t2.route_id AND (t1.route_id IS NOT NULL OR t2.route_id IS NOT NULL))
-    OR
-    (t1.mode <> t2.mode AND (t1.mode IS NOT NULL OR t2.mode IS NOT NULL))
-    OR
-    (t1.direction <> t2.direction AND (t1.direction IS NOT NULL OR t2.direction IS NOT NULL))
-    OR
-    (t1.vehicle_id <> t2.vehicle_id AND (t1.vehicle_id IS NOT NULL OR t2.vehicle_id IS NOT NULL))
+SELECT *
+FROM joined_transactions
+WHERE has_mismatched_customer_id
+    OR has_mismatched_device_id
+    OR has_mismatched_device_id_issuer
+    OR has_mismatched_route_id
+    OR has_mismatched_mode
+    OR has_mismatched_direction
+    OR has_mismatched_vehicle_id


### PR DESCRIPTION
* **Update payments view to use non-'Route Z' route_id** - In cases where the route IDs don't match between tap on and off 
transactions, use the route ID that is not 'Route Z'
* **Remove test from validate transaction pairs task** - It is helpful to have the table with potentially invalid rows still generated, and we can set this table up in another platform to alert, but the data is currently a little unreliable to have failures hold up the rest of the pipeline. In particular, [this question](https://metabase.k8s.calitp.jarv.us/question/180-which-correlated-tap-on-and-off-transactions-have-differing-information) in Metabase can be set up with alerts for when there are any results in the table.

This PR resolves #796 