### PR TITLE
docs(airflow): adding how to check the logs of PodOperators

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -49,8 +49,8 @@ parts:
     chapters:
       - file: airflow/overview
         sections:
-        - file: airflow/static-schedule-pipeline
         - file: airflow/local-setup
+        - file: airflow/static-schedule-pipeline
         - file: airflow/production-maintenance
         - file: airflow/dags-maintenance
       - file: kubernetes/README

--- a/docs/airflow/local-setup.md
+++ b/docs/airflow/local-setup.md
@@ -1,10 +1,7 @@
 # Local Airflow
 
 ## Running Airflow Locally
-You can run an instance of airflow locally using `docker-compose`. To do so,
-* In the `data-infra` repo, within the `airflow` directory, run:
-
-`docker-compose up`.
+You can run an instance of airflow locally using `docker-compose`. To do so, in the `data-infra` repo, within the `airflow` directory, run: `docker-compose up`.
 
 ## Pulling Pod Logs for PodOperator DAG Tasks
 To pull pod logs for PodOperator DAG tasks during a local airflow run,
@@ -13,6 +10,7 @@ To pull pod logs for PodOperator DAG tasks during a local airflow run,
 
 `resource.labels.pod_name="pod.name"`
 ex.
+
 `resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`
 
 If you're unsure of the name of a pod, in your local Airflow UI:

--- a/docs/airflow/local-setup.md
+++ b/docs/airflow/local-setup.md
@@ -1,5 +1,19 @@
-# Local Setup
+# Local Airflow
 
-It is possible to run airflow locally using `docker-compose`.
+## Running Airflow Locally
+You can run an instance of airflow locally using `docker-compose`. To do so,
+* In the `data-infra` repo, within the `airflow` directory, run:
+`docker-compose up`.
 
-Within the `airflow` directory run: `docker-compose up`.
+## Pulling PodOperator Logs for a Local Airflow Run
+To pull pod logs,
+1. Navigate to GCP > Operations > Logging > Logs Explorer > _query field_
+2. Run the following query, substituting the name of the terminated pod with the pod whose logs you would like to retrieve:
+`resource.labels.pod_name="pod.name"`
+ex.
+`resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`
+
+If you're unsure of the name of a pod, in your local Airflow UI:
+1. Navigate to the logs section for an individual PodOperator DAG task
+2. Search for log messages similar to this, which will provide the name of the pod:
+`Pod not yet started: gtfs-rt-validation.87a693a129d64ccdb3d9d21bf29c2f46`

--- a/docs/airflow/local-setup.md
+++ b/docs/airflow/local-setup.md
@@ -3,17 +3,22 @@
 ## Running Airflow Locally
 You can run an instance of airflow locally using `docker-compose`. To do so,
 * In the `data-infra` repo, within the `airflow` directory, run:
+
 `docker-compose up`.
 
 ## Pulling Pod Logs for PodOperator DAG Tasks
 To pull pod logs for PodOperator DAG tasks during a local airflow run,
-1. Navigate to GCP > Operations > Logging > Logs Explorer > _query field_
+1. Navigate to `GCP` > `Operations` > `Logging` > `Logs Explorer` > _the query field_
 2. Run the following query, substituting the name of the pod with the pod whose logs you would like to retrieve:
+
 `resource.labels.pod_name="pod.name"`
+
 ex.
+
 `resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`
 
 If you're unsure of the name of a pod, in your local Airflow UI:
 1. Navigate to the logs section for an individual PodOperator DAG task
 2. Search for log messages similar to this, which will provide the name of the pod:
+
 `Pod not yet started: gtfs-rt-validation.87a693a129d64ccdb3d9d21bf29c2f46`

--- a/docs/airflow/local-setup.md
+++ b/docs/airflow/local-setup.md
@@ -9,8 +9,8 @@ To pull pod logs for PodOperator DAG tasks during a local airflow run,
 2. Run the following query, substituting the name of the pod with the pod whose logs you would like to retrieve:
 
 `resource.labels.pod_name="pod.name"`
-ex.
-`resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`
+
+ex. `resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`
 
 If you're unsure of the name of a pod, in your local Airflow UI:
 1. Navigate to the logs section for an individual PodOperator DAG task

--- a/docs/airflow/local-setup.md
+++ b/docs/airflow/local-setup.md
@@ -5,10 +5,10 @@ You can run an instance of airflow locally using `docker-compose`. To do so,
 * In the `data-infra` repo, within the `airflow` directory, run:
 `docker-compose up`.
 
-## Pulling PodOperator Logs for a Local Airflow Run
-To pull pod logs,
+## Pulling Pod Logs for PodOperator DAG Tasks
+To pull pod logs for PodOperator DAG tasks during a local airflow run,
 1. Navigate to GCP > Operations > Logging > Logs Explorer > _query field_
-2. Run the following query, substituting the name of the terminated pod with the pod whose logs you would like to retrieve:
+2. Run the following query, substituting the name of the pod with the pod whose logs you would like to retrieve:
 `resource.labels.pod_name="pod.name"`
 ex.
 `resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`

--- a/docs/airflow/local-setup.md
+++ b/docs/airflow/local-setup.md
@@ -10,7 +10,6 @@ To pull pod logs for PodOperator DAG tasks during a local airflow run,
 
 `resource.labels.pod_name="pod.name"`
 ex.
-
 `resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`
 
 If you're unsure of the name of a pod, in your local Airflow UI:

--- a/docs/airflow/local-setup.md
+++ b/docs/airflow/local-setup.md
@@ -12,9 +12,7 @@ To pull pod logs for PodOperator DAG tasks during a local airflow run,
 2. Run the following query, substituting the name of the pod with the pod whose logs you would like to retrieve:
 
 `resource.labels.pod_name="pod.name"`
-
 ex.
-
 `resource.labels.pod_name="gtfs-rt-validation.85d1bfec8223489d886be905ff234a03"`
 
 If you're unsure of the name of a pod, in your local Airflow UI:

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -1,10 +1,10 @@
 (technical-onboarding)=
 # Technical Onboarding
-:::{admonition} How to use this page
+:::{admonition} Bookmark this Page for Quick Access to Team Resources
 :class: tip
 **Analysts**
 * See below for list of our collaboration and analysis tools.
-* Privileges have already been created for you to access the resources below.
+* As part of your onboarding, privileges have already been created for you to access the resources below.
 
 **Non-Analyst Team Members**
 * Any of the tools below are available to you as well!

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -1,6 +1,6 @@
 (technical-onboarding)=
 # Technical Onboarding
-:::{admonition} Bookmark this Page for Quick Access to Team Resources
+:::{admonition} Bookmark this page for quick access to team resources
 :class: tip
 **Analysts**
 * See below for list of our collaboration and analysis tools.


### PR DESCRIPTION
## Docs changes checklist

Adding how to check the logs of PodOperators when running airflow locally

- [x] Make sure the preview website was able to be generated

This PR updates the `docs/developers/airflow/local-setup` in order to....

Add the information outlined in #1055 related to:
* navigating GCP to find logs for PodOperators in the airflow UI when running locally
* fiding the name of the pod when you don't know it

Misc Changes
* reordered TOC to make more sense in the airflow section
* updated phrasing on the `technical onboarding` chapter welcome page
