### PR TITLE
Use different Soltrans trip updates URL

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1182,7 +1182,7 @@ soltrans:
     - gtfs_schedule_url: https://soltrans.connexionz.net/rtt/public/resource/gtfs.zip
       gtfs_rt_vehicle_positions_url: https://soltrans.connexionz.net/rtt/public/utility/gtfsrealtime.aspx/vehicleposition
       gtfs_rt_service_alerts_url: https://soltrans.connexionz.net/rtt/public/utility/gtfsrealtime.aspx/alert
-      gtfs_rt_trip_updates_url: https://soltrans.connexionz.net/rtt/public/utility/gtfsrealtime.aspx/tripupdate
+      gtfs_rt_trip_updates_url: https://soltrans.connexionz.net/rtt/public/utility/gtfsrealtime.aspx/tripupdate2
     - gtfs_schedule_url: http://api.511.org/transit/datafeeds?api_key={{ MTC_511_API_KEY}}&operator_id=ST
       gtfs_rt_vehicle_positions_url: http://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=ST
       gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}


### PR DESCRIPTION
# Overall Description

This updates the Soltrans trip updates URL to be the one on their website.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## agencies.yml changes checklist

- [x] Include this section whenever any change to the `airflow/data/agencies.yml` file occurs, otherwise please omit this section.
- [x] Manually made sure any new feeds have `itp_id`s that are not duplicative
- [ ] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [x] Made sure the Airtable database has consistent information
- [x] Fill out the following section describing what feeds were added/updated

As discussed in https://github.com/cal-itp/data-infra/issues/1178#issuecomment-1069383947, this updates the Soltrans trip updates URL to be the one in airtable and the one on their website. The other URL does work, but this other one seems to have more info.