### PR TITLE
only tick when seconds are evenly divisible by 20

### DIFF
--- a/services/gtfs-rt-archive/src/gtfs_rt_archive/threads/ticker.py
+++ b/services/gtfs-rt-archive/src/gtfs_rt_archive/threads/ticker.py
@@ -28,7 +28,6 @@ class Ticker(threading.Thread):
     def run(self):
 
         self.tickid = 0
-        self.tick()
 
-        while time.sleep(self.tickint) is None:
+        while time.sleep(self.tickint - (time.time() % self.tickint)) is None:
             self.tick()


### PR DESCRIPTION
# Overall Description

Currently the loop is `while True: sleep(20); tick()`. But since `tick()` isn't infinitely fast the actual delay is slightly larger than 20 seconds. This just says "sleep however much time until time.time() is a multiple of 20". This will stop the drift and make it so every timestamp is a multiple of 20.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [ ] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.