### PR TITLE
Feat initial airtable views

### DIFF
--- a/airflow/dags/airtable_loader/california_transit_service_component.yml
+++ b/airflow/dags/airtable_loader/california_transit_service_component.yml
@@ -1,8 +1,0 @@
-operator: operators.AirtableToWarehouseOperator
-
-air_base_id: appPnJWrQ7ui4UmIl
-air_table_name: "Service - Component"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_service_component
-
-id_name: service_component_id

--- a/airflow/dags/airtable_views/METADATA.yml
+++ b/airflow/dags/airtable_views/METADATA.yml
@@ -1,0 +1,20 @@
+description: "Load data from Airtable"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "hunter.owens@dot.ca.gov"
+      - "evan.siroky@dot.ca.gov"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+wait_for_defaults:
+    timeout: 3600
+latest_only: True

--- a/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
+++ b/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
@@ -1,0 +1,26 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.airtable_california_transit_gtfs_datasets"
+
+description: Data from the GTFS datasets table in the California Transit Airtable base. See Airtable data documentation for more information about its contents. This table represents only the most recent extract and does not track changes in data over time.
+
+fields:
+  gtfs_dataset_id: Internal Airtable ID for this GTFS dataset record, used for joining with other Airtable views tables
+  name: GTFS dataset name
+  data: Single-select categorical choice imported as a string; example values "GTFS Alerts"; "GTFS Schedule"
+
+tests:
+  check_null:
+    - gtfs_dataset_id
+  check_unique:
+    - gtfs_dataset_id
+
+external_dependencies:
+  - airtable_loader: california_transit_gtfs_datasets
+---
+
+SELECT
+  gtfs_dataset_id,
+  name,
+  data,
+FROM `airtable.california_transit_gtfs_datasets`

--- a/airflow/dags/airtable_views/california_transit_gtfs_service_data.sql
+++ b/airflow/dags/airtable_views/california_transit_gtfs_service_data.sql
@@ -1,0 +1,34 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.airtable_california_transit_gtfs_service_data"
+
+description: Data from the gtfs service data table in the California Transit Airtable base. See Airtable data documentation for more information about its contents. This table represents only the most recent extract and does not track changes in data over time.
+
+fields:
+  service_id: Internal Airtable ID for this GTFS service data record, used for joining with other Airtable views tables
+  name: Name for the GTFS dataset <> service relationship
+  services: Internal Airtable ID for the service record in this relationship
+  gtfs_dataset: Internal Airtable ID for the gtfs_dataset record in this relationship
+  category: Indicates whether this is a primary, precursor, or unknown-type GTFS dataset/service relationship
+
+tests:
+  check_null:
+    - gtfs_service_data_id
+    - name
+  check_unique:
+    - gtfs_service_data_id
+
+external_dependencies:
+  - airtable_loader: california_transit_gtfs_service_data
+---
+
+  SELECT
+    gtfs_service_data_id,
+    name,
+    -- service and gtfs_dataset are 1:1 foreign key fields
+    -- but they export as an array from airtable
+    -- turn them into a string for joining
+    REPLACE(REPLACE(REPLACE(services, "'",""), "[", ""), "]", "") services,
+    REPLACE(REPLACE(REPLACE(gtfs_dataset, "'",""), "[", ""), "]", "") gtfs_dataset,
+    category
+  FROM `airtable.california_transit_gtfs_service_data`

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_aggregated_to_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_aggregated_to_x_self.sql
@@ -3,9 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_gtfs_datasets_aggregated_to_x_self
 
-description: | Self-join mapping table for the GTFS gtfs_datasets table,
-aggregated_to column in the California Transit Airtable base.
-Each row represents a relationship between two gtfs_datasets records.
+description: Self-join mapping table for the GTFS gtfs_datasets table, aggregated_to column in the California Transit Airtable base. Each row represents a relationship between two gtfs_datasets records.
 
 fields:
   gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
@@ -24,7 +22,7 @@ tests:
     - aggregated_to_id
 
 external_dependencies:
