### PR TITLE
refactor(airflow): upgrade to airflow v2

### DIFF
--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -60,7 +60,7 @@ jobs:
 
     # push to prod services when merging into main branch
     - name: Push agencies data to google cloud and prod services
-      if: ${{ github.repository == 'cal-itp/data-infra' && github.ref == 'refs/pull/851/merge' }}
+      if: ${{ github.repository == 'cal-itp/data-infra' && github.ref == 'refs/heads/main' }}
       run: |
         # replace agencies.yml with filled in template for gtfs rt extract service
         gsutil -m rsync -d -c -r airflow/dags gs://$AIRFLOW_BUCKET/dags

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -60,15 +60,16 @@ jobs:
 
     # push to prod services when merging into main branch
     - name: Push agencies data to google cloud and prod services
-      if: ${{ github.repository == 'cal-itp/data-infra' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.repository == 'cal-itp/data-infra' && github.ref == 'refs/pull/851/merge' }}
       run: |
-        gsutil -m rsync -d -c -r airflow/dags gs://us-west2-calitp-airflow-pro-332827a9-bucket/dags
-        gsutil -m rsync -d -c -r airflow/plugins gs://us-west2-calitp-airflow-pro-332827a9-bucket/plugins
-        gsutil -m rsync -d -c -r airflow/data gs://us-west2-calitp-airflow-pro-332827a9-bucket/data
-        # replace agencies.yml with filled in template for airflow
-        gsutil -m cp airflow/data/agencies.yml gs://us-west2-calitp-airflow-pro-332827a9-bucket/data/agencies_raw.yml
-        gsutil -m cp airflow/data/agencies.filled.yml gs://us-west2-calitp-airflow-pro-332827a9-bucket/data/agencies.yml
         # replace agencies.yml with filled in template for gtfs rt extract service
+        gsutil -m rsync -d -c -r airflow/dags gs://$AIRFLOW_BUCKET/dags
+        gsutil -m rsync -d -c -r airflow/plugins gs://$AIRFLOW_BUCKET/plugins
+        gsutil -m rsync -d -c -r airflow/data gs://$AIRFLOW_BUCKET/data
+        # replace agencies.yml with filled in template for airflow
+        gsutil -m cp airflow/data/agencies.yml gs://$AIRFLOW_BUCKET/data/agencies_raw.yml
+        gsutil -m cp airflow/data/agencies.filled.yml gs://$AIRFLOW_BUCKET/data/agencies.yml
+
         kubectl apply -f - <<EOF
         apiVersion: v1
         kind: Secret
@@ -79,6 +80,8 @@ jobs:
           data_agencies.yaml: $(base64 -w0 airflow/data/agencies.filled.yml)
         EOF
         kubectl -n gtfs-rt rollout restart deployments/gtfs-rt-archive
+      env:
+        AIRFLOW_BUCKET: "us-west2-calitp-airflow2-pr-171e4e47-bucket"
 
     # push to preprod services when merging to other branches
     - name: Push agencies data to preprod services

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:1.10.14
+FROM apache/airflow:2.1.4
 
 # install gcloud as root, then switch back to airflow
 USER root

--- a/airflow/dags/gtfs_views/METADATA.yml
+++ b/airflow/dags/gtfs_views/METADATA.yml
@@ -18,4 +18,4 @@ default_args:
     #sla: !timedelta 'hours: 2'
 wait_for_defaults:
     timeout: 3600
-latest_only: False
+latest_only: True

--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -1,6 +1,4 @@
 # flake8: noqa
-# TODO: after upgrading airflow, using a relative import raises the error
-# "attempted relative import with no known parent package"
 from operators.external_table import ExternalTable
 from operators.once_off_external_task_sensor import OnceOffExternalTaskSensor
 from operators.pod_operator import PodOperator

--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -1,9 +1,11 @@
 # flake8: noqa
