### PR TITLE
feat: adjust apps resource requests and node pool assignments

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -10,11 +10,13 @@ jupyterhub:
       name: ghcr.io/cal-itp/calitp-py
       tag: hub-v9
     memory:
+      # Much more than 10 and we risk bumping up against the actual capacity of e2-highmem-2
       limit: 10G
-      guarantee: 4G
+      # Very roughly I have seen most usage in the 2-3GB range
+      guarantee: 3G
     cpu:
       limit: 1
-      guarantee: 1
+      guarantee: 0.5
     storage:
       extraVolumes:
       - name: gcloud-auth

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -9,6 +9,12 @@ jupyterhub:
     image:
       name: ghcr.io/cal-itp/calitp-py
       tag: hub-v9
+    memory:
+      limit: 10G
+      guarantee: 4G
+    cpu:
+      limit: 1
+      guarantee: 1
     storage:
       extraVolumes:
       - name: gcloud-auth

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -8,7 +8,7 @@ jupyterhub:
     defaultUrl: "/lab"
     image:
       name: ghcr.io/cal-itp/calitp-py
-      tag: hub-v9
+      tag: hub-v10
     memory:
       # Much more than 10 and we risk bumping up against the actual capacity of e2-highmem-2
       limit: 10G

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -30,8 +30,9 @@ jupyterhub:
             - >
               cp /tmp/custom.sh /home/jovyan/.profile;
   scheduling:
-    userScheduler:
-      enabled: false
+    userPods:
+      nodeAffinity:
+        matchNodePurpose: require
   hub:
     db:
       pvc:

--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -32,9 +32,9 @@ spec:
               mountPath: /secrets/gcs-upload-svcacct
           resources:
             requests:
-              memory: 5.0Gi
+              memory: 2.0Gi
             limits:
-              memory: 5.0Gi
+              memory: 2.0Gi
       volumes:
         - name: agencies-data
           secret:


### PR DESCRIPTION
Adjust both JupyterHub and RT resource requests based on [Grafana charts](https://monitoring.k8s.calitp.jarv.us/d/967c0gU7k/jupyterhub-monitoring) and [discussion](https://github.com/cal-itp/data-infra/issues/1323#issuecomment-1090764303).
Require JupyterHub user pods to schedule on the proper node pool. We want to enable this so that as we add resource requests that may spread out pods, we don't accidentally spread to other node pools.
Bumps hub to use v10 of the jupyter image to get the resource usage library.

closes https://github.com/cal-itp/data-infra/issues/592
related to https://github.com/cal-itp/data-infra/issues/1323