### PR TITLE
restore jupyterhub image, and commit to this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,9 @@
 /ci                                     @lottspot
 /services                               @lottspot
 
+# jupyter service, e.g. updating the image
+/kubernetes/apps/charts/jupyterhub      @lottspot @charlie-costanzo
+
 # project documentation
 /docs                                   @charlie-costanzo @holly-g
 

--- a/docs/kubernetes/JupyterHub.md
+++ b/docs/kubernetes/JupyterHub.md
@@ -162,6 +162,14 @@ Upgrade with:
 helm upgrade jupyterhub kubernetes/apps/charts/jupyterhub -n jupyterhub
 ```
 
+Note that if you haven't yet connected to the kubernetes cluster, you may need to run the following.
+
+```
+source kubernetes/gke/config-cluster.sh
+export KUBECONFIG=$HOME/.kube/data-infra-apps.yaml
+gcloud container clusters get-credentials "$GKE_NAME" --region "$GKE_REGION"
+```
+
 ## Domain Name Changes
 
 At the time of this writing, a JupyterHub deployment is available at `https://hubtest.k8s.calitp.jarv.us`.

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -8,7 +8,7 @@ jupyterhub:
     defaultUrl: "/lab"
     image:
       name: ghcr.io/cal-itp/calitp-py
-      tag: v0.0.10
+      tag: hub-v1
     storage:
       extraVolumes:
       - name: gcloud-auth

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -8,7 +8,7 @@ jupyterhub:
     defaultUrl: "/lab"
     image:
       name: ghcr.io/cal-itp/calitp-py
-      tag: v0.0.6
+      tag: v0.0.10
     storage:
       extraVolumes:
       - name: gcloud-auth


### PR DESCRIPTION
This PR updates the hub image to what should be the current version. I'd forgotten to commit it, and noticed recently the version must have reverted back to the one committed here.

Added @charlie-costanzo to CODEOWNERS, and am recording a screencast right now on the process of building an updating images.

edit: rolled in documentation to address https://github.com/cal-itp/data-infra/issues/668