### PR TITLE
Validate an hour of data across all feeds

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -56,6 +56,7 @@ docker-compose up
 ```
 
 To access the web UI, visit `http://localhost:8080`.
+The default login and password for airflow's image are both "airflow".
 
 To run a DAG, you can either test it via the web UI or run a one-off with:
 

--- a/airflow/dags/gtfs_loader/calitp_feed_latest.sql
+++ b/airflow/dags/gtfs_loader/calitp_feed_latest.sql
@@ -2,13 +2,11 @@
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_schedule_history.calitp_feed_latest"
 dependencies:
-  - calitp_feed_updates
+  - calitp_feed_status
 
 ---
 
 SELECT
-    calitp_itp_id
-    , calitp_url_number
-    , MAX(calitp_extracted_at) as calitp_extracted_at
-FROM `{{ "gtfs_schedule_history.calitp_feed_updates" | table }}`
-GROUP BY 1, 2
+    *
+FROM `gtfs_schedule_history.calitp_feed_status`
+WHERE is_latest_load

--- a/airflow/dags/gtfs_loader/calitp_feed_status.sql
+++ b/airflow/dags/gtfs_loader/calitp_feed_status.sql
@@ -1,0 +1,114 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_schedule_history.calitp_feed_status"
+
+description: |
+  Report the status of each feed in agencies.yml every day extraction was run
+  across all time.
+
+fields:
+  calitp_itp_id: Internal feed itp id.
+  calitp_url_number: Internal feed URL number.
+  is_feed_updated: Whether the feed was updated (i.e. any loadable file was changed).
+  is_extract_success: Whether the feed downloaded successfully.
+  is_parse_error: |
+    Whether the feed errored on parse. Note that the pipeline only attempts to parse
+    updated feeds.
+  crnt_is_feed_exists: Whether the feed exists in the latest agencies.yml file.
+  is_latest_load: |
+    Whether this is the latest feed data loaded. Note that latest feeds must have been
+    extracted, parsed, and currently exist in agencies.yml.
+
+dependencies:
+  - gtfs_schedule_history_load
+  - calitp_status_load
+---
+
+WITH
+
+renamed_status AS (
+
+    -- prefix calitp to internal id columns, for easy joining
+
+    SELECT
+        itp_id AS calitp_itp_id,
+        url_number as calitp_url_number,
+        calitp_extracted_at,
+        status,
+        calitp_extracted_at = MAX(calitp_extracted_at) OVER () AS is_latest
+    FROM gtfs_schedule_history.calitp_status
+
+),
+
+current_feeds AS (
+
+    -- the latest feeds in agencies.yml
+
+    SELECT DISTINCT calitp_itp_id, calitp_url_number
+    FROM renamed_status
+    WHERE is_latest
+),
+
+
+feed_status AS (
+
+    -- join in whether there was a parse error, and whether a feed was updated
+
+    SELECT
+        renamed_status.calitp_itp_id,
+        renamed_status.calitp_url_number,
+        renamed_status.calitp_extracted_at,
+        renamed_status.status = "success"
+            AS is_extract_success,
+
+        -- detect whether there is an entry in calitp_feed_updates
+        feed_updates.calitp_itp_id IS NOT NULL
+            AS is_feed_updated,
+
+
+        -- detect whether there is a True parse error in feed_parse_result
+        COALESCE(feed_parse_result.parse_error_encountered, false)
+            AS is_parse_error,
+
+        -- detect whether feed currently exists (i.e. in agencies.yml)
+        current_feeds.calitp_itp_id IS NOT NULL
+            AS crnt_is_feed_exists
+
+    FROM renamed_status
+    LEFT JOIN gtfs_schedule_history.calitp_feed_updates AS feed_updates
+        USING (calitp_itp_id, calitp_url_number, calitp_extracted_at)
+    LEFT JOIN gtfs_schedule_history.calitp_feed_parse_result AS feed_parse_result
+        USING (calitp_itp_id, calitp_url_number, calitp_extracted_at)
+    LEFT JOIN current_feeds
+        USING (calitp_itp_id, calitp_url_number)
+
+),
+
+feed_status_latest AS (
+
+    -- calculate latest feed that was extracted, parsed, and exists in the current agencies.yml
+
+    SELECT
+        -- grouping cols
+        calitp_itp_id,
+        calitp_url_number,
+
+        -- aggregates
+        MAX(calitp_extracted_at) AS calitp_extracted_at,
+        true AS is_latest_load
+    FROM feed_status
+    WHERE
+        is_extract_success
+        AND NOT is_parse_error
+        AND crnt_is_feed_exists
+        AND is_feed_updated
+    GROUP BY 1, 2
+
+)
+
+SELECT
+    feed_status.*,
+    COALESCE(feed_status_latest.is_latest_load, false) AS is_latest_load
+FROM feed_status
+LEFT JOIN feed_status_latest
+    USING (calitp_itp_id, calitp_url_number, calitp_extracted_at)

