### PR TITLE
Fix - GTFS Schedule: Reduce wait tasks for gtfs_schedule DAG

### DIFF
--- a/airflow/dags/gtfs_schedule/agency.sql
+++ b/airflow/dags/gtfs_schedule/agency.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.agency
 
 description: Latest-only table for agency
 
-external_dependencies:
-  - gtfs_views_staging: agency_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/attributions.sql
+++ b/airflow/dags/gtfs_schedule/attributions.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.attributions
 
 description: Latest-only table for attributions
 
-external_dependencies:
-  - gtfs_views_staging: attributions_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/calendar.sql
+++ b/airflow/dags/gtfs_schedule/calendar.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.calendar
 
 description: Latest-only table for calendar
 
-external_dependencies:
-  - gtfs_views_staging: calendar_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/calendar_dates.sql
+++ b/airflow/dags/gtfs_schedule/calendar_dates.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.calendar_dates
 
 description: Latest-only table for calendar_dates
 
-external_dependencies:
-  - gtfs_views_staging: calendar_dates_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/dummy_views_staging.yml
+++ b/airflow/dags/gtfs_schedule/dummy_views_staging.yml
@@ -1,0 +1,4 @@
+operator: airflow.operators.dummy_operator.DummyOperator
+
+external_dependencies:
+  - gtfs_views_staging: all

--- a/airflow/dags/gtfs_schedule/fare_attributes.sql
+++ b/airflow/dags/gtfs_schedule/fare_attributes.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.fare_attributes
 
 description: Latest-only table for fare_attributes
 
-external_dependencies:
-  - gtfs_views_staging: fare_attributes_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/fare_rules.sql
+++ b/airflow/dags/gtfs_schedule/fare_rules.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.fare_rules
 
 description: Latest-only table for fare_rules
 
-external_dependencies:
-  - gtfs_views_staging: fare_rules_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/feed_info.sql
+++ b/airflow/dags/gtfs_schedule/feed_info.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.feed_info
 
 description: Latest-only table for feed_info
 
-external_dependencies:
-  - gtfs_views_staging: feed_info_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/frequencies.sql
+++ b/airflow/dags/gtfs_schedule/frequencies.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.frequencies
 
 description: Latest-only table for frequencies
 
-external_dependencies:
-  - gtfs_views_staging: frequencies_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/levels.sql
+++ b/airflow/dags/gtfs_schedule/levels.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.levels
 
 description: Latest-only table for levels
 
-external_dependencies:
-  - gtfs_views_staging: levels_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/pathways.sql
+++ b/airflow/dags/gtfs_schedule/pathways.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.pathways
 
 description: Latest-only table for pathways
 
-external_dependencies:
-  - gtfs_views_staging: pathways_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/routes.sql
+++ b/airflow/dags/gtfs_schedule/routes.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.routes
 
 description: Latest-only table for routes
 
-external_dependencies:
-  - gtfs_views_staging: routes_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/shapes.sql
+++ b/airflow/dags/gtfs_schedule/shapes.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.shapes
 
 description: Latest-only table for shapes
 
-external_dependencies:
-  - gtfs_views_staging: shapes_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/stop_times.sql
+++ b/airflow/dags/gtfs_schedule/stop_times.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.stop_times
 
 description: Latest-only table for stop_times
 
-external_dependencies:
-  - gtfs_views_staging: stop_times_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/stops.sql
+++ b/airflow/dags/gtfs_schedule/stops.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.stops
 
 description: Latest-only table for stops
 
-external_dependencies:
-  - gtfs_views_staging: stops_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/transfers.sql
+++ b/airflow/dags/gtfs_schedule/transfers.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.transfers
 
 description: Latest-only table for transfers
 
-external_dependencies:
-  - gtfs_views_staging: transfers_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/translations.sql
+++ b/airflow/dags/gtfs_schedule/translations.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.translations
 
 description: Latest-only table for translations
 
-external_dependencies:
-  - gtfs_views_staging: translations_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/trips.sql
+++ b/airflow/dags/gtfs_schedule/trips.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.trips
 
 description: Latest-only table for trips
 
-external_dependencies:
-  - gtfs_views_staging: trips_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 

--- a/airflow/dags/gtfs_schedule/validation_notices.sql
+++ b/airflow/dags/gtfs_schedule/validation_notices.sql
@@ -5,8 +5,8 @@ dst_table_name: gtfs_schedule.validation_notices
 
 description: Latest-only table for validation_notices
 
-external_dependencies:
-  - gtfs_views_staging: validation_notices_clean
+dependencies:
+  - dummy_views_staging
 ---
 {{
 


### PR DESCRIPTION
# Overall Description

This PR addresses this issue identified by @evansiroky [on Slack](https://cal-itp.slack.com/archives/C0332307HKM/p1648095081505499):

> The new gtfs_schedule DAG has A LOT of "wait" tasks that are all running at the same time. I believe this is causing a lot of other tasks to not get queued up. So the wait tasks merely running may be preventing other tasks that they are waiting on from getting completed on time.

Basically, many DAGs failed to run last night (3/23/22) because all the "wait for" dependency tasks stalled out, presumably because too many were running at once. 

This PR refactors the dependencies for the `gtfs_schedule` DAG task so that all tasks just wait for one dummy task that waits for the entire `gtfs_views_staging` DAG instead of each DAG task waiting for its own external dependency. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

As usual, `stop_times` doesn't run for size reasons but everything else does.

![image](https://user-images.githubusercontent.com/55149902/159931759-f27f9c1e-cf75-48f5-80ff-018ad6425660.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_schedule` DAG in order to refactor the task dependencies as described above.