### PR TITLE
enable service alert validations in the unioned table

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_fact_daily_validation_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_fact_daily_validation_errors.sql
@@ -37,12 +37,9 @@ external_dependencies:
 -- so use calitp_itp_id plus calitp_url_number as identifier
 
 with unioned as (
-    -- TODO: re-enable this when we've had a service alert validation error message, if ever
-    -- Without any files, bigquery just has a single default "index" column and you can't
-    -- specify a schema for parquet format external tables
---     select *
---     from `cal-itp-data-infra.gtfs_rt.validation_service_alerts`
---     union all
+    select *
+    from `cal-itp-data-infra.gtfs_rt.validation_service_alerts`
+    union all
     select *
     from `cal-itp-data-infra.gtfs_rt.validation_trip_updates`
     union all


### PR DESCRIPTION
Brings back service alert validation output into the unioned validations table. Previously, we didn't have any errors, so BigQuery threw a mismatching column error.