### PR TITLE
adding script for testing urls

### DIFF
--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -54,6 +54,15 @@ jobs:
         python script/headers_validate.py \
           './airflow/data/headers.filled.yml' \
           './airflow/data/schema_headers_entry.yml'
+    - name: Verify urls from agencies.yml
+      run: |
+        git diff './airflow/data/agencies.yml' \
+          ${{ github.event.pull_request.base.sha }} \
+          ${{ github.sha }} > AGENCIES_DIFF
+        python script/agencies_verify.py \
+          './airflow/data/headers.filled.yml' \
+          './airflow/data/agencies.filled.yml' \
+          AGENCIES_DIFF
 
     - if: ${{ github.repository == 'cal-itp/data-infra' }}
       uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -21,6 +21,17 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+    - name: Verify urls from agencies.yml
+      run: |
+        git rev-list --all
+        git fetch origin main ${{ github.event.pull_request.base.sha }}
+        git diff './airflow/data/agencies.yml' \
+          ${{ github.event.pull_request.base.sha }} \
+          ${{ github.sha }} > AGENCIES_DIFF
+        python script/agencies_verify.py \
+          './airflow/data/headers.filled.yml' \
+          './airflow/data/agencies.filled.yml' \
+          AGENCIES_DIFF
     - name: Install python packages
       run: |
         pip install jinja2==2.11.3 PyYAML==5.4.1 jsonschema==3.2.0 pandas==1.1.4
@@ -54,16 +65,6 @@ jobs:
         python script/headers_validate.py \
           './airflow/data/headers.filled.yml' \
           './airflow/data/schema_headers_entry.yml'
-    - name: Verify urls from agencies.yml
-      run: |
-        git fetch origin main ${{ github.event.pull_request.base.sha }}
-        git diff './airflow/data/agencies.yml' \
-          ${{ github.event.pull_request.base.sha }} \
-          ${{ github.sha }} > AGENCIES_DIFF
-        python script/agencies_verify.py \
-          './airflow/data/headers.filled.yml' \
-          './airflow/data/agencies.filled.yml' \
-          AGENCIES_DIFF
 
     - if: ${{ github.repository == 'cal-itp/data-infra' }}
       uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.8
     - name: Install python packages
       run: |
-        pip install jinja2==2.11.3 PyYAML==5.4.1 jsonschema==3.2.0 pandas==1.1.4 requests==2.22.0
+        pip install -r scripts/requirements.txt
     # Create the secrets.csv from the contents of the `AGENCY_SECRETS` environment variable / GitHub
     # repository secret. The contents of this environment variable should be directly copied from
     # the contents of a filled-out ./airflow/data/example-secrets.csv file.

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.8
     - name: Install python packages
       run: |
-        pip install -r scripts/requirements.txt
+        pip install -r script/requirements.txt
     # Create the secrets.csv from the contents of the `AGENCY_SECRETS` environment variable / GitHub
     # repository secret. The contents of this environment variable should be directly copied from
     # the contents of a filled-out ./airflow/data/example-secrets.csv file.
@@ -57,6 +57,11 @@ jobs:
     - name: Verify urls from agencies.yml
       run: |
         git diff ${{ github.event.pull_request.base.sha }} './airflow/data/agencies.yml' > AGENCIES_DIFF
+        python script/yml_convert.py \
+          AGENCIES_DIFF \
+          AGENCIES_DIFF \
+          './airflow/data/secrets.csv' \
+          --unsafe
         python script/agencies_verify.py \
           './airflow/data/agencies.filled.yml' \
           './airflow/data/headers.filled.yml' \

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -21,17 +21,16 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+    - name: Install python packages
+      run: |
+        pip install jinja2==2.11.3 PyYAML==5.4.1 jsonschema==3.2.0 pandas==1.1.4 requests==2.22.0
     - name: Verify urls from agencies.yml
       run: |
-        git rev-list --all | grep ${{ github.event.pull_request.base.sha }}
         git diff ${{ github.event.pull_request.base.sha }} './airflow/data/agencies.yml' > AGENCIES_DIFF
         python script/agencies_verify.py \
           './airflow/data/headers.filled.yml' \
           './airflow/data/agencies.filled.yml' \
           AGENCIES_DIFF
