### PR TITLE
fix(airflow): use v2 cluster in local dev envs

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -65,7 +65,7 @@ x-airflow-common:
     GOOGLE_CLOUD_PROJECT: cal-itp-data-infra
 
     # Composer variables for kubernetes
-    POD_CLUSTER_NAME: "us-west2-calitp-airflow-pro-332827a9-gke"
+    POD_CLUSTER_NAME: "us-west2-calitp-airflow2-pr-171e4e47-gke"
     POD_LOCATION: "us-west2-a"
     AIRFLOW_ENV: "development"
     CALITP_USER: "pipeline"


### PR DESCRIPTION
The original value is pointing at our airflow-v1 cluster which is due for retirement soon

I'm not positive this is the only place we need to make any change, as I'm not sure where people have been getting the service account auth file they use for this and whether that service account has the same access to the v2 cluster as it did to the v1 cluster

Before this get merged, could someone who already had a working local setup for running airflow jobs that run on k8s switch to this branch and restart your docker containers (e.g. `docker-compose down && docker-compose up`) and verify everything still works as expected