-- airtable_loader: california_transit_gtfs_datasets
+  - airtable_loader: california_transit_gtfs_datasets
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_aggregated_to_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_aggregated_to_x_self.sql
@@ -1,0 +1,53 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_gtfs_datasets_aggregated_to_x_self
+
+description: | Self-join mapping table for the GTFS gtfs_datasets table,
+aggregated_to column in the California Transit Airtable base.
+Each row represents a relationship between two gtfs_datasets records.
+
+fields:
+  gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
+  aggregated_to_id: Internal Airtable ID for a gtfs_datasets record
+  gtfs_dataset_name: gtfs_datasets record name
+  aggregated_to_name: gtfs_datasets record name
+
+tests:
+  check_null:
+    - gtfs_dataset_id
+    - aggregated_to_id
+    - gtfs_dataset_name
+    - aggregated_to_name
+  check_composite_unique:
+    - gtfs_dataset_id
+    - aggregated_to_id
+
+external_dependencies:
+- airtable_loader: california_transit_gtfs_datasets
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+
+unnested_t1 AS (
+    SELECT
+        T1.gtfs_dataset_id as gtfs_dataset_id
+        , T1.name as gtfs_dataset_name
+        , CAST(aggregated_to AS STRING) AS aggregated_to_id
+    FROM
+        `airtable.california_transit_gtfs_datasets` T1
+        , UNNEST(JSON_VALUE_ARRAY(aggregated_to)) aggregated_to
+),
+t2 AS (
+    SELECT
+        T2.gtfs_dataset_id as aggregated_to_id
+        , T2.name as aggregated_to_name
+    FROM
+        `airtable.california_transit_gtfs_datasets` T2
+)
+
+SELECT *
+FROM unnested_t1
+LEFT JOIN t2 USING(aggregated_to_id)

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced.sql
@@ -1,0 +1,57 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced
+
+description: |
+Mapping table for the GTFS gtfs_datasets table, dataset_producers column
+and the organizations table, gtfs_datasets_produced column in the California Transit
+Airtable base. Each row represents a relationship between a gtfs_datasets
+record and a organizations record.
+
+fields:
+  gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
+  organization_id: Internal Airtable ID for a organizations record
+  gtfs_dataset_name: gtfs_datasets record name
+  organization_name: organizations record name
+
+tests:
+  check_null:
+    - gtfs_dataset_id
+    - organization_id
+    - gtfs_dataset_name
+    - organization_name
+  check_composite_unique:
+    - gtfs_dataset_id
+    - organization_id
+
+external_dependencies:
+- airtable_loader: california_transit_gtfs_datasets
+- airtable_loader: california_transit_organizations
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+unnested_t1 AS (
+    SELECT
+        T1.gtfs_dataset_id
+        , T1.name as gtfs_dataset_name
+        , CAST(dataset_producers AS STRING) AS organization_id
+    FROM
+        `airtable.california_transit_gtfs_datasets` T1
+        , UNNEST(JSON_VALUE_ARRAY(dataset_producers)) dataset_producers
+),
+unnested_t2 AS (
+    SELECT
+        T2.organization_id
+        , T2.name as organization_name
+        , CAST(gtfs_datasets_produced AS STRING) AS gtfs_dataset_id
+    FROM
+        `airtable.california_transit_organizations` T2
+        , UNNEST(JSON_VALUE_ARRAY(gtfs_datasets_produced)) gtfs_datasets_produced
+)
+
+SELECT *
+FROM unnested_t1
+FULL OUTER JOIN unnested_t2 USING(gtfs_dataset_id, organization_id)

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced.sql
@@ -3,11 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced
 
-description: |
-Mapping table for the GTFS gtfs_datasets table, dataset_producers column
-and the organizations table, gtfs_datasets_produced column in the California Transit
-Airtable base. Each row represents a relationship between a gtfs_datasets
-record and a organizations record.
+description: Mapping table for the GTFS gtfs_datasets table, dataset_producers column and the organizations table, gtfs_datasets_produced column in the California Transit Airtable base. Each row represents a relationship between a gtfs_datasets record and a organizations record.
 
 fields:
   gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
@@ -26,8 +22,8 @@ tests:
     - organization_id
 
 external_dependencies:
-- airtable_loader: california_transit_gtfs_datasets
-- airtable_loader: california_transit_organizations
+  - airtable_loader: california_transit_gtfs_datasets
+  - airtable_loader: california_transit_organizations
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets.sql
@@ -1,0 +1,57 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets
+
+description: |
+Mapping table for the GTFS gtfs_datasets table, dataset_publisher column
+and the organizations table, gtfs_datasets column in the California Transit
+Airtable base. Each row represents a relationship between a gtfs_datasets
+record and a organizations record.
+
+fields:
+  gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
+  organization_id: Internal Airtable ID for a organizations record
+  gtfs_dataset_name: gtfs_datasets record name
+  organization_name: organizations record name
+
+tests:
+  check_null:
+    - gtfs_dataset_id
+    - organization_id
+    - gtfs_dataset_name
+    - organization_name
+  check_composite_unique:
+    - gtfs_dataset_id
+    - organization_id
+
+external_dependencies:
+- airtable_loader: california_transit_gtfs_datasets
+- airtable_loader: california_transit_organizations
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+unnested_t1 AS (
+    SELECT
+        T1.gtfs_dataset_id
+        , T1.name as gtfs_dataset_name
+        , CAST(dataset_publisher AS STRING) AS organization_id
+    FROM
+        `airtable.california_transit_gtfs_datasets` T1
+        , UNNEST(JSON_VALUE_ARRAY(dataset_publisher)) dataset_publisher
+),
+unnested_t2 AS (
+    SELECT
+        T2.organization_id
+        , T2.name as organization_name
+        , CAST(gtfs_datasets AS STRING) AS gtfs_dataset_id
+    FROM
+        `airtable.california_transit_organizations` T2
+        , UNNEST(JSON_VALUE_ARRAY(gtfs_datasets)) gtfs_datasets
+)
+
+SELECT *
+FROM unnested_t1
+FULL OUTER JOIN unnested_t2 USING(gtfs_dataset_id, organization_id)

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets.sql
@@ -3,11 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets
 
-description: |
-Mapping table for the GTFS gtfs_datasets table, dataset_publisher column
-and the organizations table, gtfs_datasets column in the California Transit
-Airtable base. Each row represents a relationship between a gtfs_datasets
-record and a organizations record.
+description: Mapping table for the GTFS gtfs_datasets table, dataset_publisher column and the organizations table, gtfs_datasets column in the California Transit Airtable base. Each row represents a relationship between a gtfs_datasets record and a organizations record.
 
 fields:
   gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
@@ -26,8 +22,8 @@ tests:
     - organization_id
 
 external_dependencies:
-- airtable_loader: california_transit_gtfs_datasets
-- airtable_loader: california_transit_organizations
+  - airtable_loader: california_transit_gtfs_datasets
+  - airtable_loader: california_transit_organizations
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset.sql
@@ -1,0 +1,57 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset
+
+description: |
+Mapping table for the GTFS gtfs_datasets table, gtfs_service_mapping column
+and the gtfs_service_data table, gtfs_dataset column in the California Transit
+Airtable base. Each row represents a relationship between a gtfs_datasets
+record and a gtfs_service_data record.
+
+fields:
+  gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
+  gtfs_service_data_id: Internal Airtable ID for a gtfs_service_data record
+  gtfs_dataset_name: gtfs_datasets record name
+  gtfs_service_data_name: gtfs_service_data record name
+
+tests:
+  check_null:
+    - gtfs_dataset_id
+    - gtfs_service_data_id
+    - gtfs_dataset_name
+    - gtfs_service_data_name
+  check_composite_unique:
+    - gtfs_dataset_id
+    - gtfs_service_data_id
+
+external_dependencies:
+- airtable_loader: california_transit_gtfs_datasets
+- airtable_loader: california_transit_gtfs_service_data
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+unnested_t1 AS (
+    SELECT
+        T1.gtfs_dataset_id
+        , T1.name as gtfs_dataset_name
+        , CAST(gtfs_service_mapping AS STRING) AS gtfs_service_data_id
+    FROM
+        `airtable.california_transit_gtfs_datasets` T1
+        , UNNEST(JSON_VALUE_ARRAY(gtfs_service_mapping)) gtfs_service_mapping
+),
+unnested_t2 AS (
+    SELECT
+        T2.gtfs_service_data_id
+        , T2.name as gtfs_service_data_name
+        , CAST(gtfs_dataset AS STRING) AS gtfs_dataset_id
+    FROM
+        `airtable.california_transit_gtfs_service_data` T2
+        , UNNEST(JSON_VALUE_ARRAY(gtfs_dataset)) gtfs_dataset
+)
+
+SELECT *
+FROM unnested_t1
+FULL OUTER JOIN unnested_t2 USING(gtfs_dataset_id, gtfs_service_data_id)

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset.sql
@@ -3,11 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset
 
-description: |
-Mapping table for the GTFS gtfs_datasets table, gtfs_service_mapping column
-and the gtfs_service_data table, gtfs_dataset column in the California Transit
-Airtable base. Each row represents a relationship between a gtfs_datasets
-record and a gtfs_service_data record.
+description: Mapping table for the GTFS gtfs_datasets table, gtfs_service_mapping column and the gtfs_service_data table, gtfs_dataset column in the California Transit Airtable base. Each row represents a relationship between a gtfs_datasets record and a gtfs_service_data record.
 
 fields:
   gtfs_dataset_id: Internal Airtable ID for a gtfs_datasets record
@@ -26,8 +22,8 @@ tests:
     - gtfs_service_data_id
 
 external_dependencies:
-- airtable_loader: california_transit_gtfs_datasets
-- airtable_loader: california_transit_gtfs_service_data
+  - airtable_loader: california_transit_gtfs_datasets
+  - airtable_loader: california_transit_gtfs_service_data
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self.sql
@@ -3,9 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self
 
-description: | Self-join mapping table for the GTFS gtfs_service_data table,
-reference_static_gtfs_service column in the California Transit Airtable base.
-Each row represents a relationship between two gtfs_service_data records.
+description: Self-join mapping table for the GTFS gtfs_service_data table, reference_static_gtfs_service column in the California Transit Airtable base. Each row represents a relationship between two gtfs_service_data records.
 
 fields:
   gtfs_service_data_id: Internal Airtable ID for a gtfs_service_data record
@@ -24,7 +22,7 @@ tests:
     - reference_static_gtfs_service_id
 
 external_dependencies:
-- airtable_loader: california_transit_gtfs_service_data
+  - airtable_loader: california_transit_gtfs_service_data
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self.sql
@@ -1,0 +1,53 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self
+
+description: | Self-join mapping table for the GTFS gtfs_service_data table,
+reference_static_gtfs_service column in the California Transit Airtable base.
+Each row represents a relationship between two gtfs_service_data records.
+
+fields:
+  gtfs_service_data_id: Internal Airtable ID for a gtfs_service_data record
+  reference_static_gtfs_service_id: Internal Airtable ID for a gtfs_service_data record
+  gtfs_service_data_name: gtfs_service_data record name
+  reference_static_gtfs_service_name: gtfs_service_data record name
+
+tests:
+  check_null:
+    - gtfs_service_data_id
+    - reference_static_gtfs_service_id
+    - gtfs_service_data_name
+    - reference_static_gtfs_service_name
+  check_composite_unique:
+    - gtfs_service_data_id
+    - reference_static_gtfs_service_id
+
+external_dependencies:
+- airtable_loader: california_transit_gtfs_service_data
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+
+unnested_t1 AS (
+    SELECT
+        T1.gtfs_service_data_id as gtfs_service_data_id
+        , T1.name as gtfs_service_data_name
+        , CAST(reference_static_gtfs_service AS STRING) AS reference_static_gtfs_service_id
+    FROM
+        `airtable.california_transit_gtfs_service_data` T1
+        , UNNEST(JSON_VALUE_ARRAY(reference_static_gtfs_service)) reference_static_gtfs_service
+),
+t2 AS (
+    SELECT
+        T2.gtfs_service_data_id as reference_static_gtfs_service_id
+        , T2.name as reference_static_gtfs_service_name
+    FROM
+        `airtable.california_transit_gtfs_service_data` T2
+)
+
+SELECT *
+FROM unnested_t1
+LEFT JOIN t2 USING(reference_static_gtfs_service_id)