-    - name: Install python packages
-      run: |
-        pip install jinja2==2.11.3 PyYAML==5.4.1 jsonschema==3.2.0 pandas==1.1.4
     # Create the secrets.csv from the contents of the `AGENCY_SECRETS` environment variable / GitHub
     # repository secret. The contents of this environment variable should be directly copied from
     # the contents of a filled-out ./airflow/data/example-secrets.csv file.

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -24,9 +24,7 @@ jobs:
     - name: Verify urls from agencies.yml
       run: |
         git rev-list --all | grep ${{ github.event.pull_request.base.sha }}
-        git diff './airflow/data/agencies.yml' \
-          ${{ github.event.pull_request.base.sha }} \
-          ${{ github.sha }} > AGENCIES_DIFF
+        git diff ${{ github.event.pull_request.base.sha }} './airflow/data/agencies.yml' > AGENCIES_DIFF
         python script/agencies_verify.py \
           './airflow/data/headers.filled.yml' \
           './airflow/data/agencies.filled.yml' \

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -24,13 +24,6 @@ jobs:
     - name: Install python packages
       run: |
         pip install jinja2==2.11.3 PyYAML==5.4.1 jsonschema==3.2.0 pandas==1.1.4 requests==2.22.0
-    - name: Verify urls from agencies.yml
-      run: |
-        git diff ${{ github.event.pull_request.base.sha }} './airflow/data/agencies.yml' > AGENCIES_DIFF
-        python script/agencies_verify.py \
-          './airflow/data/headers.filled.yml' \
-          './airflow/data/agencies.filled.yml' \
-          AGENCIES_DIFF
     # Create the secrets.csv from the contents of the `AGENCY_SECRETS` environment variable / GitHub
     # repository secret. The contents of this environment variable should be directly copied from
     # the contents of a filled-out ./airflow/data/example-secrets.csv file.
@@ -61,6 +54,13 @@ jobs:
         python script/headers_validate.py \
           './airflow/data/headers.filled.yml' \
           './airflow/data/schema_headers_entry.yml'
+    - name: Verify urls from agencies.yml
+      run: |
+        git diff ${{ github.event.pull_request.base.sha }} './airflow/data/agencies.yml' > AGENCIES_DIFF
+        python script/agencies_verify.py \
+          './airflow/data/headers.filled.yml' \
+          './airflow/data/agencies.filled.yml' \
+          AGENCIES_DIFF
 
     - if: ${{ github.repository == 'cal-itp/data-infra' }}
       uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -23,8 +23,7 @@ jobs:
         python-version: 3.8
     - name: Verify urls from agencies.yml
       run: |
-        git rev-list --all
-        git fetch origin main ${{ github.event.pull_request.base.sha }}
+        git rev-list --all | grep ${{ github.event.pull_request.base.sha }}
         git diff './airflow/data/agencies.yml' \
           ${{ github.event.pull_request.base.sha }} \
           ${{ github.sha }} > AGENCIES_DIFF

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -58,8 +58,8 @@ jobs:
       run: |
         git diff ${{ github.event.pull_request.base.sha }} './airflow/data/agencies.yml' > AGENCIES_DIFF
         python script/agencies_verify.py \
-          './airflow/data/headers.filled.yml' \
           './airflow/data/agencies.filled.yml' \
+          './airflow/data/headers.filled.yml' \
           AGENCIES_DIFF
 
     - if: ${{ github.repository == 'cal-itp/data-infra' }}

--- a/.github/workflows/push_to_gcloud.yml
+++ b/.github/workflows/push_to_gcloud.yml
@@ -56,6 +56,7 @@ jobs:
           './airflow/data/schema_headers_entry.yml'
     - name: Verify urls from agencies.yml
       run: |
+        git fetch origin main ${{ github.event.pull_request.base.sha }}
         git diff './airflow/data/agencies.yml' \
           ${{ github.event.pull_request.base.sha }} \
           ${{ github.sha }} > AGENCIES_DIFF

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1,5 +1,5 @@
 ac-transit:
-  agency_name: AC Transit
+  agency_name: AC Transit (testing)
   feeds:
     - gtfs_schedule_url: https://api.actransit.org/transit/gtfs/download?token={{ AC_TRANSIT_API_KEY }}
       gtfs_rt_vehicle_positions_url: https://api.actransit.org/gtfsrt/vehicles?token={{ AC_TRANSIT_API_KEY }}

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1,5 +1,5 @@
 ac-transit:
-  agency_name: AC Transit (testing)
+  agency_name: AC Transit
   feeds:
     - gtfs_schedule_url: https://api.actransit.org/transit/gtfs/download?token={{ AC_TRANSIT_API_KEY }}
       gtfs_rt_vehicle_positions_url: https://api.actransit.org/gtfsrt/vehicles?token={{ AC_TRANSIT_API_KEY }}

