### PR TITLE
fix(gtfs-schedule): fix get-latest logic

### DIFF
--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -105,12 +105,11 @@ def get_latest_schedule_data(table):
 
     return f"""
         SELECT
-            * EXCEPT(calitp_deleted_at)
+            t1.* EXCEPT(calitp_deleted_at)
         FROM gtfs_views_staging.{table}_clean t1
-        LEFT JOIN gtfs_schedule_history.calitp_feed_latest t2
+        -- inner join to only get the ones that are latest load
+        INNER JOIN gtfs_schedule_history.calitp_feed_latest t2
             USING(calitp_itp_id, calitp_url_number, calitp_extracted_at)
-        WHERE
-            t2.is_latest_load = true
 """
 
 

--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -106,9 +106,11 @@ def get_latest_schedule_data(table):
     return f"""
         SELECT
             * EXCEPT(calitp_deleted_at)
-        FROM gtfs_views_staging.{table}_clean
+        FROM gtfs_views_staging.{table}_clean t1
+        LEFT JOIN gtfs_schedule_history.calitp_feed_latest t2
+            USING(calitp_itp_id, calitp_url_number, calitp_extracted_at)
         WHERE
-            calitp_deleted_at = "2099-01-01"
+            t2.is_latest_load = true
 """
 
 


### PR DESCRIPTION
# Overall Description

_🚨 Merging into `refactor_gtfs_views_staging` to merge all of #1137 fixes together._ 

Realized that my logic in #1162 might lead to unexpected outcomes because of issues like #1184 (ideally they **should** be equivalent, but right now they're not). I refactored the "get latest" logic to better match the way that it is done currently. 

Technically this doesn't touch any DAG task objects directly (just the macro that they call), but I did confirm that `gtfs_schedule` still runs (except `stop_times` which hits the query limit):

![image](https://user-images.githubusercontent.com/55149902/158699358-16b7a7b7-d2cf-4c8b-b9cb-b511effdf3b5.png)

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~

