### PR TITLE
Docs: close out analytics_tools/python_libraries 

### DIFF
--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -38,14 +38,14 @@ While most Python packages an analyst uses comes in JupyterHub, there may be add
 ## calitp
 `calitp` is an internal library of utility functions used to access our warehouse data.
 
-Most notably, you can use the following function to import a `tbl` from the warehouse:
+Most notably, you can import the following function at the top of your notebook to import a `tbl` from the warehouse:
 
 ```python
 from calitp.tables import tbl
 ```
 
 Example:
-```code-cell
+```{code-cell}
 from calitp.tables import tbl
 
 tbl.views.gtfs_schedule_fact_daily_feed_routes()

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -13,7 +13,7 @@ kernelspec:
   name: python3
 ---
 (python-libraries)=
-# Python Libraries (WIP)
+# Python Libraries
 The following libraries are available and recommended for use by Cal-ITP data analysts.
 
 ## Table of Contents

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -36,9 +36,24 @@ While most Python packages an analyst uses comes in JupyterHub, there may be add
 
 (calitp)=
 ## calitp
+`calitp` is an internal library of utility functions used to access our warehouse data.
+
+Most notably, you can use the following function to import a `tbl` from the warehouse:
+
+```python
+from calitp.tables import tbl
+```
+
+Example:
+```code-cell
+from calitp.tables import tbl
+
+tbl.views.gtfs_schedule_fact_daily_feed_routes()
+```
+
 (siuba)=
 ## siuba
-Siuba is a tool that allows the same analysis code to run on a pandas DataFrame,
+`siuba` is a tool that allows the same analysis code to run on a pandas DataFrame,
 as well as generate SQL for different databases.
 It supports most [pandas Series methods](https://pandas.pydata.org/pandas-docs/stable/reference/series.html) analysts use.
 See the [siuba docs](https://siuba.readthedocs.io) for more information.

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -38,7 +38,7 @@ While most Python packages an analyst uses comes in JupyterHub, there may be add
 ## calitp
 `calitp` is an internal library of utility functions used to access our warehouse data.
 
-Most notably, you can import the following function at the top of your notebook to import a `tbl` from the warehouse:
+Most notably, you can include the following function at the top of your notebook to import a `tbl` from the warehouse:
 
 ```python
 from calitp.tables import tbl


### PR DESCRIPTION
/analytics_tools/python_libraries 
- Add information for library `calitp`
- Removed 'WIP'