### PR TITLE
fix(gtfs-schedule): trim whitespace before view creation

### DIFF
--- a/airflow/dags/gtfs_views_staging/agency_clean.sql
+++ b/airflow/dags/gtfs_views_staging/agency_clean.sql
@@ -5,8 +5,22 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(agency_id) as agency_id
+    , TRIM(agency_name) as agency_name
+    , TRIM(agency_url) as agency_url
+    , TRIM(agency_timezone) as agency_timezone
+    , TRIM(agency_lang) as agency_lang
+    , TRIM(agency_phone) as agency_phone
+    , TRIM(agency_fare_url) as agency_fare_url
+    , TRIM(agency_email) as agency_email
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS agency_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.agency`

--- a/airflow/dags/gtfs_views_staging/calendar_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_clean.sql
@@ -5,11 +5,25 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(start_date, end_date, calitp_deleted_at),
-    PARSE_DATE("%Y%m%d",start_date) AS start_date,
-    PARSE_DATE("%Y%m%d",end_date) AS end_date,
-    FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
-        AS calendar_key,
-    COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(service_id) as service_id
+    , TRIM(monday) as monday
+    , TRIM(tuesday) as tuesday
+    , TRIM(wednesday) as wednesday
+    , TRIM(thursday) as thursday
+    , TRIM(friday) as friday
+    , TRIM(saturday) as saturday
+    , TRIM(sunday) as sunday
+    , PARSE_DATE("%Y%m%d", TRIM(start_date)) AS start_date
+    , PARSE_DATE("%Y%m%d", TRIM(end_date)) AS end_date
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        AS calendar_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.calendar`

--- a/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
@@ -4,8 +4,17 @@ dst_table_name: "gtfs_schedule_type2.calendar_dates_clean"
 dependencies:
   - type2_loaded
 ---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-  * EXCEPT(date, calitp_deleted_at)
-  , PARSE_DATE("%Y%m%d",date) AS date
+  calitp_itp_id
+  , calitp_url_number
+  , TRIM(service_id) as service_id
+  , TRIM(exception_type) as exception_type
+  , calitp_extracted_at
+  , calitp_hash
+  , PARSE_DATE("%Y%m%d", TRIM(date)) AS date
   , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.calendar_dates`

--- a/airflow/dags/gtfs_views_staging/feed_info_clean.sql
+++ b/airflow/dags/gtfs_views_staging/feed_info_clean.sql
@@ -5,11 +5,24 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(feed_start_date, feed_end_date, calitp_deleted_at),
-    PARSE_DATE("%Y%m%d",feed_start_date) AS feed_start_date,
-    PARSE_DATE("%Y%m%d",feed_end_date) AS feed_end_date,
-    FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
-        AS feed_info_key,
-    COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(feed_publisher_name) as feed_publisher_name
+    , TRIM(feed_publisher_url) as feed_publisher_url
+    , TRIM(feed_lang) as feed_lang
+    , TRIM(default_lang) as default_lang
+    , TRIM(feed_version) as feed_version
+    , TRIM(feed_contact_email) as feed_contact_email
+    , TRIM(feed_contact_url) as feed_contact_url
+    , calitp_extracted_at
+    , calitp_hash
+    , PARSE_DATE("%Y%m%d", TRIM(feed_start_date)) AS feed_start_date
+    , PARSE_DATE("%Y%m%d", TRIM(feed_end_date)) AS feed_end_date
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        AS feed_info_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.feed_info`

