### PR TITLE
Refactor gtfs views staging cleaning

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_feeds.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_feeds.sql
@@ -27,8 +27,8 @@ feed_feed_info AS (
             AS is_composite_feed
         , COALESCE(GREATEST(T1.calitp_extracted_at, T2.calitp_extracted_at), T1.calitp_extracted_at) AS calitp_extracted_at
         , COALESCE(LEAST(T1.calitp_deleted_at, T2.calitp_deleted_at), T1.calitp_deleted_at) AS calitp_deleted_at
-    FROM `gtfs_schedule_type2.calitp_feeds` T1
-    LEFT JOIN `gtfs_schedule_type2.feed_info_clean` T2
+    FROM `gtfs_views_staging.calitp_feeds` T1
+    LEFT JOIN `gtfs_views_staging.feed_info_clean` T2
         ON
             T1.calitp_itp_id = T2.calitp_itp_id
             AND T1.calitp_url_number = T2.calitp_url_number

--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_pathways.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_pathways.sql
@@ -12,4 +12,4 @@ dependencies:
   - dummy_gtfs_schedule_dims
 ---
 
-  SELECT * FROM `gtfs_schedule_type2.pathways_clean`
+  SELECT * FROM `gtfs_views_staging.pathways_clean`

--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_routes.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_routes.sql
@@ -27,8 +27,8 @@ route_agencies AS (
         , T2.* EXCEPT(calitp_itp_id, calitp_url_number, agency_id, calitp_extracted_at, calitp_deleted_at, calitp_hash)
         , COALESCE(GREATEST(T1.calitp_extracted_at, T2.calitp_extracted_at), T1.calitp_extracted_at) AS calitp_extracted_at
         , COALESCE(LEAST(T1.calitp_deleted_at, T2.calitp_deleted_at), T1.calitp_deleted_at) AS calitp_deleted_at
-    FROM `gtfs_schedule_type2.routes_clean` T1
-    LEFT JOIN `gtfs_schedule_type2.agency_clean` T2
+    FROM `gtfs_views_staging.routes_clean` T1
+    LEFT JOIN `gtfs_views_staging.agency_clean` T2
         ON T1.calitp_itp_id = T2.calitp_itp_id
         AND T1.calitp_url_number = T2.calitp_url_number
         AND T1.agency_id = T2.agency_id

--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_stop_times.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_stop_times.sql
@@ -17,7 +17,7 @@ raw_time_parts AS (
     SELECT *
       , REGEXP_EXTRACT_ALL(arrival_time, "([0-9]+)") AS part_arr
       , REGEXP_EXTRACT_ALL(departure_time, "([0-9]+)") AS part_dep
-      FROM `gtfs_schedule_type2.stop_times_clean`
+      FROM `gtfs_views_staging.stop_times_clean`
 ),
 int_time_parts AS (
     SELECT

--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_stops.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_stops.sql
@@ -12,4 +12,4 @@ dependencies:
   - dummy_gtfs_schedule_dims
 ---
 
-  SELECT * FROM `gtfs_schedule_type2.stops_clean`
+  SELECT * FROM `gtfs_views_staging.stops_clean`

--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_trips.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_trips.sql
@@ -19,7 +19,7 @@ WITH trip_dupes AS (
     SELECT
         *
         , ROW_NUMBER() OVER (PARTITION BY trip_key) calitp_dupe_number
-    FROM `gtfs_schedule_type2.trips_clean` T
+    FROM `gtfs_views_staging.trips_clean` T
 
 )
 

--- a/airflow/dags/gtfs_views/gtfs_schedule_stg_calendar_long.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_stg_calendar_long.sql
@@ -33,5 +33,5 @@ SELECT
   , calitp_deleted_at
   , "{{dow | title}}" AS day_name
   , {{dow}} AS service_indicator
-FROM `gtfs_schedule_type2.calendar_clean`
+FROM `gtfs_views_staging.calendar_clean`
 {% endfor %}

--- a/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_stg_daily_service.sql
@@ -33,7 +33,7 @@ WITH
     FROM (
         -- deduplicate calendar_dates, which does not have a unique id column
         -- and has identical entries in rare cases
-        SELECT DISTINCT * FROM `gtfs_schedule_type2.calendar_dates_clean`
+        SELECT DISTINCT * FROM `gtfs_views_staging.calendar_dates_clean`
     )
   ),
 

--- a/airflow/dags/gtfs_views/reports_gtfs_schedule_index.sql
+++ b/airflow/dags/gtfs_views/reports_gtfs_schedule_index.sql
@@ -47,7 +47,7 @@ has_feed_info_end_date AS (
         , calitp_itp_id
         , calitp_url_number
         , TRUE AS has_feed_info
-    FROM `gtfs_schedule_type2.feed_info_clean` FI
+    FROM `gtfs_views_staging.feed_info_clean` FI
     JOIN publish_dates_crnt PD ON
         FI.calitp_extracted_at <= PD.date_end
         AND COALESCE(FI.calitp_deleted_at, "2099-01-01") > PD.date_end

--- a/airflow/dags/gtfs_views/validation_dim_codes.sql
+++ b/airflow/dags/gtfs_views/validation_dim_codes.sql
@@ -10,4 +10,4 @@ dependencies:
 --       we will end up with multiple entries for code (our primary key)
 --       we either need to change track this table, or use only the most recent
 --       levels of code x severity
-SELECT DISTINCT code, severity FROM `gtfs_schedule_type2.validation_notices_clean`
+SELECT DISTINCT code, severity FROM `gtfs_views_staging.validation_notices_clean`

--- a/airflow/dags/gtfs_views/validation_fact_daily_feed_notices.sql
+++ b/airflow/dags/gtfs_views/validation_fact_daily_feed_notices.sql
@@ -14,7 +14,7 @@ SELECT
     , T1.calitp_deleted_at AS validation_deleted_at
     , T1.* EXCEPT (calitp_extracted_at, calitp_deleted_at)
 
-FROM `gtfs_schedule_type2.validation_notices_clean` T1
+FROM `gtfs_views_staging.validation_notices_clean` T1
 JOIN `views.dim_date` D
     ON T1.calitp_extracted_at <= D.full_date
         AND T1.calitp_deleted_at > D.full_date

--- a/airflow/dags/gtfs_views_staging/agency_clean.sql
+++ b/airflow/dags/gtfs_views_staging/agency_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.agency_clean"
+dst_table_name: "gtfs_views_staging.agency_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/agency_clean.sql
+++ b/airflow/dags/gtfs_views_staging/agency_clean.sql
@@ -5,8 +5,22 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(agency_id) as agency_id
+    , TRIM(agency_name) as agency_name
+    , TRIM(agency_url) as agency_url
+    , TRIM(agency_timezone) as agency_timezone
+    , TRIM(agency_lang) as agency_lang
+    , TRIM(agency_phone) as agency_phone
+    , TRIM(agency_fare_url) as agency_fare_url
+    , TRIM(agency_email) as agency_email
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS agency_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.agency`

--- a/airflow/dags/gtfs_views_staging/attributions_clean.sql
+++ b/airflow/dags/gtfs_views_staging/attributions_clean.sql
@@ -1,0 +1,29 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_views_staging.attributions_clean"
+dependencies:
+  - type2_loaded
+---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(organization_name) as organization_name
+    , TRIM(attribution_id) as attribution_id
+    , TRIM(agency_id) as agency_id
+    , TRIM(route_id) as route_id
+    , TRIM(trip_id) as trip_id
+    , is_producer
+    , is_operator
+    , is_authority
+    , TRIM(attribution_url) as attribution_url
+    , TRIM(attribution_email) as attribution_email
+    , TRIM(attribution_phone) as attribution_phone
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS attribution_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+FROM `gtfs_schedule_type2.attributions`

--- a/airflow/dags/gtfs_views_staging/calendar_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.calendar_clean"
+dst_table_name: "gtfs_views_staging.calendar_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/calendar_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_clean.sql
@@ -4,13 +4,26 @@ dst_table_name: "gtfs_schedule_type2.calendar_clean"
 dependencies:
   - type2_loaded
 ---
--- Trim service_id for 273, 271 specific issue
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(start_date, end_date, calitp_deleted_at, service_id),
-    TRIM(service_id) as service_id,
-    PARSE_DATE("%Y%m%d",start_date) AS start_date,
-    PARSE_DATE("%Y%m%d",end_date) AS end_date,
-    FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
-        AS calendar_key,
-    COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(service_id) as service_id
+    , TRIM(monday) as monday
+    , TRIM(tuesday) as tuesday
+    , TRIM(wednesday) as wednesday
+    , TRIM(thursday) as thursday
+    , TRIM(friday) as friday
+    , TRIM(saturday) as saturday
+    , TRIM(sunday) as sunday
+    , PARSE_DATE("%Y%m%d", TRIM(start_date)) AS start_date
+    , PARSE_DATE("%Y%m%d", TRIM(end_date)) AS end_date
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        AS calendar_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.calendar`

--- a/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.calendar_dates_clean"
+dst_table_name: "gtfs_views_staging.calendar_dates_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
@@ -4,10 +4,17 @@ dst_table_name: "gtfs_schedule_type2.calendar_dates_clean"
 dependencies:
   - type2_loaded
 ---
--- Trim service_id for 273, 271 specific issue
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-  * EXCEPT(date, calitp_deleted_at, service_id)
+  calitp_itp_id
+  , calitp_url_number
   , TRIM(service_id) as service_id
-  , PARSE_DATE("%Y%m%d",date) AS date
+  , TRIM(exception_type) as exception_type
+  , calitp_extracted_at
+  , calitp_hash
+  , PARSE_DATE("%Y%m%d", TRIM(date)) AS date
   , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.calendar_dates`

--- a/airflow/dags/gtfs_views_staging/calitp_feeds.sql
+++ b/airflow/dags/gtfs_views_staging/calitp_feeds.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.calitp_feeds"
+dst_table_name: "gtfs_views_staging.calitp_feeds"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/fare_attributes_clean.sql
+++ b/airflow/dags/gtfs_views_staging/fare_attributes_clean.sql
@@ -1,0 +1,25 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_views_staging.fare_attributes_clean"
+dependencies:
+  - type2_loaded
+---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(fare_id) as fare_id
+    , TRIM(price) as price
+    , TRIM(currency_type) as currency_type
+    , TRIM(payment_method) as payment_method
+    , TRIM(transfers) as transfers
+    , TRIM(agency_id) as agency_id
+    , TRIM(transfer_duration) as transfer_duration
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS fare_attribute_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+FROM `gtfs_schedule_type2.fare_attributes`

--- a/airflow/dags/gtfs_views_staging/fare_rules_clean.sql
+++ b/airflow/dags/gtfs_views_staging/fare_rules_clean.sql
@@ -1,0 +1,23 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_views_staging.fare_rules_clean"
+dependencies:
+  - type2_loaded
+---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(fare_id) as fare_id
+    , TRIM(route_id) as route_id
+    , TRIM(origin_id) as origin_id
+    , TRIM(destination_id) as destination_id
+    , TRIM(contains_id) as contains_id
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS fare_rule_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+FROM `gtfs_schedule_type2.fare_rules`

--- a/airflow/dags/gtfs_views_staging/feed_info_clean.sql
+++ b/airflow/dags/gtfs_views_staging/feed_info_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.feed_info_clean"
+dst_table_name: "gtfs_views_staging.feed_info_clean"
 dependencies:
   - type2_loaded
 ---
@@ -8,7 +8,9 @@ dependencies:
 -- Trim all string fields
 -- Incoming schema explicitly defined in gtfs_schedule_history external table definition
 
-SELECT
+-- select distinct because of Foothill Transit feed with exact duplicates
+-- duplicates here result in duplicate feed_keys downstream
+SELECT DISTINCT
     calitp_itp_id
     , calitp_url_number
     , TRIM(feed_publisher_name) as feed_publisher_name

--- a/airflow/dags/gtfs_views_staging/feed_info_clean.sql
+++ b/airflow/dags/gtfs_views_staging/feed_info_clean.sql
@@ -5,13 +5,24 @@ dependencies:
   - type2_loaded
 ---
 
--- select distinct because of Foothill Transit feed with exact duplicates
--- duplicates here result in duplicate feed_keys downstream
-SELECT DISTINCT
-    * EXCEPT(feed_start_date, feed_end_date, calitp_deleted_at),
-    PARSE_DATE("%Y%m%d",feed_start_date) AS feed_start_date,
-    PARSE_DATE("%Y%m%d",feed_end_date) AS feed_end_date,
-    FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
-        AS feed_info_key,
-    COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(feed_publisher_name) as feed_publisher_name
+    , TRIM(feed_publisher_url) as feed_publisher_url
+    , TRIM(feed_lang) as feed_lang
+    , TRIM(default_lang) as default_lang
+    , TRIM(feed_version) as feed_version
+    , TRIM(feed_contact_email) as feed_contact_email
+    , TRIM(feed_contact_url) as feed_contact_url
+    , calitp_extracted_at
+    , calitp_hash
+    , PARSE_DATE("%Y%m%d", TRIM(feed_start_date)) AS feed_start_date
+    , PARSE_DATE("%Y%m%d", TRIM(feed_end_date)) AS feed_end_date
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        AS feed_info_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.feed_info`

--- a/airflow/dags/gtfs_views_staging/frequencies_clean.sql
+++ b/airflow/dags/gtfs_views_staging/frequencies_clean.sql
@@ -1,0 +1,23 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_views_staging.frequencies_clean"
+dependencies:
+  - type2_loaded
+---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(trip_id) as trip_id
+    , TRIM(start_time) as start_time
+    , TRIM(end_time) as end_time
+    , TRIM(headway_secs) as headway_secs
+    , TRIM(exact_times) as exact_times
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS frequency_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+FROM `gtfs_schedule_type2.frequencies`

--- a/airflow/dags/gtfs_views_staging/levels_clean.sql
+++ b/airflow/dags/gtfs_views_staging/levels_clean.sql
@@ -1,0 +1,21 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_views_staging.levels_clean"
+dependencies:
+  - type2_loaded
+---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(level_id) as level_id
+    , level_index
+    , TRIM(level_name) as level_name
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS level_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+FROM `gtfs_schedule_type2.levels`

--- a/airflow/dags/gtfs_views_staging/pathways_clean.sql
+++ b/airflow/dags/gtfs_views_staging/pathways_clean.sql
@@ -5,8 +5,26 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(pathway_id) as pathway_id
+    , TRIM(from_stop_id) as from_stop_id
+    , TRIM(to_stop_id) as to_stop_id
+    , pathway_mode
+    , is_bidirectional
+    , length
+    , traversal_time
+    , stair_count
+    , max_slope
+    , min_width
+    , TRIM(signposted_as) as signposted_as
+    , TRIM(reversed_signposted_as) as reversed_signposted_as
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS pathway_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.pathways`

--- a/airflow/dags/gtfs_views_staging/pathways_clean.sql
+++ b/airflow/dags/gtfs_views_staging/pathways_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.pathways_clean"
+dst_table_name: "gtfs_views_staging.pathways_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/routes_clean.sql
+++ b/airflow/dags/gtfs_views_staging/routes_clean.sql
@@ -5,11 +5,27 @@ dependencies:
   - type2_loaded
 ---
 
-
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
 
 SELECT
-    * EXCEPT(calitp_deleted_at),
-    FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
-        AS route_key,
-    COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(route_id) as route_id
+    , TRIM(route_type) as route_type
+    , TRIM(agency_id) as agency_id
+    , TRIM(route_short_name) as route_short_name
+    , TRIM(route_long_name) as route_long_name
+    , TRIM(route_desc) as route_desc
+    , TRIM(route_url) as route_url
+    , TRIM(route_color) as route_color
+    , TRIM(route_text_color) as route_text_color
+    , TRIM(route_sort_order) as route_sort_order
+    , TRIM(continuous_pickup) as continuous_pickup
+    , TRIM(continuous_drop_off) as continuous_drop_off
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        AS route_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.routes`

--- a/airflow/dags/gtfs_views_staging/routes_clean.sql
+++ b/airflow/dags/gtfs_views_staging/routes_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.routes_clean"
+dst_table_name: "gtfs_views_staging.routes_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/stop_times_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stop_times_clean.sql
@@ -6,7 +6,22 @@ dependencies:
 ---
 
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(trip_id) as trip_id
+    , TRIM(stop_id) as stop_id
+    , TRIM(stop_sequence) as stop_sequence
+    , TRIM(arrival_time) as arrival_time
+    , TRIM(departure_time) as departure_time
+    , TRIM(stop_headsign) as stop_headsign
+    , TRIM(pickup_type) as pickup_type
+    , TRIM(drop_off_type) as drop_off_type
+    , TRIM(continuous_pickup) as continuous_pickup
+    , TRIM(continuous_drop_off) as continuous_drop_off
+    , TRIM(shape_dist_traveled) as shape_dist_traveled
+    , TRIM(timepoint) as timepoint
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
         AS stop_time_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at

--- a/airflow/dags/gtfs_views_staging/stop_times_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stop_times_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.stop_times_clean"
+dst_table_name: "gtfs_views_staging.stop_times_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/stops_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stops_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.stops_clean"
+dst_table_name: "gtfs_views_staging.stops_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/stops_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stops_clean.sql
@@ -13,8 +13,8 @@ SELECT
     , calitp_url_number
     , TRIM(stop_id) as stop_id
     , TRIM(tts_stop_name) as tts_stop_name
-    , stop_lat
-    , stop_lon
+    , SAFE_CAST(TRIM(stop_lat) AS FLOAT64) as stop_lat
+    , SAFE_CAST(TRIM(stop_lon) AS FLOAT64) as stop_lon
     , TRIM(zone_id) as zone_id
     , TRIM(parent_station) as parent_station
     , TRIM(stop_code) as stop_code

--- a/airflow/dags/gtfs_views_staging/stops_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stops_clean.sql
@@ -5,8 +5,29 @@ dependencies:
   - type2_loaded
 ---
 
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(stop_id) as stop_id
+    , TRIM(tts_stop_name) as tts_stop_name
+    , stop_lat
+    , stop_lon
+    , TRIM(zone_id) as zone_id
+    , TRIM(parent_station) as parent_station
+    , TRIM(stop_code) as stop_code
+    , TRIM(stop_name) as stop_name
+    , TRIM(stop_desc) as stop_desc
+    , TRIM(stop_url) as stop_url
+    , TRIM(location_type) as location_type
+    , TRIM(stop_timezone) as stop_timezone
+    , TRIM(wheelchair_boarding) as wheelchair_boarding
+    , TRIM(level_id) as level_id
+    , TRIM(platform_code) as platform_code
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS stop_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.stops`

--- a/airflow/dags/gtfs_views_staging/transfers_clean.sql
+++ b/airflow/dags/gtfs_views_staging/transfers_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_views_staging.levels_clean"
+dst_table_name: "gtfs_views_staging.transfers_clean"
 dependencies:
   - type2_loaded
 ---
@@ -11,11 +11,11 @@ dependencies:
 SELECT
     calitp_itp_id
     , calitp_url_number
-    , TRIM(level_id) as level_id
-    , level_index
-    , TRIM(level_name) as level_name
+    , TRIM(from_stop_id) as from_stop_id
+    , TRIM(to_stop_id) as to_stop_id
+    , TRIM(transfer_type) as transfer_type
     , calitp_extracted_at
     , calitp_hash
-    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS level_key
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS transfer_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
-FROM `gtfs_schedule_type2.levels`
+FROM `gtfs_schedule_type2.transfers`

--- a/airflow/dags/gtfs_views_staging/transfers_clean.sql
+++ b/airflow/dags/gtfs_views_staging/transfers_clean.sql
@@ -1,0 +1,21 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_views_staging.levels_clean"
+dependencies:
+  - type2_loaded
+---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(level_id) as level_id
+    , level_index
+    , TRIM(level_name) as level_name
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS level_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+FROM `gtfs_schedule_type2.levels`

--- a/airflow/dags/gtfs_views_staging/translations_clean.sql
+++ b/airflow/dags/gtfs_views_staging/translations_clean.sql
@@ -1,0 +1,25 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "gtfs_views_staging.translations_clean"
+dependencies:
+  - type2_loaded
+---
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+SELECT
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(table_name) as table_name
+    , TRIM(field_name) as field_name
+    , TRIM(language) as language
+    , TRIM(translation) as translation
+    , TRIM(record_id) as record_id
+    , TRIM(record_sub_id) as record_sub_id
+    , TRIM(field_value) as field_value
+    , calitp_extracted_at
+    , calitp_hash
+    , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS translation_key
+    , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+FROM `gtfs_schedule_type2.translations`

--- a/airflow/dags/gtfs_views_staging/trips_clean.sql
+++ b/airflow/dags/gtfs_views_staging/trips_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.trips_clean"
+dst_table_name: "gtfs_views_staging.trips_clean"
 dependencies:
   - type2_loaded
 ---

--- a/airflow/dags/gtfs_views_staging/trips_clean.sql
+++ b/airflow/dags/gtfs_views_staging/trips_clean.sql
@@ -4,10 +4,25 @@ dst_table_name: "gtfs_schedule_type2.trips_clean"
 dependencies:
   - type2_loaded
 ---
--- Trim service_id for 273, 271 specific issue
+
+-- Trim all string fields
+-- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
 SELECT
-    * EXCEPT(calitp_deleted_at, service_id)
+    calitp_itp_id
+    , calitp_url_number
+    , TRIM(route_id) as route_id
     , TRIM(service_id) as service_id
+    , TRIM(trip_id) as trip_id
+    , TRIM(shape_id) as shape_id
+    , TRIM(trip_headsign) as trip_headsign
+    , TRIM(trip_short_name) as trip_short_name
+    , TRIM(direction_id) as direction_id
+    , TRIM(block_id) as block_id
+    , TRIM(wheelchair_accessible) as wheelchair_accessible
+    , TRIM(bikes_allowed) as bikes_allowed
+    , calitp_extracted_at
+    , calitp_hash
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS trip_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.trips`

--- a/airflow/dags/gtfs_views_staging/validation_notices_clean.sql
+++ b/airflow/dags/gtfs_views_staging/validation_notices_clean.sql
@@ -5,7 +5,55 @@ dependencies:
   - type2_loaded
 ---
 
+-- Must trim string fields that come from raw GTFS tables that we clean & load into views
+-- (To allow joining with the cleaned data after this is run)
+-- Don't trim stopId because we don't load stops into views
+-- This table has over 70 columns, so even though EXCEPT is a bit messy it still seems cleaner
+
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    * EXCEPT(
+      calitp_deleted_at
+      , fareId
+      , previousFareId
+      , routeId
+      , currentDate
+      , feedEndDate
+      , routeColor
+      , routeTextColor
+      , tripId
+      , tripIdA
+      , tripIdB
+      , routeShortName
+      , routeLongName
+      , routeDesc
+      , stopId
+      , stopName
+      , serviceIdA
+      , serviceIdB
+      , departureTime
+      , arrivalTime
+      , parentStation
+      , parentStopName)
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    , TRIM(fareId) as fareId
+    , TRIM(previousFareId) as previousFareId
+    , TRIM(routeId) as routeId
+    , TRIM(currentDate) as currentDate
+    , TRIM(feedEndDate) as feedEndDate
+    , TRIM(routeColor) as routeColor
+    , TRIM(routeTextColor) as routeTextColor
+    , TRIM(tripId) as tripId
+    , TRIM(tripIdA) as tripIdA
+    , TRIM(tripIdB) as tripIdB
+    , TRIM(routeShortName) as routeShortName
+    , TRIM(routeLongName) as routeLongName
+    , TRIM(routeDesc) as routeDesc
+    , TRIM(stopId) as stopId
+    , TRIM(stopName) as stopName
+    , TRIM(serviceIdA) as serviceIdA
+    , TRIM(serviceIdB) as serviceIdB
+    , TRIM(departureTime) as departureTime
+    , TRIM(arrivalTime) as arrivalTime
+    , TRIM(parentStation) as parentStation
+    , TRIM(parentStopName) as parentStopName
 FROM `gtfs_schedule_type2.validation_notices`

--- a/airflow/dags/gtfs_views_staging/validation_notices_clean.sql
+++ b/airflow/dags/gtfs_views_staging/validation_notices_clean.sql
@@ -1,6 +1,6 @@
 ---
 operator: operators.SqlToWarehouseOperator
-dst_table_name: "gtfs_schedule_type2.validation_notices_clean"
+dst_table_name: "gtfs_views_staging.validation_notices_clean"
 dependencies:
   - type2_loaded
 ---


### PR DESCRIPTION
# Overall Description

_🚨 Note that I am requesting to merge this into the `refactor-gtfs-views-staging` branch. We need to do a bunch of PRs that should move together (see #1137). I would like to get them reviewed by merging into this placeholder branch, and then just merge that whole branch at once into main to avoid having to be concerned with the timing of merging a bunch of PRs one by one into main._ 

This PR does three things:

1. **New dataset:** Creates a `gtfs_views_staging` BigQuery dataset, updates all the `gtfs_views_staging` tasks creating `_clean` data to write to this dataset, and updates all `gtfs_views` consumers of this data to reference this new dataset. This separates the `clean` GTFS schedule data out from the `type2`. 
   * See open question on #1073 -- I think we should just set the variable manually for now so that these end up in the right place
2. **Cleans additional data:** There were a few files (`attributions`, `levels`, `fare_attributes`, `fare_rules`, `transfers`, `translations`) that we were loading into `type2` but not loading into clean. This was going to introduce a problem in the next step of this process, which will transfer `gtfs_schedule` to look at this `clean` data rather than at the raw data it pulls now. 
3. **Whitespace:** This PR includes the changes from #1022 to trim whitespace at the "data cleaning" step. We will address the concerns raised in that PR with the `gtfs_schedule` dataset changes noted above (and that is why this PR will need to be merged together with others.) 
   * As part of this, this PR undoes #1027 because it is no longer needed.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ This *will* address #946 as part of #1137 when it merges into main.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
Stop times related DAG tasks fail due to size (query limit), not related to this PR.
![image](https://user-images.githubusercontent.com/55149902/156052402-f9a551e9-f790-4458-9ee8-f39c6cd8831d.png)
![image](https://user-images.githubusercontent.com/55149902/156052475-36e20e44-efeb-473a-8bd7-4b70f3f82752.png)

- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_views_staging` and `gtfs_views` DAGs in order to....

Adds the following DAG tasks (cleaning existing type2 tables that were not previously cleaned):

- `gtfs_views_staging.attributions_clean`
- `gtfs_views_staging.fare_attributes_clean`
- `gtfs_views_staging.fare_rules_clean`
- `gtfs_views_staging.layers_clean`
- `gtfs_views_staging.transfers_clean`
- `gtfs_views_staging.translations_clean`

Updates the following DAG tasks:

- All the `_clean` tasks in `gtfs_views_staging` to trim whitespace & write to `gtfs_views_staging` dataset instead of `gtfs_schedule_type2`
- All the tasks in `views` that point to `_clean` tables, to point to the `gtfs_views_staging` datatset 