### PR TITLE
feat(airflow): add examples of doc_md to sandbox

### DIFF
--- a/airflow/dags/sandbox/op_python_to_warehouse.py
+++ b/airflow/dags/sandbox/op_python_to_warehouse.py
@@ -4,6 +4,9 @@
 # fields:
 #   g: The g field python
 #   x: The x field python
+# doc_md: |
+#   This is an example of the PythonOperator.
+#
 # dependencies:
 #   - create_dataset
 # ---

--- a/airflow/dags/sandbox/op_sql_to_warehouse.sql
+++ b/airflow/dags/sandbox/op_sql_to_warehouse.sql
@@ -1,6 +1,9 @@
 ---
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "sandbox.sql_to_warehouse"
+description: "this is a table description"
+doc_md: |
+  This is a description that shows up in airflow.
 
 dependencies:
   - op_python_to_warehouse


### PR DESCRIPTION
This PR adds examples to two sandbox tasks, which show the use of airflow v2's doc_md argument. Resolves https://github.com/cal-itp/data-infra/issues/661.

This argument allows you to add documentation that is visible from the airflow UI. It is not the most prominent, but on the upside can be styled with lists, headers, etc..!

![image](https://user-images.githubusercontent.com/2574498/147508032-14e4db85-c457-4ee8-9e55-6d7fc2964fb1.png)
