### PR TITLE
chore(docs): Moving DAG maintenance information

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -58,6 +58,7 @@ parts:
         - file: airflow/static-schedule-pipeline
         - file: airflow/local-setup
         - file: airflow/production-maintenance
+        - file: airflow/dags-maintenance
       - file: kubernetes/README
         sections:
         - file: kubernetes/JupyterHub

--- a/docs/airflow/dags-maintenance.md
+++ b/docs/airflow/dags-maintenance.md
@@ -1,0 +1,122 @@
+# DAGs maintenance
+Use this page to find information on maintenance of the DAGs that support our data pipelines.
+
+1. [GTFS Schedule DAGs](gtfs-schedule-dags)
+1. [GTFS Realtime DAGs](gtfs-realtime-dags)
+1. [MST Payments DAGs](mst-payments-dags)
+1. [Transit Database DAGs](transit-database-dags)
+1. [Views DAGs](views-dags)
+
+(gtfs-schedule-dags)=
+## GTFS Schedule - DAGs Maintenance
+
+### DAGs overview
+
+### common issues
+
+### backfilling
+
+(gtfs-realtime-dags)=
+## GTFS Realtime - DAGs Maintenance
+
+### DAGs Overview
+
+Currently, 3 DAGs are used with GTFS RT data:
+
+* `rt_loader_files`: Populates a table called `gtfs_rt.calitp_files` that has one row per
+    sample of GTFS RT data. For example, a vehicle positions file downloaded at a specific point in time.
+* `rt_loader`: handles the rectangling and loading of GTFS RT and validation data.
+* `rt_views`: exposes user-friendly views for analysis.
+
+Internal data should live in the `gtfs_rt` dataset on bigquery, while those that are
+broadly useful across the org should live in `views`.
+
+### Extraction
+
+Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md). Within the service, `agencies.yml` is read into separate threads and each RT feed is uploaded to a GCPBucketWriter via a post request. This data is stored in a kubernetes cluster `data-infra-apps`.
+
+### Logging
+
+Within the gtfs-rt-archive service, A logger channel is set up with the `logging` facility for Python. If an error is raised within the service, the log messages are also uploaded and stored in the cluster `data-infra-apps`. Within this logger object some of the errors we are currently logging and their associated error levels:
+
+* missing feeds (Warning)
+* missing itp_id (Warning)
+* event dropped (Warning)
+* ticker (Debug)
+* error fetching URL (Info)
+
+Google cloud automatically creates specific buckets called 'logging buckets' when a kubernetes cluster is stood up, these are called `_Default` and `_Required`. Cloud Logging provides these two predefined sinks for each Cloud Project. All logs that are generated in a resource are automatically processed through those two sinks and then are stored either in the `_Required` or `_Default` Buckets. `_Required` has retention for 400 days and appears to have mostly audit log functionality for data compliance. We are mostly using _Default which has a retention of 30 days to log all of our cloud services. `_Default` gets updated from the kubernetes cluster in hourly batches. We created a log sink called `rt-extract-to-bigquery` that filters the logs within `_Default` for the namespace `resource.labels.namespace_name="gtfs-rt"`. To reliably route logs, the log router stores the logs temporarily, which buffers against temporary disruptions on any sink. According to this documentation, the log logging frequency between Cloud Logging and Bigquery is [near real-time](https://cloud.google.com/logging/docs/export/using_exported_logs#bigquery-frequency).
+
+Within The BigQuery table, the error messages are stored within the stdout table. The table names are generated automatically through the cloud router and cannot be renamed. The stout table is a partitioned table that does not have any limits on storage size currently. See [Google Cloud Log Router docs](https://cloud.google.com/logging/docs/routing/overview) for more information. The raw logs may be browsed in the [Logs Explorer](https://console.cloud.google.com/logs/query?project=cal-itp-data-infra).
+
+### Validation
+
+Validation of GTFS RT uses the [gtfs-rt-validator-api](https://github.com/cal-itp/gtfs-rt-validator-api).
+This repo publishes a docker image on every release, so that it can used from a KubernetesPodOperator.
+It allows for fetching GTFS RT and schedule data from our cloud storage, validating, and putting the results
+back into cloud storage.
+
+Note that the validation process requires two pieces per feed:
+
+* a zipped GTFS Schedule
+* realtime feed data (e.g. vehicle positions, trip updates, service alerts)
+
+### Backfilling
+
+This DAG does not have any tasks that `depends_on_past`, so you should be able to
+clear and re-run tasks as needed.
+
+(mst-payments-dags)=
+## MST Payments - DAGs Maintenance
+
+The ETL is currently a scheduled Google Data Transfer job that transfers all files to `gcs://littlepay-data-extract-prod`
+
+From there, tables are loaded into BigQuery as external tables in the `transaction_data` buclet.
+
+### DAGs Overview
+
+The payments data is loaded and transformed in the payments_loader and payments_views dags.
+
+The payments_loader dag has three kinds of tasks:
+
+* ExternalTable operator tasks (e.g. `customer_funding_source`). These define the underlying data.
+* `calitp_included_payments_data` - a table of underlying payments table names defined in the task above.
+* `preprocessing_columns` - move data from `gs://littlepay-data-extract-prod` to `gs://gtfs-data`,
+  then process to keep only columns defined in external tables.
+
+The payments_views is made of SQL queries that transform the loaded tables above.
+
+### Adding new tables in payments_loader
+
+* Copy the `customer_funding_source` task. The new task name should match the table it creates.
+* Alter `destination_project_dataset_table` and `source_objects` to match the new table name.
+* Edit `schema_fields` to be the columns in the new table. If you are unsure of a column type,
+  specify it as "STRING".
+    * Keep a `calitp_extracted_at` column at the end of the table. This column contains the execution date of the load task, and is added automatically by the `preprocess_columns` task.
+* In the `calitp_included_payments_data` task,
+    * add a row for this new table.
+    * add a depedency in yaml header to this new table.
+* In the `docs/datasets/mst_payments.md` file, add an entry into the `Tables` table describing the new data set.
+
+### Adding a new table to payments_views
+
+* Ensure your task is given the same name as the table it creates.
+* Be sure to include an `external_dependency` on payments_loader (see other views in payments_views).
+
+### Backfilling
+
+Clear the `preprocessing_columns` task for every day you want to re-run.
+These tasks do not depend on past. However, because the extracted data in the littlepay bucket
+can be mutated by littlepay, so if you clear a past task, you should clear them all!
+
+(transit-database-dags)=
+## Transit Database - DAGs Maintenance
+
+### DAGs Overview
+
+(views-dags)=
+## Views - DAGs Maintenance
+
+### DAGs overview
+
+Views are held in the [`gtfs_views`](https://github.com/cal-itp/data-infra/tree/main/airflow/dags/gtfs_views) DAG.

--- a/docs/airflow/dags-maintenance.md
+++ b/docs/airflow/dags-maintenance.md
@@ -1,4 +1,4 @@
-# DAGs maintenance
+# DAGs Maintenance
 Use this page to find information on maintenance of the DAGs that support our data pipelines.
 
 1. [GTFS Schedule DAGs](gtfs-schedule-dags)
@@ -10,11 +10,11 @@ Use this page to find information on maintenance of the DAGs that support our da
 (gtfs-schedule-dags)=
 ## GTFS Schedule - DAGs Maintenance
 
-### DAGs overview
+### DAGs Overview
 
-### common issues
+### Common Issues
 
-### backfilling
+### Backfilling
 
 (gtfs-realtime-dags)=
 ## GTFS Realtime - DAGs Maintenance
@@ -86,7 +86,7 @@ The payments_loader dag has three kinds of tasks:
 
 The payments_views is made of SQL queries that transform the loaded tables above.
 
-### Adding new tables in payments_loader
+### Adding New Tables in payments_loader
 
 * Copy the `customer_funding_source` task. The new task name should match the table it creates.
 * Alter `destination_project_dataset_table` and `source_objects` to match the new table name.
@@ -98,7 +98,7 @@ The payments_views is made of SQL queries that transform the loaded tables above
     * add a depedency in yaml header to this new table.
 * In the `docs/datasets/mst_payments.md` file, add an entry into the `Tables` table describing the new data set.
 
-### Adding a new table to payments_views
+### Adding a New Table to payments_views
 
 * Ensure your task is given the same name as the table it creates.
 * Be sure to include an `external_dependency` on payments_loader (see other views in payments_views).
@@ -117,6 +117,4 @@ can be mutated by littlepay, so if you clear a past task, you should clear them 
 (views-dags)=
 ## Views - DAGs Maintenance
 
-### DAGs overview
-
-Views are held in the [`gtfs_views`](https://github.com/cal-itp/data-infra/tree/main/airflow/dags/gtfs_views) DAG.
+### DAGs Overview

--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -31,51 +31,6 @@ Note that this data is still a work in progress, so many tables are still intern
 | `validation_trip_updates` | Similar to above, but for trip updates. | |
 | `validation_vehicle_positions` | Similar to above, but for vehicle positions. | |
 
-## Maintenance
+## DAGs Maintenance
 
-### DAGs Overview
-
-Currently, 3 DAGs are used with GTFS RT data:
-
-* `rt_loader_files`: Populates a table called `gtfs_rt.calitp_files` that has one row per
-    sample of GTFS RT data. For example, a vehicle positions file downloaded at a specific point in time.
-* `rt_loader`: handles the rectangling and loading of GTFS RT and validation data.
-* `rt_views`: exposes user-friendly views for analysis.
-
-Internal data should live in the `gtfs_rt` dataset on bigquery, while those that are
-broadly useful across the org should live in `views`.
-
-### Extraction
-
-Extraction of GTFS RT feeds is handled by the [gtfs-rt-archive service](../services/gtfs-rt-archive.md). Within the service, `agencies.yml` is read into separate threads and each RT feed is uploaded to a GCPBucketWriter via a post request. This data is stored in a kubernetes cluster `data-infra-apps`.
-
-### Logging
-
-Within the gtfs-rt-archive service, A logger channel is set up with the `logging` facility for Python. If an error is raised within the service, the log messages are also uploaded and stored in the cluster `data-infra-apps`. Within this logger object some of the errors we are currently logging and their associated error levels:
-
-* missing feeds (Warning)
-* missing itp_id (Warning)
-* event dropped (Warning)
-* ticker (Debug)
-* error fetching URL (Info)
-
-Google cloud automatically creates specific buckets called 'logging buckets' when a kubernetes cluster is stood up, these are called `_Default` and `_Required`. Cloud Logging provides these two predefined sinks for each Cloud Project. All logs that are generated in a resource are automatically processed through those two sinks and then are stored either in the `_Required` or `_Default` Buckets. `_Required` has retention for 400 days and appears to have mostly audit log functionality for data compliance. We are mostly using _Default which has a retention of 30 days to log all of our cloud services. `_Default` gets updated from the kubernetes cluster in hourly batches. We created a log sink called `rt-extract-to-bigquery` that filters the logs within `_Default` for the namespace `resource.labels.namespace_name="gtfs-rt"`. To reliably route logs, the log router stores the logs temporarily, which buffers against temporary disruptions on any sink. According to this documentation, the log logging frequency between Cloud Logging and Bigquery is [near real-time](https://cloud.google.com/logging/docs/export/using_exported_logs#bigquery-frequency).
-
-Within The BigQuery table, the error messages are stored within the stdout table. The table names are generated automatically through the cloud router and cannot be renamed. The stout table is a partitioned table that does not have any limits on storage size currently. See [Google Cloud Log Router docs](https://cloud.google.com/logging/docs/routing/overview) for more information. The raw logs may be browsed in the [Logs Explorer](https://console.cloud.google.com/logs/query?project=cal-itp-data-infra).
-
-### Validation
-
-Validation of GTFS RT uses the [gtfs-rt-validator-api](https://github.com/cal-itp/gtfs-rt-validator-api).
-This repo publishes a docker image on every release, so that it can used from a KubernetesPodOperator.
-It allows for fetching GTFS RT and schedule data from our cloud storage, validating, and putting the results
-back into cloud storage.
-
-Note that the validation process requires two pieces per feed:
-
-* a zipped GTFS Schedule
-* realtime feed data (e.g. vehicle positions, trip updates, service alerts)
-
-### Backfilling
-
-This DAG does not have any tasks that `depends_on_past`, so you should be able to
-clear and re-run tasks as needed.
+You can find further information on DAGs maintenance for GTFS Realtime data [on this page](gtfs-realtime-dags).

--- a/docs/datasets_and_tables/gtfs_schedule.md
+++ b/docs/datasets_and_tables/gtfs_schedule.md
@@ -10,10 +10,6 @@
 
 ## Dashboards
 
-## Maintenance
+## DAGs Maintenance
 
-### DAGs overview
-
-### common issues
-
-### backfilling
+You can find further information on DAGs maintenance for GTFS Schedule data [on this page](gtfs-schedule-dags).

--- a/docs/datasets_and_tables/mst_payments.md
+++ b/docs/datasets_and_tables/mst_payments.md
@@ -15,44 +15,6 @@ Currently, Payments data is hosted by Littlepay, who exposes the "Littlepay Data
 
 The table best used for caculating ridership is `mst_ridership_materialized` table.
 
-## Maintenance
+## DAGs Maintenance
 
-The ETL is currently a scheduled Google Data Transfer job that transfers all files to `gcs://littlepay-data-extract-prod`
-
-From there, tables are loaded into BigQuery as external tables in the `transaction_data` buclet.
-
-### DAGs Overview
-
-The payments data is loaded and transformed in the payments_loader and payments_views dags.
-
-The payments_loader dag has three kinds of tasks:
-
-* ExternalTable operator tasks (e.g. `customer_funding_source`). These define the underlying data.
-* `calitp_included_payments_data` - a table of underlying payments table names defined in the task above.
-* `preprocessing_columns` - move data from `gs://littlepay-data-extract-prod` to `gs://gtfs-data`,
-  then process to keep only columns defined in external tables.
-
-The payments_views is made of SQL queries that transform the loaded tables above.
-
-### Adding new tables in payments_loader
-
-* Copy the `customer_funding_source` task. The new task name should match the table it creates.
-* Alter `destination_project_dataset_table` and `source_objects` to match the new table name.
-* Edit `schema_fields` to be the columns in the new table. If you are unsure of a column type,
-  specify it as "STRING".
-    * Keep a `calitp_extracted_at` column at the end of the table. This column contains the execution date of the load task, and is added automatically by the `preprocess_columns` task.
-* In the `calitp_included_payments_data` task,
-    * add a row for this new table.
-    * add a depedency in yaml header to this new table.
-* In the `docs/datasets/mst_payments.md` file, add an entry into the `Tables` table describing the new data set.
-
-### Adding a new table to payments_views
-
-* Ensure your task is given the same name as the table it creates.
-* Be sure to include an `external_dependency` on payments_loader (see other views in payments_views).
-
-### Backfilling
-
-Clear the `preprocessing_columns` task for every day you want to re-run.
-These tasks do not depend on past. However, because the extracted data in the littlepay bucket
-can be mutated by littlepay, so if you clear a past task, you should clear them all!
+You can find further information on DAGs maintenance for MST Payments data [on this page](mst-payments-dags).

--- a/docs/datasets_and_tables/transitdatabase.md
+++ b/docs/datasets_and_tables/transitdatabase.md
@@ -89,6 +89,6 @@ Currently neither of the above processes or datasets either rely on or contribut
 
 ## Dashboards
 
-## DAGs
+## DAGs Maintenance
 
 You can find further information on DAGs maintenance for Transit Database data [on this page](transit-database-dags).

--- a/docs/datasets_and_tables/transitdatabase.md
+++ b/docs/datasets_and_tables/transitdatabase.md
@@ -89,6 +89,6 @@ Currently neither of the above processes or datasets either rely on or contribut
 
 ## Dashboards
 
-## Maintenance
+## DAGs
 
-### DAGs overview
+You can find further information on DAGs maintenance for Transit Database data [on this page](transit-database-dags).

--- a/docs/datasets_and_tables/views.md
+++ b/docs/datasets_and_tables/views.md
@@ -8,8 +8,8 @@
 | `views.gtfs_schedule_service_daily` | `calendar.txt` data from GTFS Static unpacked and joined with `calendar_dates.txt` to reflect service schedules on a given day. Critically, it uses the data that was current on `service_date`. For `service_date` values in the future, uses most recent data in warehouse. | |
 | `views.validation_notices` | One line per specific validation violation (e.g. each invalid phone number). See `validation_code_descriptions` for human friendly code labels, and `validation_notice_fields` for looking up what columns in `validation_notices` different codes have data for (e.g. the code `"invalid_phone_number"` sets the `fieldValue` column). | |
 
-## Maintenance
-
-### DAGs overview
+## DAGS Maintenance
 
 Views are held in the [`gtfs_views`](https://github.com/cal-itp/data-infra/tree/main/airflow/dags/gtfs_views) DAG.
+
+You can find further information on DAGs maintenance for Views [on this page](views-dags).

--- a/docs/datasets_and_tables/views.md
+++ b/docs/datasets_and_tables/views.md
@@ -8,8 +8,6 @@
 | `views.gtfs_schedule_service_daily` | `calendar.txt` data from GTFS Static unpacked and joined with `calendar_dates.txt` to reflect service schedules on a given day. Critically, it uses the data that was current on `service_date`. For `service_date` values in the future, uses most recent data in warehouse. | |
 | `views.validation_notices` | One line per specific validation violation (e.g. each invalid phone number). See `validation_code_descriptions` for human friendly code labels, and `validation_notice_fields` for looking up what columns in `validation_notices` different codes have data for (e.g. the code `"invalid_phone_number"` sets the `fieldValue` column). | |
 
-## DAGS Maintenance
-
-Views are held in the [`gtfs_views`](https://github.com/cal-itp/data-infra/tree/main/airflow/dags/gtfs_views) DAG.
+## DAGs Maintenance
 
 You can find further information on DAGs maintenance for Views [on this page](views-dags).


### PR DESCRIPTION
Moving the DAG maintenance information from the `Analysts/Datasets and Tables` chapter of Data Services documentation to the new `Developers/Airflow/DAGs Maintenance` section of docs

As detailed in issue #783 :

> - move the airflow sections into the dedicated airflow part of the docs
> - put a link to the corresponding airflow section from each datasets page
> - match up the names of corresponding datasets and airflow docs

