### PR TITLE
fix(airtable): add dummy airtable loader for external dependencies

### DIFF
--- a/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
+++ b/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
@@ -15,8 +15,8 @@ tests:
   check_unique:
     - gtfs_dataset_id
 
-external_dependencies:
-  - airtable_loader: california_transit_gtfs_datasets
+dependencies:
+  - dummy_airtable_loader
 ---
 
 SELECT

--- a/airflow/dags/airtable_views/california_transit_gtfs_service_data.sql
+++ b/airflow/dags/airtable_views/california_transit_gtfs_service_data.sql
@@ -18,8 +18,8 @@ tests:
   check_unique:
     - gtfs_service_data_id
 
-external_dependencies:
-  - airtable_loader: california_transit_gtfs_service_data
+dependencies:
+  - dummy_airtable_loader
 ---
 
   SELECT

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_aggregated_to_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_aggregated_to_x_self.sql
@@ -21,8 +21,8 @@ tests:
     - gtfs_dataset_id
     - aggregated_to_id
 
-external_dependencies:
-  - airtable_loader: california_transit_gtfs_datasets
+dependencies:
+  - dummy_airtable_loader
 ---
 
 {{

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_producers_x_organizations_gtfs_datasets_produced.sql
@@ -21,9 +21,8 @@ tests:
     - gtfs_dataset_id
     - organization_id
 
-external_dependencies:
-  - airtable_loader: california_transit_gtfs_datasets
-  - airtable_loader: california_transit_organizations
+dependencies:
+  - dummy_airtable_loader
 ---
 
 {{

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_dataset_publisher_x_organizations_gtfs_datasets.sql
@@ -21,9 +21,8 @@ tests:
     - gtfs_dataset_id
     - organization_id
 
-external_dependencies:
-  - airtable_loader: california_transit_gtfs_datasets
-  - airtable_loader: california_transit_organizations
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_datasets_gtfs_service_mapping_x_gtfs_service_data_gtfs_dataset.sql
@@ -21,9 +21,8 @@ tests:
     - gtfs_dataset_id
     - gtfs_service_data_id
 
-external_dependencies:
-  - airtable_loader: california_transit_gtfs_datasets
-  - airtable_loader: california_transit_gtfs_service_data
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_gtfs_service_data_reference_static_gtfs_service_x_self.sql
@@ -21,8 +21,8 @@ tests:
     - gtfs_service_data_id
     - reference_static_gtfs_service_id
 
-external_dependencies:
-  - airtable_loader: california_transit_gtfs_service_data
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_managed_x_services_provider.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_managed_x_services_provider.sql
@@ -21,9 +21,8 @@ tests:
     - organization_id
     - service_id
 
-external_dependencies:
-  - airtable_loader: california_transit_organizations
-  - airtable_loader: california_transit_services
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_operated_x_services_operator.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_mobility_services_operated_x_services_operator.sql
@@ -21,9 +21,8 @@ tests:
     - organization_id
     - service_id
 
-external_dependencies:
-  - airtable_loader: california_transit_organizations
-  - airtable_loader: california_transit_services
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_map_organizations_parent_organization_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_organizations_parent_organization_x_self.sql
@@ -21,8 +21,8 @@ tests:
     - organization_id
     - parent_organization_id
 
-external_dependencies:
-  - airtable_loader: california_transit_organizations
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services.sql
+++ b/airflow/dags/airtable_views/california_transit_map_services_gtfs_services_association_x_gtfs_service_data_services.sql
@@ -21,9 +21,8 @@ tests:
     - service_id
     - gtfs_service_data_id
 
-external_dependencies:
-  - airtable_loader: california_transit_services
-  - airtable_loader: california_transit_gtfs_service_data
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_map_services_paratransit_for_x_self.sql
+++ b/airflow/dags/airtable_views/california_transit_map_services_paratransit_for_x_self.sql
@@ -21,8 +21,8 @@ tests:
     - service_id
     - paratransit_for_id
 
-external_dependencies:
-  - airtable_loader: california_transit_services
+dependencies:
+  - dummy_airtable_loader
 ---
 {{
 

--- a/airflow/dags/airtable_views/california_transit_organizations.sql
+++ b/airflow/dags/airtable_views/california_transit_organizations.sql
@@ -19,8 +19,8 @@ tests:
   check_unique:
     - organization_id
 
-external_dependencies:
-  - airtable_loader: california_transit_organizations
+dependencies:
+  - dummy_airtable_loader
 ---
 -- roles is a multi-select field in airtable
 -- turn it into a string that's comma-delimited

--- a/airflow/dags/airtable_views/california_transit_services.sql
+++ b/airflow/dags/airtable_views/california_transit_services.sql
@@ -18,8 +18,8 @@ tests:
   check_unique:
     - service_id
 
-external_dependencies:
-  - airtable_loader: california_transit_services
+dependencies:
+  - dummy_airtable_loader
 ---
 
   SELECT

--- a/airflow/dags/airtable_views/dummy_airtable_loader.yml
+++ b/airflow/dags/airtable_views/dummy_airtable_loader.yml
@@ -1,0 +1,4 @@
+operator: airflow.operators.dummy_operator.DummyOperator
+
+external_dependencies:
+  - airtable_loader: all


### PR DESCRIPTION
# Overall Description

Restructure dependencies for the `airtable_views` DAG to resolve #1080. Basically, it seems likely that there's a gusty bug such that specifying multiple `external_dependencies` is not working correctly. 

Also, it seems that elsewhere in our pipeline when we have a "staging" and  "views", we usually have the views depend on a `DummyOperator` that waits for the entire staging DAG to complete. 

So, I am making the Airtable flow align with that convention, which also addresses the original problem. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/153943211-73fb7ed8-86c7-4c9e-9f64-ecea9ab14b1b.png)

- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `airtable_views` DAG in order to standardize the external dependency handling.

Adds the following DAG tasks:

- `dummy_airtable_loader.yml` - waits for `airtable_loader` to complete, following pattern from elsewhere in our codebase

Updates the following DAG tasks:
- all existing `airtable_views` tasks were updated to have their dependencies point to the dummy rather than the external dependencies 