### PR TITLE
Docs(How we work): Updated Meeting Descriptions

### DIFF
--- a/docs/analytics_welcome/how_we_work.md
+++ b/docs/analytics_welcome/how_we_work.md
@@ -8,8 +8,8 @@ The section below outlines our team's primary meetings and their purposes, as we
 | Name | Cadence | Description |
 | -------- | -------- | -------- |
 | **Technical Onboarding** | Week 1 <br/> 40 Mins | To ensure access to tools and go over best practices. |
-| **Data Services All-Hands** | Mondays <br/> 1 Hour | A team-wide data services sync. |
-| **Analyst Stand-ups** | Tues-Fri <br/> 15 Mins | A short sync to share yesterdays work, today's work, and any blockers. |
+| **Data Services All-Hands** | Every Other Monday <br/> 1 Hour | A team-wide data services sync. |
+| **Analyst Stand-ups** | Tues & Thurs <br/> 45 Mins | An opportunity to share your screen and discuss what you've been working on. |
 | **Lunch n' Learn** | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/> Access recordings of **previous Lunch n' Learns** [at this link](https://youtube.com/playlist?list=PLJA3syyg1ijm36JFZ95v79zAuv-5c8hfZ). |
 
 (slack-intro)=


### PR DESCRIPTION
Added updated information on analyst meetings as they have changed recently
## Docs changes checklist

- [ ] Make sure the preview website was able to be generated
- [ ] Fill out the following section describing what docs were added/updated

This PR updates:
`Analytics Welcome`/`How We Work`
* Change the information around weekly all hands and analyst standups to reflect our new formats
