### PR TITLE
run RT validations on new node pool

### DIFF
--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -22,5 +22,23 @@ arguments:
 is_delete_operator_pod: true
 get_logs: true
 
+pod_location: us-west2-a
+cluster_name: data-infra-apps
+
+tolerations:
+  - key: pod-role
+    operator: Equal
+    value: computetask
+    effect: NoSchedule
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: pod-role
+          operator: In
+          values:
+          - computetask
+
 dependencies:
   - create_validation_params

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -22,7 +22,8 @@ arguments:
 is_delete_operator_pod: true
 get_logs: true
 
-pod_location: us-west2-a
+is_gke: true
+pod_location: us-west1
 cluster_name: data-infra-apps
 
 tolerations:

--- a/airflow/plugins/operators/pod_operator.py
+++ b/airflow/plugins/operators/pod_operator.py
@@ -1,7 +1,7 @@
+import inspect
 import os
 
 from functools import wraps
-from pprint import pprint
 
 from airflow.contrib.operators.gcp_container_operator import GKEPodOperator
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
@@ -14,20 +14,24 @@ def PodOperator(*args, **kwargs):
     # TODO: tune this, and add resource limits
     namespace = "default"
 
-    if kwargs.get('name') == 'gtfs-rt-validation':
-        pprint(kwargs)
-        # raise RuntimeError
-
-    if is_development():
+    if is_development() or kwargs.pop("is_gke", False):
         return GKEPodOperator(
             *args,
             in_cluster=False,
             project_id="cal-itp-data-infra",  # there currently isn't a staging cluster
-            location='us-west1',#kwargs.get('pod_location', os.environ["POD_LOCATION"]),
-            cluster_name='data-infra-apps',#kwargs.get('cluster_name', os.environ["POD_CLUSTER_NAME"]),
+            location=kwargs.pop("pod_location", os.environ["POD_LOCATION"]),
+            cluster_name=kwargs.pop("cluster_name", os.environ["POD_CLUSTER_NAME"]),
             namespace=namespace,
             **kwargs,
         )
 
     else:
         return KubernetesPodOperator(*args, namespace=namespace, **kwargs)
+
+
+PodOperator._gusty_parameters = (
+    *inspect.signature(KubernetesPodOperator.__init__).parameters.keys(),
+    "is_gke",
+    "pod_location",
+    "cluster_name",
+)

--- a/airflow/plugins/operators/pod_operator.py
+++ b/airflow/plugins/operators/pod_operator.py
@@ -1,6 +1,8 @@
 import os
 
 from functools import wraps
+from pprint import pprint
+
 from airflow.contrib.operators.gcp_container_operator import GKEPodOperator
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
@@ -12,13 +14,17 @@ def PodOperator(*args, **kwargs):
     # TODO: tune this, and add resource limits
     namespace = "default"
 
+    if kwargs.get('name') == 'gtfs-rt-validation':
+        pprint(kwargs)
+        # raise RuntimeError
+
     if is_development():
         return GKEPodOperator(
             *args,
             in_cluster=False,
             project_id="cal-itp-data-infra",  # there currently isn't a staging cluster
-            location=os.environ["POD_LOCATION"],
-            cluster_name=os.environ["POD_CLUSTER_NAME"],
+            location='us-west1',#kwargs.get('pod_location', os.environ["POD_LOCATION"]),
+            cluster_name='data-infra-apps',#kwargs.get('cluster_name', os.environ["POD_CLUSTER_NAME"]),
             namespace=namespace,
             **kwargs,
         )


### PR DESCRIPTION
Points the RT validation job at new node pool, separate from the composer workers.

I will move the parsing jobs next, though they are not pod operators yet.