### PR TITLE
fix: pin click 8.0.0

### DIFF
--- a/.github/workflows/check-requirements.yml
+++ b/.github/workflows/check-requirements.yml
@@ -1,0 +1,16 @@
+name: Check requirements
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - run: pip install -r airflow/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Vim
 .*.sw[po]
 
+# JetBrains
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -12,3 +12,7 @@ gtfs-realtime-bindings==0.0.7
 geopandas
 shapely
 pyairtable==1.0.0
+structlog==21.5.0
+typer==0.4.0
+click==8.0.0
+humanize==3.14.0


### PR DESCRIPTION
I broke the Airflow requirements.txt; for some reason, the composer install failed even though typer should be compatible with click 8.0.0; this should? fix things.

I think we need a CI/CD task to test installing the requirements.