### PR TITLE
fix(gtfs-schedule): add null and uniqueness checks for cleaned data

### DIFF
--- a/airflow/dags/gtfs_views_staging/agency_clean.sql
+++ b/airflow/dags/gtfs_views_staging/agency_clean.sql
@@ -3,6 +3,13 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.agency_clean"
 dependencies:
   - type2_loaded
+
+tests:
+  check_null:
+    - calitp_hash
+    - agency_key
+  check_unique:
+    - agency_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/attributions_clean.sql
+++ b/airflow/dags/gtfs_views_staging/attributions_clean.sql
@@ -3,6 +3,13 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.attributions_clean"
 dependencies:
   - type2_loaded
+
+tests:
+  check_null:
+    - calitp_hash
+    - attribution_key
+  check_unique:
+    - attribution_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/calendar_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_clean.sql
@@ -3,6 +3,13 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.calendar_clean"
 dependencies:
   - type2_loaded
+
+tests:
+  check_null:
+    - calitp_hash
+    - calendar_key
+  check_unique:
+    - calendar_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
+++ b/airflow/dags/gtfs_views_staging/calendar_dates_clean.sql
@@ -3,12 +3,21 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.calendar_dates_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - calendar_dates_key
+  check_unique:
+    - calendar_dates_key
 ---
 
 -- Trim all string fields
 -- Incoming schema explicitly defined in gtfs_schedule_history external table definition
 
-SELECT
+-- there are exact duplicates in files from itp id 182, url number 0, feed from 2021-09-17
+-- so do a select distinct
+
+SELECT DISTINCT
   calitp_itp_id
   , calitp_url_number
   , TRIM(service_id) as service_id
@@ -16,5 +25,7 @@ SELECT
   , calitp_extracted_at
   , calitp_hash
   , PARSE_DATE("%Y%m%d", TRIM(date)) AS date
+  , FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        AS calendar_dates_key
   , COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
 FROM `gtfs_schedule_type2.calendar_dates`

--- a/airflow/dags/gtfs_views_staging/fare_attributes_clean.sql
+++ b/airflow/dags/gtfs_views_staging/fare_attributes_clean.sql
@@ -3,6 +3,13 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.fare_attributes_clean"
 dependencies:
   - type2_loaded
+
+tests:
+  check_null:
+    - calitp_hash
+    - fare_attribute_key
+  check_unique:
+    - fare_attribute_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/fare_rules_clean.sql
+++ b/airflow/dags/gtfs_views_staging/fare_rules_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.fare_rules_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - fare_rule_key
+  check_unique:
+    - fare_rule_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/fare_rules_clean.sql
+++ b/airflow/dags/gtfs_views_staging/fare_rules_clean.sql
@@ -14,7 +14,9 @@ tests:
 -- Trim all string fields
 -- Incoming schema explicitly defined in gtfs_schedule_history external table definition
 
-SELECT
+-- SELECT DISTINCT because there are identical dups in multiple feeds
+
+SELECT DISTINCT
     calitp_itp_id
     , calitp_url_number
     , TRIM(fare_id) as fare_id

--- a/airflow/dags/gtfs_views_staging/feed_info_clean.sql
+++ b/airflow/dags/gtfs_views_staging/feed_info_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.feed_info_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - feed_info_key
+  check_unique:
+    - feed_info_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/frequencies_clean.sql
+++ b/airflow/dags/gtfs_views_staging/frequencies_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.frequencies_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - frequency_key
+  check_unique:
+    - frequency_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/levels_clean.sql
+++ b/airflow/dags/gtfs_views_staging/levels_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.levels_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - level_key
+  check_unique:
+    - level_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/pathways_clean.sql
+++ b/airflow/dags/gtfs_views_staging/pathways_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.pathways_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - pathway_key
+  check_unique:
+    - pathway_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/routes_clean.sql
+++ b/airflow/dags/gtfs_views_staging/routes_clean.sql
@@ -3,6 +3,13 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.routes_clean"
 dependencies:
   - type2_loaded
+
+tests:
+  check_null:
+    - calitp_hash
+    - route_key
+  check_unique:
+    - route_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/shapes_clean.sql
+++ b/airflow/dags/gtfs_views_staging/shapes_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.shapes_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - shape_key
+  check_unique:
+    - shape_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/stop_times_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stop_times_clean.sql
@@ -3,6 +3,13 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.stop_times_clean"
 dependencies:
   - type2_loaded
