### PR TITLE
fix(gtfs schedule): Partition validation notices by `calitp_itp_id` AND `calitp_url number`

### DIFF
--- a/airflow/dags/gtfs_schedule_history2/validation_notices_load.sql
+++ b/airflow/dags/gtfs_schedule_history2/validation_notices_load.sql
@@ -21,7 +21,12 @@ marked_deleted AS (
    SELECT
      *
      , LEAD(calitp_extracted_at)
-         OVER (PARTITION BY calitp_itp_id ORDER BY calitp_extracted_at)
+         OVER (
+          PARTITION BY
+            calitp_itp_id,
+            calitp_url_number
+          ORDER BY
+            calitp_extracted_at)
          AS calitp_deleted_at
    FROM fixed_extracted
 ),


### PR DESCRIPTION
# Overall Description

Fixes #1334. `gtfs_schedule_history2.validation_notices_load` was populating `calitp_deleted_at` by `LEAD`-ing `calitp_extracted_at` to the next row. However, it was not partitioning the window by `calitp_url_number`, so `calitp_extracted_at` dates were being comingled across `url_number` boundaries. This PR fixes that by adding `calitp_url_number` to the `PARTITION BY`.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [x] Verify that all affected DAG tasks were able to run in a local environment
- [x] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully

![image](https://user-images.githubusercontent.com/55149902/162035578-148b4226-995f-4edf-a652-e4a05f1cb8c7.png)

- [x] ~Add/update documentation in the `docs/airflow` folder as needed~
- [x] Fill out the following section describing what DAG tasks were added/updated

See PR description