--- a/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_managed_x_services_provider.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_managed_x_services_provider.sql
@@ -3,11 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_organizations_mobility_services_managed_x_services_provider
 
-description: |
-Mapping table for the GTFS organizations table, mobility_services_managed column
-and the services table, provider column in the California Transit
-Airtable base. Each row represents a relationship between a organizations
-record and a services record.
+description: Mapping table for the GTFS organizations table, mobility_services_managed column and the services table, provider column in the California Transit Airtable base. Each row represents a relationship between a organizations record and a services record.
 
 fields:
   organization_id: Internal Airtable ID for a organizations record
@@ -26,8 +22,8 @@ tests:
     - service_id
 
 external_dependencies:
-- airtable_loader: california_transit_organizations
-- airtable_loader: california_transit_services
+  - airtable_loader: california_transit_organizations
+  - airtable_loader: california_transit_services
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_managed_x_services_provider.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_managed_x_services_provider.sql
@@ -1,0 +1,57 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_organizations_mobility_services_managed_x_services_provider
+
+description: |
+Mapping table for the GTFS organizations table, mobility_services_managed column
+and the services table, provider column in the California Transit
+Airtable base. Each row represents a relationship between a organizations
+record and a services record.
+
+fields:
+  organization_id: Internal Airtable ID for a organizations record
+  service_id: Internal Airtable ID for a services record
+  organization_name: organizations record name
+  service_name: services record name
+
+tests:
+  check_null:
+    - organization_id
+    - service_id
+    - organization_name
+    - service_name
+  check_composite_unique:
+    - organization_id
+    - service_id
+
+external_dependencies:
+- airtable_loader: california_transit_organizations
+- airtable_loader: california_transit_services
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+unnested_t1 AS (
+    SELECT
+        T1.organization_id
+        , T1.name as organization_name
+        , CAST(mobility_services_managed AS STRING) AS service_id
+    FROM
+        `airtable.california_transit_organizations` T1
+        , UNNEST(JSON_VALUE_ARRAY(mobility_services_managed)) mobility_services_managed
+),
+unnested_t2 AS (
+    SELECT
+        T2.service_id
+        , T2.name as service_name
+        , CAST(provider AS STRING) AS organization_id
+    FROM
+        `airtable.california_transit_services` T2
+        , UNNEST(JSON_VALUE_ARRAY(provider)) provider
+)
+
+SELECT *
+FROM unnested_t1
+FULL OUTER JOIN unnested_t2 USING(organization_id, service_id)

--- a/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_operated_x_services_operator.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_operated_x_services_operator.sql
@@ -1,0 +1,57 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_organizations_mobility_services_operated_x_services_operator
+
+description: |
+Mapping table for the GTFS organizations table, mobility_services_operated column
+and the services table, operator column in the California Transit
+Airtable base. Each row represents a relationship between a organizations
+record and a services record.
+
+fields:
+  organization_id: Internal Airtable ID for a organizations record
+  service_id: Internal Airtable ID for a services record
+  organization_name: organizations record name
+  service_name: services record name
+
+tests:
+  check_null:
+    - organization_id
+    - service_id
+    - organization_name
+    - service_name
+  check_composite_unique:
+    - organization_id
+    - service_id
+
+external_dependencies:
+- airtable_loader: california_transit_organizations
+- airtable_loader: california_transit_services
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+unnested_t1 AS (
+    SELECT
+        T1.organization_id
+        , T1.name as organization_name
+        , CAST(mobility_services_operated AS STRING) AS service_id
+    FROM
+        `airtable.california_transit_organizations` T1
+        , UNNEST(JSON_VALUE_ARRAY(mobility_services_operated)) mobility_services_operated
+),
+unnested_t2 AS (
+    SELECT
+        T2.service_id
+        , T2.name as service_name
+        , CAST(operator AS STRING) AS organization_id
+    FROM
+        `airtable.california_transit_services` T2
+        , UNNEST(JSON_VALUE_ARRAY(operator)) operator
+)
+
+SELECT *
+FROM unnested_t1
+FULL OUTER JOIN unnested_t2 USING(organization_id, service_id)

--- a/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_operated_x_services_operator.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_operated_x_services_operator.sql
@@ -3,11 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_organizations_mobility_services_operated_x_services_operator
 
-description: |
-Mapping table for the GTFS organizations table, mobility_services_operated column
-and the services table, operator column in the California Transit
-Airtable base. Each row represents a relationship between a organizations
-record and a services record.
+description: Mapping table for the GTFS organizations table, mobility_services_operated column and the services table, operator column in the California Transit Airtable base. Each row represents a relationship between a organizations record and a services record.
 
 fields:
   organization_id: Internal Airtable ID for a organizations record
@@ -26,8 +22,8 @@ tests:
     - service_id
 
 external_dependencies:
