### PR TITLE
Fix filter gtfs schedule to is in latest

### DIFF
--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -119,9 +119,9 @@ def get_latest_schedule_data(table):
         SELECT
             t1.* EXCEPT(calitp_deleted_at)
         FROM gtfs_views_staging.{table}_clean t1
-        LEFT JOIN gtfs_views_staging.calitp_feeds USING(calitp_itp_id, calitp_url_number)
-        WHERE calitp_deleted_at = '2099-01-01'
-        AND calitp_id_in_latest
+        LEFT JOIN gtfs_views_staging.calitp_feeds t2 USING(calitp_itp_id, calitp_url_number)
+        WHERE t1.calitp_deleted_at = '2099-01-01'
+        AND t2.calitp_id_in_latest
 """
 
 

--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -116,10 +116,21 @@ def scd_join(
 def get_latest_schedule_data(table):
 
     return f"""
+
+        WITH is_in_latest AS (
+            SELECT DISTINCT
+                calitp_itp_id,
+                calitp_url_number,
+                calitp_id_in_latest
+            FROM gtfs_views_staging.calitp_feeds
+            WHERE calitp_id_in_latest
+        )
+
         SELECT
             t1.* EXCEPT(calitp_deleted_at)
         FROM gtfs_views_staging.{table}_clean t1
-        LEFT JOIN gtfs_views_staging.calitp_feeds t2 USING(calitp_itp_id, calitp_url_number)
+        LEFT JOIN is_in_latest t2
+            USING(calitp_itp_id, calitp_url_number)
         WHERE t1.calitp_deleted_at = '2099-01-01'
         AND t2.calitp_id_in_latest
 """

--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -119,7 +119,9 @@ def get_latest_schedule_data(table):
         SELECT
             t1.* EXCEPT(calitp_deleted_at)
         FROM gtfs_views_staging.{table}_clean t1
+        LEFT JOIN gtfs_views_staging.calitp_feeds USING(calitp_itp_id, calitp_url_number)
         WHERE calitp_deleted_at = '2099-01-01'
+        AND calitp_id_in_latest
 """
 
 


### PR DESCRIPTION
# Overall Description

Fixes #235 by only including data in `gtfs_schedule` (`GTFS Schedule Feeds Latest`) where that agency appears in the current `agencies.yml`. 

Also partially addresses #988.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

As usual `stop_times` does not run due to query limit
![image](https://user-images.githubusercontent.com/55149902/161637844-fb468475-e98f-47ea-b274-d8c7296f3102.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `gtfs_schedule` DAG (via its macro in `macros.py`) in order to only pull data from agencies that are still in `agencies.yml`