### PR TITLE
Make sure docs get published from main branch

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Overall Description

Fixes https://github.com/cal-itp/data-infra/issues/1326 by making sure the doc publishing GitHub action is ran on the main branch.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.
