### PR TITLE
service-release-candidate.yml: fix first time candidate build

### DIFF
--- a/.github/workflows/service-release-candidate.yml
+++ b/.github/workflows/service-release-candidate.yml
@@ -50,7 +50,9 @@ jobs:
 
         # branch setup
         git update-ref -d "$candidate_remote_ref"
-        git fetch "$remote_name" "$candidate_ref"
+        if [[ $(git ls-remote "$remote_name" "$candidate_ref") ]]; then
+          git fetch "$remote_name" "$candidate_ref"
+        fi
 
         # build & push
         commit_msg="Release candidate: $source_branch


### PR DESCRIPTION
A new "release candidate branch" concept was introduced in #1179, but the workflow which builds these branches errors out when attempting to create a new release candidate branch (as opposed to updating an existing one). This hotfix resolves that issue.