-- airtable_loader: california_transit_organizations
-- airtable_loader: california_transit_services
+  - airtable_loader: california_transit_organizations
+  - airtable_loader: california_transit_services
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_organizations_parent_organization_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_parent_organization_x_self.sql
@@ -1,0 +1,53 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_organizations_parent_organization_x_self
+
+description: | Self-join mapping table for the GTFS organizations table,
+parent_organization column in the California Transit Airtable base.
+Each row represents a relationship between two organizations records.
+
+fields:
+  organization_id: Internal Airtable ID for a organizations record
+  parent_organization_id: Internal Airtable ID for a organizations record
+  organization_name: organizations record name
+  parent_organization_name: organizations record name
+
+tests:
+  check_null:
+    - organization_id
+    - parent_organization_id
+    - organization_name
+    - parent_organization_name
+  check_composite_unique:
+    - organization_id
+    - parent_organization_id
+
+external_dependencies:
+- airtable_loader: california_transit_organizations
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+
+unnested_t1 AS (
+    SELECT
+        T1.organization_id as organization_id
+        , T1.name as organization_name
+        , CAST(parent_organization AS STRING) AS parent_organization_id
+    FROM
+        `airtable.california_transit_organizations` T1
+        , UNNEST(JSON_VALUE_ARRAY(parent_organization)) parent_organization
+),
+t2 AS (
+    SELECT
+        T2.organization_id as parent_organization_id
+        , T2.name as parent_organization_name
+    FROM
+        `airtable.california_transit_organizations` T2
+)
+
+SELECT *
+FROM unnested_t1
+LEFT JOIN t2 USING(parent_organization_id)

--- a/airflow/dags/airtable_views/california_transit_map_organizations_parent_organization_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_parent_organization_x_self.sql
@@ -3,9 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_organizations_parent_organization_x_self
 
-description: | Self-join mapping table for the GTFS organizations table,
-parent_organization column in the California Transit Airtable base.
-Each row represents a relationship between two organizations records.
+description: Self-join mapping table for the GTFS organizations table, parent_organization column in the California Transit Airtable base. Each row represents a relationship between two organizations records.
 
 fields:
   organization_id: Internal Airtable ID for a organizations record
@@ -24,7 +22,7 @@ tests:
     - parent_organization_id
 
 external_dependencies:
-- airtable_loader: california_transit_organizations
+  - airtable_loader: california_transit_organizations
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services.sql
+++ b/airflow/dags/airtable_views/california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services.sql
@@ -1,0 +1,57 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services
+
+description: |
+Mapping table for the GTFS services table, gtfs_services_association column
+and the gtfs_service_data table, services column in the California Transit
+Airtable base. Each row represents a relationship between a services
+record and a gtfs_service_data record.
+
+fields:
+  service_id: Internal Airtable ID for a services record
+  gtfs_service_data_id: Internal Airtable ID for a gtfs_service_data record
+  service_name: services record name
+  gtfs_service_data_name: gtfs_service_data record name
+
+tests:
+  check_null:
+    - service_id
+    - gtfs_service_data_id
+    - service_name
+    - gtfs_service_data_name
+  check_composite_unique:
+    - service_id
+    - gtfs_service_data_id
+
+external_dependencies:
+- airtable_loader: california_transit_services
+- airtable_loader: california_transit_gtfs_service_data
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+unnested_t1 AS (
+    SELECT
+        T1.service_id
+        , T1.name as service_name
+        , CAST(gtfs_services_association AS STRING) AS gtfs_service_data_id
+    FROM
+        `airtable.california_transit_services` T1
+        , UNNEST(JSON_VALUE_ARRAY(gtfs_services_association)) gtfs_services_association
+),
+unnested_t2 AS (
+    SELECT
+        T2.gtfs_service_data_id
+        , T2.name as gtfs_service_data_name
+        , CAST(services AS STRING) AS service_id
+    FROM
+        `airtable.california_transit_gtfs_service_data` T2
+        , UNNEST(JSON_VALUE_ARRAY(services)) services
+)
+
+SELECT *
+FROM unnested_t1
+FULL OUTER JOIN unnested_t2 USING(service_id, gtfs_service_data_id)

--- a/airflow/dags/airtable_views/california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services.sql
+++ b/airflow/dags/airtable_views/california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services.sql
@@ -3,11 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services
 
-description: |
-Mapping table for the GTFS services table, gtfs_services_association column
-and the gtfs_service_data table, services column in the California Transit
-Airtable base. Each row represents a relationship between a services
-record and a gtfs_service_data record.
+description: Mapping table for the GTFS services table, gtfs_services_association column and the gtfs_service_data table, services column in the California Transit Airtable base. Each row represents a relationship between a services record and a gtfs_service_data record.
 
 fields:
   service_id: Internal Airtable ID for a services record
@@ -26,8 +22,8 @@ tests:
     - gtfs_service_data_id
 
 external_dependencies:
-- airtable_loader: california_transit_services
-- airtable_loader: california_transit_gtfs_service_data
+  - airtable_loader: california_transit_services
+  - airtable_loader: california_transit_gtfs_service_data
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_map_services_paratransit_for_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_services_paratransit_for_x_self.sql
@@ -1,0 +1,53 @@
+---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_california_transit_map_services_paratransit_for_x_self
+
+description: | Self-join mapping table for the GTFS services table,
+paratransit_for column in the California Transit Airtable base.
+Each row represents a relationship between two services records.
+
+fields:
+  service_id: Internal Airtable ID for a services record
+  paratransit_for_id: Internal Airtable ID for a services record
+  service_name: services record name
+  paratransit_for_name: services record name
+
+tests:
+  check_null:
+    - service_id
+    - paratransit_for_id
+    - service_name
+    - paratransit_for_name
+  check_composite_unique:
+    - service_id
+    - paratransit_for_id
+
+external_dependencies:
+- airtable_loader: california_transit_services
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+
+unnested_t1 AS (
+    SELECT
+        T1.service_id as service_id
+        , T1.name as service_name
+        , CAST(paratransit_for AS STRING) AS paratransit_for_id
+    FROM
+        `airtable.california_transit_services` T1
+        , UNNEST(JSON_VALUE_ARRAY(paratransit_for)) paratransit_for
+),
+t2 AS (
+    SELECT
+        T2.service_id as paratransit_for_id
+        , T2.name as paratransit_for_name
+    FROM
+        `airtable.california_transit_services` T2
+)
+
+SELECT *
+FROM unnested_t1
+LEFT JOIN t2 USING(paratransit_for_id)

