### PR TITLE
feat(gtfs-archiver) : added view table specific for http error codes

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "views.gtfs_rt_extraction_html_errors"
+dst_table_name: "views.gtfs_rt_extraction_http_errors"
 
 description: |
   Each row is a unique text payload returned for a HTTP Error for the calitp RT_archiver

--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -26,7 +26,7 @@ WITH
     textPayload,
     timestamp,
     REGEXP_EXTRACT(textPayload, r'\[txn (.*?)\]') AS file_hash,
-    REGEXP_EXTRACT(textpayload,r'error fetching url ([a-zA-Z].*): HTTP Error') AS url_name,
+    REGEXP_EXTRACT(textpayload,r'error fetching url ([a-zA-Z].*): HTTP Error') AS download_url,
     REGEXP_EXTRACT(textpayload,"(HTTP Error [0-9]+.*)") AS http_error,
   FROM
     `cal-itp-data-infra.gtfs_rt_logs.stdout`
@@ -50,7 +50,7 @@ SELECT
   calitp_itp_id,
   calitp_url_number,
   textPayload,
-  url_name,
+  download_url,
   http_error,
   COUNT(*) AS n_count,
   MAX(timestamp) AS max_date

--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -3,8 +3,16 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "views.gtfs_rt_extraction_html_errors"
 
 description: |
+  Each row is a unique text payload returned for a HTTP Error for the calitp RT_archiver
 
 fields:
+  calitp_itp_id: Feed ITP ID.
+  calitp_url_number: Feed URL number.
+  textPayload: Error message that contains feed key, header length, download url, and error response.
+  download_url: Feed url extracted from textPayload.
+  http_error: Extracted HTTP error code.
+  n_count: Count of each row, distinct text textPayload.
+  max_date: Max timestamp.
 
 ---
 
@@ -33,7 +41,7 @@ WITH
   WHERE
     textPayload LIKE "%error fetching %"
     ),
