### PR TITLE
fix(gtfs-rt): fix data types for vehicle positions external table schema

### DIFF
--- a/airflow/dags/rt_loader/external_vehicle_positions.sql
+++ b/airflow/dags/rt_loader/external_vehicle_positions.sql
@@ -30,11 +30,11 @@ CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.vehicle_positions` (
         scheduleRelationship STRING
       >,
       position STRUCT <
-        latitude NUMERIC,
-        longitude NUMERIC,
-        bearing NUMERIC,
-        odometer INT64,
-        speed NUMERIC
+        latitude FLOAT64,
+        longitude FLOAT64,
+        bearing FLOAT64,
+        odometer FLOAT64,
+        speed FLOAT64
       >,
       currentStopSequence INT64,
       stopId STRING,


### PR DESCRIPTION
# Overall Description

Some of the data types I picked in #1056 were wrong (I misunderstood how the data types in the [GTFS documentation](https://gtfs.org/reference/realtime/v2/) mapped to the [BigQuery data types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_types)), and I didn't catch them because of the limited testing data I used in the `gtfs-data-test` bucket. 

This PR fixes `NUMERIC` (and one `INT64`) to be the correct `FLOAT64` type. 

To test this, I ensured that queries that were failing with the current definition succeed with the new definitions on the actual prod data by making an external table in `staging` that still reads data from the prod RT bucket (table is: `cal-itp-data-infra-staging.gtfs_rt.vehicle_positions_test_prod_source`)

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/153235377-6d1ac64f-74fa-454d-b391-7b41c967b382.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_loader` DAG in order to update the following DAG tasks:

- `external_vehicle_positions.sql`: Corrects data types in external table schema definition
