### PR TITLE
fix(gtfs-rt): define json schema for vehicle positions external table

### DIFF
--- a/airflow/dags/rt_loader/external_service_alerts.sql
+++ b/airflow/dags/rt_loader/external_service_alerts.sql
@@ -8,5 +8,6 @@ dependencies:
 CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.service_alerts`
 OPTIONS (
     format = "JSON",
-    uris = ["{{get_bucket()}}/rt-processed/service_alerts/*.jsonl.gz"]
+    uris = ["{{get_bucket()}}/rt-processed/service_alerts/*.jsonl.gz"],
+    ignore_unknown_values = True
 )

--- a/airflow/dags/rt_loader/external_trip_updates.sql
+++ b/airflow/dags/rt_loader/external_trip_updates.sql
@@ -8,5 +8,6 @@ dependencies:
 CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.trip_updates`
 OPTIONS (
     format = "JSON",
-    uris = ["{{get_bucket()}}/rt-processed/trip_updates/*.jsonl.gz"]
+    uris = ["{{get_bucket()}}/rt-processed/trip_updates/*.jsonl.gz"],
+    ignore_unknown_values = True
 )

--- a/airflow/dags/rt_loader/external_vehicle_positions.sql
+++ b/airflow/dags/rt_loader/external_vehicle_positions.sql
@@ -5,8 +5,48 @@ dependencies:
   - parse_rt_vehicle_positions
 ---
 
-CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.vehicle_positions`
+CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.vehicle_positions` (
+    header STRUCT<
+      timestamp INT64,
+      incrementality STRING,
+      gtfsRealtimeVersion STRING
+    >,
+    id STRING,
+    vehicle STRUCT<
+      vehicle STRUCT <
+        licensePlate STRING,
+        label STRING,
+        id STRING
+      >,
+      trip STRUCT <
+        tripId STRING,
+        routeId STRING,
+        directionId INT64,
+        startTime STRING,
+        startDate STRING,
+        scheduleRelationship STRING
+      >,
+      position STRUCT <
+        latitude NUMERIC,
+        longitude NUMERIC,
+        bearing NUMERIC,
+        odometer INT64,
+        speed NUMERIC
+      >,
+      currentStopSequence INT64,
+      stopId STRING,
+      currentStatus STRING,
+      timestamp INT64,
+      congestionLevel STRING,
+      occupancyStatus STRING,
+      occupancyPercentage INT64
+    >,
+    calitp_itp_id INT64,
+    calitp_url_number INT64,
+    calitp_filepath STRING
+)
 OPTIONS (
     format = "JSON",
-    uris = ["{{get_bucket()}}/rt-processed/vehicle_positions/*.jsonl.gz"]
+    uris = ["{{get_bucket()}}/rt-processed/vehicle_positions/*.jsonl.gz"],
+    ignore_unknown_values = True
 )

--- a/airflow/dags/rt_loader/external_vehicle_positions.sql
+++ b/airflow/dags/rt_loader/external_vehicle_positions.sql
@@ -6,12 +6,15 @@ dependencies:
 ---
 
 CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.vehicle_positions` (
+    calitp_itp_id INT64,
+    calitp_url_number INT64,
+    calitp_filepath STRING,
+    id STRING,
     header STRUCT<
       timestamp INT64,
       incrementality STRING,
       gtfsRealtimeVersion STRING
     >,
-    id STRING,
     vehicle STRUCT<
       vehicle STRUCT <
         licensePlate STRING,
@@ -40,10 +43,7 @@ CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.vehicle_positions` (
       congestionLevel STRING,
       occupancyStatus STRING,
       occupancyPercentage INT64
-    >,
-    calitp_itp_id INT64,
-    calitp_url_number INT64,
-    calitp_filepath STRING
+    >
 )
 OPTIONS (
     format = "JSON",


### PR DESCRIPTION
# Overall Description
Resolves #1051 by:
* Explicitly defining the JSON schema in `external_vehicle_positions.sql`
* Adding the [`ignore_unknown_values` flag](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json#json_options) to all the external table tasks here; this will allow rarely-used fields to be ignored instead of preventing access to the table (I am not sure if we want this to be enabled long-term, but it seemed like it would help smooth things out here in the short term)

**Note that this PR _narrowly_ resolves the issue by focusing only on vehicle positions data.** I wanted to unblock @edasmalchi and vehicle positions is significantly simpler than trip updates. If this approach works out well, we can apply it to service alerts and trip updates as well in a subsequent PR. 

### Resulting fields

Heads up for @edasmalchi -- the field names now follow the JSON hierarchy, so `latitude` and `longitude` are now accessed via `vehicle.position.latitude` and `vehicle.position.longitude` respectively. Right now things follow the [actual GTFS docs](https://gtfs.org/reference/realtime/v2/#message-vehicleposition) pretty closely, with the exception that they show everything in snake case but our processing (which is actually Google's default processing for GTFS pb messages) turns that into camel case, so `current_stop_sequence` in the docs becomes `currentStopSequence` in our table. 

Below are screenshots of the schema, I am hesitant to add these to our actual docs until things have stabilized more but putting here for at least some reference. 

Top-level fields & `header`:
<img width="473" alt="image" src="https://user-images.githubusercontent.com/55149902/153080282-0e4ead56-f686-432b-93d0-9f3dbf0cce68.png">

`vehicle.vehicle` (🙄), `vehicle.trip`, and `vehicle.position`:
<img width="429" alt="image" src="https://user-images.githubusercontent.com/55149902/153080394-085db0d2-7860-4608-af3e-ec80285292c2.png">

And finally other fields immediately under `vehicle` (`vehicle.<field>`):
<img width="422" alt="image" src="https://user-images.githubusercontent.com/55149902/153080501-690a65a6-7be5-4c76-9ddf-7a0fab810319.png">

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
<img width="523" alt="image" src="https://user-images.githubusercontent.com/55149902/153078726-5e6b3608-58ef-4b3a-bb0b-42bea416ef6c.png">

- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_loader` DAG in order to....

Update the following DAG tasks:

- `external_vehicle_positions.sql`: explicitly define JSON schema for the external table; add ignore unknown values flag
- `external_service_alerts.sql` & `external_trip_updates.sql`: add ignore unknown values flag only