### PR TITLE
 Amplitude DAG: Save JSONL in ingest_amplitude_raw_* bucket

### DIFF
--- a/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
+++ b/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
@@ -67,6 +67,6 @@ CREATE OR REPLACE EXTERNAL TABLE `amplitude.benefits_events` (
 )
 OPTIONS (
     format = "JSON",
-    uris = ["{{get_bucket()}}/amplitude/benefits/*.jsonl"],
+    uris = ["gs://ingest_amplitude_raw_dev/amplitude/benefits/*.jsonl"],
     ignore_unknown_values = True
 )

--- a/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
+++ b/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
@@ -67,6 +67,6 @@ CREATE OR REPLACE EXTERNAL TABLE `amplitude.benefits_events` (
 )
 OPTIONS (
     format = "JSON",
-    uris = ["gs://ingest_amplitude_raw_dev/amplitude/benefits/*.jsonl"],
+    uris = ["{{'gs://ingest_amplitude_raw_dev' if get_bucket() == 'gs://gtfs-data-test' else 'gs://ingest_amplitude_raw_prod'}}/amplitude/benefits/*.jsonl"],
     ignore_unknown_values = True
 )

--- a/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
+++ b/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
@@ -67,6 +67,6 @@ CREATE OR REPLACE EXTERNAL TABLE `amplitude.benefits_events` (
 )
 OPTIONS (
     format = "JSON",
-    uris = ["{{'gs://ingest_amplitude_raw_dev' if get_bucket() == 'gs://gtfs-data-test' else 'gs://ingest_amplitude_raw_prod'}}/amplitude/benefits/*.jsonl"],
+    uris = ["{{'gs://ingest_amplitude_raw_dev' if is_development() else 'gs://ingest_amplitude_raw_prod'}}/amplitude/benefits/*.jsonl"],
     ignore_unknown_values = True
 )

--- a/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
+++ b/airflow/dags/amplitude_benefits/jsonl_bigquery.sql
@@ -67,6 +67,6 @@ CREATE OR REPLACE EXTERNAL TABLE `amplitude.benefits_events` (
 )
 OPTIONS (
     format = "JSON",
-    uris = ["{{'gs://ingest_amplitude_raw_dev' if is_development() else 'gs://ingest_amplitude_raw_prod'}}/amplitude/benefits/*.jsonl"],
+    uris = ["{{'gs://ingest_amplitude_raw_dev' if is_development() else 'gs://ingest_amplitude_raw_prod'}}/benefits/*.jsonl"],
     ignore_unknown_values = True
 )

--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -1,7 +1,14 @@
 import pandas as pd
+from calitp.config import is_development
 
 # To add a macro, add its definition in the appropriate section
 # And then add it to the dictionary at the bottom of this file
+
+# Is Development ======================================================
+
+def is_development_macro():
+   return is_development()
+
 
 # Payments =============================================================
 
@@ -230,4 +237,5 @@ data_infra_macros = {
     "sql_enrich_duplicates": sql_enrich_duplicates,
     "sql_airtable_mapping": airtable_mapping_generate_sql,
     "get_latest_schedule_data": get_latest_schedule_data,
+    "is_development": is_development_macro
 }

--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -1,3 +1,5 @@
+"""Macros for Operators"""
+
 import pandas as pd
 from calitp.config import is_development
 
@@ -6,8 +8,11 @@ from calitp.config import is_development
 
 # Is Development ======================================================
 
+
 def is_development_macro():
-   return is_development()
+    """Make calitp-py's is_development function available via macro"""
+
+    return is_development()
 
 
 # Payments =============================================================
@@ -147,7 +152,12 @@ def airtable_mapping_generate_sql(table1, table2, col1, col2):
             name2 = col1 + "_name"
             id2 = col1 + "_id"
         sql = SELF_JOIN_SQL_TEMPLATE.format(
-            table=table1, col=col1, name1=name1, id1=id1, name2=name2, id2=id2,
+            table=table1,
+            col=col1,
+            name1=name1,
+            id1=id1,
+            name2=name2,
+            id2=id2,
         )
     else:
         if table2[-1:] == "s":
@@ -237,5 +247,5 @@ data_infra_macros = {
     "sql_enrich_duplicates": sql_enrich_duplicates,
     "sql_airtable_mapping": airtable_mapping_generate_sql,
     "get_latest_schedule_data": get_latest_schedule_data,
-    "is_development": is_development_macro
+    "is_development": is_development_macro,
 }

--- a/airflow/plugins/operators/amplitude_to_flattened_json.py
+++ b/airflow/plugins/operators/amplitude_to_flattened_json.py
@@ -10,6 +10,7 @@ import requests
 import pandas as pd
 
 from airflow.models import BaseOperator
+from calitp.config import is_development
 
 DATE_FORMAT = "%Y%m%dT%H"
 
@@ -119,5 +120,11 @@ class AmplitudeToFlattenedJSONOperator(BaseOperator):
         )
         gcs_file_path = f"amplitude/{self.app_name}/{start}-{end}.jsonl"
 
+        bucket_name = "ingest_amplitude_raw_dev" if is_development() else "ingest_amplitude_raw_prod"
+
         # if a file already exists at `gcs_file_path`, GCS will overwrite the existing file
-        calitp.save_to_gcfs(events_jsonl.encode(), gcs_file_path, use_pipe=True)
+        calitp.save_to_gcfs(
+            events_jsonl.encode(),
+            gcs_file_path,
+            bucket=bucket_name,
+            use_pipe=True)

--- a/airflow/plugins/operators/amplitude_to_flattened_json.py
+++ b/airflow/plugins/operators/amplitude_to_flattened_json.py
@@ -118,7 +118,7 @@ class AmplitudeToFlattenedJSONOperator(BaseOperator):
         events_jsonl = events_df.to_json(
             orient="records", lines=True, date_format="iso"
         )
-        gcs_file_path = f"amplitude/{self.app_name}/{start}-{end}.jsonl"
+        gcs_file_path = f"{self.app_name}/{start}-{end}.jsonl"
 
         bucket_name = "ingest_amplitude_raw_dev" if is_development() else "ingest_amplitude_raw_prod"
 


### PR DESCRIPTION
# Overall Description

close #1240 part of #960 #1116 

- Save `jsonl` file from Amplitude into new `ingest_amplitude_raw_dev` or `ingest_amplitude_raw_prod` bucket
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/3673236/160694428-5695017b-0c5f-42ce-8552-4dd2b999bfbf.png">

- Read `jsonl` file from new buckets
- Add `is_development` function to macros, so that operators can use it

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/3673236/160716379-7ace42a0-d8af-4940-a02b-909e3ac64210.png">
<img width="716" alt="image" src="https://user-images.githubusercontent.com/3673236/160716749-847c8a80-8a37-40ea-ba8f-9db4d83b1b70.png">

This PR updates the `amplitude_benefits` DAG in order to....
- Update `api_to_jsonl`: Save the JSONL file to `gs://ingest_amplitude_raw_dev` or `gs://ingest_amplitude_raw_prod` bucket
- Update `jsonl_bigquery `: Get the JSONL file from `gs://ingest_amplitude_raw_dev` or `gs://ingest_amplitude_raw_prod` bucket, as determined by `is_development()` macro, as defined in [airflow/dags/macros.py](https://github.com/cal-itp/data-infra/pull/1279/files#diff-a9dc672975f537be6f0ec7ec039c377c09ee4fa15c24bed81c7306ccd0753308)


