### PR TITLE
Release candidate pruning workflow

### DIFF
--- a/.github/workflows/cleanup-release-candidates.yml
+++ b/.github/workflows/cleanup-release-candidates.yml
@@ -1,0 +1,32 @@
+name: Cleanup release candidate branches
+
+on:
+  delete:
+    branches:
+      - '!candidates/*'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+  REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+
+
+jobs:
+  delete-release-candidate:
+    runs-on: ubuntu-latest
+    steps:
+
+    # This step is only for credential setup
+    - name: Check out repo
+      uses: actions/checkout@v2
+
+    - name: 'Delete orphaned release candidates'
+      run: |
+        while read candidate_sha1 candidate_ref; do
+          source_branch=${candidate_ref#refs/heads/candidates/}
+          source_ref=refs/heads/$source_branch
+          if ! [[ $(git ls-remote "$REPO_URL" "$source_ref") ]]; then
+            printf 'Pruning orphaned release candidate: %s\n' "$candidate_ref"
+            git push "$REPO_URL" --delete "$candidate_ref"
+          fi
+        done <<< "$(git ls-remote "$REPO_URL" 'refs/heads/candidates/*')"
+        printf 'All orphaned release candidates successfully pruned\n'


### PR DESCRIPTION
The git flow changes merged in #1197 introduced the concept of a "release candidate" as an auto-built deployment branch. That changeset did not however include a method to cleanup these branches when no longer required. This changeset introduces said cleanup method.