+
+tests:
+  check_null:
+    - calitp_hash
+    - stop_time_key
+  check_unique:
+    - stop_time_key
 ---
 
 SELECT

--- a/airflow/dags/gtfs_views_staging/stops_clean.sql
+++ b/airflow/dags/gtfs_views_staging/stops_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.stops_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - stop_key
+  check_unique:
+    - stop_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/transfers_clean.sql
+++ b/airflow/dags/gtfs_views_staging/transfers_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.transfers_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - transfer_key
+  check_unique:
+    - transfer_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/transfers_clean.sql
+++ b/airflow/dags/gtfs_views_staging/transfers_clean.sql
@@ -16,7 +16,7 @@ tests:
 
 -- SELECT DISTINCT because there are many fully identical dups in feed ITP ID 279, URL 0
 
-SELECT
+SELECT DISTINCT
     calitp_itp_id
     , calitp_url_number
     , TRIM(from_stop_id) as from_stop_id

--- a/airflow/dags/gtfs_views_staging/transfers_clean.sql
+++ b/airflow/dags/gtfs_views_staging/transfers_clean.sql
@@ -14,6 +14,8 @@ tests:
 -- Trim all string fields
 -- Incoming schema explicitly defined in gtfs_schedule_history external table definition
 
+-- SELECT DISTINCT because there are many fully identical dups in feed ITP ID 279, URL 0
+
 SELECT
     calitp_itp_id
     , calitp_url_number

--- a/airflow/dags/gtfs_views_staging/translations_clean.sql
+++ b/airflow/dags/gtfs_views_staging/translations_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.translations_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - translation_key
+  check_unique:
+    - translation_key
 ---
 
 -- Trim all string fields

--- a/airflow/dags/gtfs_views_staging/translations_clean.sql
+++ b/airflow/dags/gtfs_views_staging/translations_clean.sql
@@ -3,13 +3,10 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.translations_clean"
 dependencies:
   - type2_loaded
-tests:
-  check_null:
-    - calitp_hash
-    - translation_key
-  check_unique:
-    - translation_key
 ---
+
+-- no tests for translations because our test has a bug and fails when table is empty
+-- see: https://github.com/cal-itp/data-infra/issues/1227
 
 -- Trim all string fields
 -- Incoming schema explicitly defined in gtfs_schedule_history external table definition

--- a/airflow/dags/gtfs_views_staging/trips_clean.sql
+++ b/airflow/dags/gtfs_views_staging/trips_clean.sql
@@ -14,7 +14,9 @@ tests:
 -- Trim all string fields
 -- Incoming schema explicitly defined in gtfs_schedule_history external table definition
 
-SELECT
+-- SELECT DISTINCT because of full duplicates in feeds with ITP IDs 45 and 75
+
+SELECT DISTINCT
     calitp_itp_id
     , calitp_url_number
     , TRIM(route_id) as route_id

--- a/airflow/dags/gtfs_views_staging/trips_clean.sql
+++ b/airflow/dags/gtfs_views_staging/trips_clean.sql
@@ -3,6 +3,12 @@ operator: operators.SqlToWarehouseOperator
 dst_table_name: "gtfs_views_staging.trips_clean"
 dependencies:
   - type2_loaded
+tests:
+  check_null:
+    - calitp_hash
+    - trip_key
+  check_unique:
+    - trip_key
 ---
 
 -- Trim all string fields


### PR DESCRIPTION
# Overall Description

Adds uniqueness and null checks for cleaned GTFS schedule data.

Also changes some `SELECT` statements to `SELECT DISTINCT` because of full duplicates found in `fare_rules`, `transfers`, and `trips`  (literally every field is the same). No tests added for `translations` because of issue #1227. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

`stop_times` doesn't run because of query limit, but I verified manually that the uniqueness check should pass in production 

![image](https://user-images.githubusercontent.com/55149902/158680806-61699514-c36d-46c3-aabf-0fe9872e7db2.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_views_staging` DAG in order to update the following DAG tasks:

- All the `_clean` tables: add checks for uniqueness (for `<record type>_key`) and non-null (`calitp_hash` and `<record_type>_key`).