### PR TITLE
Update agencies.yml with latest RT URL info

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -138,9 +138,9 @@ beach-cities-transit:
   agency_name: Beach Cities Transit
   feeds:
     - gtfs_schedule_url: https://www.redondo.org/civicax/filebank/blobdload.aspx?BlobID=33555
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://redondobeachbct.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://redondobeachbct.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://redondobeachbct.com/gtfs-rt/tripupdates
   itp_id: 260
 bear-transit:
   agency_name: Bear Transit
@@ -442,13 +442,13 @@ emery-go-round:
   agency_name: Emery Go-Round
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/emerygoround-ca-us/emerygoround-ca-us.zip
+      gtfs_rt_vehicle_positions_url: https://egrshuttle.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://egrshuttle.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://egrshuttle.com/gtfs-rt/tripupdates
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=EM
       gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=EM
       gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
       gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=EM
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=EM
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
   itp_id: 106
 eureka-transit-service:
   agency_name: Eureka Transit Service
@@ -730,8 +730,8 @@ merced-the-bus:
   agency_name: Merced The Bus
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/mercedthebus-ca-us/mercedthebus-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
+      gtfs_rt_vehicle_positions_url: https://thebuslive.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://thebuslive.com/gtfs-rt/alerts
       gtfs_rt_trip_updates_url: null
   itp_id: 343
 metro:
@@ -910,9 +910,9 @@ presidigo:
   agency_name: PresidiGo
   feeds:
     - gtfs_schedule_url: https://presidiobus.com/gtfs
-      gtfs_rt_vehicle_positions_url: https://presidiobus.net/gtfs-rt/vehiclepositions
-      gtfs_rt_service_alerts_url: https://presidiobus.net/gtfs-rt/alerts
-      gtfs_rt_trip_updates_url: https://presidiobus.net/gtfs-rt/tripupdates
+      gtfs_rt_vehicle_positions_url: https://presidiobus.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://presidiobus.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://presidiobus.com/gtfs-rt/tripupdates
   itp_id: 257
 placer-county-transit:
   agency_name: Placer County Transit
@@ -998,9 +998,9 @@ sacramento-regional-transit-district:
   agency_name: Sacramento Regional Transit District
   feeds:
     - gtfs_schedule_url: http://iportal.sacrt.com/GTFS/SRTD/google_transit.zip
-      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_vehicle_positions_url: http://gtfsrt.sacrt.com/apps/gtfsrt/SRTD/vehiclepositions
       gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_trip_updates_url: http://gtfsrt.sacrt.com/apps/gtfsrt/SRTD/tripupdates
   itp_id: 273
 sage-stage:
   agency_name: Sage Stage
@@ -1170,9 +1170,9 @@ sonoma-marin-area-rail-transit:
   agency_name: Sonoma-Marin Area Rail Transit
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://mysmartbus.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://mysmartbus.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://mysmartbus.com/gtfs-rt/tripupdates
   itp_id: 315
 south-county-transit-link:
   agency_name: South County Transit Link
@@ -1342,9 +1342,9 @@ tulare-county-area-transit:
   agency_name: Tulare County Area Transit
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/tcat-flex-ca-us/tcat-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://tularetransit.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://tularetransit.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://tularetransit.com/gtfs-rt/tripupdates
   itp_id: 346
 tuolumne-transit:
   agency_name: Tuolumne County Transit Agency
@@ -1366,13 +1366,13 @@ union-city-transit:
   agency_name: Union City Transit
   feeds:
     - gtfs_schedule_url: https://data.trilliumtransit.com/gtfs/unioncity-ca-us/unioncity-ca-us.zip
+      gtfs_rt_vehicle_positions_url: https://uctransit.info/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://uctransit.info/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://uctransit.info/gtfs-rt/tripupdates
+    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=UC
       gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=UC
       gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
       gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=UC
-    - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=UC
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
   itp_id: 350
 unitrans:
   agency_name: Unitrans
@@ -1394,17 +1394,17 @@ ventura-county-transportation-commission:
   agency_name: Ventura County Transportation Commission
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/vctc-ca-us/vctc-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://govcbus.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://govcbus.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://govcbus.com/gtfs-rt/tripupdates
   itp_id: 380
 victor-valley-transit:
   agency_name: Victor Valley Transit
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/victorville-ca-us/victorville-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://ontime.vvta.org/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://ontime.vvta.org/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://ontime.vvta.org/gtfs-rt/tripupdates
   itp_id: 360
 vine-transit:
   agency_name: Vine Transit


### PR DESCRIPTION
This PR manually adds a bunch of RT URLs that were present in the transit database that didn't make their way into the agencies.yml file yet.