### PR TITLE
Update agencies.yml to reflect current Tulare County operations

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -390,14 +390,6 @@ desert-roadrunner:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 238
-dinuba-area-regional-transit:
-  agency_name: Dinuba Area Regional Transit
-  feeds:
-    - gtfs_schedule_url:  https://tularecog.org/tcag/data-gis-modeling/gtfs-data/dinuba-area-regional-transit-gtfs/
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
-  itp_id: 93
 downeylink:
   agency_name: DowneyLINK
   feeds:
@@ -958,14 +950,6 @@ plumas-transit-systems:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 254
-porterville-transit:
-  agency_name: Porterville Transit
-  feeds:
-    - gtfs_schedule_url: https://tularecog.org/tcag/data-gis-modeling/gtfs-data/porterville-transit-gtfs/
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
-  itp_id: 256
 redding-area-bus-authority:
   agency_name: Redding Area Bus Authority
   feeds:
@@ -1408,9 +1392,9 @@ tulare-county-area-transit:
   agency_name: Tulare County Area Transit
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/tcat-flex-ca-us/tcat-ca-us.zip
-      gtfs_rt_vehicle_positions_url: https://tularetransit.com/gtfs-rt/vehiclepositions
-      gtfs_rt_service_alerts_url: https://tularetransit.com/gtfs-rt/alerts
-      gtfs_rt_trip_updates_url: https://tularetransit.com/gtfs-rt/tripupdates
+      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_service_alerts_url: null
+      gtfs_rt_trip_updates_url: null
   itp_id: 346
 tuolumne-transit:
   agency_name: Tuolumne County Transit Agency
@@ -1612,3 +1596,11 @@ tracer:
     gtfs_rt_service_alerts_url: null
     gtfs_rt_trip_updates_url: null
   itp_id: 341
+time:
+  agency_name: Tulare InterModal Express
+  feeds:
+  - gtfs_schedule_url: https://tularetransit.com/gtfs
+    gtfs_rt_vehicle_positions_url: https://tularetransit.com/gtfs-rt/vehiclepositions
+    gtfs_rt_service_alerts_url: https://tularetransit.com/gtfs-rt/alerts
+    gtfs_rt_trip_updates_url: https://tularetransit.com/gtfs-rt/tripupdates
+  itp_id: 483


### PR DESCRIPTION
# Overall Description

Some consolidation of data about certain transit agencies have occurred within Tulare County.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## agencies.yml changes checklist

- [x] Include this section whenever any change to the `airflow/data/agencies.yml` file occurs, otherwise please omit this section.
- [x] Manually made sure any new feeds have `itp_id`s that are not duplicative
- [x] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [ ] Made sure the Airtable database has consistent information
- [x] Fill out the following section describing what feeds were added/updated

With the new aggregated feed made available via Tulare County Regional Transit Agency, this PR serves as both a status update and correction to the GTFS data being downloaded from Tulare County transit agencies. This update makes `agencies.yml` up-to-date for the 5 transit services (6 if you count both of Dinuba Area Regional Transit services) serving Tulare County as follows:

#### Dinuba Area Regional Transit

- removed from agencies.yml
- data can now be found in agencies.yml feed associated with ITP ID 474 (Tulare County Regional Transit Agency)
- *Airtable needs to be updated to reflect that the Dinuba Area Regional Transit services can now be found in the Tulare County Regional Transit Agency gtfs dataset*

#### Porterville Transit

- removed from agencies.yml
- data can now be found in agencies.yml feed associated with ITP ID 474 (Tulare County Regional Transit Agency)
- *Airtable needs to be updated to reflect that the Porterville Transit service can now be found in the Tulare County Regional Transit Agency gtfs dataset*

#### Tulare County Area Transit

- Is included in the aggregated feed found in agencies.yml feed associated with ITP ID 474 (Tulare County Regional Transit Agency)
- Can also be found with apparently greater detail in the agencies.yml feed associated with ITP ID 346
- The realtime URLs were incorrectly associated with this feed and should instead refer to Tulare InterModal Express.
- *Airtable needs to be updated to reflect that the Tulare County Area Transit service can now also be found in the Tulare County Regional Transit gtfs dataset*

#### Tulare InterModal Express

- Their schedule data is included in the aggregated feed found in agencies.yml feed associated with ITP ID 474 (Tulare County Regional Transit Agency)
- However, I confirmed that there is GTFS-RT data available for this service that was miscategorized as being associated with Tulare County Area Transit. The GTFS-RT data is incompatible with ITP ID 474 (Tulare County Regional Transit Agency) and specifically refers to a feed that we have not been downloading yet.
- I went ahead and created ITP ID 483 and associated it in airtable with the City of Tulare 
- I added a new agencies.yml entry for Tulare InterModal Express with the proper GTFS schedule and RT data
- *Airtable needs to be updated to reflect that the Tulare InterModal Express service can now also be found in the Tulare County Regional Transit gtfs dataset*

#### Visalia Transit

- No changes needed.