### PR TITLE
feat(gtfs-rt): wide hourly view of calitp files

### DIFF
--- a/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files_wide_hourly.sql
+++ b/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files_wide_hourly.sql
@@ -1,0 +1,26 @@
+---
+operator: operators.SqlToWarehouseOperator
+# write to views even though this is not in views DAG so we can run more often if needed
+dst_table_name: "views.gtfs_rt_fact_files_wide_hourly"
+
+description: |
+  Each row is one day of realtime data for a given feed (ITP ID + URL number + realtime type),
+  with count of files downloaded by hour.
+  Note that presence of a file is not a guarantee that the downloaded file is complete or valid.
+
+
+fields:
+  date_extracted: Date extracted from calitp_extracted_at
+  calitp_itp_id: Feed ITP ID
+  calitp_url_number: Feed URL number
+  name: File type (service_alerts, trip_updates, or vehicle_positions)
+  file_count_0: Count of files extracted during hour 0 UTC
+
+dependencies:
+  - rt_views_gtfs_rt_fact_files
+---
+
+SELECT *
+FROM
+(SELECT date_extracted, calitp_itp_id, calitp_url_number, name, calitp_extracted_at, hour_extracted FROM `views.gtfs_rt_fact_files`)
+PIVOT(count(calitp_extracted_at) file_count_hr FOR hour_extracted in (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23))

--- a/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files_wide_hourly.sql
+++ b/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files_wide_hourly.sql
@@ -22,5 +22,18 @@ dependencies:
 
 SELECT *
 FROM
-(SELECT date_extracted, calitp_itp_id, calitp_url_number, name, calitp_extracted_at, hour_extracted FROM `views.gtfs_rt_fact_files`)
-PIVOT(count(calitp_extracted_at) file_count_hr FOR hour_extracted in (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23))
+    (SELECT
+        date_extracted,
+        calitp_itp_id,
+        calitp_url_number,
+        name,
+        calitp_extracted_at,
+        hour_extracted
+    FROM `views.gtfs_rt_fact_files`)
+PIVOT(
+    count(calitp_extracted_at) file_count_hr
+    FOR hour_extracted in
+        (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+         11, 12, 13, 14, 15, 16, 17, 18, 19,
+         20, 21, 22, 23)
+    )


### PR DESCRIPTION
# Overall Description

Make a wide hourly view (count by hour by day) of file saves for GTFS RT data.

This is to facilitate visualization in Metabase.... I tried really hard to do it with pivot tables in Metabase and it just was too slow and doesn't allow much flexibility. Decided it was worth just doing on the BQ side. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ - no issues

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/154772384-1b73bf06-1738-4d92-8edc-477dae4bd9f3.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_loader_files` DAG in order to add the following DAG tasks:

- `rt_views_gtfs_rt_fact_files_wide_hourly`: takes existing `gtfs_rt_fact_files` and creates a wide hourly view of it