--- a/airflow/dags/gtfs_loader/gtfs_schedule_tables_load.py
+++ b/airflow/dags/gtfs_loader/gtfs_schedule_tables_load.py
@@ -1,29 +1,44 @@
 # ---
 # python_callable: main
 # dependencies:
-#   - calitp_feed_latest
+#   - calitp_feed_status
 #   - gtfs_schedule_history_load
 # ---
 
 from sqlalchemy import sql
-from calitp import get_table, write_table
+from calitp import get_table, query_sql, write_table
 from calitp.config import get_bucket
+from calitp.storage import get_fs
 
 GTFS_DATA_PATH = "{bucket}/schedule/processed/{extracted_at}_{itp_id}_{url_number}"
 
+QUERY_LATEST_TABLES = """
+SELECT calitp_itp_id, calitp_url_number, calitp_extracted_at
+FROM gtfs_schedule_history.calitp_feed_status
+WHERE is_latest_load
+"""
+
 
 def main():
+    fs = get_fs()
 
     df_loading = get_table(
         "gtfs_schedule_history.calitp_included_gtfs_tables", as_df=True
     )
 
     data_paths = (
-        get_table("gtfs_schedule_history.calitp_feed_latest", as_df=True)
+        query_sql(QUERY_LATEST_TABLES, as_df=True)
         .rename(columns=lambda s: s.replace("calitp_", ""))
         .apply(lambda d: GTFS_DATA_PATH.format(bucket=get_bucket(), **d), axis=1)
         .tolist()
     )
+
+    # double check that no paths we are attempting to load are missing from
+    # schedule/processed. Since the validation results are also put there for
+    # each feed daily, we look for a specific file: routes.txt.
+    missing_paths = list(filter(lambda p: not fs.exists(f"{p}/routes.txt"), data_paths))
+    if missing_paths:
+        raise Exception("Missing processed data for loading: %s" % missing_paths)
 
     for _, (tbl_name, tbl_file) in df_loading[["table_name", "file_name"]].iterrows():
         file_paths = [f"{path}/{tbl_file}" for path in data_paths]

--- a/airflow/dags/rt_loader/create_validation_params.py
+++ b/airflow/dags/rt_loader/create_validation_params.py
@@ -32,7 +32,9 @@ def main(execution_date, **kwargs):
     # Note that raw RT data is currently stored in the production bucket,
     # and not copied to the staging bucket
     prefix_path_schedule = f"{get_bucket()}/schedule/{execution_date}"
-    prefix_path_rt = f"gtfs-data/rt/{date_string}T00:00:*"
+
+    # This prefix limits the validation to only 1 hour of data currently
+    prefix_path_rt = f"gtfs-data/rt/{date_string}T00:*"
 
     params = raw_params.assign(
         gtfs_schedule_path=lambda d: prefix_path_schedule
@@ -48,8 +50,8 @@ def main(execution_date, **kwargs):
         + "/*",
     )
 
+    path = f"rt-processed/calitp_validation_params/{date_string}.csv"
+    print(f"saving {params.shape[0]} validation params to {path}")
     save_to_gcfs(
-        params.to_csv(index=False).encode(),
-        f"rt-processed/calitp_validation_params/{date_string}.csv",
-        use_pipe=True,
+        params.to_csv(index=False).encode(), path, use_pipe=True,
     )