--- a/airflow/dags/airtable_views/california_transit_map_services_paratransit_for_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_services_paratransit_for_x_self.sql
@@ -3,9 +3,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_california_transit_map_services_paratransit_for_x_self
 
-description: | Self-join mapping table for the GTFS services table,
-paratransit_for column in the California Transit Airtable base.
-Each row represents a relationship between two services records.
+description: Self-join mapping table for the GTFS services table, paratransit_for column in the California Transit Airtable base. Each row represents a relationship between two services records.
 
 fields:
   service_id: Internal Airtable ID for a services record
@@ -24,7 +22,7 @@ tests:
     - paratransit_for_id
 
 external_dependencies:
-- airtable_loader: california_transit_services
+  - airtable_loader: california_transit_services
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/dags/airtable_views/california_transit_organizations.sql
+++ b/airflow/dags/airtable_views/california_transit_organizations.sql
@@ -1,0 +1,34 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.airtable_california_transit_organizations"
+
+description: Data from the organizations table in the California Transit Airtable base. See Airtable data documentation for more information about its contents. This table represents only the most recent extract and does not track changes in data over time.
+
+fields:
+  organization_id: Internal Airtable ID for this organization record, used for joining with other Airtable views tables
+  name: Organization name
+  organization_type: Categorical data; example values "City/Town", "Joint Powers Agency"
+  roles: Categorical choices imported as a string where a comma separates different selections; example values "Regional Transportation Planning Agency, Metropolitan Planning Organization"; "Metropolitan Planning Organization"
+  itp_id: Cal-ITP ID
+  details: Text description related to the organization
+
+tests:
+  check_null:
+    - organization_id
+    - name
+  check_unique:
+    - organization_id
+
+external_dependencies:
+  - airtable_loader: california_transit_organizations
+---
+-- roles is a multi-select field in airtable
+-- turn it into a string that's comma-delimited
+  SELECT
+    organization_id,
+    name,
+    organization_type,
+    REPLACE(REPLACE(REPLACE(roles, "'",""), "[", ""), "]", "") roles,
+    itp_id,
+    details
+  FROM `airtable.california_transit_organizations`

--- a/airflow/dags/airtable_views/california_transit_services.sql
+++ b/airflow/dags/airtable_views/california_transit_services.sql
@@ -1,0 +1,33 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.airtable_california_transit_services"
+
+description: Data from the services table in the California Transit Airtable base. See Airtable data documentation for more information about its contents. This table represents only the most recent extract and does not track changes in data over time.
+
+fields:
+  service_id: Internal Airtable ID for this service record, used for joining with other Airtable views tables
+  name: Service name
+  service_type: Categorical choices imported as a string where a comma separates different selections; example values "ADA paratransit, on-demand"; "fixed-route"
+  mode: Categorical choices imported as a string where a comma separates different selections; example values "bus, car/van"; "ferry"
+  currently_operating: Boolean for whether service is currently active
+
+tests:
+  check_null:
+    - service_id
+    - name
+  check_unique:
+    - service_id
+
+external_dependencies:
+  - airtable_loader: california_transit_services
+---
+
+  SELECT
+    service_id,
+    name,
+    -- service type and mode are multi-select fields in airtable
+    -- turn them into a string that's comma-delimited
+    REPLACE(REPLACE(REPLACE(service_type, "'",""), "[", ""), "]", "") service_type,
+    REPLACE(REPLACE(REPLACE(mode, "'",""), "[", ""), "]", "") mode,
+    currently_operating
+  FROM `airtable.california_transit_services`

--- a/airflow/plugins/generate_airtable_mapping_table.py
+++ b/airflow/plugins/generate_airtable_mapping_table.py
@@ -117,8 +117,8 @@ tests:
     - {id2}
 
 external_dependencies:
-- airtable_loader: california_transit_{table1}
-- airtable_loader: california_transit_{table2}
+  - airtable_loader: california_transit_{table1}
+  - airtable_loader: california_transit_{table2}
 ---
 
 -- follow the sandbox example for unnesting airtable data
@@ -172,7 +172,7 @@ tests:
     - {id2}
 
 external_dependencies:
-- airtable_loader: california_transit_{table}
+  - airtable_loader: california_transit_{table}
 ---
 
 -- follow the sandbox example for unnesting airtable data

--- a/airflow/plugins/generate_airtable_mapping_table.py
+++ b/airflow/plugins/generate_airtable_mapping_table.py
@@ -98,10 +98,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_{table_name}
 
-description: Mapping table for the GTFS {table1} table, {table1_col}
-column and the {table2} table, {table2_col} column in the
-California Transit Airtable base. Each row represents a
-relationship between a {table1} record and a {table2} record.
+description: Mapping table for the GTFS {table1} table, {table1_col} column and the {table2} table, {table2_col} column in the California Transit Airtable base. Each row represents a relationship between a {table1} record and a {table2} record.
 
 fields:
   {id1}: Internal Airtable ID for a {table1} record
