### PR TITLE
Point prod Airflow dbt task to cal-itp-data-infra rather than staging

### DIFF
--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -19,7 +19,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_TARGET: staging_service_account
+  DBT_TARGET: prod_service_account
 
 secrets:
   - deploy_type: volume

--- a/warehouse/macros/generate_schema_name.sql
+++ b/warehouse/macros/generate_schema_name.sql
@@ -6,7 +6,7 @@
 
     {%- if not custom_schema_name -%}
         {{ default_schema }}
-    {%- elif target.name in ('prod',) -%}
+    {%- elif target.name.startswith('prod') -%}
         {{ custom_schema_name | trim }}
     {%- else -%}
         {{ default_schema }}_{{ custom_schema_name | trim }}

--- a/warehouse/profiles.yml
+++ b/warehouse/profiles.yml
@@ -5,7 +5,7 @@ calitp_warehouse:
       &prod
       execution_project: cal-itp-data-infra
       database: cal-itp-data-infra
-      schema: views
+      schema: staging
       fixed_retries: 1
       location: us-west2
       method: oauth

--- a/warehouse/profiles.yml
+++ b/warehouse/profiles.yml
@@ -1,11 +1,11 @@
 calitp_warehouse:
-  target: staging
+  target: prod
   outputs:
     prod:
       &prod
       execution_project: cal-itp-data-infra
       database: cal-itp-data-infra
-      schema: staging
+      schema: views
       fixed_retries: 1
       location: us-west2
       method: oauth

--- a/warehouse/profiles.yml
+++ b/warehouse/profiles.yml
@@ -1,5 +1,5 @@
 calitp_warehouse:
-  target: prod
+  target: staging
   outputs:
     prod:
       &prod


### PR DESCRIPTION
# Overall Description

This PR has the prod Airflow dbt run write to `cal-itp-data-infra` by default to maintain compatibility with existing architecture (for example, data availability in Metabase) during the transition. Previously it was writing to `cal-itp-data-infra-staging` by default, which caused the RT files views to become stale even though the dbt Airflow task ran successfully (🎉).

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] ~Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.~