### PR TITLE
Misc Docs Fixes - Review Findings

### DIFF
--- a/docs/analytics_publishing/how_to_publish.md
+++ b/docs/analytics_publishing/how_to_publish.md
@@ -7,7 +7,7 @@ Analysts have a variety of tools available to publish their final deliverables. 
 * Is the deliverable format PDF, HTML, interactive dashboard, or a slide deck?
 
 Analysts can string together a combination of these solutions:
-* Static visualizations can be inserted direclty into the slide deck
+* Static visualizations can be inserted directly into the slide deck
 * HTML visualizations can be rendered in GitHub Pages and embedded as a URL into slide deck
 * Static, HTML reports can be rendered in GitHub Pages.
 * Reports can be rendered as PDFs and emailed to stakeholders.

--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -130,6 +130,6 @@ LIMIT 10
 (notebook-shortcuts)=
 ### Jupyter Notebook Best Practices
 
-External resources providing shortcuts and best practices:
+External resources:
 * [Cheat Sheet - Jupyter Notebook ](https://defkey.com/jupyter-notebook-shortcuts?pdf=true&modifiedDate=20200909T053706)
 * [Using Markdown in Jupyter Notebook](https://www.datacamp.com/community/tutorials/markdown-in-jupyter-notebook)

--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -15,6 +15,7 @@ Analyses on JupyterHub are done using notebooks, which allow users to mix narrat
 1. [Increasing the Query Limit](#increasing-the-query-limit)
 1. [Environment Variables](#environment-variables)
 1. [Querying with SQL in JupyterHub](querying-sql-jupyterhub)
+1. [Jupyter Notebook Best Practices](notebook-shortcuts)
 
 ## Using JupyterHub
 For Python users, we have deployed a cloud-based instance of JupyterHub to creating, using, and sharing notebooks easy.
@@ -125,3 +126,10 @@ WHERE
     calitp_feed_name = "AC Transit (0)"
 LIMIT 10
 ```
+
+(notebook-shortcuts)=
+### Jupyter Notebook Best Practices
+
+External resources providing shortcuts and best practices:
+* [Jupyter Notebook Cheat Sheet](https://defkey.com/jupyter-notebook-shortcuts?pdf=true&modifiedDate=20200909T053706)
+* [Markdown in Jupyter Notebook](https://www.datacamp.com/community/tutorials/markdown-in-jupyter-notebook)

--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -131,5 +131,5 @@ LIMIT 10
 ### Jupyter Notebook Best Practices
 
 External resources providing shortcuts and best practices:
-* [Jupyter Notebook Cheat Sheet](https://defkey.com/jupyter-notebook-shortcuts?pdf=true&modifiedDate=20200909T053706)
-* [Markdown in Jupyter Notebook](https://www.datacamp.com/community/tutorials/markdown-in-jupyter-notebook)
+* [Cheat Sheet - Jupyter Notebook ](https://defkey.com/jupyter-notebook-shortcuts?pdf=true&modifiedDate=20200909T053706)
+* [Using Markdown in Jupyter Notebook](https://www.datacamp.com/community/tutorials/markdown-in-jupyter-notebook)

--- a/docs/analytics_tools/overview.md
+++ b/docs/analytics_tools/overview.md
@@ -4,7 +4,7 @@ Welcome to the Analytics Tools section! If you're here, you're ready to begin co
 **What you should know after reading**:
 * [How to use our BI & dashboarding tool](metabase)
 * [How to use our cloud notebook](jupyterhub)
-* How to query the warehouse with SQL
+* [How to query the warehouse with SQL](querying-sql-jupyterhub)
 * [What Python libraries are suggested](python-libraries)
 * [Where code is kept](saving-code)
 * [How to store new data](storing-new-data), and [best practices](data-catalogs).

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -133,4 +133,4 @@ See [data-analyses/example_reports](https://github.com/cal-itp/data-analyses/tre
 ## pandas
 The library pandas is very commonly used in data analysis, and the external resources below provide a brief overview of it's use.
 
-* [pandas Cheat Sheet](https://pandas.pydata.org/Pandas_Cheat_Sheet.pdf)
+* [Cheat Sheet - pandas](https://pandas.pydata.org/Pandas_Cheat_Sheet.pdf)

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -121,7 +121,8 @@ make setup_env
 # In notebook:
 import shared_utils
 
-# Note: you may need to select 'Kernel' -> 'Restart Kernel' from the top menu in order to successfully `import shared_utils` after `make`
+# Note: you may need to select 'Kernel' -> 'Restart Kernel' from the top menu
+# in order to successfully `import shared_utils` after `make`
 
 shared_utils.geography_utils.WGS84
 ```

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -23,6 +23,7 @@ The following libraries are available and recommended for use by Cal-ITP data an
 <br> - [Basic Query](#basic-query)
 <br> - [Collect Query Results](#collect-query-results)
 <br> - [Show Query SQL](#show-query-sql)
+<br> - [More siuba Resources](more-siuba-resources)
 1. [shared utils](#shared-utils)
 1. [pandas](pandas-resources)
 
@@ -56,11 +57,7 @@ tbl.views.gtfs_schedule_fact_daily_feed_routes()
 ## siuba
 `siuba` is a tool that allows the same analysis code to run on a pandas DataFrame,
 as well as generate SQL for different databases.
-It supports most [pandas Series methods](https://pandas.pydata.org/pandas-docs/stable/reference/series.html) analysts use.
-
-siuba Resources:
-* [siuba docs](https://siuba.readthedocs.io)
-* ['Tidy Tuesday' live analyses with siuba](https://www.youtube.com/playlist?list=PLiQdjX20rXMHc43KqsdIowHI3ouFnP_Sf)
+It supports most [pandas Series methods](https://pandas.pydata.org/pandas-docs/stable/reference/series.html) analysts use. See the [siuba docs](https://siuba.readthedocs.io) for more information.
 
 The examples below go through the basics of using siuba, collecting a database query to a local DataFrame,
 and showing SQL test queries that siuba code generates.
@@ -107,6 +104,11 @@ While `collect()` fetches query results, `show_query()` prints out the SQL code 
 
 ```
 Note that here the pandas Series method `str.contains` corresponds to `regexp_contains` in Google BigQuery.
+
+(more-siuba-resources)=
+### More siuba Resources:
+* [siuba docs](https://siuba.readthedocs.io)
+* ['Tidy Tuesday' live analyses with siuba](https://www.youtube.com/playlist?list=PLiQdjX20rXMHc43KqsdIowHI3ouFnP_Sf)
 
 ## shared utils
 A set of shared utility functions can also be installed, similarly to any Python library. The [shared_utils](https://github.com/cal-itp/data-analyses/shared_utils) are stored here. Generalized functions for analysis are added as collaborative work evolves so we aren't constantly reinventing the wheel.

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -121,10 +121,10 @@ make setup_env
 # In notebook:
 import shared_utils
 
+shared_utils.geography_utils.WGS84
+
 # Note: you may need to select 'Kernel' -> 'Restart Kernel' from the top menu
 # in order to successfully `import shared_utils` after `make`
-
-shared_utils.geography_utils.WGS84
 ```
 
 See [data-analyses/example_reports](https://github.com/cal-itp/data-analyses/tree/main/example_report) for examples in how to use `shared_utils` for [general functions](https://github.com/cal-itp/data-analyses/blob/main/example_report/shared_utils_examples.ipynb), [charts](https://github.com/cal-itp/data-analyses/blob/main/example_report/example_charts.ipynb), and [maps](https://github.com/cal-itp/data-analyses/blob/main/example_report/example_maps.ipynb).

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -131,6 +131,6 @@ See [data-analyses/example_reports](https://github.com/cal-itp/data-analyses/tre
 
 (pandas-resources)=
 ## pandas
-pandas is a very commonly used library in data analysis, and the external resources below provide a brief overview of it's use.
+The library pandas is very commonly used in data analysis, and the external resources below provide a brief overview of it's use.
 
 * [pandas Cheat Sheet](https://pandas.pydata.org/Pandas_Cheat_Sheet.pdf)

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -125,8 +125,8 @@ import shared_utils
 
 shared_utils.geography_utils.WGS84
 
-# Note: you may need to select 'Kernel' -> 'Restart Kernel' from the top menu
-# in order to successfully `import shared_utils` after `make`
+# Note: you may need to select Kernel -> Restart Kernel from the top menu
+# after make setup_env in order to successfully import shared_utils
 ```
 
 See [data-analyses/example_reports](https://github.com/cal-itp/data-analyses/tree/main/example_report) for examples in how to use `shared_utils` for [general functions](https://github.com/cal-itp/data-analyses/blob/main/example_report/shared_utils_examples.ipynb), [charts](https://github.com/cal-itp/data-analyses/blob/main/example_report/example_charts.ipynb), and [maps](https://github.com/cal-itp/data-analyses/blob/main/example_report/example_maps.ipynb).

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -24,6 +24,7 @@ The following libraries are available and recommended for use by Cal-ITP data an
 <br> - [Collect Query Results](#collect-query-results)
 <br> - [Show Query SQL](#show-query-sql)
 1. [shared utils](#shared-utils)
+1. [pandas](pandas-resources)
 
 ## Add New Packages
 
@@ -56,7 +57,10 @@ tbl.views.gtfs_schedule_fact_daily_feed_routes()
 `siuba` is a tool that allows the same analysis code to run on a pandas DataFrame,
 as well as generate SQL for different databases.
 It supports most [pandas Series methods](https://pandas.pydata.org/pandas-docs/stable/reference/series.html) analysts use.
-See the [siuba docs](https://siuba.readthedocs.io) for more information.
+
+siuba Resources:
+* [siuba docs](https://siuba.readthedocs.io)
+* ['Tidy Tuesday' live analyses with siuba](https://www.youtube.com/playlist?list=PLiQdjX20rXMHc43KqsdIowHI3ouFnP_Sf)
 
 The examples below go through the basics of using siuba, collecting a database query to a local DataFrame,
 and showing SQL test queries that siuba code generates.
@@ -123,3 +127,9 @@ shared_utils.geography_utils.WGS84
 ```
 
 See [data-analyses/example_reports](https://github.com/cal-itp/data-analyses/tree/main/example_report) for examples in how to use `shared_utils` for [general functions](https://github.com/cal-itp/data-analyses/blob/main/example_report/shared_utils_examples.ipynb), [charts](https://github.com/cal-itp/data-analyses/blob/main/example_report/example_charts.ipynb), and [maps](https://github.com/cal-itp/data-analyses/blob/main/example_report/example_maps.ipynb).
+
+(pandas-resources)=
+## pandas
+pandas is a very commonly used library in data analysis, and the external resources below provide a brief overview of it's use.
+
+* [pandas Cheat Sheet](https://pandas.pydata.org/Pandas_Cheat_Sheet.pdf)

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -117,6 +117,8 @@ make setup_env
 # In notebook:
 import shared_utils
 
+# Note: you may need to select 'Kernel' -> 'Restart Kernel' from the top menu in order to successfully `import shared_utils` after `make`
+
 shared_utils.geography_utils.WGS84
 ```
 

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -30,7 +30,6 @@ We'll work through getting set up with GitHub on JupyterHub and cloning one GitH
 1. Clone the Git repo: `git clone git@github.com:cal-itp/data-analyses.git`
 1. Double check  with `ls` to list and see that the remote repo was successfully cloned into your "local" (cloud-based) filesystem.
 1. Change into the `data-analyses` directory: `cd data-analyses`
-1. Point to the remote repo: `git remote add origin git@github.com:cal-itp/data-analyses.git`. Double check it's set with: `git remote -v`
 1. Pull from the `main` branch and sync your remote and local repos: `git pull origin main`
 
 ### Project Workflow

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -12,6 +12,7 @@ Doing work locally and pushing directly from the command line is a similar workf
     * Someone is collaborating on my branch, how do we [stay in sync](#pulling-and-pushing-changes)?
     * The `main` branch is ahead, and I want to [sync my branch with `main`](rebase-and-merge)
     * [Helpful Hints](#helpful-hints)
+    * [External Git Resources](external-git-resources)
 2. [Pushing in the Github User Interface](#pushing-drag-drop)
 
 ## Pushing from JupyterHub
@@ -110,6 +111,7 @@ git reset --hard origin/main`
 * To delete a file that's been added in a previous commit: `git rm notebooks/my-notebook.ipynb`
 * Cherry pick a commit and apply it to your branch: `git cherry-pick COMMIT_HASH`. Read more from [Stack Overflow](https://stackoverflow.com/questions/9339429/what-does-cherry-picking-a-commit-with-git-mean) and [Atlassian](https://www.atlassian.com/git/tutorials/cherry-pick).
 
+(external-git-resources)=
 ### External Resources
 * [Git Terminal Cheat Sheet](https://gist.github.com/cferdinandi/ef665330286fd5d7127d)
 * [Git Decision Tree - 'So you have a mess on your hands'](http://justinhileman.info/article/git-pretty/full/)

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -110,6 +110,10 @@ git reset --hard origin/main`
 * To delete a file that's been added in a previous commit: `git rm notebooks/my-notebook.ipynb`
 * Cherry pick a commit and apply it to your branch: `git cherry-pick COMMIT_HASH`. Read more from [Stack Overflow](https://stackoverflow.com/questions/9339429/what-does-cherry-picking-a-commit-with-git-mean) and [Atlassian](https://www.atlassian.com/git/tutorials/cherry-pick).
 
+### External Resources
+* [Git Terminal Cheat Sheet](https://gist.github.com/cferdinandi/ef665330286fd5d7127d)
+* [Git Decision Tree - 'So you have a mess on your hands'](http://justinhileman.info/article/git-pretty/full/)
+
 (pushing-drag-drop)=
 ## Pushing in the Github User Interface
 

--- a/docs/analytics_welcome/how_we_work.md
+++ b/docs/analytics_welcome/how_we_work.md
@@ -11,6 +11,9 @@ The section below outlines our team's primary meetings and their purposes, as we
 | Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
 | Analyst Stand-ups | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
 | Lunch n' Learn | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. |
+
+Access recordings of previous Lunch n' Learns at this link.
+
 ### Meeting Standards
 #### Agendas
 #### Daily Stand-ups

--- a/docs/analytics_welcome/how_we_work.md
+++ b/docs/analytics_welcome/how_we_work.md
@@ -12,7 +12,7 @@ The section below outlines our team's primary meetings and their purposes, as we
 | Analyst Stand-ups | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
 | Lunch n' Learn | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. |
 
-Access recordings of previous Lunch n' Learns at this link.
+Access recordings of previous Lunch n' Learns [at this link](https://docs.google.com/spreadsheets/d/17rlex4h2OPKK3KwUY_lUZbA1avJ2o_PLyRD6w04iN0o/edit?usp=sharing).
 
 ### Meeting Standards
 #### Agendas

--- a/docs/analytics_welcome/how_we_work.md
+++ b/docs/analytics_welcome/how_we_work.md
@@ -10,7 +10,7 @@ The section below outlines our team's primary meetings and their purposes, as we
 | Technical Onboarding | Week 1 <br/> 40 Mins | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
 | Analyst Stand-ups | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
-| Lunch n' Learn | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. |
+| Lunch n' Learn | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/< Access **recordings of previous Lunch n' Learns** [at this link](https://docs.google.com/spreadsheets/d/17rlex4h2OPKK3KwUY_lUZbA1avJ2o_PLyRD6w04iN0o/edit?usp=sharing). |
 
 Access recordings of previous Lunch n' Learns [at this link](https://docs.google.com/spreadsheets/d/17rlex4h2OPKK3KwUY_lUZbA1avJ2o_PLyRD6w04iN0o/edit?usp=sharing).
 

--- a/docs/analytics_welcome/how_we_work.md
+++ b/docs/analytics_welcome/how_we_work.md
@@ -10,7 +10,7 @@ The section below outlines our team's primary meetings and their purposes, as we
 | Technical Onboarding | Week 1 <br/> 40 Mins | To ensure access to tools and go over best practices. |
 | Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
 | Analyst Stand-ups | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
-| Lunch n' Learn | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/< Access **recordings of previous Lunch n' Learns** [at this link](https://docs.google.com/spreadsheets/d/17rlex4h2OPKK3KwUY_lUZbA1avJ2o_PLyRD6w04iN0o/edit?usp=sharing). |
+| Lunch n' Learn | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/> Access **recordings of previous Lunch n' Learns** [at this link](https://docs.google.com/spreadsheets/d/17rlex4h2OPKK3KwUY_lUZbA1avJ2o_PLyRD6w04iN0o/edit?usp=sharing). |
 
 Access recordings of previous Lunch n' Learns [at this link](https://docs.google.com/spreadsheets/d/17rlex4h2OPKK3KwUY_lUZbA1avJ2o_PLyRD6w04iN0o/edit?usp=sharing).
 


### PR DESCRIPTION
This PR will include:

/analytics_welcome/how_we_work
* Adding link to past lunch n learn recordings

/analytics_tools/python_libraries
* _shared_utils: add that you may need to restart the kernel after making

/analytics_tools/welcome
* add URL to querying with SQL section in /analytics_tools/notebooks

/analytics_tools/saving_code:
* per  Laurie - "I think this line is unnecessary? At least for me it failed fatally and said that the remote origin was already set"
  * `git remote add origin git@github.com:cal-itp/data-analyses.git`
  * (Step 9)

/analytics_tools/notebooks
* Link to a resource on how to use the markdown cells or best practices (like being able to view 2 notebooks at once, re-arranging cells, splitting cells, etc)
* @amandaha8 found that "these little tricks were not so obvious to a beginner until people point them out, would have been great to know them earlier!"

/analytics_publishing/how_to_publish
* Typo
![image (1)](https://user-images.githubusercontent.com/25835059/147165909-39fa3146-a79f-4ed3-9239-2b6f9d9e9f8e.png)


For the Jupyter Hub part, maybe you can link to a resource on how to use the markdown cells or best practices (like being able to view 2 notebooks at once, re-arranging cells, splitting cells, etc).  I found that these little tricks were not so obvious to a beginner until people point them out, would have been great to know them earlier!

Misc:
* External tutorial documents related to
  * Pandas
  * Git
  * Siuba / Tidy Tuesday