### PR TITLE
generate and use new validation params and arguments for RT validation, and load into bigquery

### DIFF
--- a/airflow/dags/rt_loader/create_validation_params.py
+++ b/airflow/dags/rt_loader/create_validation_params.py
@@ -48,6 +48,7 @@ def main(execution_date, **kwargs):
                 lambda row: {
                     "gtfs_schedule_path": f"{prefix_path_schedule}/{row.calitp_itp_id}_{row.calitp_url_number}",
                     "gtfs_rt_glob_path": f"{prefix_path_rt}/{row.calitp_itp_id}/{row.calitp_url_number}/*{row.entity}*",
+                    "output_filename": row.entity,
                 },
                 axis="columns",
                 result_type="expand",

--- a/airflow/dags/rt_loader/external_validation_service_alerts.sql
+++ b/airflow/dags/rt_loader/external_validation_service_alerts.sql
@@ -6,6 +6,6 @@ dependencies:
 
 CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_service_alerts
 OPTIONS (
-    uris=["{{get_bucket()}}/rt-processed/validation/*/validation_results/*/*/service_alerts.parquet"],
+    uris=["{{get_bucket()}}/rt-processed/validation/*/service_alerts.parquet"],
     format="PARQUET"
 )

--- a/airflow/dags/rt_loader/external_validation_service_alerts.sql
+++ b/airflow/dags/rt_loader/external_validation_service_alerts.sql
@@ -1,5 +1,21 @@
 ---
 operator: operators.SqlQueryOperator
+description: |
+  GTFS RT validation errors as returned by the validator. Each row corresponds to
+  the number of occurrences of a given error for a single itp_id/url/tick/entity combination.
+fields:
+  calitp_itp_id: |
+    The ITP ID associated with the service alert.
+  calitp_url_number: |
+    The URL number associated with the service alert.
+  calitp_extracted_at: |
+    When the original file was downloaded.
+  rt_feed_type: |
+    The type of RT feed entity; will always be service alerts.
+  error_id: |
+    An error ID as defined in the GTFS RT validator repo.
+  n_occurrences: |
+    The number of occurrences of this error.
 dependencies:
     - load_rt_validations
 ---

--- a/airflow/dags/rt_loader/external_validation_service_alerts.sql
+++ b/airflow/dags/rt_loader/external_validation_service_alerts.sql
@@ -1,38 +1,11 @@
 ---
 operator: operators.SqlQueryOperator
-description: |
-  GTFS RT validation errors as returned by the validator. Each entry corresponds
-  to a <filename>.results.json file that is spit out by the validator.
-fields:
-  errorMessage: |
-    An object with fields for messageId, gtfsRTFeedIterationModel, validationRule,
-    errorDetails.
-  occurrenceList: |
-    An array of objects with these fields: occurenceId, messageLogModel, prefix
+dependencies:
+    - load_rt_validations
 ---
 
-CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_service_alerts (
-    errorMessage STRUCT<
-      messageId INT64,
-      gtfsRTFeedIterationModel STRING,
-      validationRule STRUCT<
-        errorId STRING,
-        severity STRING,
-        title STRING,
-        errorDescription STRING,
-        occurrenceSuffix STRING
-      >,
-      errorDetails STRING
-    >,
-    occurrenceList ARRAY<
-      STRUCT<
-        occurrenceId INT64,
-        messageLogModel STRING,
-        prefix STRING
-      >
-    >
-)
+CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_service_alerts
 OPTIONS (
-    uris=["gs://calitp-py-ci/gtfs-rt-validator-api/test_output_full/*gtfs_rt_service_alerts_url"],
-    format="JSON"
+    uris=["{{get_bucket()}}/rt-processed/validation/*/validation_results/*/*/service_alerts.parquet"],
+    format="PARQUET"
 )

--- a/airflow/dags/rt_loader/external_validation_trip_updates.sql
+++ b/airflow/dags/rt_loader/external_validation_trip_updates.sql
@@ -6,6 +6,6 @@ dependencies:
 
 CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_trip_updates
 OPTIONS (
-    uris=["{{get_bucket()}}/rt-processed/validation/*/validation_results/*/*/trip_updates.parquet"],
+    uris=["{{get_bucket()}}/rt-processed/validation/*/trip_updates.parquet"],
     format="PARQUET"
 )

--- a/airflow/dags/rt_loader/external_validation_trip_updates.sql
+++ b/airflow/dags/rt_loader/external_validation_trip_updates.sql
@@ -1,5 +1,21 @@
 ---
 operator: operators.SqlQueryOperator
