### PR TITLE
Add additional field documentation to California Transit GTFS Datasets BigQuery Dataset

### DIFF
--- a/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
+++ b/airflow/dags/airtable_views/california_transit_gtfs_datasets.sql
@@ -8,6 +8,8 @@ fields:
   gtfs_dataset_id: Internal Airtable ID for this GTFS dataset record, used for joining with other Airtable views tables
   name: GTFS dataset name
   data: Single-select categorical choice imported as a string; example values "GTFS Alerts"; "GTFS Schedule"
+  uri: The URI where the GTFS Schedule or GTFS Realtime feed that references currently scheduled service can be downloaded from
+  future_uri: The URI where the GTFS Schedule or GTFS Realtime feed that references future scheduled service can be downloaded from
 
 tests:
   check_null:


### PR DESCRIPTION
# Overall Description

I forgot to initially add field-level documentation for these fields in https://github.com/cal-itp/data-infra/pull/1160.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.

## Airflow DAG changes checklist

- [x] Include this section whenever any change to a DAG in the `airflow/dags` folder occurs, otherwise please omit this section.
- [ ] Verify that all affected DAG tasks were able to run in a local environment
- [ ] Take a screenshot of the graph view of the affected DAG in the local environment showing that all affected DAG tasks completed successfully
- [x] Add/update documentation in the `docs/airflow` folder as needed
- [x] Fill out the following section describing what DAG tasks were added/updated

This PR updates the `airtable_views.california_transit_gtfs_datasets` DAG task in order to add proper field-level documentaiton.