### PR TITLE
Revert metabase upgrade: v0.42.3 -> v0.41.1

### DIFF
--- a/kubernetes/apps/values/metabase-preprod.yaml
+++ b/kubernetes/apps/values/metabase-preprod.yaml
@@ -1,6 +1,6 @@
 images:
   metabase:
-    src: metabase/metabase:v0.42.3
+    src: metabase/metabase:v0.41.1
 
 workloads:
   metabase:

--- a/kubernetes/apps/values/metabase.yaml
+++ b/kubernetes/apps/values/metabase.yaml
@@ -1,6 +1,6 @@
 images:
   metabase:
-    src: metabase/metabase:v0.42.3
+    src: metabase/metabase:v0.41.1
 
 workloads:
   metabase:


### PR DESCRIPTION
The production upgrade (performed on a sidechannel due to a CI pipeline bug fixed in #1295) resulted in a migration failure. This rollback will allow troubleshooting to continue in the preprod environment while prod can remain functional.