@@ -156,9 +153,7 @@ operator: operators.SqlToWarehouseOperator
 
 dst_table_name: views.airtable_{table_name}
 
-description: Self-join mapping table for the GTFS {table} table, {col}
-column in the California Transit Airtable base. Each row represents a
-relationship between two {table} records.
+description: Self-join mapping table for the GTFS {table} table, {col} column in the California Transit Airtable base. Each row represents a relationship between two {table} records.
 
 fields:
   {id1}: Internal Airtable ID for a {table} record

--- a/airflow/plugins/generate_airtable_mapping_table.py
+++ b/airflow/plugins/generate_airtable_mapping_table.py
@@ -1,0 +1,207 @@
+# This is a little helper to generate SqlToWarehouse operator tasks
+# to create mapping tables for Airtable data
+
+# To run, start IPython within the airflow/plugins directory:
+# `python3 -m IPython` or similar
+# `import generate_airtable_mapping_table`
+# `generate_airtable_mapping_table.process_csv(
+#   '<path to CSV file>',
+#  '<path to directory to write outputs
+#   (should probably be airflow/dags/airtable_views)>')`
+
+# the CSV file should have four fields: table1, table2, col1, col2
+# where table1 and table2 are warehouse (not raw Airtable) table names
+# and col1 and col2 are the corresponding (warehouse) column names
+# that define the linked record relationship
+# in cases of self-joins, leave table2 and col2 blank
+# and just define the table in table1 and the foreign key column in col1
+# (for example, services.paratransit_for)
+
+import pandas as pd
+
+
+def generate_sql(table1, table2, col1, col2):
+    # fill in SQL template -- first construct name and id column names
+
+    if table1[-1:] == "s":
+        name1 = table1[:-1] + "_name"
+        id1 = table1[:-1] + "_id"
+    else:
+        name1 = table1 + "_name"
+        id1 = table1 + "_id"
+
+    # check if self-join (if self-join, table2 is null)
+    if pd.isnull(table2):
+        # for self join, new column name & id are generated
+        # from the self-join key column's name
+        table_name = "california_transit_map_{table1}_{col1}_x_self".format(
+            table1=table1, col1=col1
+        )
+        if col1[-1:] == "s":
+            name2 = col1[:-1] + "_name"
+            id2 = col1[:-1] + "_id"
+        else:
+            name2 = col1 + "_name"
+            id2 = col1 + "_id"
+        sql = SELF_JOIN_SQL_TEMPLATE.format(
+            table_name=table_name,
+            table=table1,
+            col=col1,
+            name1=name1,
+            id1=id1,
+            name2=name2,
+            id2=id2,
+        )
+    else:
+        table_name = "california_transit_map_{table1}_{col1}_x_{table2}_{col2}".format(
+            table1=table1, col1=col1, table2=table2, col2=col2
+        )
+        if table2[-1:] == "s":
+            name2 = table2[:-1] + "_name"
+            id2 = table2[:-1] + "_id"
+        else:
+            name2 = table2 + "_name"
+            id2 = table2 + "_id"
+        sql = TWO_TABLE_SQL_TEMPLATE.format(
+            table_name=table_name,
+            table1=table1,
+            table2=table2,
+            table1_col=col1,
+            table2_col=col2,
+            id1=id1,
+            id2=id2,
+            name1=name1,
+            name2=name2,
+        )
+    return table_name, sql
+
+
+def write_file(directory, table1, table2, col1, col2):
+    table_name, sql = generate_sql(table1, table2, col1, col2)
+    filepath = directory + table_name + ".sql"
+    with open(filepath, "w") as f:
+        print("writing to {}".format(filepath))
+        f.write(sql)
+
+
+def process_csv(input_csv, directory="../dags/airtable_views/"):
+    csv = pd.read_csv(input_csv)
+    for row in csv.itertuples(index=False, name="row"):
+        print("Processing: {}".format(row))
+        write_file(directory, row.table1, row.table2, row.col1, row.col2)
+
+
+# sql templates -- one for two different tables, other for self-join
+
+TWO_TABLE_SQL_TEMPLATE = """---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_{table_name}
+
+description: Mapping table for the GTFS {table1} table, {table1_col}
+column and the {table2} table, {table2_col} column in the
+California Transit Airtable base. Each row represents a
+relationship between a {table1} record and a {table2} record.
+
+fields:
+  {id1}: Internal Airtable ID for a {table1} record
+  {id2}: Internal Airtable ID for a {table2} record
+  {name1}: {table1} record name
+  {name2}: {table2} record name
+
+tests:
+  check_null:
+    - {id1}
+    - {id2}
+    - {name1}
+    - {name2}
+  check_composite_unique:
+    - {id1}
+    - {id2}
+
+external_dependencies:
+- airtable_loader: california_transit_{table1}
+- airtable_loader: california_transit_{table2}
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+unnested_t1 AS (
+    SELECT
+        T1.{id1}
+        , T1.name as {name1}
+        , CAST({table1_col} AS STRING) AS {id2}
+    FROM
+        `airtable.california_transit_{table1}` T1
+        , UNNEST(JSON_VALUE_ARRAY({table1_col})) {table1_col}
+),
+unnested_t2 AS (
+    SELECT
+        T2.{id2}
+        , T2.name as {name2}
+        , CAST({table2_col} AS STRING) AS {id1}
+    FROM
+        `airtable.california_transit_{table2}` T2
+        , UNNEST(JSON_VALUE_ARRAY({table2_col})) {table2_col}
+)
+
+SELECT *
+FROM unnested_t1
+FULL OUTER JOIN unnested_t2 USING({id1}, {id2})
+"""
+
+SELF_JOIN_SQL_TEMPLATE = """---
+operator: operators.SqlToWarehouseOperator
+
+dst_table_name: views.airtable_{table_name}
+
+description: Self-join mapping table for the GTFS {table} table, {col}
+column in the California Transit Airtable base. Each row represents a
+relationship between two {table} records.
+
+fields:
+  {id1}: Internal Airtable ID for a {table} record
+  {id2}: Internal Airtable ID for a {table} record
+  {name1}: {table} record name
+  {name2}: {table} record name
+
+tests:
+  check_null:
+    - {id1}
+    - {id2}
+    - {name1}
+    - {name2}
+  check_composite_unique:
+    - {id1}
+    - {id2}
+
+external_dependencies:
+- airtable_loader: california_transit_{table}
+---
+
+-- follow the sandbox example for unnesting airtable data
+
+WITH
+
+unnested_t1 AS (
+    SELECT
+        T1.{id1} as {id1}
+        , T1.name as {name1}
+        , CAST({col} AS STRING) AS {id2}
+    FROM
+        `airtable.california_transit_{table}` T1
+        , UNNEST(JSON_VALUE_ARRAY({col})) {col}
+),
+t2 AS (
+    SELECT
+        T2.{id1} as {id2}
+        , T2.name as {name2}
+    FROM
+        `airtable.california_transit_{table}` T2
+)
+
+SELECT *
+FROM unnested_t1
+LEFT JOIN t2 USING({id2})
+"""


