### PR TITLE
fix(gtfs schedule): fix get latest logic.... again

### DIFF
--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -107,9 +107,7 @@ def get_latest_schedule_data(table):
         SELECT
             t1.* EXCEPT(calitp_deleted_at)
         FROM gtfs_views_staging.{table}_clean t1
-        -- inner join to only get the ones that are latest load
-        INNER JOIN gtfs_schedule_history.calitp_feed_latest t2
-            USING(calitp_itp_id, calitp_url_number, calitp_extracted_at)
+        WHERE calitp_deleted_at = '2099-01-01'
 """
 
 


### PR DESCRIPTION
# Overall Description

It looks like c6f1c8c09d5b02e343fb65fee44150145940f8e5 (and its follow up c6d23b4e028182d32955ec19d8b6f45471c9f760) was wrong and caused #1267. Basically, the original `get_latest` logic was right -- we need to check for `2099-01-01` deleted at, because the way that we do `merge_updates` means that the `calitp_extracted_at` for individual rows won't necessarily line up with the latest feed/file extract (.... I know I'm a broken record about this at this point but row-level versioning strikes again.)

Basically, with the current logic, we are missing current rows that should be present because their `extracted_at` date (post-`merge_updates`) doesn't align with the latest *feed* update. 

Going back to using `calitp_deleted_at` opens us up to #1184 (so we will have some data present that shouldn't be, because the file has been deleted), but the volume of data affected by that will be smaller. And we need to fix that too anyway. 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
(as usual, `stop_times` does not complete because of query limit)
![image](https://user-images.githubusercontent.com/55149902/160713796-f865fcbd-f829-40f0-8a4e-e4f660ed3137.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_schedule` DAG in order to fix the get_latest logic, to correspond to how latest data should be identified post-`merge_updates`.
