### PR TITLE
Gtfs rt logging documentation

### DIFF
--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -47,7 +47,7 @@ broadly useful across the org should live in `views`.
 
 ### Extraction
 
-Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).Within the service, agencies.yml is read into seperate threads and each RT feed is uploaded to a GCPBucketWriter via a post request. This data is stored in a kubernetes cluster 'data-infra-apps'.
+Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).Within the service, agencies.yml is read into separate threads and each RT feed is uploaded to a GCPBucketWriter via a post request. This data is stored in a kubernetes cluster 'data-infra-apps'.
 
 ### Logging
 

--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -47,11 +47,18 @@ broadly useful across the org should live in `views`.
 
 ### Extraction
 
-Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).Within this service is some basic logging functionality that exports the logs to an external table 'std.out' that reads the data in this bucket.
+Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md).Within the service, agencies.yml is read into seperate threads and each RT feed is uploaded to a GCPBucketWriter via a post request. This data is stored in a kubernetes cluster 'data-infra-apps'.
 
 ### Logging
 
-All GTFS RT feed logs are loaded directly to Bigquery via a [Google Logger Router called `rt-extract-to-bigquery`](https://console.cloud.google.com/logs/router?project=cal-itp-data-infra). Note that this data is saved to its own dataset (`gtfs_rt_logs`), since routers do not allow table names to be customized. Within `gtfs_rt_logs`, the data specific to URL feeds failing to download is stored in `stdout`.
+Within the gtfs-rt-archive service, A logger channel is set up with the 'logging' facility for Python. If an error is raised within the service, the log messages are also uploaded and stored in the cluster 'data-infra-apps'. Within this logger object some of the errors we are currently logging and their associated error levels:
+* missing feeds (Warning)
+* missing itp_id (Warning)
+* event dropped (Warning)
+* ticker (Debug)
+* error fetching URL (Info)
+ Google cloud automatically creates specific buckets called 'logging buckets' when a kubernetes cluster is stood up, these are called _Default and _Required. Cloud Logging provides these two predefined sinks for each Cloud Project. All logs that are generated in a resource are automatically processed through those two sinks and then are stored either in the _Required or _Default Buckets. _Required has retention for 400 days and appears to have mostly audit log functionality for data compliance. We are mostly using _Default which has a retention of 30 days to log all of our cloud services. _Default gets updated from the kubernetes cluster in hourly batches. We created a log sink called "rt-extract-to-bigquery' that filters the logs within _Default for the namespace 'resource.labels.namespace_name="gtfs-rt"'. To reliably route logs, the log router stores the logs temporarily, which buffers against temporary disruptions on any sink. According to this documentation, the log logging frequency between Cloud Logging and Bigquery is [near real-time](https://cloud.google.com/logging/docs/export/using_exported_logs#bigquery-frequency).
+Within The BigQuery table, the error messages are stored within the stdout table. The table names are generated automatically through the cloud router and cannot be renamed. The stout table is a partitioned table that does not have any limits on storage size currently.
 
 See [Google Cloud Log Router docs](https://cloud.google.com/logging/docs/routing/overview) for more information.
 The raw logs may be browsed in the [Logs Explorer](https://console.cloud.google.com/logs/query?project=cal-itp-data-infra).


### PR DESCRIPTION
Updated documentation to further explain the connections between the 'data-infra-apps' kubernetes cluster and the google cloud log sink 'rt-extract-to-bigquery'. I kept the two separate sections 'Logging' and 'Extraction' even though the gtfs-rt-archive service does both at the same time. 