### PR TITLE
data(gtfs): update Amtrak

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -41,7 +41,7 @@ amador-regional-transit-system:
 amtrak:
   agency_name: Amtrak
   feeds:
-    - gtfs_schedule_url: https://storage.googleapis.com/gtfs-data/schedule-assets/amtrak_transit_feed2021-09-03-20211013T204324Z-001.zip
+    - gtfs_schedule_url: https://content.amtrak.com/content/gtfs/GTFS.zip
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null


### PR DESCRIPTION
# Overall Description

Updates Amtrak's GTFS Schedule  URI in `agencies.yml` to be a permalink on the amtrak.com website.

Closes #1143

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## agencies.yml changes checklist

- [x] Manually made sure any new feeds have `itp_id`s that are not duplicative
- [x] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [x] Made sure the Airtable database has consistent information
- [x] Fill out the following section describing what feeds were added/updated

This PR updates `agencies.yml` in order to:

 -  update Amtrak's GTFS Schedule  URI in `agencies.yml` to be a permalink on the amtrak.com website.
