### PR TITLE
Fix regression causing data to not be loaded

### DIFF
--- a/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
+++ b/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py
@@ -40,7 +40,10 @@ def main(execution_date, ti, **kwargs):
         .convert_dtypes()
     )
 
-    table_details = zip(tables.file_name, tables.is_required, schemas)
+    # this zip needs to be converted to a list in order to be iterated through multiple
+    # times in an inner loop per each feed update below. This resolves a regression as
+    # described in https://github.com/cal-itp/data-infra/issues/848.
+    table_details = list(zip(tables.file_name, tables.is_required, schemas))
     fs = get_fs()
     bucket = get_bucket()
 


### PR DESCRIPTION
This fixes a regression created in 926fa255331d440a30b0031a189e0f542fd9fd3e that is now resulting in numerous feeds not being properly loaded in subsequent DAG tasks.

Since DAGs need to reran, I am saying this refs #848 and #849 instead of fixes them.