### PR TITLE
Explicitly state the need to wait on a release candidate build action

### DIFF
--- a/docs/ci/Git-Flow-Services.md
+++ b/docs/ci/Git-Flow-Services.md
@@ -80,7 +80,7 @@ app_name=gtfs-rt-archive
 git_remote=origin
 topic_branch=$(git branch --show-current)
 # load the helm or kustomize specific parameters
-source ci/vars/releases/prod-$app_name.env
+source ci/vars/releases/preprod-$app_name.env
 
 if   [[ $RELEASE_DRIVER == 'kustomize' ]]; then
   # bump the newTag version to match the newly pushed app version

--- a/docs/ci/Git-Flow-Services.md
+++ b/docs/ci/Git-Flow-Services.md
@@ -97,6 +97,10 @@ git commit -am "ops($app_name): release new version"
 # trigger a release candidate build
 git push $git_remote
 
+#
+# wait for the "Build release candidate" action to complete in GitHub
+#
+
 # fetch the release candidate
 git fetch $git_remote candidates/$topic_branch
 


### PR DESCRIPTION
This will help avoid confusion by anyone who is unaware that a release candidate will need to complete a possibly slow build step before it is available to be fetched in its most current form