### PR TITLE
fix(gtfs-schedule): targeted whitespace fixes for sacrt service_id

### DIFF
--- a/airflow/dags/gtfs_views_staging/calendar_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_clean.sql
@@ -6,7 +6,8 @@ dependencies:
 ---
 
 SELECT
-    * EXCEPT(start_date, end_date, calitp_deleted_at),
+    * EXCEPT(start_date, end_date, calitp_deleted_at, service_id),
+    TRIM(service_id) as service_id,
     PARSE_DATE("%Y%m%d",start_date) AS start_date,
     PARSE_DATE("%Y%m%d",end_date) AS end_date,
     FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))

--- a/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
@@ -5,7 +5,8 @@ dependencies:
   - type2_loaded
 ---
 SELECT
-  * EXCEPT(date, calitp_deleted_at)
+  * EXCEPT(date, calitp_deleted_at, service_id)
+  , TRIM(service_id) as service_id
   , PARSE_DATE("%Y%m%d",date) AS date
   , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.calendar_dates`

--- a/airflow/dags/gtfs_views_staging/trips_clean.sql
+++ b/airflow/dags/gtfs_views_staging/trips_clean.sql
@@ -6,7 +6,8 @@ dependencies:
 ---
 
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    * EXCEPT(calitp_deleted_at, service_id)
+    , TRIM(service_id) as service_id
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS trip_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.trips`


### PR DESCRIPTION
# Overall Description

While we work out universal whitespace handling in #1022 / #946, we are pushing a limited fix to address just the SacRT and Roseville data that was missing in our reports. 

The intention is that this fix will be backed out (/become irrelevant) once a final approach is decided in the overarching issues. 

## Checklist for all PRs

- [ ] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [ ] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [ ] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [ ] Verify that all affected DAG tasks were able to run in a local environment

Re-ran the affected DAG tasks only (in `staging`, can verify that updated times for `calendar_clean`, `calendar_dates_clean`, and `trips_clean` are later than updated times for other tables): 
![image](https://user-images.githubusercontent.com/55149902/152227291-bcdf040a-88e3-4d43-b8c1-94181a377cf6.png)

Re-ran everything downstream of 



- [ ] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
- [ ] Add/update documentation in the `docs/airflow` folder as needed
- [ ] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `insert DAG name` DAG in order to....

Adds the following DAG tasks:

- ...
- ...

Updates the following DAG tasks:

- ...
- ...
