### PR TITLE
feat(gtfs-rt): create fact_daily_feeds

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_fact_daily_feeds.sql
+++ b/airflow/dags/rt_views/gtfs_rt_fact_daily_feeds.sql
@@ -1,0 +1,62 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_rt_fact_daily_feeds"
+
+description: |
+  Each row represents a GTFS realtime feed (combination of ITP ID, URL number,
+  and realtime data type) that was present in our extraction list on the given date.
+  Note that a feed can be added to the  list at any point in the day
+  and this table contains no information about extractions success or failure;
+  i.e., a feed may be listed here even if no data was successfully pulled,
+  or if only partial data was pulled.
+
+
+fields:
+  date: Date for which this feed was present in our extraction list
+  calitp_itp_id: Feed ITP ID
+  calitp_url_number: Feed URL number
+  url: Feed URL
+  type: GTFS realtime type (service_alerts, trip_updates, or vehicle_positions)
+
+tests:
+    check_null:
+        - calitp_itp_id
+        - calitp_url_number
+        - date
+        - type
+        - url
+    # do not include URL here in case we have duplicate labeling of different URLs
+    check_composite_unique:
+        - calitp_itp_id
+        - calitp_url_number
+        - date
+        - type
+
+dependencies:
+  - gtfs_schedule_fact_daily_feeds
+---
+
+-- note that for realtime we do not (yet) have a feed_key-type identifier
+-- so use calitp_itp_id plus calitp_url_number as identifier
+
+SELECT
+    calitp_itp_id,
+    calitp_url_number,
+    date,
+    url,
+    -- turn type from a label like gtfs_rt_<file_type>_url
+    -- to just file_type
+    REGEXP_EXTRACT(type, r"gtfs_rt_(.*)_url") as type
+FROM `cal-itp-data-infra.views.gtfs_schedule_fact_daily_feeds`
+-- in fact_daily_feeds, there are columns for each RT type
+-- UNPIVOT to transform this into one column with all types
+-- UNPIVOT has EXCLUDE_NULL set to true by default so this returns only urls that are present
+UNPIVOT(
+    url for type in (
+        raw_gtfs_rt_vehicle_positions_url,
+        raw_gtfs_rt_trip_updates_url,
+        raw_gtfs_rt_service_alerts_url)
+    )
+-- join so that we have calitp_itp_id and calitp_url_number
+LEFT JOIN `cal-itp-data-infra.views.gtfs_schedule_dim_feeds`
+    USING(feed_key)


### PR DESCRIPTION
# Overall Description

This creates a table listing all the RT URLs from `agencies.yaml` by date. This can be left-joined with the other RT files views to help identify feeds that are missing data entirely (i.e., feeds that we had URLs for on the given date but didn't get any data pulled).

**Note that this table pulls from the _schedule_ pipeline** -- I didn't see any reason to duplicate a bunch of existing logic. The RT URLs from `gtfs_schedule_fact_daily_feeds` come from `agencies.yaml`, which is what we want. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ none

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
`extraction_errors` fails because it hits the query limit, unrelated.
![image](https://user-images.githubusercontent.com/55149902/155171116-a336b185-ab03-43e7-9821-73524b8e8814.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_views` DAG in order to add the following DAG tasks:

- `gtfs_rt_fact_daily_feeds`: A long view of all RT URLs present by feed by date