### PR TITLE
fix(gtfs-schedule): update validation type 2 dependencies

### DIFF
--- a/airflow/dags/gtfs_schedule_history2/validation_notices_load.sql
+++ b/airflow/dags/gtfs_schedule_history2/validation_notices_load.sql
@@ -1,8 +1,8 @@
 ---
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_schedule_type2.validation_notices"
-dependencies:
-  - gtfs_schedule_history_load
+external_dependencies:
+  - gtfs_loader: gtfs_validation_history_load
 ---
 
 WITH


### PR DESCRIPTION
Checked by confirming that the external task dependency was created (but did not run the DAG):

![image](https://user-images.githubusercontent.com/2574498/145889630-7554d863-4b59-436a-a9a3-44adafae0c04.png)

Note that if gusty can not find a task dependency, then it does not fail, but silently drops the dependency. This has bit us a couple times, so I've opened an issue!: https://github.com/chriscardillo/gusty/issues/38