### PR TITLE
Fix tmpdir creation in helm CI step

### DIFF
--- a/ci/steps/release-helm-changes.sh
+++ b/ci/steps/release-helm-changes.sh
@@ -62,7 +62,7 @@ fi
 # helm template output cannot be passed directly to kubectl diff.
 # this workaround wraps the output of helm template in a kustomize directory to allow
 # native diffing.
-diff_tmpdir=$(mktemp -d -t "$RELEASE_HELM_CHART")
+diff_tmpdir=$(mktemp -d -t "$RELEASE_HELM_NAME.XXXXXX")
 trap "rm -rf $diff_tmpdir" EXIT
 helm template "$RELEASE_HELM_NAME" "$chart_path" "${helm_opts[@]}" > "$diff_tmpdir/manifest.yaml"
 cat <<EOF > "$diff_tmpdir/kustomization.yaml"


### PR DESCRIPTION
The exclusion of X characters in the tmpdir name template causes the command, and consequently the [deployment job](https://github.com/cal-itp/data-infra/runs/5774090158?check_suite_focus=true), to fail.