### PR TITLE
Fix broken yaml

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_errors.sql
@@ -3,7 +3,7 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "views.gtfs_rt_extraction_errors"
 
 description: |
-Each row is a unique error message of a feed that failed to fetch the feed url used in agency.yml
+  Each row is a unique error message of a feed that failed to fetch the feed url used in agency.yml
 
 
 fields:


### PR DESCRIPTION
https://github.com/cal-itp/data-infra/pull/879 had a change that include invalid YAML in the Gusty top matter. Unfortunately, it appears nobody (myself included) tested whether airflow would start after adding a change to one of the DAG tasks. This change fixes it and the local sandbox DAG has ran successfully (as opposed to production which failed today).