### PR TITLE
fix(airtable): rename columns that contain colons

### DIFF
--- a/airflow/dags/airtable_loader/california_transit_services.yml
+++ b/airflow/dags/airtable_loader/california_transit_services.yml
@@ -12,3 +12,5 @@ rename_fields:
   "# TripUpdates": num_trip_updates
   "# Alerts": num_service_alerts
   "# VehiclePositions": num_vehicle_positions
+  "Product: GRaaS": "product_graas"
+  "Product: Payments": "product_payments"


### PR DESCRIPTION
# Overall Description

Manually rename two Airtable columns that were causing the Airtable operator to fail.

Led to creation of:

* #1217 
* [calitp-py#41](https://github.com/cal-itp/calitp-py/issues/41)

However since there was this lower-impact fix, I figured I'd just do this to unblock the DAG and we can prioritize the bigger-picture things longer term.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
![image](https://user-images.githubusercontent.com/55149902/158196284-b32c2532-f55a-45b0-9e9a-4d4c196fdf74.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `airtable_loader` DAG in order to updates the following DAG tasks:

- `california_transit_services`: Add manual name overrides to handle column names containing colons