### PR TITLE
fix(docs): correct gtfs ckan readme link

### DIFF
--- a/docs/services/gtfs-ckan-uploader.md
+++ b/docs/services/gtfs-ckan-uploader.md
@@ -1,3 +1,3 @@
 # GTFS CKAN Uploader
 
-See readme in [services/gtfs-ckan-uploader](https://github.com/cal-itp/data-infra/tree/main/services/gtfs-rt-archive/README.md).
+See readme in [services/gtfs-ckan-uploader](https://github.com/cal-itp/data-infra/tree/main/services/gtfs-ckan-uploader/README.md).


### PR DESCRIPTION
Quick fix for a broken link in our docs (that I added a while ago 😬)