### PR TITLE
fix(airflow/local): disable catchup by default

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -53,6 +53,14 @@ x-airflow-common:
     AIRFLOW__CORE__BASE_LOG_FOLDER: /opt/airflow/gcs/logs
     AIRFLOW__CORE__PLUGINS_FOLDER: /opt/airflow/gcs/plugins
     AIRFLOW__WEBSERVER__RELOAD_ON_PLUGIN_CHANGE: 'true'
+
+    # this option prevents a DAG from trying to run all dagruns back to its
+    # start date. this lets you it spin up docker, unpause a dag, and just
+    # get the latest run. Or pause a DAG for a long time, and not have it
+    # try to run on a million dates when unpaused.
+    AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT: 'false'
+
+
     CALITP_BQ_MAX_BYTES: 10000000000
     CALITP_SLACK_URL: ${CALITP_SLACK_URL}
 


### PR DESCRIPTION
I'm brand new to Airflow development, and have no sense of best practices, but while I was trying to get up and running locally I found it really annoying in my venture to run DAGs that activating any DAG immediately starting spawning months worth of backfilling task instances.

Setting this as part of the local dev environment defaults seemed to make sense to me. This won't affect deployed environments at all since the `docker-compose.yaml` only defines the local dev environments. It seems to successfully prevent activated DAGs from immediately spawning tons of catchup tasks so you can, as a local dev, start with just spawning one task