### PR TITLE
fix(gtfs schedule): remove duplicate feed_info entries

### DIFF
--- a/airflow/dags/gtfs_views_staging/feed_info_clean.sql
+++ b/airflow/dags/gtfs_views_staging/feed_info_clean.sql
@@ -5,7 +5,9 @@ dependencies:
   - type2_loaded
 ---
 
-SELECT
+-- select distinct because of Foothill Transit feed with exact duplicates
+-- duplicates here result in duplicate feed_keys downstream
+SELECT DISTINCT
     * EXCEPT(feed_start_date, feed_end_date, calitp_deleted_at),
     PARSE_DATE("%Y%m%d",feed_start_date) AS feed_start_date,
     PARSE_DATE("%Y%m%d",feed_end_date) AS feed_end_date,


### PR DESCRIPTION
# Overall Description

Resolves #1079 by changing `feed_info_clean` to use `SELECT DISTINCT` rather than `SELECT` to drop the full duplicate rows in the current Foothill Transit feed. This issue is causing the GTFS Guidelines dashboard to not populate because of the `vews.gtfs_schedule_dim_feeds` failure (and then subsequent downstream failures). 

I submitted #1093 as a follow up for this, however that seemed less important than getting this data flowing again (and, as noted in #1093, Foothill Transit *is* throwing a `more_than_one_entity` validation warning from the GTFS validator for this file, as it should be; that validation is preserved even if the duplicate is dropped here.)

I confirmed that the only row removed with this change is the one Foothill Transit duplicate; no other rows are affected (table length decreases by exactly 1). 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.
## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully 
Stop_times failure is a query limit issue, unrelated:
![image](https://user-images.githubusercontent.com/55149902/154331853-bfadb506-a4f6-4257-8796-f9a5f94d907b.png)

Also confirmed that `dim_feeds` no longer throws the error with this change:
![image](https://user-images.githubusercontent.com/55149902/154331965-31e055e3-f031-4517-a50f-53e307a4b5ff.png)


- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_views_staging` DAG in order to update the following DAG tasks:

- `feed_info_clean`: remove duplicates
