### PR TITLE
Hotfix stops typing

### DIFF
--- a/airflow/dags/gtfs_schedule_history/stops.yml
+++ b/airflow/dags/gtfs_schedule_history/stops.yml
@@ -15,9 +15,9 @@ schema_fields:
   - name: tts_stop_name
     type: STRING
   - name: stop_lat
-    type: FLOAT64
+    type: STRING
   - name: stop_lon
-    type: FLOAT64
+    type: STRING
 
   - name: zone_id
     type: STRING

--- a/airflow/dags/gtfs_views_staging/stops_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stops_clean.sql
@@ -6,7 +6,9 @@ dependencies:
 ---
 
 SELECT
-    * EXCEPT(calitp_deleted_at)
+    * EXCEPT(calitp_deleted_at, stop_lat, stop_lon)
+    , SAFE_CAST(stop_lat AS FLOAT64)
+    , SAFE_CAST(stop_lon AS FLOAT64)
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS stop_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.stops`

--- a/airflow/dags/gtfs_views_staging/stops_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stops_clean.sql
@@ -7,8 +7,8 @@ dependencies:
 
 SELECT
     * EXCEPT(calitp_deleted_at, stop_lat, stop_lon)
-    , SAFE_CAST(stop_lat AS FLOAT64)
-    , SAFE_CAST(stop_lon AS FLOAT64)
+    , SAFE_CAST(stop_lat AS FLOAT64) as stop_lat
+    , SAFE_CAST(stop_lon AS FLOAT64) as stop_lon
     , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS stop_key
     , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.stops`


### PR DESCRIPTION
# Overall Description

This PR refactors how data types are applied for `stop_lat` and `stop_lon` to resolve #1148. 

Currently we assert that they are floats in `gtfs_schedule_history`, but there's no standard way for the pipeline to handle data type violations at that point. 

This PR specifically casts them as floats in `gtfs_views_staging` instead, which is the appropriate place to handle data typing issues. This will allow the bad Amtrak data into the warehouse as a null (there will be a record with a latitude but no longitude), but we thought that was a good first step to unblock the pipeline.

See #1151 for thoughts on subsequent steps we might want to take.

 🚨 **After merging this PR, we will need to take the following manual steps _in this order_:**
1. Manually re-run the `gtfs_schedule_history` DAG to get the data type changes for `gtfs_schedule_history` (this DAG is a once-only -- it does not have a scheduled re-run to pick up the changes)
2. Manually run the following query in production with the screenshotted query settings to propagate the `gtfs_schedule_history` data type changes into `gtfs_schedule_type2`
```
-- you have to enumerate all the columns *in order* so the INSERT statement in merge_updates will work
SELECT 
    calitp_itp_id,
    calitp_url_number,
    stop_id,
    tts_stop_name,
    CAST(stop_lat AS STRING) as stop_lat,
    CAST(stop_lon AS STRING) as stop_lon,
    zone_id,
    parent_station,
    stop_code,
    stop_name,
    stop_desc,
    stop_url,
    location_type,
    stop_timezone,
    wheelchair_boarding,
    level_id,
    platform_code,
    calitp_extracted_at,
    calitp_deleted_at,
    calitp_hash
FROM `cal-itp-data-infra.gtfs_schedule_type2.stops`
```
(substitute `cal-itp-data-infra` as the project in the "Dataset" field instead of `cal-itp-data-infra-staging`)
<img width="702" alt="image" src="https://user-images.githubusercontent.com/55149902/156386176-8e00aefd-257a-4d79-a3f0-36c813a384d1.png">


## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

`gtfs_schedule_history`: re-run manually
![image](https://user-images.githubusercontent.com/55149902/156390515-1d331251-9fd8-4c93-8e06-333f14068464.png)

`gtfs_loader.gtfs_schedule_tables_load` -- succeeds after `schedule_history` is re-run:
![image](https://user-images.githubusercontent.com/55149902/156391205-9c9a9de6-fd97-4a65-8423-7dda8a8d5dcb.png)

`gtfs_schedule_history2` (only runs successfully after manual interventions described above): 
![image](https://user-images.githubusercontent.com/55149902/156390363-15740513-e802-4413-8309-7aa108be415d.png)

`gtfs_views_staging` (stop times fails because of query limit):
![image](https://user-images.githubusercontent.com/55149902/156390614-edc6b74a-84ac-4281-b79f-b82e0aedb044.png)

`gtfs_views` -- again stop times fails because of query limits, but `stops` and its immediate dependencies succeed:
![image](https://user-images.githubusercontent.com/55149902/156390778-2d45b8f1-79c6-4b48-8c6d-0df872bf3a78.png)

- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_schedule_history` and `gtfs_views_staging` DAGs in order to move the assertion of data types later in the pipeline.

Updates the following DAG tasks:

- `gtfs_schedule_history.stops` -- change `stop_lat` and `stop_lon` to strings
- `gtfs_schedule_views_staging` -- adds safe casting of `stop_lat` and `stop_lon` to floats -- this will turn invalid data into nulls