### PR TITLE
Add Tuolumne gtfs entry to agencies.yml

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1322,6 +1322,13 @@ tulare-county-area-transit:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 346
+tuolumne-transit:
+  agency_name: Tuolumne County Transit Agency
+  feeds:
+    - gtfs_schedule_url: https://drive.google.com/file/d/1qyFpp5A_DeMkVjSV-dANyLNCSFZ9b-Zx/view?usp=sharing
+      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_service_alerts_url: null
+      gtfs_rt_trip_updates_url: null
 turlock-transit:
   agency_name: Turlock Transit
   feeds:

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1329,7 +1329,7 @@ tuolumne-transit:
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
-  itp_id: 475
+  itp_id: 482
 turlock-transit:
   agency_name: Turlock Transit
   feeds:

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1329,6 +1329,7 @@ tuolumne-transit:
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
+  itp_id: 475
 turlock-transit:
   agency_name: Turlock Transit
   feeds:


### PR DESCRIPTION
In order to validate the new Tuolumne County Transit GTFS feed, it needs to be in the `agencies.yml` in our Airflow pipeline.

This entry currently points to a publicly accessible feed that is temporarily stored on Drive.  The end-goal is to have this stored on the Tuolumne website, but while that is in the words this should probably point to somewhere on GCS (@evansiroky and Team DS – this is your purview )