### PR DESCRIPTION
# Overall Description

This PR adds the initial Airtable views that should be sufficient to answer the questions in #984 and #985. 🚨 Reviewers please don't merge without confirming that the questions below have been addressed.

Specifically, this PR:
1. Creates `views` versions of `organizations`, `services`, `gtfs service data`, and `gtfs datasets` -- these tables contain only a limited subset of columns that seemed necessary as a first pass
   * ❓ Do these columns look sufficient for a first attempt? Are any really core, stable facts about these entities missing? (Columns are enumerated in each `california_transit_<table name>.sql` file) -- would appreciate @edasmalchi or @e-lo check here
   * ❓ How do we feel about the naming for the main views / tables (`airtable_california_transit_<table name>`)? The names are long, but until #1005 I think this might be our best bet? -- hope @evansiroky can weigh in 
2. Creates a `generate_airtable_mapping_table.py` helper that can be used to generate mapping DAG tasks programmatically 
   * ❓ Would appreciate feedback on the right place store this -- maybe @evansiroky, @atvaccaro, or @mjumbewu can advise
   * ❓ Do we want to store the initial CSV that I used to generate this first batch in the repo? If so, where? (File attached for reference) -- also a Q for @evansiroky, @atvaccaro, or @mjumbewu 
3. Using the helper, creates a bunch of mapping tables between the listed tables
   * ❓ Do these capture the specific relationships we care about to answer #984 / #985 ? -- hoping @evansiroky, @edasmalchi, or @e-lo can advise
   * ❓ How do we feel about the naming convention? -- appreciate thoughts from anyone 

## Checklist for all PRs

- [ ] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [ ] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [ ] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [ ] Verify that all affected DAG tasks were able to run in a local environment
- [ ] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/153294591-16c17c1f-8fd4-4bed-8d0b-47d55b9d3adf.png)
- [ ] Add/update documentation in the `docs/airflow` folder as needed
   - ❓ Do we want to add docs about these to the `Transit Database` section of the docs, the `Airflow` section of the docs, both, neither? I don't have any docs info in here yet because I wanted to confirm that we feel good about this approach and ask what we think is most important to document -- cc @charlie-costanzo here
   - ❓ Is it ok for me to add docs in a follow-up PR?
- [ ] Fill out the following section describing what DAG tasks were added/updated

This PR **creates** the `airtable_views` DAG in order to....

Add the following DAG tasks:

**Primary views**:
- `california_transit_gtfs_datasets.sql`
- `california_transit_gtfs_service_data.sql`
- `california_transit_organizations.sql`
- `california_transit_services.sql`

**Mapping tables**: 
- `california_transit_map_gtfs_datasets_aggregated_to_x_self.sql`
- `california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced.sql`
- `california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets.sql`
- `california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset.sql`
- `california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self.sql`
- `california_transit_map_organizations_mobility_services_managed_x_services_provider.sql`
- `california_transit_map_organizations_mobility_services_operated_x_services_operator.sql`
- `california_transit_map_organizations_parent_organization_x_self.sql`
- `california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services.sql`
- `california_transit_map_services_paratransit_for_x_self.sql`

Here's a screenshot of what one of these mapping tables looks like (`airtable_california_transit_map_organizations_mobility_services_managed_x_services_provider.sql`), just to illustrate:
![image](https://user-images.githubusercontent.com/55149902/153297829-011e8e6e-2e6e-4d86-a1dd-9d7bd50f61e0.png)

**Here's the CSV file I fed into my helper to generate the mapping DAG tasks**:
[mapping_tables.csv](https://github.com/cal-itp/data-infra/files/8036379/mapping_tables.csv)
