### PR TITLE
Remediate failed upgrade to metabase v0.42.3

### DIFF
--- a/kubernetes/apps/charts/metabase/values.yaml
+++ b/kubernetes/apps/charts/metabase/values.yaml
@@ -50,7 +50,7 @@ configs:
     MB_DB_PORT: "5432"
     MB_DB_USER: admin
     MB_DB_PASS: admin
-    MB_DB_HOST: database.metabase.svc.cluster.local
+    MB_DB_HOST: database
 
 ingress:
   enabled: false

--- a/kubernetes/apps/charts/metabase/values.yaml
+++ b/kubernetes/apps/charts/metabase/values.yaml
@@ -4,7 +4,7 @@
 
 images:
   database:
-    src: postgres:9.6
+    src: postgres:13.5
     imagePullSecrets:
     - name: regcred
   metabase:

--- a/kubernetes/apps/values/metabase-preprod.yaml
+++ b/kubernetes/apps/values/metabase-preprod.yaml
@@ -15,6 +15,7 @@ configs:
   metabase:
     MB_DB_USER: admin
     MB_DB_PASS: admin
+    MB_DB_HOST: database.metabase-preprod.svc.cluster.local
 
 volumes:
   database:

--- a/kubernetes/apps/values/metabase.yaml
+++ b/kubernetes/apps/values/metabase.yaml
@@ -15,6 +15,7 @@ configs:
   metabase:
     MB_DB_USER: admin
     MB_DB_PASS: admin
+    MB_DB_HOST: database.metabase.svc.cluster.local
 
 volumes:
   database:

--- a/kubernetes/apps/values/postgresql-backup-metabase.yaml
+++ b/kubernetes/apps/values/postgresql-backup-metabase.yaml
@@ -1,3 +1,6 @@
+cronjob:
+  image: ghcr.io/jarvusinnovations/restic-toolkit:1.3.0
+
 secretMounts:
   - name: gcs-upload-svcacct
     mountPath: /secrets/gcs-upload-svcacct


### PR DESCRIPTION
These changes address problems discovered in the process of completing the metabase rollback deployed in #1294. A summary of the problems:

- Due to a hard coded value in the chart, the preprod metabase was inadvertently connected to/using the production metabase DB. This is likely what caused the failed migrations to begin with.
- The postgresql client version used by the backup job was far newer than the postgresql server version used by metabase. This was causing DB restore attempts to fail.
- The postgresql client version used by the backup job was not version-pinned. This created a situation which would allow client and server versions to drift out of compatibility.

This changeset resolves all of these issues.