### PR TITLE
Upgrade prod metabase to v0.42.3

### DIFF
--- a/kubernetes/apps/values/metabase.yaml
+++ b/kubernetes/apps/values/metabase.yaml
@@ -1,6 +1,6 @@
 images:
   metabase:
-    src: metabase/metabase:v0.41.1
+    src: metabase/metabase:v0.42.3
 
 workloads:
   metabase:


### PR DESCRIPTION
The upgrade in #1293 only effected the upgrade for preprod deployments. This effects the upgrade for prod deployments as well.