--- a/airflow/dags/gtfs_views_staging/pathways_clean.sql
+++ b/airflow/dags/gtfs_views_staging/pathways_clean.sql
@@ -5,8 +5,26 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(pathway_id) as pathway_id
+    , TRIM(from_stop_id) as from_stop_id
+    , TRIM(to_stop_id) as to_stop_id
+    , pathway_mode
+    , is_bidirectional
+    , length
+    , traversal_time
+    , stair_count
+    , max_slope
+    , min_width
+    , TRIM(signposted_as) as signposted_as
+    , TRIM(reversed_signposted_as) as reversed_signposted_as
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS pathway_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.pathways`

--- a/airflow/dags/gtfs_views_staging/routes_clean.sql
+++ b/airflow/dags/gtfs_views_staging/routes_clean.sql
@@ -5,11 +5,27 @@ dependencies:
   - type2_loaded
 ---
 
-
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
 
 SELECT
-    * EXCEPT(calitp_deleted_at),
-    FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
-        AS route_key,
-    COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(route_id) as route_id
+    , TRIM(route_type) as route_type
+    , TRIM(agency_id) as agency_id
+    , TRIM(route_short_name) as route_short_name
+    , TRIM(route_long_name) as route_long_name
+    , TRIM(route_desc) as route_desc
+    , TRIM(route_url) as route_url
+    , TRIM(route_color) as route_color
+    , TRIM(route_text_color) as route_text_color
+    , TRIM(route_sort_order) as route_sort_order
+    , TRIM(continuous_pickup) as continuous_pickup
+    , TRIM(continuous_drop_off) as continuous_drop_off
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        AS route_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.routes`

--- a/airflow/dags/gtfs_views_staging/stop_times_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stop_times_clean.sql
@@ -6,7 +6,22 @@ dependencies:
 ---
 
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(trip_id) as trip_id
+    , TRIM(stop_id) as stop_id
+    , TRIM(stop_sequence) as stop_sequence
+    , TRIM(arrival_time) as arrival_time
+    , TRIM(departure_time) as departure_time
+    , TRIM(stop_headsign) as stop_headsign
+    , TRIM(pickup_type) as pickup_type
+    , TRIM(drop_off_type) as drop_off_type
+    , TRIM(continuous_pickup) as continuous_pickup
+    , TRIM(continuous_drop_off) as continuous_drop_off
+    , TRIM(shape_dist_traveled) as shape_dist_traveled
+    , TRIM(timepoint) as timepoint
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
         AS stop_time_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at

--- a/airflow/dags/gtfs_views_staging/stops_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stops_clean.sql
@@ -5,8 +5,29 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(stop_id) as stop_id
+    , TRIM(tts_stop_name) as tts_stop_name
+    , stop_lat
+    , stop_lon
+    , TRIM(zone_id) as zone_id
+    , TRIM(parent_station) as parent_station
+    , TRIM(stop_code) as stop_code
+    , TRIM(stop_name) as stop_name
+    , TRIM(stop_desc) as stop_desc
+    , TRIM(stop_url) as stop_url
+    , TRIM(location_type) as location_type
+    , TRIM(stop_timezone) as stop_timezone
+    , TRIM(wheelchair_boarding) as wheelchair_boarding
+    , TRIM(level_id) as level_id
+    , TRIM(platform_code) as platform_code
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS stop_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.stops`

--- a/airflow/dags/gtfs_views_staging/trips_clean.sql
+++ b/airflow/dags/gtfs_views_staging/trips_clean.sql
@@ -5,8 +5,24 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(route_id) as route_id
+    , TRIM(service_id) as service_id
+    , TRIM(trip_id) as trip_id
+    , TRIM(shape_id) as shape_id
+    , TRIM(trip_headsign) as trip_headsign
+    , TRIM(trip_short_name) as trip_short_name
+    , TRIM(direction_id) as direction_id
+    , TRIM(block_id) as block_id
+    , TRIM(wheelchair_accessible) as wheelchair_accessible
+    , TRIM(bikes_allowed) as bikes_allowed
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS trip_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.trips`

--- a/airflow/dags/gtfs_views_staging/validation_notices_clean.sql
+++ b/airflow/dags/gtfs_views_staging/validation_notices_clean.sql
@@ -5,7 +5,55 @@ dependencies:
   - type2_loaded
 ---
 
