### PR TITLE
docs(general): Making clarity tweaks to get docs 'live'

### DIFF
--- a/docs/analytics_examples/overview.md
+++ b/docs/analytics_examples/overview.md
@@ -1,3 +1,4 @@
+(analysis-examples-overview)=
 # Analysis Examples
 The section below provides examples of various elements of the analysis process.
 

--- a/docs/analytics_examples/sample-catalog-viewer.md
+++ b/docs/analytics_examples/sample-catalog-viewer.md
@@ -1,4 +1,5 @@
 (sample-catalog)=
 # Sample Data Catalog
+This sample catalogue is used as an example in the [Using Data Catalogues](data-catalogs) section of the [Introduction to Analytics Tools](intro-analytics-tools) chapter.
 ```{literalinclude} sample-catalog.yml
 ```

--- a/docs/analytics_publishing/how_to_publish.md
+++ b/docs/analytics_publishing/how_to_publish.md
@@ -1,4 +1,5 @@
-# Publishing Reports with Pull Requests (WIP)
+(publishing-with-pull-requests)=
+# Publishing Reports with Pull Requests
 
 Analysts have a variety of tools available to publish their final deliverables. With iterative work, analysts can implement certain best practices within these bounds to do as much as is programmatically practical. The workflow will look different depending on these factors:
 

--- a/docs/analytics_publishing/overview.md
+++ b/docs/analytics_publishing/overview.md
@@ -1,6 +1,5 @@
 (publish-analyses)=
-# How to Publish Analyses (WIP)
-After reading this section, you should be able to:
-* x
-* y
-* z
+# How to Publish Analyses
+This section outlines the process of 'publishing' an analysis after an analyst has completed it to promote visibility and preserve it for long-term access and use.
+* [Publishing Reports with Pull Requests](publishing-with-pull-requests)
+* [Where Reports Live](where-reports-live)

--- a/docs/analytics_publishing/where_reports_live.md
+++ b/docs/analytics_publishing/where_reports_live.md
@@ -1,2 +1,3 @@
+(where-reports-live)=
 # Where Reports Live (WIP)
 To-do

--- a/docs/analytics_tools/data_catalogs.md
+++ b/docs/analytics_tools/data_catalogs.md
@@ -74,12 +74,12 @@ To import this dataset as a dataframe within the notebook:
 ```python
 df = catalog.ca_open_data.cdcr_population_covid_tracking.read()
 ```
-
+(catalogue-cloud-storage)=
 ### Google Cloud Storage
 
 When putting GCS files into the catalog, note that geospatial datasets (zipped shapefiles, GeoJSONs) require the additional `use_fsspec: true` argument compared to tabular datasets (parquets, CSVs). Geoparquets, the exception, are catalogued like tabular datasets.
 
