### PR TITLE
fix(workflow): removed duplicate build-docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,9 +1,6 @@
 name: Publish docs to gh-pages
 
 on:
-  push:
-    paths:
-      - 'docs/**'
   pull_request:
     paths:
       - 'docs/**'


### PR DESCRIPTION
# Overall Description

The build docs workflow was previously set up to run on both `push` and `pull request`, causing the docs to build too frequently. The `build on push` setting was removed as `build on pull request` seems more appropriate for a docs workflow.

**Files effected**:
`workflows/publish-docs.yml`
* removed build on push workflow

Flagged by @themightychris in [this thread](https://jarvus.slack.com/archives/G01R32T28BT/p1648242158416259)