+-- Must trim string fields that come from raw GTFS tables that we clean & load into views
+-- (To allow joining with the cleaned data after this is run)
+-- Don't trim stopId because we don't load stops into views
+-- This table has over 70 columns, so even though EXCEPT is a bit messy it still seems cleaner
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    * EXCEPT(
+      calitp_deleted_at
+      , fareId
+      , previousFareId
+      , routeId
+      , currentDate
+      , feedEndDate
+      , routeColor
+      , routeTextColor
+      , tripId
+      , tripIdA
+      , tripIdB
+      , routeShortName
+      , routeLongName
+      , routeDesc
+      , stopId
+      , stopName
+      , serviceIdA
+      , serviceIdB
+      , departureTime
+      , arrivalTime
+      , parentStation
+      , parentStopName)
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    , TRIM(fareId) as fareId
+    , TRIM(previousFareId) as previousFareId
+    , TRIM(routeId) as routeId
+    , TRIM(currentDate) as currentDate
+    , TRIM(feedEndDate) as feedEndDate
+    , TRIM(routeColor) as routeColor
+    , TRIM(routeTextColor) as routeTextColor
+    , TRIM(tripId) as tripId
+    , TRIM(tripIdA) as tripIdA
+    , TRIM(tripIdB) as tripIdB
+    , TRIM(routeShortName) as routeShortName
+    , TRIM(routeLongName) as routeLongName
+    , TRIM(routeDesc) as routeDesc
+    , TRIM(stopId) as stopId
+    , TRIM(stopName) as stopName
+    , TRIM(serviceIdA) as serviceIdA
+    , TRIM(serviceIdB) as serviceIdB
+    , TRIM(departureTime) as departureTime
+    , TRIM(arrivalTime) as arrivalTime
+    , TRIM(parentStation) as parentStation
+    , TRIM(parentStopName) as parentStopName
 FROM `gtfs_schedule_type2.validation_notices`


### PR DESCRIPTION
# Overall Description

This PR resolves #946 by trimming whitespace at the `gtfs_views_staging` step in the GTFS pipeline, thereby addressing #914. 🚨 **Reviewers please do not merge this without talking to me, I would like to make sure that we receive multiple reviews to confirm this approach since it has side effects.** 

We need to do *some* trimming this week so that SacRT will have service information in the January reports. If people do not agree with the approach outlined here, we can make a separate PR to just make a targeted fix for `service_id` for SacRT and postpone the larger decision. 

Please see extensive notes about considerations for how to handle the whitespace issue in #946. In the end, I chose the approach I did (trimming in SQL) based on the arguments put forth by @machow:

>   If it seems like a legit loading issue (e.g. "we are parsing csvs wrong"), then I could see changing the pre-processing task. But in the case of even slight ambiguity I would say fixing belongs in SQL transformation, because whether it's an error is a business decision.
    In other words, the validator can change how it handles this, and guidelines could change. But if pre-processed out..
        it would be annoying to migrate raw data load to reflect these business realities, when we have a staging layer for that.
        it would be difficult to understand the business impact of the decision (e.g. answering how often does this occur?)

However, I want to make sure we are all in alignment on this based on the considerations outlined below.

## Additional notes

Numbered for ease of reference.

1. ✅ `views.gtfs_schedule_fact_daily_trips` does now show trips for SacRT (the original issue we wanted to address); this is visible in `staging` now.
2. ✅ I confirmed that I didn't accidentally drop any columns in my enumeration, using a query on `INFORMATION_SCHEMA.COLUMNS`. 
3. ❓ I checked how many tables/columns have leading/trailing whitespace, to see whether we should just trim ID columns or whether we should trim all string columns. I confirmed that there are leading / trailing whitespaces in dozens of columns and across most of the tables that we load (it's not isolated to just one or two locations). It seemed better to trim across the board based on Chris and Elizabeth's feedback that preserving these spaces isn't appropriate anyway. However, see subsequent warnings. 
4. ⚠️ This trimming only occurs right before we create the `views`. This means that we are not doing any trimming on files (like `shapes`) that we do not yet load into `views`. **This means that joins between `views` and other data, like `shapes` would not be fully supported; `shape_id` in the `trips` views would be trimmed, but `shape_id` in `gtfs_schedule_type2.shapes` would not be trimmed.** This would be a new, stricter semantic boundary between `views` and earlier data. 
    - ⚠️ In particular, this would mean that the data in `GTFS Schedule Feeds Latest` in Metabase (which corresponds to the `gtfs_schedule` dataset in BigQuery) would no longer align with the `views` data and joins between the two would not be supported. **The `GTFS Schedule Feeds Latest` data would be untrimmed and subject to joining problems like the SacRT issue.**
5. ⚠️ Trimming requires that we explicitly enumerate columns. This means that we now have to keep `gtfs_views_staging` in sync with `gtfs_schedule_history` where we define what fields we load from the raw files. I don't think that this is a huge problem (I don't think we anticipate that these fields will change often, and any failure to keep them in sync will be obvious because the new field won't appear in `views` unless it's added here). 
6. ⛔  We effectively cannot handle quoted vs. unquoted fields differently. I really do not think it's practical in our pipeline, no matter what stage we trim at. So this step will trim the whitespace from `"<space>7"` and `<space>7` alike. 

