### PR TITLE
fix(gtfs-rt): fix external dependency reference

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_fact_daily_feeds.sql
+++ b/airflow/dags/rt_views/gtfs_rt_fact_daily_feeds.sql
@@ -32,8 +32,8 @@ tests:
         - date
         - type
 
-dependencies:
-  - gtfs_schedule_fact_daily_feeds
+external_dependencies:
+  - gtfs_views: gtfs_schedule_fact_daily_feeds
 ---
 
 -- note that for realtime we do not (yet) have a feed_key-type identifier


### PR DESCRIPTION
# Overall Description

Fixes dependency reference.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ none

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/155345871-35670059-1c92-4e22-9557-e10fb633852e.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_views` DAG in order to updates the following DAG tasks:

- `gtfs_rt_fact_daily_feeds` - fixes the dependency to be an external dependency (so this will actually wait for the `gtfs_schedule` task to run)