### PR TITLE
Feat gtfs rt daily file total

### DIFF
--- a/airflow/dags/rt_loader_files/calitp_files_process.py
+++ b/airflow/dags/rt_loader_files/calitp_files_process.py
@@ -11,6 +11,7 @@ This is for the rt files extracted per feed every 20 seconds.
 
 from calitp import save_to_gcfs
 from calitp.storage import get_fs
+from calitp.config import get_bucket
 
 import pandas as pd
 
@@ -29,7 +30,7 @@ def main(execution_date, **kwargs):
     # bucket = get_bucket()
 
     # <datetime>/<itp_id>/<url_number>/<filename>
-    all_files = fs.glob(f"gs://gtfs-data/rt/{date_string}*/*/*/*", detail=True)
+    all_files = fs.glob(f"{get_bucket()}/rt/{date_string}*/*/*/*", detail=True)
     fs.dircache.clear()
 
     raw_res = pd.DataFrame(all_files.values())

--- a/airflow/dags/rt_loader_files/calitp_files_process.py
+++ b/airflow/dags/rt_loader_files/calitp_files_process.py
@@ -25,10 +25,6 @@ def main(execution_date, **kwargs):
 
     date_string = execution_date.to_date_string()
 
-    # note that we will only use the prod bucket, even on staging, since the RT
-    #
-    # bucket = get_bucket()
-
     # <datetime>/<itp_id>/<url_number>/<filename>
     all_files = fs.glob(f"{get_bucket()}/rt/{date_string}*/*/*/*", detail=True)
     fs.dircache.clear()

--- a/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files_wide_hourly.sql
+++ b/airflow/dags/rt_loader_files/rt_views_gtfs_rt_fact_files_wide_hourly.sql
@@ -7,6 +7,7 @@ description: |
   Each row is one day of realtime data for a given feed (ITP ID + URL number + realtime type),
   with count of files downloaded by hour.
   Note that presence of a file is not a guarantee that the downloaded file is complete or valid.
+  Hours here are in UTC.
 
 
 fields:
@@ -14,26 +15,48 @@ fields:
   calitp_itp_id: Feed ITP ID
   calitp_url_number: Feed URL number
   name: File type (service_alerts, trip_updates, or vehicle_positions)
-  file_count_0: Count of files extracted during hour 0 UTC
+  file_count_hr_0: Count of files extracted during hour 0 UTC
 
 dependencies:
   - rt_views_gtfs_rt_fact_files
 ---
 
+WITH
+daily_tot AS (
+  SELECT
+    date_extracted,
+    calitp_itp_id,
+    calitp_url_number,
+    name,
+    count(calitp_extracted_at) as file_count_day
+  FROM `views.gtfs_rt_fact_files`
+  GROUP BY
+    date_extracted,
+    calitp_itp_id,
+    calitp_url_number,
+    name
+),
+wide_hourly AS (
+  SELECT *
+  FROM
+      (SELECT
+          date_extracted,
+          calitp_itp_id,
+          calitp_url_number,
+          name,
+          calitp_extracted_at,
+          hour_extracted
+      FROM `views.gtfs_rt_fact_files`)
+  PIVOT(
+      count(calitp_extracted_at) file_count_hr
+      FOR hour_extracted in
+          (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+          11, 12, 13, 14, 15, 16, 17, 18, 19,
+          20, 21, 22, 23)
+      )
+)
+
 SELECT *
-FROM
-    (SELECT
-        date_extracted,
-        calitp_itp_id,
-        calitp_url_number,
-        name,
-        calitp_extracted_at,
-        hour_extracted
-    FROM `views.gtfs_rt_fact_files`)
-PIVOT(
-    count(calitp_extracted_at) file_count_hr
-    FOR hour_extracted in
-        (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-         11, 12, 13, 14, 15, 16, 17, 18, 19,
-         20, 21, 22, 23)
-    )
+FROM daily_tot
+LEFT JOIN wide_hourly
+  USING(date_extracted, calitp_itp_id, calitp_url_number, name)


### PR DESCRIPTION
# Overall Description

Add a "daily total" column to the wide hourly view of the RT files. This will allow us to sort dashboards on this column to more easily identify issues. 

Also makes the `calitp_files` loading use `get_bucket` so we can actually run it on test files. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ none

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/155391566-417a029c-f5a3-4407-8761-4e1ce33ff378.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_loader_files` DAG in order to update the following DAG tasks:

- `fact_files_wide_hourly`: Adds a daily total column for easier summarizing/sorting
- `calitp_files_process`: Uses `get_bucket` instead of hard-coding production path