### PR TITLE
dbt: persist docs

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -34,6 +34,9 @@ clean-targets:         # directories to be removed by `dbt clean`
 models:
   calitp_warehouse:
     schema: staging
+    +persist_docs:
+      relation: true
+      columns: true
     # Config indicated by + and applies to all files under models/example/
     +materialized: view
 


### PR DESCRIPTION
# Overall Description

🚨 _Merging to `dbt-mvp` not `main`_

Small PR to set the `persist_docs` flag so that documentation is written to BigQuery in addition to the dbt docs.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~