-from .external_table import ExternalTable
-from .once_off_external_task_sensor import OnceOffExternalTaskSensor
-from .pod_operator import PodOperator
-from .python_taskflow_operator import PythonTaskflowOperator
-from .sql_to_warehouse_operator import SqlToWarehouseOperator
-from .csv_to_warehouse_operator import CsvToWarehouseOperator
-from .python_to_warehouse_operator import PythonToWarehouseOperator
-from .sql_query_operator import SqlQueryOperator
+# TODO: after upgrading airflow, using a relative import raises the error
+# "attempted relative import with no known parent package"
+from operators.external_table import ExternalTable
+from operators.once_off_external_task_sensor import OnceOffExternalTaskSensor
+from operators.pod_operator import PodOperator
+from operators.python_taskflow_operator import PythonTaskflowOperator
+from operators.sql_to_warehouse_operator import SqlToWarehouseOperator
+from operators.csv_to_warehouse_operator import CsvToWarehouseOperator
+from operators.python_to_warehouse_operator import PythonToWarehouseOperator
+from operators.sql_query_operator import SqlQueryOperator

--- a/airflow/plugins/operators/csv_to_warehouse_operator.py
+++ b/airflow/plugins/operators/csv_to_warehouse_operator.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pandas_gbq
 
 from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 
 from calitp import save_to_gcfs, to_snakecase
 from calitp.config import get_project_id
@@ -44,7 +43,6 @@ def csv_to_warehouse(src_uri, table_name, fields=None, dst_bucket_dir="csv"):
 class CsvToWarehouseOperator(BaseOperator):
     template_fields = ("src_uri", "table_name")
 
-    @apply_defaults
     def __init__(
         self, src_uri, table_name, fields=None, dst_bucket_dir="csv", *args, **kwargs
     ):

--- a/airflow/plugins/operators/once_off_external_task_sensor.py
+++ b/airflow/plugins/operators/once_off_external_task_sensor.py
@@ -1,4 +1,4 @@
-from airflow.sensors import ExternalTaskSensor
+from airflow.sensors.external_task_sensor import ExternalTaskSensor
 from airflow.utils.db import provide_session
 
 

--- a/airflow/plugins/operators/python_taskflow_operator.py
+++ b/airflow/plugins/operators/python_taskflow_operator.py
@@ -1,9 +1,7 @@
-from airflow.operators import PythonOperator
-from airflow.utils.decorators import apply_defaults
+from airflow.operators.python import PythonOperator
 
 
 class PythonTaskflowOperator(PythonOperator):
-    @apply_defaults
     def __init__(
         self,
         python_callable,

--- a/airflow/plugins/operators/python_to_warehouse_operator.py
+++ b/airflow/plugins/operators/python_to_warehouse_operator.py
@@ -1,6 +1,6 @@
 import inspect
 
-from airflow.operators import PythonOperator
+from airflow.operators.python import PythonOperator
 from calitp.config import format_table_name
 from calitp.sql import sql_patch_comments
 

--- a/airflow/plugins/operators/sql_query_operator.py
+++ b/airflow/plugins/operators/sql_query_operator.py
@@ -2,8 +2,6 @@
 # flake8: noqa
 
 from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
-
 from calitp import get_engine
 from sqlalchemy import sql
 
@@ -12,7 +10,6 @@ class SqlQueryOperator(BaseOperator):
 
     template_fields = ("sql",)
 
-    @apply_defaults
     def __init__(self, sql, **kwargs):
         super().__init__(**kwargs)
 


### PR DESCRIPTION
This PR makes some small tweaks to make our pipeline airflow v2 compatible. Note that because we are on airflow v1.10.14 (and not v1.10.15) AFAIK this code is not compatible with our current setup. We will need to push this to the new cluster, and once it's working, disable the original one.

TODO before ready:

- [x] : latest only operators failing (getting on call with Chris C to understand / resolve)
  * appears resolved. Chris has never seen this, and they started working. (may have been startup quirks?)
- [x] : it looks like in some cases tasks ran even when their upstream dependencies were waiting or failed? (couldn't reproduce)

TODO for release:

- [x] : update github action to push this code to the new cluster. get from https://github.com/cal-itp/data-infra/pull/784
- [x] : turn on sandbox and verify it works
- [x] : turn on loaders and verify they work
- [x] : before 8pm, pause all DAGs on old cluster, turn on gtfs_download (our only live data extractor)
- [x] : verify feeds downloaded
  * inspect download logs
  * glance at gtfs-data/schedule/<execution date>
  * query for agency.txt from gtfs_schedule_history.calitp_files_updates

(Note that gtfs_download is the only DAG to use xcom)