### PR TITLE
feature(payments): Add cleaned authorisations table

### DIFF
--- a/airflow/dags/payments_views_staging/stg_cleaned_authorisations.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_authorisations.sql
@@ -1,0 +1,21 @@
+---
+operator: operators.SqlToWarehouseOperator
+dst_table_name: "payments.stg_cleaned_authorisations"
+
+description: >
+  Authorisations are sent to the acquiring bank to get approval to charge a card
+  or to verify that a card is valid. Authorisations are performed against
+  aggregations containing micropayments. Authorisations that are declined may be
+  reattempted later as part of a debt recovery process.
+
+dependencies:
+  - stg_enriched_authorisations
+---
+
+select distinct * except (
+    calitp_file_name,
+    calitp_n_dupes,
+    calitp_n_dupe_ids,
+    calitp_dupe_number)
+from payments.stg_enriched_authorisations
+where calitp_dupe_number = 1


### PR DESCRIPTION
# Overall Description

Add a first draft of a cleaned version of the littlepay authorisations table, based on investigation in [this notebook](https://github.com/cal-itp/data-analyses/blob/main/littlepay_data_issues/authorisations.ipynb).

![image](https://user-images.githubusercontent.com/146749/156855086-a4607dbd-b0a2-4625-802c-407e883e5988.png)

Closes #797 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `payments_views_staging` DAG in order to add a step to create a cleaned version of the littlepay authorisations table: `payments.stg_cleaned_authorisations`

Adds the following DAG tasks:

- `payments.stg_cleaned_authorisations`
