### PR TITLE
bug(extracted/deleted): added Coalesce for each subtable(calendar/calendar_dates) to remove null values 

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
@@ -56,6 +56,8 @@ WITH
       , calitp_url_number
       , service_id
       , service_date
+      , calitp_extracted_at
+      , calitp_deleted_at
       , TRUE AS service_inclusion
     FROM cal_dates_daily
     WHERE cal_dates_daily.exception_type = "1"
@@ -68,6 +70,8 @@ WITH
       , calitp_url_number
       , service_id
       , service_date
+      , calitp_extracted_at
+      , calitp_deleted_at
       , TRUE AS service_exclusion
     FROM cal_dates_daily
     WHERE cal_dates_daily.exception_type = "2"
@@ -99,7 +103,7 @@ SELECT
       OR COALESCE(service_inclusion, FALSE)
       AS is_in_service
 FROM calendar_daily
-FULL JOIN date_include USING(calitp_itp_id, calitp_url_number, service_id, service_date)
-FULL JOIN date_exclude USING(calitp_itp_id, calitp_url_number, service_id, service_date)
+FULL JOIN date_include USING(calitp_itp_id, calitp_url_number, service_id, service_date, calitp_extracted_at, calitp_deleted_at)
+FULL JOIN date_exclude USING(calitp_itp_id, calitp_url_number, service_id, service_date, calitp_extracted_at, calitp_deleted_at)
 # TODO: remove hardcoding--set this to be 1 month in the future, etc..
 WHERE service_date < DATE_ADD(CURRENT_DATE(), INTERVAL 1 YEAR)

--- a/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
@@ -84,6 +84,7 @@ WITH
       , t1.start_date AS service_start_date
       , t1.end_date AS service_end_date
       , t2.full_date AS service_date
+      , COALESCE(GREATEST(t1))
     FROM  `views.gtfs_schedule_stg_calendar_long` t1
     JOIN `views.dim_date` t2
       ON
@@ -98,12 +99,25 @@ WITH
         AND COALESCE(t1.end_date, DATE("2099-01-01")) >= t2.full_date
   )
 SELECT
-  *
+  * EXCEPT(calitp_extracted_at, calitp_deleted_at)
   , (service_indicator="1" AND NOT COALESCE(service_exclusion, FALSE))
       OR COALESCE(service_inclusion, FALSE)
       AS is_in_service
-FROM calendar_daily
-FULL JOIN date_include USING(calitp_itp_id, calitp_url_number, service_id, service_date, calitp_extracted_at, calitp_deleted_at)
-FULL JOIN date_exclude USING(calitp_itp_id, calitp_url_number, service_id, service_date, calitp_extracted_at, calitp_deleted_at)
+# Need to coalesce by each individual column of calendar_daily, date_include, and date_exclude tables to account for null values,
+# then select the greatest/least to populate extracted/deleted at. Cannot have it as one coalesce because it selects sequentially.
+# Chose to use latest extracted date/ earliest deleted date for the most conservative option.
+  , GREATEST(
+        COALESCE(t1.calitp_extracted_at, DATE("1900-01-01"))
+        , COALESCE(t2.calitp_extracted_at, DATE("1900-01-01"))
+        , COALESCE(t3.calitp_extracted_at, DATE("1900-01-01")))
+        AS calitp_extracted_at
+  , LEAST(
+        COALESCE(t1.calitp_deleted_at, DATE("2100-01-01"))
+        , COALESCE(t2.calitp_deleted_at, DATE("2100-01-01"))
+        , COALESCE(t3.calitp_deleted_at, DATE("2100-01-01")))
+        AS calitp_deleted_at
+FROM calendar_daily t1
+FULL JOIN date_include t2 USING(calitp_itp_id, calitp_url_number, service_id, service_date)
+FULL JOIN date_exclude t3 USING(calitp_itp_id, calitp_url_number, service_id, service_date)
 # TODO: remove hardcoding--set this to be 1 month in the future, etc..
 WHERE service_date < DATE_ADD(CURRENT_DATE(), INTERVAL 1 YEAR)

--- a/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
@@ -84,7 +84,6 @@ WITH
       , t1.start_date AS service_start_date
       , t1.end_date AS service_end_date
       , t2.full_date AS service_date
-      , COALESCE(GREATEST(t1))
     FROM  `views.gtfs_schedule_stg_calendar_long` t1
     JOIN `views.dim_date` t2
       ON


### PR DESCRIPTION
For calitp_id 170, 16, and 48, extracted at/deleted values were null in gtfs_schedule_fact_daily_trips, this was due to those columns not being selected in a calendar_dates subtable prior to the join with calendar_dates that is used to populate gtfs_schedule_fact_daily_trips. By adding those to the select column and the join column, we are able to populate those values for calitp_id 170, 16, and 48. I also verified that it did not alter other calitp result values. Tested with calitp_id 98 to verify it didn't alter other results. 