### PR TITLE
chore(airflow): restore google cloud connection ID

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -55,6 +55,10 @@ x-airflow-common:
     AIRFLOW__WEBSERVER__RELOAD_ON_PLUGIN_CHANGE: 'true'
     CALITP_BQ_MAX_BYTES: 10000000000
 
+    # connections - required to allow local testing of pod operators
+    # see https://stackoverflow.com/a/55064944/1144523
+    AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: "google-cloud-platform://:@:?extra__google_cloud_platform__project=cal-itp-data-infra"
+
     # API keys
     CALITP_AIRTABLE_API_KEY: "${CALITP_AIRTABLE_API_KEY}"
 


### PR DESCRIPTION
Re-add the Airflow Google Cloud Default connection ID to allow local running of PodOperator DAG tasks (specifically, to allow testing of #991). 