### PR TITLE
Gtfs add graas rt urls

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -386,7 +386,7 @@ desert-roadrunner:
   agency_name: Desert Roadrunner
   feeds:
     - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/paloverde_valley-ca-us/paloverde_valley-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_vehicle_positions_url: https://{{ GRAAS_SERVER_URL}}/vehicle-positions.pb?agency=desert-roadrunner
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 238
@@ -1132,7 +1132,7 @@ santa-ynez-valley-transit:
   agency_name: Santa Ynez Valley Transit
   feeds:
     - gtfs_schedule_url: http://mjcaction.com/MJC_GTFS_Public/syvt_google_transit.zip
-      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_vehicle_positions_url: https://{{ GRAAS_SERVER_URL}}/vehicle-positions.pb?agency=santa-ynez-valley-transit
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 312
@@ -1576,7 +1576,7 @@ glenn-transit:
   agency_name: Glenn County Transit
   feeds:
   - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/glenn-ca-us/glenn-ca-us.zip
-    gtfs_rt_vehicle_positions_url: null
+    gtfs_rt_vehicle_positions_url: https://{{ GRAAS_SERVER_URL}}/vehicle-positions.pb?agency=glenn-transit
     gtfs_rt_service_alerts_url: null
     gtfs_rt_trip_updates_url: null
   itp_id: 122
@@ -1584,7 +1584,7 @@ tcrta:
   agency_name: Tulare County Regional Transit Agency
   feeds:
   - gtfs_schedule_url: https://tularecog.org/tcag/data-gis-modeling/gtfs-data/tulare-county-regional-transit-agency-tcrta-gtfs
-    gtfs_rt_vehicle_positions_url: null
+    gtfs_rt_vehicle_positions_url: https://{{ GRAAS_SERVER_URL}}/vehicle-positions.pb?agency=tcrta
     gtfs_rt_service_alerts_url: null
     gtfs_rt_trip_updates_url: null
   itp_id: 474


### PR DESCRIPTION
# Overall Description

Original PR here: #1163.

Add RT URLs for 4 GRaaS agencies. These are not production rt feeds yet - all are in testing/development. For this reason, we are hiding the server URL within a GH secret. Here is the request to add the secret, which blocks one of the tests from passing: https://github.com/cal-itp/data-infra/pull/1163

Note that the url is formatted in the way that it is because the yml value needs to start with a string (not a variable) in order to pass the tests.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## agencies.yml changes checklist

- [x] Include this section whenever any change to the `airflow/data/agencies.yml` file occurs, otherwise please omit this section.
- [x] Manually made sure any new feeds have `itp_id`s that are not duplicative
- [x] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [ ] Made sure the Airtable database has consistent information
- [x] Fill out the following section describing what feeds were added/updated

This PR updates `agencies.yml` in order to add 4 draft rt feeds for testing purposes.

Add the following gtfs datasets:
- no new agencies added

Update the following gtfs datsets:
- add glenn-transit draft rt feed
- add tcrta draft rt feed
- add santa-ynez-valley-transit draft rt feed
- add desert-roadrunner draft rt feed
