### PR TITLE
fix(gtfs-schedule): attributions - don't assume integers on ingest

### DIFF
--- a/airflow/dags/gtfs_schedule_history/attributions.yml
+++ b/airflow/dags/gtfs_schedule_history/attributions.yml
@@ -26,11 +26,11 @@ schema_fields:
   - name: trip_id
     type: STRING
   - name: is_producer
-    type: INTEGER
+    type: STRING
   - name: is_operator
-    type: INTEGER
+    type: STRING
   - name: is_authority
-    type: INTEGER
+    type: STRING
   - name: attribution_url
     type: STRING
   - name: attribution_email

--- a/airflow/dags/gtfs_views_staging/attributions_clean.sql
+++ b/airflow/dags/gtfs_views_staging/attributions_clean.sql
@@ -16,9 +16,9 @@ SELECT
     , TRIM(agency_id) as agency_id
     , TRIM(route_id) as route_id
     , TRIM(trip_id) as trip_id
-    , is_producer
-    , is_operator
-    , is_authority
+    , CAST(TRIM(is_producer) AS INT64) as is_producer
+    , CAST(TRIM(is_operator) AS INT64) as is_operator
+    , CAST(TRIM(is_authority) AS INT64) as is_authority
     , TRIM(attribution_url) as attribution_url
     , TRIM(attribution_email) as attribution_email
     , TRIM(attribution_phone) as attribution_phone


### PR DESCRIPTION
# Overall Description

_🚨 Note that I am requesting to merge this into the `refactor-gtfs-views-staging` branch. We need to do a bunch of PRs that should move together (see https://github.com/cal-itp/data-infra/issues/1137). I would like to get them reviewed by merging into this placeholder branch, and then just merge that whole branch at once into main via https://github.com/cal-itp/data-infra/pull/1157 to avoid dealing with the timing of merging a bunch of PRs one by one into main._

Will address #1155 once #1157 is merged. 

Stops asserting that a bunch of fields in `attributions` are integers on ingest (in the `gtfs_schedule_history` external table) and instead ingest them as strings and `CAST` to integers on `_clean`. We can change this to `SAFE_CAST` if we ever need to. 

**Note: When this is merged, we need to take steps like we did in #1154 to overwrite the existing `gtfs_schedule_type2.attributions` table so that it will accept the new string data:**
1. Re-run the `gtfs_schedule_history.attributions` DAG task manually (once-only task, does not run on its own). 
2. Run the following query:
```
SELECT
    calitp_itp_id,
    calitp_url_number,
    organization_name,
    attribution_id,
    agency_id,
    route_id,
    trip_id,
    CAST(is_producer AS STRING) as is_producer,
    CAST(is_operator AS STRING) as is_operator,
    CAST(is_authority AS STRING) as is_authority,
    attribution_url,
    attribution_email,
    attribution_phone,
    calitp_extracted_at,
    calitp_deleted_at,
    calitp_hash
FROM `cal-itp-data-infra.gtfs_schedule_type2.attributions`
```
With the following settings (but pointed at `cal-itp-data-infra` instead of `staging`):
![image](https://user-images.githubusercontent.com/55149902/158690307-3de08d67-2c40-4c48-aa1a-b3248c9db77d.png)

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

![image](https://user-images.githubusercontent.com/55149902/158689876-1b366027-0eef-4844-96d6-05bce626b4e1.png)

![image](https://user-images.githubusercontent.com/55149902/158689833-c7b368b5-a8ad-4aa7-a3ef-5fcfe9ea66f9.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the the following DAG tasks:

- `gtfs_schedule_history.attributions`: stops asserting that things are integers
- `gtfs_views_staging.attributions_clean`: converts things to integers here instead
