### PR TITLE
fix(gtfs-rt): parse internal ids to ints to match schema

### DIFF
--- a/airflow/dags/rt_loader_files/calitp_files_process.py
+++ b/airflow/dags/rt_loader_files/calitp_files_process.py
@@ -46,8 +46,8 @@ def main(execution_date, **kwargs):
 
     ser_id = raw_res["name"].str.split("/")
 
-    raw_res["calitp_itp_id"] = ser_id.str.get(-3)
-    raw_res["calitp_url_number"] = ser_id.str.get(-2)
+    raw_res["calitp_itp_id"] = int(ser_id.str.get(-3))
+    raw_res["calitp_url_number"] = int(ser_id.str.get(-2))
     raw_res["calitp_extracted_at"] = ser_id.str.get(-4)
 
     raw_res["full_path"] = raw_res["name"]


### PR DESCRIPTION
Pairing with @Nkdiaz -- the table schema has ids like calitp id as integers. however, the loader is loading strings. going to merge, since it's a pretty small change and will let us re-run / check everything