--- a/airflow/dags/rt_loader/create_validation_params.py
+++ b/airflow/dags/rt_loader/create_validation_params.py
@@ -1,0 +1,55 @@
+# ---
+# python_callable: main
+# provide_context: true
+# dependencies:
+#   - external_calitp_validation_params
+# external_dependencies:
+#   - gtfs_loader: calitp_feed_status
+# ---
+
+from calitp import query_sql, save_to_gcfs
+from calitp.config import get_bucket
+
+
+def main(execution_date, **kwargs):
+    date_string = execution_date.to_date_string()
+
+    raw_params = query_sql(
+        f"""
+        SELECT
+            calitp_itp_id,
+            calitp_url_number,
+            calitp_extracted_at
+        FROM gtfs_schedule_history.calitp_feed_status
+        WHERE
+            is_extract_success
+            AND NOT is_parse_error
+            AND calitp_extracted_at = "{date_string}"
+        """,
+        as_df=True,
+    )
+
+    # Note that raw RT data is currently stored in the production bucket,
+    # and not copied to the staging bucket
+    prefix_path_schedule = f"{get_bucket()}/schedule/{execution_date}"
+    prefix_path_rt = f"gtfs-data/rt/{date_string}T00:00:*"
+
+    params = raw_params.assign(
+        gtfs_schedule_path=lambda d: prefix_path_schedule
+        + "/"
+        + d.calitp_itp_id.astype(str)
+        + "_"
+        + d.calitp_url_number.astype(str),
+        gtfs_rt_glob_path=lambda d: prefix_path_rt
+        + "/"
+        + d.calitp_itp_id.astype(str)
+        + "/"
+        + d.calitp_url_number.astype(str)
+        + "/*",
+    )
+
+    save_to_gcfs(
+        params.to_csv(index=False).encode(),
+        f"rt-processed/calitp_validation_params/{date_string}.csv",
+        use_pipe=True,
+    )

--- a/airflow/dags/rt_loader/external_calitp_validation_params.sql
+++ b/airflow/dags/rt_loader/external_calitp_validation_params.sql
@@ -1,0 +1,24 @@
+---
+operator: operators.SqlQueryOperator
+description: |
+  Parameters passed to GTFS RT validation.
+fields:
+  calitp_itp_id: Internal ITP ID.
+  calitp_url_number: Internal URL number.
+  gtfs_schedule_path: Path to GTFS Schedule data used in validation.
+  gtfs_rt_glob_path: |
+    Path to GTFS RT data used in validation. Wildcards (*) allow the path to grab
+    every individual RT file we store.
+---
+
+CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_service_alerts (
+    calitp_itp_id INT64,
+    calitp_url_number INT64,
+    calitp_extracted_at DATE,
+    gtfs_schedule_path STRING,
+    gtfs_rt_glob_path STRING
+)
+OPTIONS (
+    uris=["{{get_bucket()}}/rt-processed/calitp_validation_params/*"],
+    format="JSON"
+)

--- a/airflow/dags/rt_loader/external_calitp_validation_params.sql
+++ b/airflow/dags/rt_loader/external_calitp_validation_params.sql
@@ -11,7 +11,7 @@ fields:
     every individual RT file we store.
 ---
 
-CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_service_alerts (
+CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.calitp_validation_params (
     calitp_itp_id INT64,
     calitp_url_number INT64,
     calitp_extracted_at DATE,

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -1,6 +1,6 @@
 operator: 'operators.PodOperator'
 name: 'gtfs-rt-validation'
-image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.2'
+image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.3'
 cmds:
   - python3
 
@@ -12,10 +12,10 @@ arguments:
         project_id="cal-itp-data-infra",
         token="cloud",
         param_csv="gs://{{get_bucket()}}/rt-processed/calitp_validation_params/{{execution_date.to_date_string()}}.csv",
-        results_bucket="gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline",
+        results_bucket="gs://{{get_bucket()}}/gtfs-rt-validator-api/test-pipeline",
         verbose=True,
         aggregate_counts=True,
-        status_result_path="gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline/status.json",
+        status_result_path="gs://{{get_bucket()}}/gtfs-rt-validator-api/test-pipeline/status.json",
     )
 
 is_delete_operator_pod: true

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -1,4 +1,3 @@
-# Note that this task currently only validates feed 126 as a proof of concept.
 operator: 'operators.PodOperator'
 name: 'gtfs-rt-validation'
 image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.2'
@@ -10,13 +9,13 @@ arguments:
   - |
     from gtfs_rt_validator_api import validate_gcs_bucket_many
     validate_gcs_bucket_many(
-        "cal-itp-data-infra",
-        "cloud",
-        "gs://{{get_bucket()}}/rt-processed/calitp_validation_params/{{execution_date.to_date_string()}}.csv",
+        project_id="cal-itp-data-infra",
+        token="cloud",
+        param_csv="gs://{{get_bucket()}}/rt-processed/calitp_validation_params/{{execution_date.to_date_string()}}.csv",
         results_bucket="gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline",
         verbose=True,
         aggregate_counts=True,
-        status_result_path="gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline/status.json"
+        status_result_path="gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline/status.json",
     )
 
 is_delete_operator_pod: true

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -1,19 +1,23 @@
 # Note that this task currently only validates feed 126 as a proof of concept.
 operator: 'operators.PodOperator'
 name: 'gtfs-rt-validation'
-image: 'ghcr.io/cal-itp/gtfs-rt-api:v0.0.1'
+image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.2'
 cmds:
-  - gtfs-rt-validator-api
+  - python3
 
 arguments:
-  - validate-gcs-bucket
-  - cal-itp-data-infra
-  - cloud
-  - "gs://calitp-py-ci/gtfs-rt-validator-api/gtfs_schedule_126"
-  - "--gtfs-rt-glob-path"
-  - "gs://calitp-py-ci/gtfs-rt-validator-api/gtfs_rt_126/2021*/126/0/*"
-  - "--results-bucket"
-  - "gs://gtfs-data/rt-processed/validation"
+  - "-c"
+  - |
+    from gtfs_rt_validator_api import validate_gcs_bucket_many
+    validate_gcs_bucket_many(
+        "cal-itp-data-infra",
+        "cloud",
+        "gs://{{get_bucket()}}/rt-processed/calitp_validation_params/{{execution_date.to_date_string()}}.csv",
+        results_bucket="gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline",
+        verbose=True,
+        aggregate_counts=True,
+        status_result_path="gs://calitp-py-ci/gtfs-rt-validator-api/test-pipeline/status.json"
+    )
 
 is_delete_operator_pod: true
 get_logs: true
@@ -22,3 +26,4 @@ dependencies:
   - external_validation_service_alerts
   - external_validation_trip_updates
   - external_validation_vehicle_positions
+  - create_validation_params

--- a/airflow/dags/sandbox/op_pod_operator.yml
+++ b/airflow/dags/sandbox/op_pod_operator.yml
@@ -1,0 +1,7 @@
+operator: 'operators.PodOperator'
+name: 'pod-sandbox-op'
+image: 'docker/whalesay'
+cmds: ["cowsay", "boo"]
+is_delete_operator_pod: true
+get_logs: true
+provide_context: true


### PR DESCRIPTION
Addresses #787

(Andrew)

Realizing I don't have the Airflow template here.

The pertinent tasks
![image](https://user-images.githubusercontent.com/4305366/153505315-4a410084-bec7-4bfd-8d54-635c788ad640.png)

I've tested and confirmed that this runs successfully on an hour of data in approximately 30 minutes across all feeds. I'd like to merge this in so we get at least some data going across the board. We can follow-up with the following.

1. Make validation data queryable via bigquery
2. Change how we sample, and/or validate more data
3. Point at the new validator image one https://github.com/cal-itp/gtfs-rt-validator-api/pull/5 is merged
4. Maybe most importantly, be aware of the validity periods of GTFS schedules; this shouldn't really be a problem right now, but does have implications for backfilling, especially