### PR TITLE
Correct Burbank Bus's RT URLs

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -207,8 +207,8 @@ burbank-bus:
   feeds:
     - gtfs_schedule_url: https://rideburbankbus.com/gtfs
       gtfs_rt_vehicle_positions_url: https://rideburbankbus.com/gtfs-rt/vehiclepositions
-      gtfs_rt_service_alerts_url: https://rideburbankbus.com/gtfs-rt/tripupdates
-      gtfs_rt_trip_updates_url: https://rideburbankbus.com/gtfs-rt/alerts
+      gtfs_rt_service_alerts_url: https://rideburbankbus.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://rideburbankbus.com/gtfs-rt/tripupdates
   itp_id: 45
 burney-express:
   agency_name: Burney Express


### PR DESCRIPTION
# Overall Description

Refs #1181

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## agencies.yml changes checklist

- [x] Include this section whenever any change to the `airflow/data/agencies.yml` file occurs, otherwise please omit this section.
- [x] Manually made sure any new feeds have `itp_id`s that are not duplicative
- [x] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [x] Made sure the Airtable database has consistent information
- [x] Fill out the following section describing what feeds were added/updated

This PR updates `agencies.yml` in order to properly associate Burbank Bus's RT URLs with the appropriate type.