### PR TITLE
fix(gtfs schedule): dim shapes geo versioning again

### DIFF
--- a/airflow/dags/gtfs_views/gtfs_schedule_dim_shapes_geo.sql
+++ b/airflow/dags/gtfs_views/gtfs_schedule_dim_shapes_geo.sql
@@ -15,6 +15,20 @@ fields:
 
 dependencies:
   - gtfs_schedule_dim_shapes
+
+tests:
+  check_null:
+    - calitp_itp_id
+    - calitp_url_number
+    - calitp_extracted_at
+    - calitp_deleted_at
+    - shape_id
+    - pt_array
+  check_composite_unique:
+    - calitp_itp_id
+    - calitp_url_number
+    - shape_id
+    - calitp_extracted_at
 ---
 
 -- note that we can't just use shape_key


### PR DESCRIPTION
# Overall Description

Fixes #1289.

1. Correctly handles shape-level versioning in `gtfs_schedule_dim_shapes_geo` by treating an entire shape as deleted and re-extracted any time that any of its constituent points change. 
2. Add tests for `gtfs_schedule_dim_shapes_geo` (null checks and composite uniqueness)

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

![image](https://user-images.githubusercontent.com/55149902/161081984-00094c6d-772a-4e50-8936-7a5138d147f5.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_views` DAG in order to make the fixes listed above in `gtfs_schedule_dim_shapes_geo`.