### PR TITLE
Add uri and future uri to airtable gtfs dataset view

### DIFF
--- a/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
+++ b/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
@@ -23,4 +23,6 @@ SELECT
   gtfs_dataset_id,
   name,
   data,
+  uri,
+  future_uri,
 FROM `airtable.california_transit_gtfs_datasets`


### PR DESCRIPTION
# Overall Description

This PR adds the `uri` and `future_uri` fields to the `views.airtable_california_transit_gtfs_datasets` dataset.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

<img width="796" alt="Screen Shot 2022-03-02 at 5 50 02 PM" src="https://user-images.githubusercontent.com/3112493/156481088-28d3ce9e-d750-4a51-97c7-c252ff65a327.png">

This PR updates the `airtable_views.california_transit_gtfs_datasets` DAG in order to add the `uri` and `future_uri` fields to the `views.airtable_california_transit_gtfs_datasets` dataset.