### PR TITLE
Update version of jupterhub image running on k8s cluster

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -8,7 +8,7 @@ jupyterhub:
     defaultUrl: "/lab"
     image:
       name: ghcr.io/cal-itp/calitp-py
-      tag: hub-v2
+      tag: hub-v3
     storage:
       extraVolumes:
       - name: gcloud-auth


### PR DESCRIPTION
Updates the version of Jupyterhub running on the k8s cluster from hub-v2 to hub-v3. This update includes the backlog of packages requested by analysts.