-Opening geospatial datasets through `intake` is the easiest way to import these datasets within a Jupyter Notebook. Otherwise, `geopandas` can read the geospatial datasets that are locally saved or downloaded first from the bucket, but not directly with a GCS file path. Refer to [storing data](./storing_data.md#setting-up-google-authentication) to set up your Google authentication.
+Opening geospatial datasets through `intake` is the easiest way to import these datasets within a Jupyter Notebook. Otherwise, `geopandas` can read the geospatial datasets that are locally saved or downloaded first from the bucket, but not directly with a GCS file path. Refer to [storing data](connecting-to-warehouse) to set up your Google authentication.
 
 ```yaml
 lehd_federal_jobs_by_tract:

--- a/docs/analytics_tools/overview.md
+++ b/docs/analytics_tools/overview.md
@@ -1,3 +1,4 @@
+(intro-analytics-tools)=
 # Introduction to Analytics Tools
 Welcome to the Analytics Tools section! If you're here, you're ready to begin conducting analyses.
 

--- a/docs/analytics_tools/storing_data.md
+++ b/docs/analytics_tools/storing_data.md
@@ -23,8 +23,8 @@ Our team uses Google Cloud Storage (GCS) buckets, specifically the `calitp-analy
 1. [Uploading Data from a Notebook](uploading-from-notebook)
 <br> - [Tabular Data](#tabular-data)
   <br> - [Parquet](#parquet)
-  <br>- [CSV](#csv)
-<br> -[Geospatial Data](#geospatial-data)
+  <br> - [CSV](#csv)
+<br> - [Geospatial Data](#geospatial-data)
   <br> - [Geoparquet](#geoparquet)
   <br> - [Zipped shapefile](#zipped-shapefile)
   <br> - [GeoJSON](#geojson)
@@ -115,11 +115,11 @@ shared_utils.utils.geoparquet_gcs_export(gdf, "my-geoparquet")
 
 #### Zipped Shapefile
 
-Refer to the [data catalogs doc](./08_data_catalogs.md#google-cloud-storage) to list a zipped shapefile, and read in the zipped shapefile with the `intake` method. Zipped shapefiles saved in GCS cannot be read in directly using `geopandas`.
+Refer to the [data catalogs doc](catalogue-cloud-storage) to list a zipped shapefile, and read in the zipped shapefile with the `intake` method. Zipped shapefiles saved in GCS cannot be read in directly using `geopandas`.
 
 #### GeoJSON
 
-Refer to the [data catalogs doc](./08_data_catalogs.md#google-cloud-storage) to list a GeoJSON, and read in the GeoJSON with the `intake` method. GeoJSONs saved in GCS cannot be read in directly using `geopandas`.
+Refer to the [data catalogs doc](catalogue-cloud-storage) to list a GeoJSON, and read in the GeoJSON with the `intake` method. GeoJSONs saved in GCS cannot be read in directly using `geopandas`.
 
 (in-gcs)=
 ## Uploading data in Google Cloud Storage

--- a/docs/analytics_welcome/about_our_team.md
+++ b/docs/analytics_welcome/about_our_team.md
@@ -1,2 +1,0 @@
-(about-our-team)=
-# Team Members (WIP)

--- a/docs/analytics_welcome/how_we_work.md
+++ b/docs/analytics_welcome/how_we_work.md
@@ -1,5 +1,5 @@
 (how-we-work)=
-# How We Work (WIP)
+# How We Work
 ## Team Meetings
 The section below outlines our team's primary meetings and their purposes, as well as our our team's shared meeting standards.
 (current-meetings)=
@@ -7,29 +7,26 @@ The section below outlines our team's primary meetings and their purposes, as we
 **New analysts**, look out for these meetings to be added to your calendar.
 | Name | Cadence | Description |
 | -------- | -------- | -------- |
-| Technical Onboarding | Week 1 <br/> 40 Mins | To ensure access to tools and go over best practices. |
-| Data Services All-Hands | Mondays <br/> 1 Hour | A team-wide data services sync. |
-| Analyst Stand-ups | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
-| Lunch n' Learn | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/> Access recordings of **previous Lunch n' Learns** [at this link](https://youtube.com/playlist?list=PLJA3syyg1ijm36JFZ95v79zAuv-5c8hfZ). |
-
-### Meeting Standards
-#### Agendas
-#### Daily Stand-ups
+| **Technical Onboarding** | Week 1 <br/> 40 Mins | To ensure access to tools and go over best practices. |
+| **Data Services All-Hands** | Mondays <br/> 1 Hour | A team-wide data services sync. |
+| **Analyst Stand-ups** | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
+| **Lunch n' Learn** | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/> Access recordings of **previous Lunch n' Learns** [at this link](https://youtube.com/playlist?list=PLJA3syyg1ijm36JFZ95v79zAuv-5c8hfZ). |
 
 (slack-intro)=
 ## Communication Channels
 
 | Channel | Purpose | Description |
 | -------- | -------- | -------- |
-| #data-analysis | Discussion | For sharing and collaborating on Cal-ITP data analyses. |
-| #data-office-hours | Discussion | A place to bring questions, issues, and observations for team discussion. |
-| #lunch-n-learn | Discussion | A channel for discussions around our weekly Lunch n' Learns. |
+| #**data-analysis** | Discussion | For sharing and collaborating on Cal-ITP data analyses. |
+| #**data-office-hours** | Discussion | A place to bring questions, issues, and observations for team discussion. |
+| #**lunch-n-learn** | Discussion | A channel for discussions around our weekly Lunch n' Learns. |
 
 ## Collaboration Tools
 
 (analytics-project-board)=
 ### GitHub Analytics Project Board
-**You can access The Analytics Project Board [using this link](https://github.com/cal-itp/data-infra/projects/6)**.
+**You can access The Analytics Project Board [using this link](https://github.com/orgs/cal-itp/projects/7/views/13)**.
+
 #### How We Track Work
 
 ##### Screencast - Navigating the Board
@@ -40,28 +37,12 @@ The screencast below introduces:
 
 <div style="position: relative; padding-bottom: 62.5%; height: 0;"><iframe src="https://www.loom.com/embed/a7332ee2e1c040edbf2d11da70b4c3ea" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
-#### Writing Issues
-
-##### Issue Best Practices
-
-##### Issue Templates
-
-##### Assignees
-
-##### Tags
-
-##### Board Stages
-
 (analytics-repo)=
 ### GitHub Analytics Repo
 
 #### Using the data-analyses Repo
-This is our main data analysis repository, for sharing quick reports and works in progress.
-
-Get set up on GitHub and clone the data-analyses repository [using this link](github-setup).
+This is our main data analysis repository, for sharing quick reports and works in progress. Get set up on GitHub and clone the data-analyses repository [using this link](github-setup).
 
 For collaborative short-term tasks, create a new folder and work off a separate branch.
 
 For longer-term projects, consider making a new repository!
-
-## Netiquette

--- a/docs/analytics_welcome/overview.md
+++ b/docs/analytics_welcome/overview.md
@@ -5,9 +5,18 @@ Welcome to the Analysts chapter of our Cal-ITP Data Services documentation!
 
 Here you will be introduced to the resources and best practices that make our analytics team work.
 
-After reading the 'Welcome' section, you will be more familiar with:
+**After reading the 'Welcome' section, you will be more familiar with**:
 * [Background on the Cal-ITP project](calitp-background)
-* [The members of our team](about-our-team)
 * [Meetings, communication channels, and other forms of collaboration](how-we-work)
 
 After you've read through this section, continue reading through the remaining sections of this chapter for further introduction to the various technical elements required to conduct an end-to-end analysis.
+
+---
+
+**Other Analytics Sections**:
+* [Technical Onboarding](technical-onboarding)
+* [Introduction to Analytics Tools](intro-analytics-tools)
+* [Introduction to the Warehouse](intro-warehouse)
+* [Datasets & Tables](datasets-tables)
+* [Analysis Examples](analysis-examples-overview)
+* [How to Publish Analyses](publish-analyses)

--- a/docs/analytics_welcome/what_is_calitp.md
+++ b/docs/analytics_welcome/what_is_calitp.md
@@ -1,27 +1,14 @@
 (calitp-background)=
-# Cal-ITP Project Information (WIP)
-## Project Domains
-Mobility Services Data
+# Cal-ITP Project Information
+[calitp.org](https://www.calitp.org/)
 
-Payments
+## Cal-ITP On-boarding Resources and Reading
+The following document provides insight into the Cal-ITP project for new team members.
+- [Cal-ITP On-boarding Resources and Reading](https://docs.google.com/document/d/1430Yc11j_RISdh4aIjuFlmCCUSPgx1Y5OL-_dzIU70E/edit?usp=sharing)
 
-GTFS
-* GTFS Static
-* GTFS RT
-* GTFS Flex
-## Clients
-MSD
+## Cal-ITP Background
+A selection of resources taken from the above document providing background on the history of Cal-ITP.
 
-DRMT
-
-Payments
-
-Demonstration Partners
-
-Policymakers
-
-Program Manager
-
-Product Management Office
-
-DLA
+- [Market Sounding](https://dot.ca.gov/-/media/dot-media/cal-itp/documents/final-cal-itp-market-sounding-market-response-summary-103119b-a11y.pdf): This 2019 market sounding laid the foundation for our current priorities. It was followed up with a business case analysis of the project in a [Feasibility Study](https://dot.ca.gov/-/media/dot-media/cal-itp/documents/calitp-feasibility-study-042420-a11y.pdf).
+- This [project framework orientation deck](https://docs.google.com/presentation/d/1zsEp2KoKyPlE34AJyqBPeSdv_ySYd6n-zcmrkdTftgo/edit) highlights some of the history of Cal-ITP,  how it came to be, and the problems it is trying to solve.
+- [The 2022 roadmap deck](https://docs.google.com/presentation/d/11DgqhoEqDUFJLTo71OkyWVtpih9-HzUF33DPT6M59N4/edit?usp=sharing) presents our 2022 milestones, projects, and collaboration teams “looking forward” for the year.

--- a/docs/datasets_and_tables/overview.md
+++ b/docs/datasets_and_tables/overview.md
@@ -13,7 +13,8 @@ kernelspec:
   name: python3
 ---
 (datasets-tables)=
-# Datasets & Tables (WIP)
+# Datasets & Tables
+Use the links below to navigate to pages that provide more information on individual datasets and tables.
 
 | page | description | datasets |
 | ---- | ----------- | -------- |

--- a/docs/warehouse/agencies.md
+++ b/docs/warehouse/agencies.md
@@ -12,7 +12,7 @@ kernelspec:
   language: python
   name: python3
 ---
- (agency-gtfs-feeds)=
+(agency-gtfs-feeds)=
 # Agency GTFS Feeds
 
 Feed information is stored in [airflow/data/agencies.yml](https://github.com/cal-itp/data-infra/blob/main/airflow/data/agencies.yml).

--- a/docs/warehouse/agencies.md
+++ b/docs/warehouse/agencies.md
@@ -12,7 +12,7 @@ kernelspec:
   language: python
   name: python3
 ---
-
+ (agency-gtfs-feeds)=
 # Agency GTFS Feeds
 
 Feed information is stored in [airflow/data/agencies.yml](https://github.com/cal-itp/data-infra/blob/main/airflow/data/agencies.yml).

--- a/docs/warehouse/metrics.md
+++ b/docs/warehouse/metrics.md
@@ -12,7 +12,7 @@ kernelspec:
   language: python
   name: python3
 ---
-
+(metric-views)=
 # Metric Views
 
 A metric table (or view) is a table that calculates meaningful measures across time.

--- a/docs/warehouse/overview.md
+++ b/docs/warehouse/overview.md
@@ -1,6 +1,8 @@
 (intro-warehouse)=
-# Introduction to the Warehouse (WIP)
-After reading this section, you should be able to:
-* x
-* y
-* z
+# Introduction to the Warehouse
+The section serves as an introduction to the Cal-ITP warehouse through conventions, best practices, and tips and tricks to better understand the Cal-ITP data warehouse.
+* [Table Naming](warehouse-table-naming)
+* [Agency GTFS Feeds](agency-gtfs-feeds)
+* [Creating New Tables (Views)](creating-new-views)
+* [Metric Views](metric-views)
+* [Helpful SQL Snippets](helpful-sql-snippets)

--- a/docs/warehouse/sql_snippets.md
+++ b/docs/warehouse/sql_snippets.md
@@ -12,9 +12,8 @@ kernelspec:
   language: python
   name: python3
 ---
-
-
-# SQL Snippets (WIP)
+(helpful-sql-snippets)=
+# Helpful SQL Snippets
 
 ## Fetching historical data for specific dates
 

--- a/docs/warehouse/table_naming.md
+++ b/docs/warehouse/table_naming.md
@@ -12,7 +12,7 @@ kernelspec:
   language: python
   name: python3
 ---
-
+(warehouse-table-naming)=
 # Table Naming
 The warehouse puts tables that are ready for end-users into the [`views` dataset](/datasets_and_tables/views/).
 They are named using a convention loosely based off of the Kimball method for modeling data,

--- a/docs/warehouse/views.md
+++ b/docs/warehouse/views.md
@@ -1,3 +1,4 @@
+(creating-new-views)=
 # Creating New Tables (Views)
 
 | operator | description | example |


### PR DESCRIPTION
## Docs changes checklist
The docs were a work in progress for a long time and as a result are oriented toward that in many ways, lacking clarity. I want to get the docs to a 'live' state, stubbing out what is needed but presenting them in a readable format. 

This PR will touch many docs:

- [ ] Make sure the preview website was able to be generated
- [ ] Fill out the following section describing what docs were added/updated

This PR updates the `insert docs/FOLDER_NAME/FILENAME as needed` in order to....
