### PR TITLE
Make update airflow requirements point to airflow v2 instance

### DIFF
--- a/.github/workflows/update_gcloud_requirements.yml
+++ b/.github/workflows/update_gcloud_requirements.yml
@@ -24,4 +24,4 @@ jobs:
           export_default_credentials: true
       - id: install-python-dependencies
         name: install-requirements
-        run: gcloud composer environments update calitp-airflow-prod --update-pypi-packages-from-file airflow/requirements.txt --location us-west2 --project cal-itp-data-infra
+        run: gcloud composer environments update calitp-airflow2-prod --update-pypi-packages-from-file airflow/requirements.txt --location us-west2 --project cal-itp-data-infra


### PR DESCRIPTION
Something missed in https://github.com/cal-itp/data-infra/pull/851 was making sure the reinstallation of requirements was done in the airflow v2 instance instead of in the v1 instance. This fixes that.