### PR TITLE
fix(gtfs-schedule): fix foothill transit static url

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -513,7 +513,7 @@ folsom-stage-line:
 foothill-transit:
   agency_name: Foothill Transit
   feeds:
-    - gtfs_schedule_url: http://foothilltransit.org/gtfs/foothilltransit-ca-us.zip
+    - gtfs_schedule_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Zip.ashx
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -514,9 +514,9 @@ foothill-transit:
   agency_name: Foothill Transit
   feeds:
     - gtfs_schedule_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Zip.ashx
-      gtfs_rt_vehicle_positions_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=VehiclePosition
-      gtfs_rt_service_alerts_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=Alert
-      gtfs_rt_trip_updates_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=TripUpdate
+      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_service_alerts_url: null
+      gtfs_rt_trip_updates_url: null
   itp_id: 112
 fresno-area-express:
   agency_name: Fresno Area Express

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -514,9 +514,9 @@ foothill-transit:
   agency_name: Foothill Transit
   feeds:
     - gtfs_schedule_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Zip.ashx
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=VehiclePosition
+      gtfs_rt_service_alerts_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=Alert
+      gtfs_rt_trip_updates_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=TripUpdate
   itp_id: 112
 fresno-area-express:
   agency_name: Fresno Area Express


### PR DESCRIPTION
# Overall Description

Change the static URL for Foothill Transit; the URL we were using was out of date. Added the new URL from [their website](http://foothilltransit.org/about/developer-resources/) (shoutout @edasmalchi for grabbing that 🙂).

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ - N/A, no issues

## agencies.yml changes checklist

- [x] Include this section whenever any change to the `airflow/data/agencies.yml` file occurs, otherwise please omit this section.
- [x] ~Manually made sure any new feeds have `itp_id`s that are not duplicative~ N/A -- no new feeds
- [x] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [ ] Made sure the Airtable database has consistent information -- I updated the URI field in `gtfs datasets`, is that sufficient?
- [x] Fill out the following section describing what feeds were added/updated

This PR updates `agencies.yml` in order to....

Update the following gtfs datsets:

- Foothill Transit (ITP ID 112) static data -- change the URL as described above