### PR TITLE
Nodepool apps v2

### DIFF
--- a/kubernetes/gke/config-nodepool.sh
+++ b/kubernetes/gke/config-nodepool.sh
@@ -1,22 +1,18 @@
 GKE_NODEPOOL_NAMES=(
-  'apps-v1'
   'apps-v2'
 )
 
 declare -A GKE_NODEPOOL_NODE_COUNTS
 GKE_NODEPOOL_NODE_COUNTS=(
-  ['apps-v1']=1
   ['apps-v2']=1
 )
 
 declare -A GKE_NODEPOOL_NODE_LOCATIONS
 GKE_NODEPOOL_NODE_LOCATIONS=(
-  ['apps-v1']=$GKE_REGION-a,$GKE_REGION-b,$GKE_REGION-c
   ['apps-v2']=$GKE_REGION-a,$GKE_REGION-b,$GKE_REGION-c
 )
 
 declare -A GKE_NODEPOOL_MACHINE_TYPES
 GKE_NODEPOOL_MACHINE_TYPES=(
-  ['apps-v1']=n1-standard-4
   ['apps-v2']=n1-standard-4
 )

--- a/kubernetes/gke/config-nodepool.sh
+++ b/kubernetes/gke/config-nodepool.sh
@@ -1,18 +1,22 @@
 GKE_NODEPOOL_NAMES=(
   'apps-v1'
+  'apps-v2'
 )
 
 declare -A GKE_NODEPOOL_NODE_COUNTS
 GKE_NODEPOOL_NODE_COUNTS=(
   ['apps-v1']=1
+  ['apps-v2']=1
 )
 
 declare -A GKE_NODEPOOL_NODE_LOCATIONS
 GKE_NODEPOOL_NODE_LOCATIONS=(
   ['apps-v1']=$GKE_REGION-a,$GKE_REGION-b,$GKE_REGION-c
+  ['apps-v2']=$GKE_REGION-a,$GKE_REGION-b,$GKE_REGION-c
 )
 
 declare -A GKE_NODEPOOL_MACHINE_TYPES
 GKE_NODEPOOL_MACHINE_TYPES=(
   ['apps-v1']=n1-standard-4
+  ['apps-v2']=n1-standard-4
 )


### PR DESCRIPTION
Ongoing investigations in light of infrastructure-related reliability issues found that two of our three cluster nodes appeared to be flapping between a healthy and unhealthy state. This ultimately resulted in problems with workloads running, as GKE was repeatedly rebooting these nodes in an attempt to repair them. This change reflects a rotation of the node pool in order to cycle out these unhealthy nodes.