+description: |
+  GTFS RT validation errors as returned by the validator. Each row corresponds to
+  the number of occurrences of a given error for a single itp_id/url/tick/entity combination.
+fields:
+  calitp_itp_id: |
+    The ITP ID associated with the trip update.
+  calitp_url_number: |
+    The URL number associated with the trip update.
+  calitp_extracted_at: |
+    When the original file was downloaded.
+  rt_feed_type: |
+    The type of RT feed entity; will always be trip updates.
+  error_id: |
+    An error ID as defined in the GTFS RT validator repo.
+  n_occurrences: |
+    The number of occurrences of this error.
 dependencies:
     - load_rt_validations
 ---

--- a/airflow/dags/rt_loader/external_validation_trip_updates.sql
+++ b/airflow/dags/rt_loader/external_validation_trip_updates.sql
@@ -1,29 +1,11 @@
 ---
 operator: operators.SqlQueryOperator
+dependencies:
+    - load_rt_validations
 ---
 
-CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_trip_updates (
-    errorMessage STRUCT<
-      messageId INT64,
-      gtfsRTFeedIterationModel STRING,
-      validationRule STRUCT<
-        errorId STRING,
-        severity STRING,
-        title STRING,
-        errorDescription STRING,
-        occurrenceSuffix STRING
-      >,
-      errorDetails STRING
-    >,
-    occurrenceList ARRAY<
-      STRUCT<
-        occurrenceId INT64,
-        messageLogModel STRING,
-        prefix STRING
-      >
-    >
-)
+CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_trip_updates
 OPTIONS (
-    uris=["gs://calitp-py-ci/gtfs-rt-validator-api/test_output_full/*gtfs_rt_trip_updates_url"],
-    format="JSON"
+    uris=["{{get_bucket()}}/rt-processed/validation/*/validation_results/*/*/trip_updates.parquet"],
+    format="PARQUET"
 )

--- a/airflow/dags/rt_loader/external_validation_vehicle_positions.sql
+++ b/airflow/dags/rt_loader/external_validation_vehicle_positions.sql
@@ -1,29 +1,11 @@
 ---
 operator: operators.SqlQueryOperator
+dependencies:
+    - load_rt_validations
 ---
 
-CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_vehicle_positions (
-    errorMessage STRUCT<
-      messageId INT64,
-      gtfsRTFeedIterationModel STRING,
-      validationRule STRUCT<
-        errorId STRING,
-        severity STRING,
-        title STRING,
-        errorDescription STRING,
-        occurrenceSuffix STRING
-      >,
-      errorDetails STRING
-    >,
-    occurrenceList ARRAY<
-      STRUCT<
-        occurrenceId INT64,
-        messageLogModel STRING,
-        prefix STRING
-      >
-    >
-)
+CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_vehicle_positions
 OPTIONS (
-    uris=["gs://calitp-py-ci/gtfs-rt-validator-api/test_output_full/*gtfs_rt_vehicle_positions_url"],
-    format="JSON"
+    uris=["{{get_bucket()}}/rt-processed/validation/*/validation_results/*/*/vehicle_positions.parquet"],
+    format="PARQUET"
 )

--- a/airflow/dags/rt_loader/external_validation_vehicle_positions.sql
+++ b/airflow/dags/rt_loader/external_validation_vehicle_positions.sql
@@ -6,6 +6,6 @@ dependencies:
 
 CREATE OR REPLACE EXTERNAL TABLE gtfs_rt.validation_vehicle_positions
 OPTIONS (
-    uris=["{{get_bucket()}}/rt-processed/validation/*/validation_results/*/*/vehicle_positions.parquet"],
+    uris=["{{get_bucket()}}/rt-processed/validation/*/vehicle_positions.parquet"],
     format="PARQUET"
 )

--- a/airflow/dags/rt_loader/external_validation_vehicle_positions.sql
+++ b/airflow/dags/rt_loader/external_validation_vehicle_positions.sql
@@ -1,5 +1,21 @@
 ---
 operator: operators.SqlQueryOperator
+description: |
+  GTFS RT validation errors as returned by the validator. Each row corresponds to
+  the number of occurrences of a given error for a single itp_id/url/tick/entity combination.
+fields:
+  calitp_itp_id: |
+    The ITP ID associated with the vehicle position.
+  calitp_url_number: |
+    The URL number associated with the vehicle position.
+  calitp_extracted_at: |
+    When the original file was downloaded.
+  rt_feed_type: |
+    The type of RT feed entity; will always be vehicle positions.
+  error_id: |
+    An error ID as defined in the GTFS RT validator repo.
+  n_occurrences: |
+    The number of occurrences of this error.
 dependencies:
     - load_rt_validations
 ---

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -1,6 +1,6 @@
 operator: 'operators.PodOperator'
 name: 'gtfs-rt-validation'