-
+--- have to join the two tables as the textPayload that is returned upon HTTP error does not contain the calitp_id and url number
   join_table AS (
   SELECT
     *

--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -34,7 +34,8 @@ WITH
     textPayload,
     timestamp,
     REGEXP_EXTRACT(textPayload, r'\[txn (.*?)\]') AS file_hash,
-    REGEXP_EXTRACT(textpayload,r'error fetching url ([a-zA-Z].*): HTTP Error') AS download_url,
+    REGEXP_EXTRACT(textpayload,r'error fetching url ([a-zA-Z].*)?=') AS download_url,
+    --- trim API tokens because sensitive info
     REGEXP_EXTRACT(textpayload,"(HTTP Error [0-9]+.*)") AS http_error,
   FROM
     `cal-itp-data-infra.gtfs_rt_logs.stdout`

--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -1,0 +1,70 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_rt_extraction_html_errors"
+
+description: |
+
+fields:
+
+---
+
+WITH
+
+  start_fetch_table AS (
+  SELECT
+    REGEXP_EXTRACT(textPayload, r'\[txn (.*?)\]') AS file_hash,
+    REGEXP_EXTRACT(textPayload, "mapper_key=([0-9]+)")AS calitp_itp_id,
+    REGEXP_EXTRACT(textPayload, "mapper_key=[0-9]+/([0-9]+)")AS calitp_url_number,
+  FROM
+    `cal-itp-data-infra.gtfs_rt_logs.stdout`
+  WHERE
+    textPayload LIKE "%start fetch%"
+    ),
+
+  error_fetch_table AS (
+  SELECT
+    textPayload,
+    timestamp,
+    REGEXP_EXTRACT(textPayload, r'\[txn (.*?)\]') AS file_hash,
+    REGEXP_EXTRACT(textpayload,r'error fetching url ([a-zA-Z].*): HTTP Error') AS url_name,
+    REGEXP_EXTRACT(textpayload,"(HTTP Error [0-9]+.*)") AS http_error,
+  FROM
+    `cal-itp-data-infra.gtfs_rt_logs.stdout`
+  WHERE
+    textPayload LIKE "%error fetching %"
+    ),
+
+  join_table AS (
+  SELECT
+    *
+  FROM
+    start_fetch_table t1
+  JOIN
+    error_fetch_table t2
+  ON
+    t1.file_hash = t2.file_hash
+  ORDER BY
+    calitp_itp_id DESC )
+
+SELECT
+  calitp_itp_id,
+  calitp_url_number,
+  textPayload,
+  url_name,
+  http_error,
+  COUNT(*) AS n_count,
+  MAX(timestamp) AS max_date
+FROM
+  join_table
+WHERE
+  timestamp >= (datetime_sub(CURRENT_TIMESTAMP(),
+      INTERVAL 28 day))
+  AND http_error IS NOT NULL
+GROUP BY
+  1,
+  2,
+  3,
+  4,
+  5
+ORDER BY
+  max_date DESC

--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -8,7 +8,7 @@ description: |
 fields:
   calitp_itp_id: Feed ITP ID.
   calitp_url_number: Feed URL number.
-  token_cleaned_textPayload: Error message that contains feed key, header length, download url, and error response. API Tokens are replaced in the string with API_TOKEN
+  token_cleaned_text_payload: Error message that contains feed key, header length, download url, and error response. API Tokens are replaced in the string with API_TOKEN
   download_url: Feed url extracted from textPayload.
   http_error: Extracted HTTP error code.
   n_count: Count of each row, distinct text textPayload.
@@ -32,10 +32,10 @@ WITH
   SELECT
     timestamp,
     REGEXP_EXTRACT(textPayload, r'\[txn (.*?)\]') AS file_hash,
-    REGEXP_EXTRACT(textpayload,r'error fetching url ([a-zA-Z].*)?=') AS download_url,
-    REGEXP_REPLACE(textpayload,'token=([0-9]+.*?:)', "API_TOKEN") AS token_cleaned_textpayload,
+    REGEXP_EXTRACT(textPayload,r'error fetching url ([a-zA-Z].*)?=') AS download_url,
+    REGEXP_REPLACE(textPayload,'token=([0-9]+.*?:)', "API_TOKEN") AS token_cleaned_text_payload,
     --- trim API tokens because sensitive info
-    REGEXP_EXTRACT(textpayload,"(HTTP Error [0-9]+.*)") AS http_error,
+    REGEXP_EXTRACT(textPayload,"(HTTP Error [0-9]+.*)") AS http_error,
   FROM
     `cal-itp-data-infra.gtfs_rt_logs.stdout`
   WHERE

--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -8,7 +8,7 @@ description: |
 fields:
   calitp_itp_id: Feed ITP ID.
   calitp_url_number: Feed URL number.
-  textPayload: Error message that contains feed key, header length, download url, and error response.
+  token_cleaned_textPayload: Error message that contains feed key, header length, download url, and error response. API Tokens are replaced in the string with API_TOKEN
   download_url: Feed url extracted from textPayload.
   http_error: Extracted HTTP error code.
   n_count: Count of each row, distinct text textPayload.
@@ -17,7 +17,6 @@ fields:
 ---
 
 WITH
-
   start_fetch_table AS (
   SELECT
     REGEXP_EXTRACT(textPayload, r'\[txn (.*?)\]') AS file_hash,
@@ -31,10 +30,10 @@ WITH
 
   error_fetch_table AS (
   SELECT
-    textPayload,
     timestamp,
     REGEXP_EXTRACT(textPayload, r'\[txn (.*?)\]') AS file_hash,
     REGEXP_EXTRACT(textpayload,r'error fetching url ([a-zA-Z].*)?=') AS download_url,
+    REGEXP_REPLACE(textpayload,'token=([0-9]+.*?:)', "API_TOKEN") AS token_cleaned_textpayload,
     --- trim API tokens because sensitive info
     REGEXP_EXTRACT(textpayload,"(HTTP Error [0-9]+.*)") AS http_error,
   FROM
@@ -58,7 +57,7 @@ WITH
 SELECT
   calitp_itp_id,
   calitp_url_number,
-  textPayload,
+  token_cleaned_textpayload,
   download_url,
   http_error,
   COUNT(*) AS n_count,

--- a/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_extraction_html_errors.sql
@@ -57,7 +57,7 @@ WITH
 SELECT
   calitp_itp_id,
   calitp_url_number,
-  token_cleaned_textpayload,
+  token_cleaned_text_payload,
   download_url,
   http_error,
   COUNT(*) AS n_count,


### PR DESCRIPTION
Added a table to view to aid in RT-Archiver analysis. This table selects all the log messages that have a generated HTTP code error 