--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -1,0 +1,63 @@
+import logging
+import requests
+import sys
+import urllib
+import yaml
+
+sys.path.append("services/gtfs-rt-archive/src/gtfs_rt_archive/")
+
+from mapperfns import map_agencies_urls, map_headers  # noqa
+
+USAGE = """
+Usage:
+python script/agencies_verify.py agencies.yml headers.yml [DIFF]
+
+Arguments:
+agencies.yml - Yaml file containing agencies to download
+headers.yml - Yaml file mapping headers onto urls in agencies.yml
+DIFF - optional git diff between two hashes (will check all urls if not provided)
+"""
+
+
+def main():
+    logger = logging.getLogger("gtfs-rt-archive")
+    successes = []
+    fails = []
+    changed_domains = None
+
+    with open(sys.argv[1], "r") as f:
+        agencies = map_agencies_urls(logger, yaml.load(f, Loader=yaml.SafeLoader))
+    with open(sys.argv[2], "r") as f:
+        headers = dict(list(map_headers(logger, yaml.load(f, Loader=yaml.SafeLoader))))
+    if len(sys.argv) > 3:
+        with open(sys.argv[3], "r") as f:
+            lines = f.readlines()
+            lines = [line for line in lines if line.startswith("+") and "http" in line]
+            changed_urls = ["http" + line.strip().split("http")[-1] for line in lines]
+            changed_domains = [
+                urllib.parse.urlparse(url).netloc for url in changed_urls
+            ]
+
+    for key, url in list(agencies):
+        domain = urllib.parse.urlparse(url).netloc
+        if changed_domains is not None and domain not in changed_domains:
+            continue
+        try:
+            result = requests.get(url, headers=headers.get(key, {}))
+            result.raise_for_status()
+        except requests.HTTPError:
+            print(f"HTTP{result.status_code}: {url}")
+            fails.append(url)
+            continue
+        successes.append(url)
+    print(f"{len(successes)}/{len(successes+fails)} urls successfully downloaded")
+    if fails:
+        print("Exiting with error because some urls failed to download")
+        exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(USAGE)
+        exit()
+    main()

--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -60,5 +60,5 @@ def main():
 if __name__ == "__main__":
     if len(sys.argv) < 3:
         print(USAGE)
-        exit()
+        exit(1)
     main()

--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -25,7 +25,8 @@ def main():
     changed_urls = None
 
     with open(sys.argv[1], "r") as f:
-        agencies = map_agencies_urls(logger, yaml.load(f, Loader=yaml.SafeLoader))
+        agencies_yaml = yaml.load(f, Loader=yaml.SafeLoader)
+        agencies = map_agencies_urls(logger, agencies_yaml, key_prefix="gtfs_")
     with open(sys.argv[2], "r") as f:
         headers = dict(list(map_headers(logger, yaml.load(f, Loader=yaml.SafeLoader))))
     if len(sys.argv) > 3:

--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -1,7 +1,6 @@
 import logging
 import requests
 import sys
-import urllib
 import yaml
 
 sys.path.append("services/gtfs-rt-archive/src/gtfs_rt_archive/")
@@ -23,7 +22,7 @@ def main():
     logger = logging.getLogger("gtfs-rt-archive")
     successes = []
     fails = []
-    changed_domains = None
+    changed_urls = None
 
     with open(sys.argv[1], "r") as f:
         agencies = map_agencies_urls(logger, yaml.load(f, Loader=yaml.SafeLoader))
@@ -34,13 +33,9 @@ def main():
             lines = f.readlines()
             lines = [line for line in lines if line.startswith("+") and "http" in line]
             changed_urls = ["http" + line.strip().split("http")[-1] for line in lines]
-            changed_domains = [
-                urllib.parse.urlparse(url).netloc for url in changed_urls
-            ]
 
     for key, url in list(agencies):
-        domain = urllib.parse.urlparse(url).netloc
-        if changed_domains is not None and domain not in changed_domains:
+        if changed_urls is not None and url not in changed_urls:
             continue
         try:
             result = requests.get(url, headers=headers.get(key, {}))

--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -45,8 +45,9 @@ def main():
         try:
             result = requests.get(url, headers=headers.get(key, {}))
             result.raise_for_status()
-        except requests.HTTPError:
-            print(f"HTTP{result.status_code}: {url}")
+        except Exception as e:
+            print(f"Failed to download {url}")
+            print(f"Reason: {e}")
             fails.append(url)
             continue
         successes.append(url)

