### PR TITLE
fix(rt): remove validation errors dependency on rt loader

### DIFF
--- a/airflow/dags/rt_views/gtfs_rt_fact_daily_validation_errors.sql
+++ b/airflow/dags/rt_views/gtfs_rt_fact_daily_validation_errors.sql
@@ -30,7 +30,6 @@ tests:
         - date
 
 external_dependencies:
-  - rt_loader: all
   - gtfs_views: gtfs_schedule_dim_feeds
 ---
 


### PR DESCRIPTION
# Overall Description

Attempted mitigation (not proper fix) for #1180. Removing the `rt_loader` dependency for the RT validations fact table.

Rationale: 
1. This dependency is not needed (nothing about the task uses execution date, so it is safe to let it get out of sync with `rt_loader` in the interest of experimentation).
2. This dependency has been causing the fact table task to fail a majority of the time recently:
![image](https://user-images.githubusercontent.com/55149902/160485580-b2910e49-4466-4412-9cad-6611f19d867e.png)

To better understand issue #1180, we want to remove this confounding variable so that the task can run more frequently and we can get a handle on the prevalence of the underlying issue. 


## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [ ] Verify that all affected DAG tasks were able to run in a local environment
- [ ] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

^ This task runs into #1180 when I try to run it in test, so I am not able to test it locally. However since it mostly doesn't run already, I am confident that removing this dependency isn't going to make anything worse.

- [x] ~Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `rt_views` DAG -- see intro for rationale

