### PR TITLE
Consolidate Modesto and StaRT into Stanislaus Regional Transit Authority

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -770,14 +770,14 @@ mission-bay-tma:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 201
-modesto-area-express:
-  agency_name: Modesto Area Express
+stanislaus-regional-transit-authority:
+  agency_name: Stanislaus Regional Transit Authority
   feeds:
-    - gtfs_schedule_url: https://www.modestoareaexpress.com/preview-gtfs.zip
+    - gtfs_schedule_url: https://www.stanrta.org/DocumentCenter/View/609/preview-gtfs.zip
       gtfs_rt_vehicle_positions_url: http://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=VehiclePosition
       gtfs_rt_service_alerts_url: http://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=Alert
       gtfs_rt_trip_updates_url: http://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=Tripupdate
-  itp_id: 203
+  itp_id: 484
 montebello-bus-lines:
   agency_name: Montebello Bus Lines
   feeds:
@@ -1236,14 +1236,6 @@ spirit-bus:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 207
-stanislaus-regional-transit:
-  agency_name: Stanislaus Regional Transit
-  feeds:
-    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/stanislaus-ca-us/stanislaus-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
-  itp_id: 325
 sunline-transit-agency:
   agency_name: SunLine Transit Agency
   feeds:

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -774,9 +774,9 @@ stanislaus-regional-transit-authority:
   agency_name: Stanislaus Regional Transit Authority
   feeds:
     - gtfs_schedule_url: https://www.stanrta.org/DocumentCenter/View/609/preview-gtfs.zip
-      gtfs_rt_vehicle_positions_url: http://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=VehiclePosition
-      gtfs_rt_service_alerts_url: http://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=Alert
-      gtfs_rt_trip_updates_url: http://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=Tripupdate
+      gtfs_rt_vehicle_positions_url: https://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=VehiclePosition
+      gtfs_rt_service_alerts_url: https://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=Alert
+      gtfs_rt_trip_updates_url: https://max.availtec.com/InfoPoint/GTFS-Realtime.ashx?Type=Tripupdate
   itp_id: 484
 montebello-bus-lines:
   agency_name: Montebello Bus Lines


### PR DESCRIPTION
# Overall Description

Modesto Area Express (MAX) + Stanislaus Regional Transit (StaRT) have consolidated to Stanislaus Regional Transit Authority (StanRTA).  This update deletes MAX and STaRT and adds StanRTA with a new Cal-ITP ID

NOTE: current feed for StanRTA is really just a copy-over of Modesto Area Express' and doesn't include Stanislaus Regional Transit - yet.  However, Stansilaus Regional Transit feed is outdated at this point.

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes

## agencies.yml changes checklist

- [x] Include this section whenever any change to the `airflow/data/agencies.yml` file occurs, otherwise please omit this section.
- [x] Manually made sure any new feeds have `itp_id`s that are not duplicative
- [x] Confirmed URIs are valid (the `move DAGs to GCS folder` GitHub action should successfully pass)
- [x] Made sure the Airtable database has consistent information
- [x] Fill out the following section describing what feeds were added/updated

This PR updates `agencies.yml` in order to....

Add the following gtfs datasets:

- Stanislaus Regional Transit Authority

Deletes the following gtfs datsets:

- Modesto Area Express
- Stanislaus Regional Transit
