### PR TITLE
fix(gtfs-schedule): daily feed files view wrong interpolation

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
@@ -40,7 +40,7 @@ raw_daily_files AS (
         -- calculate the leading date, so we can fill in missing rows, where
         -- extraction failed to run.
         , LEAD(T1.calitp_extracted_at)
-            OVER (PARTITION BY T1.calitp_itp_id, T1.calitp_url_number ORDER BY T1.calitp_extracted_at)
+            OVER (PARTITION BY T1.calitp_itp_id, T1.calitp_url_number, T1.name ORDER BY T1.calitp_extracted_at)
             AS tmp_next_date
 
     FROM `gtfs_schedule_history.calitp_files_updates` T1

--- a/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
@@ -12,6 +12,11 @@ tests:
     - file_key
     - date
 
+description: |>
+  Each row of this table is a file extracted from a feed on a given day. Note that on days where
+  the extractor failed to download files for a feed, we interpolate by using the previous day's files.
+  This is tracked using the is_interpolated column.
+
 dependencies:
   - gtfs_schedule_dim_feeds
   - dim_date

--- a/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_fact_daily_feed_files.sql
@@ -12,7 +12,7 @@ tests:
     - file_key
     - date
 
-description: |>
+description: |
   Each row of this table is a file extracted from a feed on a given day. Note that on days where
   the extractor failed to download files for a feed, we interpolate by using the previous day's files.
   This is tracked using the is_interpolated column.


### PR DESCRIPTION
Our interpolation incorrectly did not partition on file name, so we ended up not correctly interpolating all previous files. Instead what happened is on days with interpolation a single file would show up.

I found a problematic case by running this  query:

```
SELECT * FROM `cal-itp-data-infra.views.gtfs_schedule_fact_daily_feed_files`
JOIN views.gtfs_schedule_dim_feeds USING (feed_key)

# switch date to "2021-05-24" note that it only interpolated the fare_attributes file
WHERE date="2021-05-23" AND calitp_itp_id=294
ORDER BY date
```

Then verified it works by adding this to the last line in the new full SQL in the task

```
WHERE date="2021-05-24" AND calitp_itp_id=294
```