### PR TITLE
feat(gtfs-rt): add calitp files to views

### DIFF
--- a/airflow/dags/rt_loader_files/calitp_files_process.py
+++ b/airflow/dags/rt_loader_files/calitp_files_process.py
@@ -2,8 +2,6 @@
 # python_callable: main
 # provide_context: true
 # task_concurrency: 4
-# dependencies:
-#   - external_calitp_files
 # ---
 
 """

--- a/airflow/dags/rt_loader_files/external_calitp_files.sql
+++ b/airflow/dags/rt_loader_files/external_calitp_files.sql
@@ -1,5 +1,8 @@
 ---
 operator: operators.SqlQueryOperator
+
+dependencies:
+  - calitp_files_process
 ---
 
 CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.calitp_files` (

--- a/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files.sql
+++ b/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files.sql
@@ -1,0 +1,38 @@
+---
+operator: operators.SqlToWarehouseOperator
+# write to views even though this is not in views DAG so we can run more often if needed
+dst_table_name: "views.gtfs_rt_fact_files"
+
+description: |
+  Each row is a GTFS realtime file that was downloaded.
+  Note that presence of a file is not a guarantee that the downloaded file is complete or valid.
+
+
+fields:
+  calitp_extracted_at: Timestamp when this file was extracted
+  calitp_itp_id: Feed ITP ID
+  calitp_url_number: Feed URL number
+  name: File type (service_alerts, trip_updates, or vehicle_positions)
+  size: File size in bytes
+  md5_hash: Hash of file contents
+  date_extracted: Date extracted from calitp_extracted_at
+  hour_extracted: Hour extracted from calitp_extracted_at
+  minute_extracted: Minute extracted from calitp_extracted_at
+
+dependencies:
+  - external_calitp_files
+---
+
+SELECT
+  calitp_extracted_at,
+  calitp_itp_id,
+  calitp_url_number,
+  -- turn name from a file path like gtfs_rt_<file_type>_url
+  -- to just file_type
+  REPLACE(REPLACE(name, "gtfs_rt_", ""), "_url", "") as name,
+  size,
+  md5_hash,
+  DATE(calitp_extracted_at) as date_extracted,
+  EXTRACT(HOUR from calitp_extracted_at) as hour_extracted,
+  EXTRACT(MINUTE from calitp_extracted_at) as minute_extracted
+FROM `gtfs_rt.calitp_files`

--- a/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files.sql
+++ b/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files.sql
@@ -29,7 +29,7 @@ SELECT
   calitp_url_number,
   -- turn name from a file path like gtfs_rt_<file_type>_url
   -- to just file_type
-  REPLACE(REPLACE(name, "gtfs_rt_", ""), "_url", "") as name,
+  REGEXP_EXTRACT(name, r"gtfs_rt_(.*)_url") as name,
   size,
   md5_hash,
   DATE(calitp_extracted_at) as date_extracted,

--- a/script/requirements.txt
+++ b/script/requirements.txt
@@ -5,3 +5,4 @@ PyYAML==5.4.1
 jsonschema==3.2.0
 pandas==1.1.4
 requests==2.22.0
+markupsafe==2.0.1


### PR DESCRIPTION
# Overall Description

Expose the existing `gtfs_rt.calitp_files` table in `views` so we can use it in Metabase. I also reordered the dependencies so that they make sense (we identify the files, then we recreate the external table, then we make the view.)

Notes about things I've done that reviewers may find controversial:
- I left this in the `rt_loader_files` DAG rather than the `views` DAG. I did this because I think we will want this `views` table to update more often than daily. After this merges I think we should consider changing this DAG to run hourly or similar. 
- I pre-extracted date, hour, minute from `calitp_extracted_at`. This is kind of duplicative but I really think everyone is going to need these columns and working with them manually in Metabase all the time would be annoying. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ Not directly related to any issues.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/154727125-247ea720-51c5-46f1-b357-b77821885f44.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_loader_files` DAG in order to add the following DAG tasks:

- `rt_views_gtfs_rt_fact_files`: pulls `gtfs_rt.calitp_files` into `views` so it can be accessed in Metabase