### PR TITLE
Fix payments point to gtfs views

### DIFF
--- a/airflow/dags/payments_views/mst_transactions_gtfs_enhanced.sql
+++ b/airflow/dags/payments_views/mst_transactions_gtfs_enhanced.sql
@@ -26,7 +26,7 @@ device_transactions AS (
         DATETIME(TIMESTAMP(transaction_date_time_utc), "America/Los_Angeles") as transaction_date_time_pacific,
         location_id,
         location_name,
-        TRIM(route_id) as route_id,
+        route_id,
         latitude,
         longitude,
         vehicle_id,

--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -27,7 +27,7 @@ fields:
   product_code: "From payments.product_data.product_code"
   product_description: "From payments.product_data.product_description"
   product_type: "From payments.product_data.product_type"
-  route_id: "The route_id of the first tap transaction"
+  route_id: "The route_id of the first tap transaction with a non-unknown route_id, else unknown ('Route Z')"
   route_long_name: "The route_long_name of the first tap transaction"
   route_short_name: "The route_short_name of the first tap transaction"
   direction: "The direction of the first tap transaction"
@@ -188,3 +188,7 @@ LEFT JOIN `payments.stg_cleaned_product_data` AS p USING (participant_id, produc
 LEFT JOIN gtfs_routes_with_participant AS r
     ON r.participant_id = m.participant_id
     AND r.route_id = (CASE WHEN t1.route_id <> 'Route Z' THEN t1.route_id ELSE COALESCE(t2.route_id, 'Route Z') END)
+    -- here, can just use t1 because transaction date will be populated
+    -- (don't have to handle unkowns the way we do with route_id)
+    AND r.calitp_extracted_at <= DATETIME(TIMESTAMP(t1.transaction_date_time_utc))
+    AND r.calitp_deleted_at > DATETIME(TIMESTAMP(t1.transaction_date_time_utc))

--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -68,8 +68,8 @@ tests:
 WITH
 
 gtfs_routes_with_participant AS (
-    SELECT participant_id, route_id, route_short_name, route_long_name
-    FROM `gtfs_schedule.routes`
+    SELECT participant_id, route_id, route_short_name, route_long_name, calitp_extracted_at, calitp_deleted_at
+    FROM `views.gtfs_schedule_dim_routes`
     JOIN `views.payments_feeds` USING (calitp_itp_id, calitp_url_number)
 ),
 
@@ -97,7 +97,8 @@ applied_adjustments AS (
 ),
 
 initial_transactions AS (
-    SELECT *
+    SELECT * EXCEPT(route_id),
+        TRIM(route_id) AS route_id
     FROM `payments.stg_cleaned_micropayment_device_transactions`
     JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
     JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)
@@ -105,7 +106,8 @@ initial_transactions AS (
 ),
 
 second_transactions AS (
-    SELECT *
+    SELECT * EXCEPT(route_id),
+        TRIM(route_id) AS route_id
     FROM `payments.stg_cleaned_micropayment_device_transactions`
     JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
     JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)

--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -97,8 +97,7 @@ applied_adjustments AS (
 ),
 
 initial_transactions AS (
-    SELECT * EXCEPT(route_id),
-        TRIM(route_id) AS route_id
+    SELECT *
     FROM `payments.stg_cleaned_micropayment_device_transactions`
     JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
     JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)

--- a/airflow/dags/payments_views/payments_rides.sql
+++ b/airflow/dags/payments_views/payments_rides.sql
@@ -105,8 +105,7 @@ initial_transactions AS (
 ),
 
 second_transactions AS (
-    SELECT * EXCEPT(route_id),
-        TRIM(route_id) AS route_id
+    SELECT *
     FROM `payments.stg_cleaned_micropayment_device_transactions`
     JOIN `payments.stg_cleaned_device_transactions` USING (littlepay_transaction_id)
     JOIN `payments.stg_cleaned_device_transaction_types` USING (littlepay_transaction_id)

--- a/airflow/dags/payments_views/sbmtd_transactions.sql
+++ b/airflow/dags/payments_views/sbmtd_transactions.sql
@@ -158,7 +158,7 @@ select
     t.is_shared_stop,
     t.all_route_ids,
     t.route_id_from_device,
-    t.likely_route_id,
+    trim(t.likely_route_id) as likely_route_id,
     r.route_long_name as likely_route_long_name,
     r.route_short_name as likely_route_short_name,
     t.vehicle_id,

--- a/airflow/dags/payments_views/sbmtd_transactions.sql
+++ b/airflow/dags/payments_views/sbmtd_transactions.sql
@@ -54,31 +54,16 @@ dated_route_stops as (
     select distinct
         route_id,
         stop_id,
-        case
-          when ((st.calitp_extracted_at >= t.calitp_extracted_at) and
-            (st.calitp_extracted_at >= r.calitp_extracted_at))
-            then st.calitp_extracted_at
-          when ((t.calitp_extracted_at >= st.calitp_extracted_at) and
-            (t.calitp_extracted_at >= r.calitp_extracted_at))
-            then t.calitp_extracted_at
-          when ((r.calitp_extracted_at >= st.calitp_extracted_at) and
-            (r.calitp_extracted_at >= t.calitp_extracted_at))
-            then r.calitp_extracted_at
-        end
-        as calitp_extracted_at,
-
-        case
-          when ((st.calitp_deleted_at <= t.calitp_deleted_at) and
-            (st.calitp_deleted_at <= r.calitp_deleted_at))
-            then st.calitp_deleted_at
-          when ((t.calitp_deleted_at <= st.calitp_deleted_at) and
-            (t.calitp_deleted_at <= r.calitp_deleted_at))
-            then t.calitp_deleted_at
-          when ((r.calitp_deleted_at <= st.calitp_deleted_at) and
-            (r.calitp_deleted_at <= t.calitp_deleted_at))
-            then r.calitp_deleted_at
-        end
-        as calitp_deleted_at
+        greatest(
+          st.calitp_extracted_at,
+          r.calitp_extracted_at,
+          t.calitp_extracted_at
+          ) as calitp_extracted_at,
+        least(
+          st.calitp_deleted_at,
+          r.calitp_deleted_at,
+          t.calitp_deleted_at
+        ) as calitp_deleted_at
     from views.gtfs_schedule_dim_stop_times as st
     join views.gtfs_schedule_dim_trips as t using (calitp_itp_id, calitp_url_number, trip_id)
     join views.gtfs_schedule_dim_routes as r using (calitp_itp_id, calitp_url_number, route_id)

--- a/airflow/dags/payments_views/sbmtd_transactions.sql
+++ b/airflow/dags/payments_views/sbmtd_transactions.sql
@@ -50,15 +50,46 @@ micropayment_device_transactions_dedupe AS (
 /*
   All the unique routes and stops across SBMTD
 */
-route_stops as (
+dated_route_stops as (
     select distinct
         route_id,
-        stop_id
-    from gtfs_schedule.stop_times as st
-    join gtfs_schedule.trips as t using (calitp_itp_id, calitp_url_number, trip_id)
-    join gtfs_schedule.routes as r using (calitp_itp_id, calitp_url_number, route_id)
+        stop_id,
+        case
+          when ((st.calitp_extracted_at >= t.calitp_extracted_at) and
+            (st.calitp_extracted_at >= r.calitp_extracted_at))
+            then st.calitp_extracted_at
+          when ((t.calitp_extracted_at >= st.calitp_extracted_at) and
+            (t.calitp_extracted_at >= r.calitp_extracted_at))
+            then t.calitp_extracted_at
+          when ((r.calitp_extracted_at >= st.calitp_extracted_at) and
+            (r.calitp_extracted_at >= t.calitp_extracted_at))
+            then r.calitp_extracted_at
+        end
+        as calitp_extracted_at,
+
+        case
+          when ((st.calitp_deleted_at <= t.calitp_deleted_at) and
+            (st.calitp_deleted_at <= r.calitp_deleted_at))
+            then st.calitp_deleted_at
+          when ((t.calitp_deleted_at <= st.calitp_deleted_at) and
+            (t.calitp_deleted_at <= r.calitp_deleted_at))
+            then t.calitp_deleted_at
+          when ((r.calitp_deleted_at <= st.calitp_deleted_at) and
+            (r.calitp_deleted_at <= t.calitp_deleted_at))
+            then r.calitp_deleted_at
+        end
+        as calitp_deleted_at
+    from views.gtfs_schedule_dim_stop_times as st
+    join views.gtfs_schedule_dim_trips as t using (calitp_itp_id, calitp_url_number, trip_id)
+    join views.gtfs_schedule_dim_routes as r using (calitp_itp_id, calitp_url_number, route_id)
     where calitp_itp_id = 293
     and calitp_url_number = 0
+),
+
+route_stops as (
+  select *
+  from dated_route_stops
+  where calitp_extracted_at < calitp_deleted_at
 ),
 
 /*
@@ -70,12 +101,17 @@ route_stops as (
 stop_stats as (
     select
         stop_id,
+        calitp_extracted_at,
+        calitp_deleted_at,
         count(*) as num_routes_for_stop,
         string_agg(route_id, ', ') as all_route_ids,
         '12X' in unnest(array_agg(route_id)) as serves_12x,
         '24X' in unnest(array_agg(route_id)) as serves_24x
     from route_stops
-    group by 1
+    group by
+      stop_id,
+      calitp_extracted_at,
+      calitp_deleted_at
 ),
 
 /*
@@ -105,7 +141,10 @@ transactions as (
     from micropayments_dedupe as m
     join micropayment_device_transactions_dedupe using (micropayment_id)
     join device_transactions_dedupe as dt using (littlepay_transaction_id, customer_id, participant_id)
-    join stop_stats as stat on stat.stop_id = dt.location_id
+    join stop_stats as stat
+      on stat.stop_id = dt.location_id
+      and datetime(timestamp(dt.transaction_date_time_utc)) >= stat.calitp_extracted_at
+      and datetime(timestamp(dt.transaction_date_time_utc)) < stat.calitp_deleted_at
     where participant_id = 'sbmtd'
       and m.type = 'DEBIT'
 )
@@ -126,8 +165,10 @@ select
     t.transaction_date_time_utc,
     DATETIME(TIMESTAMP(transaction_date_time_utc), "America/Los_Angeles") as transaction_date_time_pacific
 from transactions as t
-left join gtfs_schedule.routes as r
+left join views.gtfs_schedule_dim_routes as r
     on r.calitp_itp_id = 293
         and r.calitp_url_number = 0
         and r.route_id = t.likely_route_id
+        and datetime(timestamp(t.transaction_date_time_utc)) >= r.calitp_extracted_at
+        and datetime(timestamp(t.transaction_date_time_utc)) < r.calitp_extracted_at
 order by t.likely_route_id nulls last

--- a/airflow/dags/payments_views/sbmtd_transactions.sql
+++ b/airflow/dags/payments_views/sbmtd_transactions.sql
@@ -142,7 +142,7 @@ transactions as (
     join micropayment_device_transactions_dedupe using (micropayment_id)
     join device_transactions_dedupe as dt using (littlepay_transaction_id, customer_id, participant_id)
     join stop_stats as stat
-      on stat.stop_id = trim(dt.location_id)
+      on stat.stop_id = dt.location_id
       and datetime(timestamp(dt.transaction_date_time_utc)) >= stat.calitp_extracted_at
       and datetime(timestamp(dt.transaction_date_time_utc)) < stat.calitp_deleted_at
     where participant_id = 'sbmtd'
@@ -158,7 +158,7 @@ select
     t.is_shared_stop,
     t.all_route_ids,
     t.route_id_from_device,
-    trim(t.likely_route_id) as likely_route_id,
+    t.likely_route_id as likely_route_id,
     r.route_long_name as likely_route_long_name,
     r.route_short_name as likely_route_short_name,
     t.vehicle_id,
@@ -168,7 +168,7 @@ from transactions as t
 left join views.gtfs_schedule_dim_routes as r
     on r.calitp_itp_id = 293
         and r.calitp_url_number = 0
-        and r.route_id = trim(t.likely_route_id)
+        and r.route_id = t.likely_route_id
         and datetime(timestamp(t.transaction_date_time_utc)) >= r.calitp_extracted_at
         and datetime(timestamp(t.transaction_date_time_utc)) < r.calitp_extracted_at
 order by t.likely_route_id nulls last

--- a/airflow/dags/payments_views/sbmtd_transactions.sql
+++ b/airflow/dags/payments_views/sbmtd_transactions.sql
@@ -142,7 +142,7 @@ transactions as (
     join micropayment_device_transactions_dedupe using (micropayment_id)
     join device_transactions_dedupe as dt using (littlepay_transaction_id, customer_id, participant_id)
     join stop_stats as stat
-      on stat.stop_id = dt.location_id
+      on stat.stop_id = trim(dt.location_id)
       and datetime(timestamp(dt.transaction_date_time_utc)) >= stat.calitp_extracted_at
       and datetime(timestamp(dt.transaction_date_time_utc)) < stat.calitp_deleted_at
     where participant_id = 'sbmtd'
@@ -168,7 +168,7 @@ from transactions as t
 left join views.gtfs_schedule_dim_routes as r
     on r.calitp_itp_id = 293
         and r.calitp_url_number = 0
-        and r.route_id = t.likely_route_id
+        and r.route_id = trim(t.likely_route_id)
         and datetime(timestamp(t.transaction_date_time_utc)) >= r.calitp_extracted_at
         and datetime(timestamp(t.transaction_date_time_utc)) < r.calitp_extracted_at
 order by t.likely_route_id nulls last

--- a/airflow/dags/payments_views_staging/stg_cleaned_device_transactions.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_device_transactions.sql
@@ -17,6 +17,8 @@ select distinct * except (
     calitp_dupe_number,
     route_id,
     location_id),
+    -- trim to align with gtfs cleaning steps
+    -- since these fields are used to join with gtfs data
     trim(route_id) as route_id,
     trim(location_id) as location_id
 from payments.stg_enriched_device_transactions

--- a/airflow/dags/payments_views_staging/stg_cleaned_device_transactions.sql
+++ b/airflow/dags/payments_views_staging/stg_cleaned_device_transactions.sql
@@ -14,6 +14,10 @@ select distinct * except (
     calitp_file_name,
     calitp_n_dupes,
     calitp_n_dupe_ids,
-    calitp_dupe_number)
+    calitp_dupe_number,
+    route_id,
+    location_id),
+    trim(route_id) as route_id,
+    trim(location_id) as location_id
 from payments.stg_enriched_device_transactions
 where calitp_dupe_number = 1


### PR DESCRIPTION
# Overall Description

_🚨 Merging into refactor_gtfs_views_staging to merge all #1137 fixes together._

This PR removes all references to `gtfs_schedule` data in `payments_views` and replaces them with references to more appropriate `views` data. This will address #1140 once it merges as part of #1157. 

Making this adjustment requires:

1. Changing the tables (to reference `views.gtfs_schedule_dim_routes` instead of `gtfs_schedule.routes`, for example)
2. Making the merges date-aware (since `gtfs_schedule` is latest-only, joins with it don't have to account for dates; joins with `dim` tables need to take account of the slowly-changing dimension)
3. Trimming IDs on the payments side. I did this as a precaution; I don't think that this data is affected by leading/trailing whitespace issues based on a few diagnostic queries, but it seemed better to be safe than sorry. 


This has a significant side effect (not the original intention for doing this work as part of the #1337 batch of issues): The current implementation was potentially getting inappropriate data, and was certainly getting incomplete data, by using `gtfs_schedule`. `gtfs_schedule` contains a **latest-only** cut of the GTFS schedule data. These payments tables are not latest-only. So by looking only at `gtfs_schedule`, some rows were losing their GTFS schedule annotations over time. See for example the results of the following query -- most of the results **did** have route info at the time they occurred, but the associated route is no longer in the latest dataset so the information is missing. If you look at the results of this query in `staging`, you will see 10% as many results, indicating that 90% of the transactions that were missing route info had it restored by looking at `views` (in a date-aware way) instead. 
```
select distinct route_id, participant_id, extract(date from datetime(timestamp(transaction_date_time_utc))) as dt
from `cal-itp-data-infra.views.mst_transactions_gtfs_enhanced`
where route_id is not null and route_short_name is null and route_long_name is null and route_id <> "Route Z"
order by dt desc
```

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

![image](https://user-images.githubusercontent.com/55149902/159062841-2708f977-429b-4515-a817-641873ee9160.png)

Note: `validate_payments_ride_adjustments` fails its test in my local dev environment but I verified that it fails them on `main` too (same # of failures, so not caused by my changes)

- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `payments_views` DAG in order to update the following DAG tasks:

- `sbmtd_transactions`, `payments_rides`, and `mst_transactions_gtfs_enhanced`: use `views` instead of `gtfs_schedule` as described above