### PR TITLE
Add feed-level retries and exception handling to RT parsing operator

### DIFF
--- a/airflow/plugins/operators/realtime_to_flattened_json_operator.py
+++ b/airflow/plugins/operators/realtime_to_flattened_json_operator.py
@@ -142,11 +142,11 @@ def handle_one_feed(feed, files, filename_prefix, iso_date, dst_path, logger):
         fs.put(
             gzip_fname, dst_path + google_cloud_file_name,
         )
-    logger.info(
-        "took {} seconds to process {} files".format(
-            (datetime.now() - start).total_seconds(), len(all_files)
+        logger.info(
+            "took {} seconds to process {} files".format(
+                (datetime.now() - start).total_seconds(), len(all_files)
+            )
         )
-    )
 
 
 def try_handle_one_feed(

--- a/airflow/plugins/operators/realtime_to_flattened_json_operator.py
+++ b/airflow/plugins/operators/realtime_to_flattened_json_operator.py
@@ -92,6 +92,7 @@ def get_google_cloud_filename(filename_prefix, feed, iso_date):
     return f"{prefix}_{iso_date}_{itp_id_url_num}{EXTENSION}"
 
 
+# Try twice in the event we get a ClientResponseError; doesn't have much of a delay (like 0.01s)
 @backoff.on_exception(
     backoff.expo, aiohttp.client_exceptions.ClientResponseError, max_tries=2
 )

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -16,3 +16,4 @@ black==19.10b0
 structlog==21.5.0
 typer==0.4.0
 humanize==3.14.0
+backoff==1.11.1


### PR DESCRIPTION
# Overall Description

Adds retries and exception handling to the rt_loader job. Fixes https://github.com/cal-itp/data-infra/issues/1049.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Verify that all affected DAG tasks were able to run in a local environment
- [ ] ~Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully~ I can do this if needed but these tasks take a very long time to run fully
- [x] Fill out the following section describing what DAG tasks were added/updated

Currently, the RT parsing operator does not retry on any errors, which includes intermittent issues interacting with GCS. This PR adds a single retry to specifically handle ClientResponseError from aoihttp, but also generically captures all exceptions (without retrying) to prevent any one exception from stopping the whole job. Any exceptions are still thrown after all feeds are processed.

Some example output:
```
[2022-02-08 13:53:31,831] {_common.py:104} INFO - Backing off handle_one_feed(...) for 0.1s (aiohttp.client_exceptions.ClientResponseError: <unprintable ClientResponseError object>)
[2022-02-08 13:53:31,905] {_common.py:119} ERROR - Giving up handle_one_feed(...) after 2 tries (aiohttp.client_exceptions.ClientResponseError: <unprintable ClientResponseError object>)
[2022-02-08 13:53:31,905] {_common.py:104} INFO - Backing off handle_one_feed(...) for 0.2s (aiohttp.client_exceptions.ClientResponseError: <unprintable ClientResponseError object>)
[2022-02-08 13:53:31,965] {_common.py:119} ERROR - Giving up handle_one_feed(...) after 2 tries (aiohttp.client_exceptions.ClientResponseError: <unprintable ClientResponseError object>)
[2022-02-08 13:53:31,979] {_common.py:119} ERROR - Giving up handle_one_feed(...) after 2 tries (aiohttp.client_exceptions.ClientResponseError: <unprintable ClientResponseError object>)
```

And successful output
```
2022-02-08 14:54.02 [info     ] writing 17676 lines (336.3 kB) from /var/folders/ls/cdr1pq6n7yn9m0cb41zkflk80000gn/T/tmpvotl4s_9/temporary.jsonl.gz to gs://gtfs-data-test/rt-processed_test_2022-01-27/trip_updates/tu_2022-02-08_126_0.jsonl.gz dst_path=gs://gtfs-data-test/rt-processed_test_2022-01-27/trip_updates/ feed=('126', '0') filename_prefix=tu i=4 iso_date=2022-02-08 len_files=1995 total_feeds=73
2022-02-08 14:54.03 [info     ] took 28.953302 seconds to process 1995 files dst_path=gs://gtfs-data-test/rt-processed_test_2022-01-27/trip_updates/ feed=('126', '0') filename_prefix=tu i=4 iso_date=2022-02-08 len_files=1995 total_feeds=73
```