### PR TITLE
fix(payments): Correct cardinality for micropayments:transactions

### DIFF
--- a/airflow/dags/payments_views/sbmtd_transactions.sql
+++ b/airflow/dags/payments_views/sbmtd_transactions.sql
@@ -107,6 +107,7 @@ transactions as (
     join device_transactions_dedupe as dt using (littlepay_transaction_id, customer_id, participant_id)
     join stop_stats as stat on stat.stop_id = dt.location_id
     where participant_id = 'sbmtd'
+      and m.type = 'DEBIT'
 )
 
 select

--- a/airflow/dags/payments_views_staging/stg_cleaned_micropayment_device_transactions.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_micropayment_device_transactions.sql
@@ -2,14 +2,19 @@
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "payments.stg_cleaned_micropayment_device_transactions"
 
+description: >
+  Creates a *:* relationship between transactions and micropayments. One
+  micropayment may be linked to multiple transactions in the case where one
+  transaction is a tap on and another is a tap off. One transaction may be
+  linked to multiple transactions when, e.g. the transaction is charged in one
+  micropayment and refunded later in another micropayment.
+
 dependencies:
   - stg_enriched_micropayment_device_transactions
 
 tests:
   check_composite_unique:
     - micropayment_id
-    - littlepay_transaction_id
-  check_unique:
     - littlepay_transaction_id
 ---
 
@@ -25,8 +30,8 @@ deduped_micropayment_device_transaction_ids as (
 
 ),
 
--- Some transactions are associated with more than one micropayment. This should
--- not happen. In the query below, we identify the micropayment_id of the
+-- Some transactions are associated with more than one DEBIT micropayment. This
+-- should not happen. In the query below, we identify the micropayment_id of the
 -- pending micropayment records that are no longer valid because they've been
 -- superceded by a completed micropayment.
 --

--- a/airflow/dags/payments_views_staging/stg_cleaned_micropayments.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_micropayments.sql
@@ -2,6 +2,13 @@
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "payments.stg_cleaned_micropayments"
 
+description: >
+  A micropayment represents a debit or credit that should be made against the
+  customer's funding source for a trip. Multiple micropayments can be aggregated
+  and settled together. Credit micropayments can be created if a refund is
+  requested for the travel associated with a debit micropayment before the
+  aggregation containing the debit micropayment is settled.
+
 dependencies:
   - stg_enriched_micropayments
 

--- a/airflow/dags/payments_views_staging/validate_cleaned_micropayment_device_transactions.sql
+++ b/airflow/dags/payments_views_staging/validate_cleaned_micropayment_device_transactions.sql
@@ -2,6 +2,11 @@
 operator: operators.SqlToWarehouseOperator
 dst_table_name: "payments.invalid_cleaned_micropayment_device_transactions"
 
+description: >
+  A device transaction should only ever be associated with a single debit
+  micropayment. This table contains micropayment information where that
+  invariant does not hold true.
+
 dependencies:
   - stg_cleaned_micropayment_device_transactions
 
@@ -12,9 +17,11 @@ tests:
 
 with
 
-multplied_transaction_ids as (
+multiple_debit_transaction_ids as (
     select littlepay_transaction_id
     from `payments.stg_cleaned_micropayment_device_transactions`
+    join `payments.stg_cleaned_micropayments` m using (micropayment_id)
+    where m.type = 'DEBIT'
     group by 1
     having count(*) > 1
 )
@@ -22,5 +29,5 @@ multplied_transaction_ids as (
 select littlepay_transaction_id, m.*
 from `payments.stg_cleaned_micropayment_device_transactions`
 join `payments.stg_cleaned_micropayments` m using (micropayment_id)
-join multplied_transaction_ids using (littlepay_transaction_id)
+join multiple_debit_transaction_ids using (littlepay_transaction_id)
 order by transaction_time desc, littlepay_transaction_id, charge_type desc


### PR DESCRIPTION
# Overall Description

We're currently enforcing that a transaction (essentially a tap) is only associated with one micropayment (essentially, we thought, a trip). However, transactions _can_ be associated with multiple micropayments. Normally we would expect only 1 micropayment per transaction except in the case of refunds, where we will see an additional micropayment with `type='CREDIT'`. This PR takes the distinction between DEBIT and CREDIT micropayments into account.

Resolves #1068

## Airflow DAG Updates

This PR updates tasks across the `payments_views_staging` and `payments_views` DAGs.

* `payments_views`
  * `payments_rides`
    * Only count DEBIT micropayments as rides
    * Add a `refund_amount` column to account for refunds
  * `sbmtd_transactions`
    * Only count DEBIT micropayments
* `payments_views_staging`
  * `stg_cleaned_micropayment_device_transactions`
    * Remove the unique `littlepay_transaction_id` check
    * Update descriptions and comments
  * `validate_cleaned_micropayment_device_transactions`
    * Check that `littlepay_transaction_id` values are unique only when joined with DEBIT micropayments

## Successful Run Screenshots

![Screenshot-2022-02-23-17:12:17](https://user-images.githubusercontent.com/146749/155417784-20a3971a-b38e-4e75-abe3-0f34725f8ddf.png)

![Screenshot-2022-02-23-17:13:33](https://user-images.githubusercontent.com/146749/155417929-898b5d3f-14be-4839-8c31-6d2c43f4627a.png)

