### PR TITLE
change calitp_log_level to info instead of debug

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/archiver-app-vars.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/archiver-app-vars.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: archiver-app-vars
 data:
-  CALITP_LOG_LEVEL: debug
+  CALITP_LOG_LEVEL: info
   CALITP_DATA_DEST_SECRET: /secrets/gcs-upload-svcacct/gcs-upload-svcacct.json
   CALITP_AGENCIES_YML: /secrets/agencies-data/data_agencies.yaml
   CALITP_HEADERS_YML: /secrets/agencies-data/data_headers.yaml


### PR DESCRIPTION
Per conversation on slack, change calitp_log_level to info instead of debug to help free up some space for RT-Archiver. Debug is a lower level than info, any message logged with info gets printed if the root level set is debug. So by changing it to info, we shall trim some extraneous logs.