### PR TITLE
Add Elk Grove Transit

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1604,3 +1604,11 @@ time:
     gtfs_rt_service_alerts_url: https://tularetransit.com/gtfs-rt/alerts
     gtfs_rt_trip_updates_url: https://tularetransit.com/gtfs-rt/tripupdates
   itp_id: 483
+elk-grove:
+  agency_name: Elk Grove Transit
+  feeds:
+  - gtfs_schedule_url: https://elkgrovetransit.com/gtfs
+    gtfs_rt_vehicle_positions_url: https://elkgrovetransit.com/gtfs-rt/vehiclepositions
+    gtfs_rt_service_alerts_url: https://elkgrovetransit.com/gtfs-rt/alerts
+    gtfs_rt_trip_updates_url: https://elkgrovetransit.com/gtfs-rt/tripupdates
+  itp_id: 105


### PR DESCRIPTION
# Overall Description

This adds Elk Grove Transit to agencies.yml.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## agencies.yml changes checklist

- [x] Include this section whenever any change to the `airflow/data/agencies.yml` file occurs, otherwise please omit this section.
- [x] Manually made sure any new feeds have `itp_id`s that are not duplicative
- [ ] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [ ] Made sure the Airtable database has consistent information
- [x] Fill out the following section describing what feeds were added/updated

This PR updates `agencies.yml` in order to add Elk Grove Transit.

Even though this agency is now being operated by SacRT, it is not showing up in SacRT's feed. I confirmed this by running SacRT's feed and Elk Grove's feed through [gtfs-to-geojson](https://github.com/BlinkTagInc/gtfs-to-geojson) and then comparing the outputted stops and shapes in QGIS:

![Screen Recording 2022-03-15 at 4 45 08 PM](https://user-images.githubusercontent.com/3112493/158490435-441b470f-1b7a-47db-84d3-f2a5ee112535.gif)

@e-lo as the airtable data maintainer, the `gtfs service data` table should be updated to note that the Sacramento Regional Schedule and RT feeds do not yet contain Elk Grove Transit.