### PR TITLE
add new daily validation errors fact table

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_fact_daily_validation_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_fact_daily_validation_errors.sql
@@ -1,0 +1,61 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "views.gtfs_rt_fact_daily_validation_errors"
+
+description: |
+  A daily roll-up of validation errors per calitp_id/url/entity/error.
+
+
+fields:
+  calitp_itp_id: Feed ITP ID
+  calitp_url_number: Feed URL number
+  rt_feed_type: GTFS realtime type (service_alerts, trip_updates, or vehicle_positions)
+  error_id: The GTFS Realtime validation error ID.
+  date: Date for which this feed was present in our extraction list.
+  occurrences: The number of occurrences for this combination.
+
+tests:
+    check_null:
+        - calitp_itp_id
+        - calitp_url_number
+        - rt_feed_type
+        - error_id
+        - date
+        - occurrences
+    check_composite_unique:
+        - calitp_itp_id
+        - calitp_url_number
+        - rt_feed_type
+        - error_id
+        - date
+
+external_dependencies:
+  - rt_loader: external_validation_service_alerts
+---
+
+-- note that for realtime we do not (yet) have a feed_key-type identifier
+-- so use calitp_itp_id plus calitp_url_number as identifier
+
+with unioned as (
+    -- TODO: re-enable this when we've had a service alert validation error message, if ever
+    -- Without any files, bigquery just has a single default "index" column and you can't
+    -- specify a schema for parquet format external tables
+--     select *
+--     from `cal-itp-data-infra.gtfs_rt.validation_service_alerts`
+--     union all
+    select *
+    from `cal-itp-data-infra.gtfs_rt.validation_trip_updates`
+    union all
+    select *
+    from `cal-itp-data-infra.gtfs_rt.validation_vehicle_positions`
+)
+SELECT
+      calitp_itp_id
+    , calitp_url_number
+    , rt_feed_type
+    , error_id
+    , DATE(calitp_extracted_at) as date
+    , sum(n_occurrences) as occurrences
+
+FROM unioned
+GROUP BY calitp_itp_id, calitp_url_number, rt_feed_type, error_id, date


### PR DESCRIPTION
# Overall Description

Adds a rolled-up daily view of validation errors for RT feeds.

Closes https://github.com/cal-itp/data-infra/issues/357

Adds a new DAG task `gtfs_rt_fact_daily_validation_errors` under `rt_views`.

```
                                               field                    test  passed
0                                           error_id              check_null    True
1                                               date              check_null    True
2                                        occurrences              check_null    True
3                                  calitp_url_number              check_null    True
4                                      calitp_itp_id              check_null    True
5                                       rt_feed_type              check_null    True
0  calitp_itp_id, calitp_url_number, rt_feed_type...  check_composite_unique    True
Tests passed
[2022-03-03 16:20:18,951] {taskinstance.py:1219} INFO - Marking task as SUCCESS. dag_id=rt_views, task_id=gtfs_rt_fact_daily_validation_errors, execution_date=20220211T000000, start_date=20220303T160913, end_date=20220303T162018
```
