### PR TITLE
chore: gitignore Mac .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 # Credentials & Secrets
 /kubernetes/secrets
 /kubernetes/gke/kube
+
+#.DS_Store files that Macs create
+.DS_Store


### PR DESCRIPTION
Adding [.DS_Store](https://en.wikipedia.org/wiki/.DS_Store) to the gitignore.