## Alternatives considered

The raw GTFS data is handled as follows:
1. Downloaded in [`gtfs_downloader`](https://github.com/cal-itp/data-infra/blob/main/airflow/dags/gtfs_downloader/download_data.py) -- we clearly do not want to do any trimming on the actual raw data
2. ⭐ Copied to `gtfs-data/schedule/processed` in [`gtfs_loader/gtfs_schedule_history_load.py`](https://github.com/cal-itp/data-infra/blob/main/airflow/dags/gtfs_loader/gtfs_schedule_history_load.py) -- **trimming whitespace as part of this operation is the best/main alternative to the current approach**
   - Trimming here would trim ALL data before it is ingested into BigQuery at all, but not before the totally raw data is validated
   - This would trim tables including `shapes` etc. that are not (yet) loaded as views -- this would remove consideration 4 above
   - We already explicitly handle columns here, so this would mitigate consideration 5 above
   - Trimming here would mean that we do not have access to the fully raw data in BQ, so it would be more difficult to assess how prevalent leading/trailing whitespace is if we ever revisit this question / if there's a situation where analysts need the raw data, it would essentially not be accessible to them
   - Not sure of potential performance impacts, because this would add an extra Pandas operation on every table being loaded (doubt it's a big deal, but wanted to note just in case)
   - I think (?) this would require explicitly re-running Airflow history to pick up the changes, current approach does it automatically
3. Loaded as external tables in [`gtfs_schedule_history`](https://github.com/cal-itp/data-infra/tree/main/airflow/dags/gtfs_schedule_history) - from what I can tell, there is not a way to trim on external table creation
4. Updates are merged into existing data in [`gtfs_schedule_history2/merge_updates.py`](https://github.com/cal-itp/data-infra/blob/main/airflow/dags/gtfs_schedule_history2/merge_updates.py) -- this step is already pretty complicated and right now it's table-agnostic; trimming requires us to enumerate columns so don't think this is appropriate
5. `gtfs_views_staging` creates the `_clean` tables -- this is the approach in this PR
6. `views` creates the final views; trimming at that point is basically just a worse, more complicated version of the approach in this PR

## Remaining TODOs

- [ ] Perform spot checks on trimmed data to confirm no ill effects
- [x] Double check all references from `views` to the `schedule_type2` data to ensure that we don't reference any untrimmed data
- [x] Fill out reviews requested to request targeted reviews from different stakeholders

## Reviews requested
@themightychris / @e-lo / @mjumbewu / @machow / @evansiroky -- The folks who weighed in on the general CSV interpretation debate. Please let me know what you think.
@edasmalchi -- Hoping you can weigh in on consideration 4 above. Would those limitations be blocking for you? If you think current approach is viable, what documentation is needed to make these caveats clear to analysts? (cc @charlie-costanzo on the docs question)
@Nkdiaz / @atvaccaro -- General code review.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

**gtfs_views_staging**: 
![image](https://user-images.githubusercontent.com/55149902/152053496-d8ce57f7-6f7e-4662-a0a4-e70e000ac9d7.png)

**gtfs_views**: (stop times fails because of query limit, I believe that's unrelated)
![image](https://user-images.githubusercontent.com/55149902/152053664-6fa2fb71-746a-49c9-9ce7-e6ad53d8a660.png)

- [ ] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_views_staging` DAG in order to trim whitespace from `*_clean` tables.

Updates the following DAG tasks:
- `<table>_clean.sql`

