### PR TITLE
fix: only keep one netlify link per PR

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -66,6 +66,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
+            unique: true,
             body: "Preview url: https://" + context.repo.repo + "-" + process.env.PR_NUMBER + suffix
           })
       env:


### PR DESCRIPTION
The docs publishing github workflow posts a netlify link back to the PR with the PR's example doc site; currently, a new comment is made by the workflow bot for each new commit pushed to the PR.

This PR adds a flag that will delete older comments with duplicate text.