### PR TITLE
updating docs with note about calitp-py and bumping version

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,7 +6,7 @@ gusty==0.6.0
 pandas-gbq==0.14.1
 pybigquery==0.7.0
 google-cloud-bigquery==2.16.1
-calitp==0.0.8
+calitp==0.0.12
 google-auth==1.32.1
 gtfs-realtime-bindings==0.0.7
 geopandas

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,7 +6,7 @@ gusty==0.6.0
 pandas-gbq==0.14.1
 pybigquery==0.7.0
 google-cloud-bigquery==2.16.1
-calitp==0.0.12
+calitp==0.0.8
 google-auth==1.32.1
 gtfs-realtime-bindings==0.0.7
 geopandas

--- a/docs/datasets_and_tables/gtfs_rt.md
+++ b/docs/datasets_and_tables/gtfs_rt.md
@@ -34,3 +34,11 @@ Note that this data is still a work in progress, so many tables are still intern
 ## DAGs Maintenance
 
 You can find further information on DAGs maintenance for GTFS Realtime data [on this page](gtfs-realtime-dags).
+
+## Raw Protobuff files
+
+Raw RT files are stored in google cloud at gs://gtfs-data/rt/ISODATE/CALITP_ID/URL_NUMBER/FEED_NAME. If data for a given feed is missing, tracking down the raw files for inspection can be tedious. The `random-protobuff` command in [calitp-py](https://github.com/cal-itp/calitp-py#random-protobuff) makes it easy to verify that the source data exists in the archive. More usage examples can be found [here](https://github.com/cal-itp/calitp-py#random-protobuff).
+
+```
+python -m calitp random-protobuff 295/0/gtfs_rt_service_alerts_url --date 2022-02-23T16:01:24
+```


### PR DESCRIPTION
# Overall Description

Updates docs with instructions about how to use random-protobuff function.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Docs changes checklist

- [X] Include this section whenever any change in the `docs` folder occurs, otherwise please omit this section.
- [x] **If you haven't already, review the [Contribute to the Docs](https://docs.calitp.org/data-infra/contribute/overview.html) section of the data services documentation for best practices, common formatting, and more**
- [x] Make sure the preview website was able to be generated
- [x] Fill out the following section describing what docs were added/updated

This PR updates `docs/datasets_and_tables/gtfs_rt.md` to briefly describe what `python -m calitp random-protobuff` does and links to the project docs with more information.
