### PR TITLE
docs(requirements): created docs/requirements.txt, now referenced in workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,12 +21,7 @@ jobs:
     - name: Install python packages
       run: |
         pip install -r airflow/requirements.txt
-        pip install git+https://github.com/machow/siuba.git@stable
-        pip install jupyter-book==0.12.0
-        # Temporary pinning of pydata-sphinx-theme to workaround Sphinx 4.3.0 error
-        # https://github.com/pydata/pydata-sphinx-theme/issues/508
-        pip install pydata-sphinx-theme==0.7.2
-        pip install sphinxcontrib-mermaid
+        pip install -r docs/requirements.txt
     - uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+git+https://github.com/machow/siuba.git@stable
+jupyter-book==0.12.0
+# Temporary pinning of pydata-sphinx-theme to workaround Sphinx 4.3.0 error
+# https://github.com/pydata/pydata-sphinx-theme/issues/508
+pydata-sphinx-theme==0.7.2
+sphinxcontrib-mermaid==0.7.1


### PR DESCRIPTION
# Overall Description

Previously, the docs build process was using the `airflow/requirements.txt` file and lines of pip installations in the build docs workflow. This PR moves those packages into a `docs/requirements.txt` file which is also now referenced in the workflow file.

Files Edited:
`.github/workflows/publish-docs.yml`
* install dependencies from new docs requirements file

Files Added:
`docs/requirements.txt`
* moved packages being installed line by line in workflow to their own requirements file