### PR TITLE
feat(gtfs-rt) SQL script to have airflow view for metabase

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
@@ -1,6 +1,15 @@
 ---
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "views.gtfs_rt_extraction_errors"
+
+description: |
+  TODO
+
+fields:
+  textPayload: TODO
+  timestamp: TODO
+  calitp_itp_id: Feed ITP ID.
+  calitp_url_number: Feed URL number.
 ---
 
 WITH

--- a/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
@@ -3,8 +3,8 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "views.gtfs_rt_extraction_errors"
 
 description: |
-Each row is a unique error message of a feed that failed to fetch the feed url used in agency.yml 
-  
+Each row is a unique error message of a feed that failed to fetch the feed url used in agency.yml
+
 
 fields:
   textPayload: error message that contains error severity, calitp id, Feed URL number, and feed file name that generated error

--- a/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
@@ -3,11 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "views.gtfs_rt_extraction_errors"
 
 description: |
-  TODO
+Each row is a unique error message of a feed that failed to fetch the feed url used in agency.yml 
+  
 
 fields:
-  textPayload: TODO
-  timestamp: TODO
+  textPayload: error message that contains error severity, calitp id, Feed URL number, and feed file name that generated error
+  timestamp: time and date of when error message was received,
   calitp_itp_id: Feed ITP ID.
   calitp_url_number: Feed URL number.
 ---

--- a/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
@@ -1,0 +1,25 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_rt_extraction_errors"
+---
+
+WITH
+download_issues AS (
+    SELECT
+        textPayload,
+        timestamp,
+        CAST(
+            REGEXP_EXTRACT(textPayload, "INFO:/gtfs-rt-archive.py:fetcher ([0-9]+)")
+            AS INT
+        ) AS calitp_itp_id,
+        CAST(
+            REGEXP_EXTRACT(textPayload, "INFO:/gtfs-rt-archive.py:fetcher [0-9]+/([0-9]+)")
+            AS INT
+        ) AS calitp_url_number
+    -- note that we've moved the logs to gtfs_rt_logs.stdout, since the table name can't be changed
+    -- but using this table for now, since it holds full data for Dec 14th
+    FROM `cal-itp-data-infra.gtfs_rt.stdout`
+    WHERE textPayload LIKE "%error fetching url%"
+)
+
+SELECT * FROM download_issues

--- a/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
@@ -27,8 +27,7 @@ download_issues AS (
             AS INT
         ) AS calitp_url_number
     -- note that we've moved the logs to gtfs_rt_logs.stdout, since the table name can't be changed
-    -- but using this table for now, since it holds full data for Dec 14th
-    FROM `cal-itp-data-infra.gtfs_rt.stdout`
+    FROM `cal-itp-data-infra.gtfs_rt_logs.stdout`
     WHERE textPayload LIKE "%error fetching url%"
 )
 

--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -47,11 +47,11 @@ broadly useful across the org should live in `views`.
 
 ### Extraction
 
-Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).
+Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).Within this service is some basic logging functionality that exports the logs to an external table 'std.out' that reads the data in this bucket.
 
 ### Logging
 
-All GTFS RT feed logs are loaded to Bigquery via a [Google Logger Router called `rt-extract-to-bigquery`](https://console.cloud.google.com/logs/router?project=cal-itp-data-infra). Note that this data is saved to its own dataset (`gtfs_rt_logs`), since routers do not allow table names to be customized.
+All GTFS RT feed logs are loaded directly to Bigquery via a [Google Logger Router called `rt-extract-to-bigquery`](https://console.cloud.google.com/logs/router?project=cal-itp-data-infra). Note that this data is saved to its own dataset (`gtfs_rt_logs`), since routers do not allow table names to be customized. Within `gtfs_rt_logs`, the data specific to URL feeds failing to download is stored in `stdout`.
 
 See [Google Cloud Log Router docs](https://cloud.google.com/logging/docs/routing/overview) for more information.
 The raw logs may be browsed in the [Logs Explorer](https://console.cloud.google.com/logs/query?project=cal-itp-data-infra).

--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -9,16 +9,17 @@ This data is processed and validated daily.
 | dataset | description |
 | ------- | ----------- |
 | `gtfs_rt` | Internal warehouse dataset for preparing GTFS RT views |
+| `gtfs_rt_logs` | Internal warehouse dataset for GTFS RT extraction logs |
 | `views.gtfs_rt_*` | User-friendly tables for analyzing GTFS RT data  |
 | `views.validation_rt_*` | User-friendly tables for analyzing GTFS RT validation data |
 
 ## View Tables
 
-Note that this data is still a work in progress, so no views have been created yet.
+Note that this data is still a work in progress, so many tables are still internal.
 
 | Tablename | Description | Notes |
 |----- | -------- | -------|
-| | | |
+| `gtfs_rt_extraction_errors` | Each feed per timepoint that failed to download. | Records go back to `2021-12-13`. |
 
 ## Internal Tables
 
@@ -46,7 +47,14 @@ broadly useful across the org should live in `views`.
 
 ### Extraction
 
-Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md). For Logs, we are using google cloud logger with a user-definited metric as a sink to output to BigQuery. The metric used is 'gtfs-rt-url-errors' and it filters for logName='stdout', namespace_name="gtfs-rt", and severity="INFO". Currently all the url-errors are treated as severity="INFO".The destination is bigquery and because the table names are not changable (gtfs_rt.stdout), they were put in their own dataset (gtfs_rt_logs).
+Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md). 
+
+### Logging
+
+All GTFS RT feed logs are loaded to Bigquery via a [Google Logger Router called `rt-extract-to-bigquery`](https://console.cloud.google.com/logs/router?project=cal-itp-data-infra). Note that this data is saved to its own dataset (`gtfs_rt_logs`), since routers do not allow table names to be customized.
+
+See [Google Cloud Log Router docs](https://cloud.google.com/logging/docs/routing/overview) for more information.
+The raw logs may be browsed in the [Logs Explorer](https://console.cloud.google.com/logs/query?project=cal-itp-data-infra).
 
 ### Validation
 

--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -47,7 +47,7 @@ broadly useful across the org should live in `views`.
 
 ### Extraction
 
-Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md). 
+Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).
 
 ### Logging
 

--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -46,7 +46,7 @@ broadly useful across the org should live in `views`.
 
 ### Extraction
 
-Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).
+Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md). For Logs, we are using google cloud logger with a user-definited metric as a sink to output to BigQuery. The metric used is 'gtfs-rt-url-errors' and it filters for logName='stdout', namespace_name="gtfs-rt", and severity="INFO". Currently all the url-errors are treated as severity="INFO".The destination is bigquery and because the table names are not changable (gtfs_rt.stdout), they were put in their own dataset (gtfs_rt_logs).
 
 ### Validation
 


### PR DESCRIPTION
Created a new table in BigQuery Views to visualize gtfs_extraction_errors from the cloud gtfs_rt_logs.std_out 
Gtfs_rt_Extraction_errors was added to cal-itp-data-infra sandbox, Then linked up Metabase to show the GTFS RT Extraction Errors by Day in metabase for easy visualization.  Rather than counts we decided to keep the raw rows so people could drilldown from summaries in metabase. We tested out two tables in metabase, Count of all errors by day (GTFS RT || Feed Extraction Errors by Day), and Count of distinct errors by day (GTFS RT || Distinct Feed Extraction Errors by Day)
@evansiroky it is worth mentioning that the urls might include the api keys which are in the URL. Not sure how you want to handle that. 