--- a/script/requirements.txt
+++ b/script/requirements.txt
@@ -4,3 +4,4 @@ jinja2==2.11.3
 PyYAML==5.4.1
 jsonschema==3.2.0
 pandas==1.1.4
+requests==2.22.0

--- a/script/yml_convert.py
+++ b/script/yml_convert.py
@@ -11,7 +11,7 @@ if len(sys.argv) < 4:
         "3 arguments required: input file, output file, and spreadsheet url"
     )
 else:
-    FNAME_IN, FNAME_OUT, SPREADSHEET_URL = sys.argv[1:]
+    FNAME_IN, FNAME_OUT, SPREADSHEET_URL = sys.argv[1:4]
 
 api_key_df = pd.read_csv(SPREADSHEET_URL)
 api_keys = dict(zip(api_key_df["name"], api_key_df["api_key"]))
@@ -24,7 +24,8 @@ template = env.from_string(agencies_path.read_text())
 new_agencies = template.render(**api_keys)
 
 try:
-    yaml.safe_load(StringIO(new_agencies))
+    if "--unsafe" not in sys.argv:
+        yaml.safe_load(StringIO(new_agencies))
 except yaml.ParserError:
     raise Exception("Filled out agencies.yml is not valid yaml")
 

--- a/services/gtfs-rt-archive/src/gtfs_rt_archive/mapperfns.py
+++ b/services/gtfs-rt-archive/src/gtfs_rt_archive/mapperfns.py
@@ -18,7 +18,7 @@ map_data : object
 """
 
 
-def map_agencies_urls(logger, yaml_data):
+def map_agencies_urls(logger, yaml_data, key_prefix="gtfs_rt"):
     """Maps unique identifiers to GTFS-RT feed urls from an agencies.yml
 
     Each URL is mapped to an identifier which is a combination of its agency id, its
@@ -43,7 +43,7 @@ def map_agencies_urls(logger, yaml_data):
 
         for i, feed_set in enumerate(agency_def["feeds"]):
             for feed_name, feed_url in feed_set.items():
-                if feed_name.startswith("gtfs_rt") and feed_url:
+                if feed_name.startswith(key_prefix) and feed_url:
 
                     agency_itp_id = agency_def["itp_id"]
                     feed_id = "{}/{}/{}".format(agency_itp_id, i, feed_name)

--- a/services/gtfs-rt-archive/src/gtfs_rt_archive/mapperfns.py
+++ b/services/gtfs-rt-archive/src/gtfs_rt_archive/mapperfns.py
@@ -58,7 +58,6 @@ def map_headers(logger, yaml_data):
     """
     seen = set()
     for item in yaml_data:
-        print(yaml_data)
         for url_set in item["URLs"]:
             itp_id = url_set["itp_id"]
             url_number = url_set["url_number"]

--- a/services/gtfs-rt-archive/src/gtfs_rt_archive/mapperfns.py
+++ b/services/gtfs-rt-archive/src/gtfs_rt_archive/mapperfns.py
@@ -58,6 +58,7 @@ def map_headers(logger, yaml_data):
     """
     seen = set()
     for item in yaml_data:
+        print(yaml_data)
         for url_set in item["URLs"]:
             itp_id = url_set["itp_id"]
             url_number = url_set["url_number"]


### PR DESCRIPTION
# Overall Description

Fixes #908. This adds an action to the push_to_gcloud workflow that runs `git diff airflow/data/agencies.yml OLD_HASH NEW_HASH` to get a list of all urls that have been added to the agencies.yml file. It then loads the actual agencies.yml file and downloads any urls matching the domains found in the diff.

Update: As you can see from the lovely column of red X's in the commit history, I did eventually get the workflow to run successfully. I didn't modify any actual urls so it passed with 0/0 urls checked.

## Instructions

* Checkout this branch and run `python script/agencies_verify.py /path/to/agencies.yml /path/to/headers.yml` to verify all urls. Note that on my current list (taken from the google bucket yesterday) the api.actransit.org urls cause 3xHTTP404 errors.
* Now do `git diff agencies.yml f18ac09 HEAD > DIFF` to emulate what github does in the workflow changes.
* Run `python script/agencies_verify.py /path/to/agencies.yml /path/to/headers.yml DIFF` to only check the domains listed in the DIFF file.
* modify agencies.yml by changing the path of some url (note, not the domain, but the path) and run the previous command again. This time that URL should 404.
## Checklist for all PRs

- [X] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.