-image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.3'
+image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.4'
 cmds:
   - python3
 
@@ -12,17 +12,15 @@ arguments:
         project_id="cal-itp-data-infra",
         token="cloud",
         param_csv="{{get_bucket()}}/rt-processed/calitp_validation_params/{{execution_date.to_date_string()}}.csv",
-        results_bucket="{{get_bucket()}}/gtfs-rt-validator-api/test-pipeline",
+        results_bucket="{{get_bucket()}}/rt-processed/validation/{{execution_date.to_date_string()}}",
+        summary_path="{{get_bucket()}}/rt-processed/validation/{{execution_date.to_date_string()}}/status.json",
         verbose=True,
         aggregate_counts=True,
-        status_result_path="{{get_bucket()}}/gtfs-rt-validator-api/test-pipeline/status.json",
+        threads=4,
     )
 
 is_delete_operator_pod: true
 get_logs: true
 
 dependencies:
-  - external_validation_service_alerts
-  - external_validation_trip_updates
-  - external_validation_vehicle_positions
   - create_validation_params

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -17,7 +17,6 @@ arguments:
         verbose=True,
         aggregate_counts=True,
         threads=4,
-        limit=8,
     )
 
 is_delete_operator_pod: true

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -17,6 +17,7 @@ arguments:
         verbose=True,
         aggregate_counts=True,
         threads=4,
+        limit=8,
     )
 
 is_delete_operator_pod: true

--- a/airflow/plugins/operators/sql_query_operator.py
+++ b/airflow/plugins/operators/sql_query_operator.py
@@ -17,4 +17,6 @@ class SqlQueryOperator(BaseOperator):
 
     def execute(self, context):
         engine = get_engine()
+
+        print(f"{engine}\n{self.sql}")
         engine.execute(sql.text(self.sql))


### PR DESCRIPTION
# Overall Description

Step towards closing https://github.com/cal-itp/data-infra/issues/787 and essentially closes https://github.com/cal-itp/data-infra/issues/786. This PR changes the RT validation to use v0.0.4 of the RT validator wrapper which will write out files identified with the itp_id, url, and entity type. It also points the external tables at the new, proper output paths for each entity type.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

This takes awhile to run fully but I've confirmed with running approximately 10 files.

```
[2022-02-23 23:31:10,160] {pod_launcher.py:149} INFO - idx=8 gtfs_schedule_path='gs://gtfs-data-test/schedule/2022-02-11T00:00:00+00:00/259_0' gtfs_rt_glob_path='gtfs-data/rt/2022-02-11T00:*/259/0/*vehicle_positions*' out_dir=None result_bucket='gs://gtfs-data-test/rt-processed/validation/2022-02-11/validation_results/259/0/vehicle_positions.parquet' event='Saving aggregate counts as: gs://gtfs-data-test/rt-processed/validation/2022-02-11/validation_results/259/0/vehicle_positions.parquet'
[2022-02-23 23:31:11,853] {pod_launcher.py:149} INFO - event='finished multiprocessing; 6 successful of 10'
[2022-02-23 23:31:14,065] {pod_launcher.py:198} INFO - Event: gtfs-rt-validation.e084662ae03d48f79c63ab11c3ec5070 had an event of type Succeeded
[2022-02-23 23:31:14,065] {pod_launcher.py:311} INFO - Event with job id gtfs-rt-validation.e084662ae03d48f79c63ab11c3ec5070 Succeeded
[2022-02-23 23:31:14,154] {pod_launcher.py:198} INFO - Event: gtfs-rt-validation.e084662ae03d48f79c63ab11c3ec5070 had an event of type Succeeded
[2022-02-23 23:31:14,154] {pod_launcher.py:311} INFO - Event with job id gtfs-rt-validation.e084662ae03d48f79c63ab11c3ec5070 Succeeded
[2022-02-23 23:31:14,313] {taskinstance.py:1219} INFO - Marking task as SUCCESS. dag_id=rt_loader, task_id=load_rt_validations, execution_date=20220211T000000, start_date=20220223T231243, end_date=20220223T233114
(.venv) ➜  airflow git:(load-rt)
```
Here's a narrow slice of the 11th
<img width="519" alt="image" src="https://user-images.githubusercontent.com/4305366/155763437-a2ab8c3c-609c-4129-9e54-c7d9bc240348.png">
