### PR TITLE
Fix gtfs rt define schemas for trip updates & service alerts

### DIFF
--- a/airflow/dags/rt_loader/external_service_alerts.sql
+++ b/airflow/dags/rt_loader/external_service_alerts.sql
@@ -5,7 +5,81 @@ dependencies:
   - parse_rt_service_alerts
 ---
 
-CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.service_alerts`
+CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.service_alerts` (
+  calitp_itp_id INT64,
+  calitp_url_number INT64,
+  calitp_filepath STRING,
+  id STRING,
+  header STRUCT<
+    timestamp INT64,
+    incrementality STRING,
+    gtfsRealtimeVersion STRING
+  >,
+  activePeriod STRUCT<
+    start INT64,
+    -- end is a reserved keyword but it's the name of the field
+    -- escape with backticks
+    `end` INT64
+    >,
+  informedEntity STRUCT <
+    agencyId STRING,
+    routeId STRING,
+    routeType INT64,
+    directionId INT64,
+    trip STRUCT <
+        tripId STRING,
+        routeId STRING,
+        directionId INT64,
+        startTime STRING,
+        startDate STRING,
+        scheduleRelationship STRING
+      >,
+    stopId STRING
+    >,
+  cause STRING,
+  effect STRING,
+  url STRUCT <
+    translation ARRAY<
+      STRUCT<
+        text STRING,
+        language STRING
+        >
+      >
+    >,
+  header_text STRUCT <
+    translation ARRAY<
+      STRUCT<
+        text STRING,
+        language STRING
+        >
+      >
+    >,
+  description_text STRUCT <
+    translation ARRAY<
+      STRUCT<
+        text STRING,
+        language STRING
+        >
+      >
+    >,
+  tts_header_text STRUCT <
+    translation ARRAY<
+      STRUCT<
+        text STRING,
+        language STRING
+        >
+      >
+    >,
+  tts_description_text STRUCT <
+    translation ARRAY<
+      STRUCT<
+        text STRING,
+        language STRING
+        >
+      >
+    >,
+  severityLevel STRING
+)
 OPTIONS (
     format = "JSON",
     uris = ["{{get_bucket()}}/rt-processed/service_alerts/*.jsonl.gz"],

--- a/airflow/dags/rt_loader/external_trip_updates.sql
+++ b/airflow/dags/rt_loader/external_trip_updates.sql
@@ -29,21 +29,22 @@ CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.trip_updates` (
       label STRING,
       id STRING
       >,
-    stopTimeUpdate ARRAY<STRUCT<
-    stopSequence INT64,
-      stopId STRING,
-      arrival STRUCT <
-        delay INT64,
-        time INT64,
-        uncertainty INT64
-        >,
-      departure STRUCT <
-        delay INT64,
-        time INT64,
-        uncertainty INT64
-        >,
-      scheduleRelationship STRING
-      >
+    stopTimeUpdate ARRAY<
+      STRUCT<
+        stopSequence INT64,
+        stopId STRING,
+        arrival STRUCT <
+          delay INT64,
+          time INT64,
+          uncertainty INT64
+          >,
+        departure STRUCT <
+          delay INT64,
+          time INT64,
+          uncertainty INT64
+          >,
+        scheduleRelationship STRING
+        >
       >,
     timestamp INT64,
     delay INT64

--- a/airflow/dags/rt_loader/external_trip_updates.sql
+++ b/airflow/dags/rt_loader/external_trip_updates.sql
@@ -5,7 +5,50 @@ dependencies:
   - parse_rt_trip_updates
 ---
 
-CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.trip_updates`
+CREATE OR REPLACE EXTERNAL TABLE `gtfs_rt.trip_updates` (
+  calitp_itp_id INT64,
+  calitp_url_number INT64,
+  calitp_filepath STRING,
+  id STRING,
+  header STRUCT<
+      timestamp INT64,
+      incrementality STRING,
+      gtfsRealtimeVersion STRING
+    >,
+  tripUpdate STRUCT <
+    trip STRUCT <
+      tripId STRING,
+      routeId STRING,
+      directionId INT64,
+      startTime STRING,
+      startDate STRING,
+      scheduleRelationship STRING
+      >,
+    vehicle STRUCT <
+      licensePlate STRING,
+      label STRING,
+      id STRING
+      >,
+    stopTimeUpdate ARRAY<STRUCT<
+    stopSequence INT64,
+      stopId STRING,
+      arrival STRUCT <
+        delay INT64,
+        time INT64,
+        uncertainty INT64
+        >,
+      departure STRUCT <
+        delay INT64,
+        time INT64,
+        uncertainty INT64
+        >,
+      scheduleRelationship STRING
+      >
+      >,
+    timestamp INT64,
+    delay INT64
+  >
+)
 OPTIONS (
     format = "JSON",
     uris = ["{{get_bucket()}}/rt-processed/trip_updates/*.jsonl.gz"],


### PR DESCRIPTION
# Overall Description

Resolves #1104 (and therefore resolves #1002) by defining schemas for trip updates and service alerts data. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/155424551-dfc1e0f5-4af7-4c39-be9f-02cb254735fc.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_loader` DAG in order to update the following DAG tasks:

- `external_trip_updates`: define schema 
- `external_service_alerts`: define schema