### PR TITLE
Add San Joaquin Swiftly RT URLs

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1111,7 +1111,7 @@ san-joaquin-regional-transit-district:
   feeds:
     - gtfs_schedule_url: http://sanjoaquinrtd.com/RTD-GTFS/RTD-GTFS.zip
       gtfs_rt_vehicle_positions_url: https://api.goswift.ly/real-time/san-joaquin/gtfs-rt-vehicle-positions
-      gtfs_rt_service_alerts_url: https://api.goswift.ly/real-time/san-joaquin/gtfs-rt-alerts
+      gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: https://api.goswift.ly/real-time/san-joaquin/gtfs-rt-trip-updates
   itp_id: 284
 san-juan-capistrano-free-weekend-trolley:

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1110,9 +1110,9 @@ san-joaquin-regional-transit-district:
   agency_name: San Joaquin Regional Transit District
   feeds:
     - gtfs_schedule_url: http://sanjoaquinrtd.com/RTD-GTFS/RTD-GTFS.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://api.goswift.ly/real-time/san-joaquin/gtfs-rt-vehicle-positions
+      gtfs_rt_service_alerts_url: https://api.goswift.ly/real-time/san-joaquin/gtfs-rt-alerts
+      gtfs_rt_trip_updates_url: https://api.goswift.ly/real-time/san-joaquin/gtfs-rt-trip-updates
   itp_id: 284
 san-juan-capistrano-free-weekend-trolley:
   agency_name: San Juan Capistrano Free Weekend Trolley

--- a/airflow/data/headers.yml
+++ b/airflow/data/headers.yml
@@ -1,19 +1,4 @@
 - header-data:
-    authorization: {{ SWIFTLY_AUTHORIZATION_KEY_CALTRANS }}
-  URLs:
-    - itp_id: 235 # OCTA
-      url_number: 1
-      rt_urls:
-        - gtfs_rt_vehicle_positions_url
-        - gtfs_rt_service_alerts_url
-        - gtfs_rt_trip_updates_url
-    - itp_id: 221 # Gold Country Stage
-      url_number: 0
-      rt_urls:
-        - gtfs_rt_vehicle_positions_url
-        - gtfs_rt_service_alerts_url
-        - gtfs_rt_trip_updates_url
-- header-data:
     authorization: {{ SWIFTLY_AUTHORIZATION_KEY_CALITP }}
   URLs:
     - itp_id: 30 # Banning Pass Transit
@@ -40,20 +25,14 @@
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
-    - itp_id: 226 # North County Transit District
+    - itp_id: 182 # Metro (Bus)
       url_number: 0
       rt_urls:
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
-    - itp_id: 259 # Redding Area Bus Authority
-      url_number: 0
-      rt_urls:
-        - gtfs_rt_vehicle_positions_url
-        - gtfs_rt_service_alerts_url
-        - gtfs_rt_trip_updates_url
-    - itp_id: 349 # Turlock Transit
-      url_number: 0
+    - itp_id: 182 # Metro (Rail)
+      url_number: 1
       rt_urls:
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
@@ -64,14 +43,38 @@
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
-    - itp_id: 182 # Metro (Bus)
+    - itp_id: 221 # Gold Country Stage
       url_number: 0
       rt_urls:
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
-    - itp_id: 182 # Metro (Rail)
+    - itp_id: 226 # North County Transit District
+      url_number: 0
+      rt_urls:
+        - gtfs_rt_vehicle_positions_url
+        - gtfs_rt_service_alerts_url
+        - gtfs_rt_trip_updates_url
+    - itp_id: 235 # OCTA
       url_number: 1
+      rt_urls:
+        - gtfs_rt_vehicle_positions_url
+        - gtfs_rt_service_alerts_url
+        - gtfs_rt_trip_updates_url
+    - itp_id: 259 # Redding Area Bus Authority
+      url_number: 0
+      rt_urls:
+        - gtfs_rt_vehicle_positions_url
+        - gtfs_rt_service_alerts_url
+        - gtfs_rt_trip_updates_url
+    - itp_id: 284 # San Joaquin Regional Transit District
+      url_number: 0
+      rt_urls:
+        - gtfs_rt_vehicle_positions_url
+        - gtfs_rt_service_alerts_url
+        - gtfs_rt_trip_updates_url
+    - itp_id: 349 # Turlock Transit
+      url_number: 0
       rt_urls:
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url

--- a/airflow/data/headers.yml
+++ b/airflow/data/headers.yml
@@ -71,7 +71,6 @@
       url_number: 0
       rt_urls:
         - gtfs_rt_vehicle_positions_url
-        - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
     - itp_id: 349 # Turlock Transit
       url_number: 0


### PR DESCRIPTION
This PR does 2 things:

- Adds the Swiftly RT URLs for San Joaquin Regional Transit District
- Refactor the headers file.
  - Add San Joaquin Regional Transit District
  - Use a single super Swiftly auth key. It appears that all the other transit agencies associated with our Caltrans Swiftly key have been given access via the Cal-ITP key. 
  - Order agencies by ITP ID