### PR TITLE
Gtfs rt archiver upsize

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -42,3 +42,17 @@ spec:
         - name: gcs-upload-svcacct
           secret:
             secretName: gcs-upload-svcacct
+      tolerations:
+        - key: resource-domain
+          operator: Equal
+          value: gtfsrt
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: resource-domain
+                operator: In
+                values:
+                - gtfsrt

--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -32,9 +32,9 @@ spec:
               mountPath: /secrets/gcs-upload-svcacct
           resources:
             requests:
-              memory: 6.5Gi
+              memory: 5.0Gi
             limits:
-              memory: 6.5Gi
+              memory: 5.0Gi
       volumes:
         - name: agencies-data
           secret:

--- a/kubernetes/gke/config-nodepool.sh
+++ b/kubernetes/gke/config-nodepool.sh
@@ -1,18 +1,32 @@
 GKE_NODEPOOL_NAMES=(
   'apps-v2'
+  'gtfsrt-v1'
 )
 
 declare -A GKE_NODEPOOL_NODE_COUNTS
 GKE_NODEPOOL_NODE_COUNTS=(
   ['apps-v2']=1
+  ['gtfsrt-v1']=1
 )
 
 declare -A GKE_NODEPOOL_NODE_LOCATIONS
 GKE_NODEPOOL_NODE_LOCATIONS=(
   ['apps-v2']=$GKE_REGION-a,$GKE_REGION-b,$GKE_REGION-c
+  ['gtfsrt-v1']=$GKE_REGION-a,$GKE_REGION-b,$GKE_REGION-c
 )
 
 declare -A GKE_NODEPOOL_MACHINE_TYPES
 GKE_NODEPOOL_MACHINE_TYPES=(
   ['apps-v2']=n1-standard-4
+  ['gtfsrt-v1']=n2-highcpu-8
+)
+
+declare -A GKE_NODEPOOL_TAINTS
+GKE_NODEPOOL_TAINTS=(
+  ['gtfsrt-v1']='resource-domain=gtfsrt:NoSchedule'
+)
+
+declare -A GKE_NODEPOOL_LABELS
+GKE_NODEPOOL_LABELS=(
+  ['gtfsrt-v1']='resource-domain=gtfsrt'
 )

--- a/kubernetes/gke/nodepool-up.sh
+++ b/kubernetes/gke/nodepool-up.sh
@@ -13,6 +13,10 @@ for GKE_NODEPOOL_NAME in "${GKE_NODEPOOL_NAMES[@]}"; do
   GKE_NODEPOOL_NODE_COUNT=${GKE_NODEPOOL_NODE_COUNTS[$GKE_NODEPOOL_NAME]}
   GKE_NODEPOOL_NODE_LOCATION=${GKE_NODEPOOL_NODE_LOCATIONS[$GKE_NODEPOOL_NAME]}
   GKE_NODEPOOL_MACHINE_TYPE=${GKE_NODEPOOL_MACHINE_TYPES[$GKE_NODEPOOL_NAME]}
+  GKE_NODEPOOL_TAINT=${GKE_NODEPOOL_TAINTS[$GKE_NODEPOOL_NAME]}
+  GKE_NODEPOOL_LABEL=${GKE_NODEPOOL_LABELS[$GKE_NODEPOOL_NAME]}
+
+  GKE_NODEPOOL_EXTRA_ARGS=()
 
   if ! [ "$GKE_NODEPOOL_NODE_COUNT"    ] ||
      ! [ "$GKE_NODEPOOL_NODE_LOCATION" ] ||
@@ -25,11 +29,20 @@ for GKE_NODEPOOL_NAME in "${GKE_NODEPOOL_NAMES[@]}"; do
     exit 1
   fi
 
+  if [ "$GKE_NODEPOOL_TAINT" ]; then
+    GKE_NODEPOOL_EXTRA_ARGS+=( --node-taints "$GKE_NODEPOOL_TAINT" )
+  fi
+
+  if [ "$GKE_NODEPOOL_LABEL" ]; then
+    GKE_NODEPOOL_EXTRA_ARGS+=( --node-labels "$GKE_NODEPOOL_LABEL" )
+  fi
+
   gcloud container node-pools describe "$GKE_NODEPOOL_NAME" --region "$GKE_REGION" --cluster "$GKE_NAME" >/dev/null ||
   gcloud container node-pools create "$GKE_NODEPOOL_NAME" \
     --region  "$GKE_REGION"                               \
     --cluster "$GKE_NAME"                                 \
     --num-nodes      "$GKE_NODEPOOL_NODE_COUNT"           \
     --machine-type "$GKE_NODEPOOL_MACHINE_TYPE"           \
-    --node-locations "$GKE_NODEPOOL_NODE_LOCATION"
+    --node-locations "$GKE_NODEPOOL_NODE_LOCATION"        \
+    "${GKE_NODEPOOL_EXTRA_ARGS[@]}"
 done


### PR DESCRIPTION
After getting a chance to dig through Grafana, we found substantial evidence that there may be a node-based CPU bottleneck with the archiver. To address this, we have deployed a node pool which:

1. Does not run any other workloads, allowing the archiver to fully utilize all cores for its own work
2. Doubles CPU capacity to 8 cores from 4
3. Moves to dedicated core instances rather than shared cores

This PR reflects the work performed to implement these changes.