### PR TITLE
gtfs-rt-archive/app.yaml: apply memory limits

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -30,6 +30,11 @@ spec:
               mountPath: /secrets/agencies-data
             - name: gcs-upload-svcacct
               mountPath: /secrets/gcs-upload-svcacct
+          resources:
+            requests:
+              memory: 6.5Gi
+            limits:
+              memory: 6.5Gi
       volumes:
         - name: agencies-data
           secret:


### PR DESCRIPTION
A memory leak has been discovered in the currently running 1.2-r2
release. In order to mitigate risk to colocated workloads while the
memory leak is worked on, memory consumption limits are being applied to
the archiver deployment.