### PR TITLE
chore(gtfs-schedule): add minimal logging to merge_updates

### DIFF
--- a/airflow/dags/gtfs_schedule_history2/merge_updates.py
+++ b/airflow/dags/gtfs_schedule_history2/merge_updates.py
@@ -88,7 +88,7 @@ def main(**kwargs):
     table_names = create_tables()
 
     for table_name in table_names:
-        logger.info("Processing {}".format(table_name))
+        logger.info("Processing table", table_name=table_name)
         # TODO: remove validation report from included tables
         if table_name == "validation_report":
             continue

--- a/airflow/dags/gtfs_schedule_history2/merge_updates.py
+++ b/airflow/dags/gtfs_schedule_history2/merge_updates.py
@@ -18,6 +18,7 @@
 # TODO: split out operators.py into submodules and move logic into there.
 
 from merge_sql import SQL_TEMPLATE
+import structlog
 
 SRC_SCHEMA = "gtfs_schedule_history"
 DST_SCHEMA = "gtfs_schedule_type2"
@@ -83,9 +84,11 @@ def merge_updates(table_name, execution_date, **kwargs):
 
 
 def main(**kwargs):
+    logger = structlog.get_logger()
     table_names = create_tables()
 
     for table_name in table_names:
+        logger.info("Processing {}".format(table_name))
         # TODO: remove validation report from included tables
         if table_name == "validation_report":
             continue


### PR DESCRIPTION
# Overall Description

`merge_updates` processes all the different GTFS data types but doesn't really give any indication of progress, which is annoying when testing. This just adds a single logging statement to let us know what file type it's working on. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~ none

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
It can't actually complete because of stop_times but here's a screenshot of it running showing the logging statements

![image](https://user-images.githubusercontent.com/55149902/156446449-5973ea91-e453-4bfb-b9a6-ba81d5c25d10.png)
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_schedule_history2` DAG in order to updates the following DAG tasks:

- `merge_updates`: add logging