### PR TITLE
jupyterhub(image): revised - bumped up version of jupyter image

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -8,7 +8,7 @@ jupyterhub:
     defaultUrl: "/lab"
     image:
       name: ghcr.io/cal-itp/calitp-py
-      tag: hub-v4
+      tag: hub-v5
     storage:
       extraVolumes:
       - name: gcloud-auth


### PR DESCRIPTION
Revision of PR 1171
This PR effects:
`kubernetes/apps/charts/jupyterhub/values.yaml`
* Bumps up release version of jupyterlab image on kubernetes cluster to include new version of calitp package

Checklist for all PRs
- [x] Run pre-commit run --all-files to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords