### PR TITLE
run the fixed RT validator API image in airflow

### DIFF
--- a/airflow/dags/rt_loader/external_validation_service_alerts.sql
+++ b/airflow/dags/rt_loader/external_validation_service_alerts.sql
@@ -1,5 +1,6 @@
 ---
 operator: operators.SqlQueryOperator
+
 description: |
   GTFS RT validation errors as returned by the validator. Each row corresponds to
   the number of occurrences of a given error for a single itp_id/url/tick/entity combination.
@@ -16,6 +17,10 @@ fields:
     An error ID as defined in the GTFS RT validator repo.
   n_occurrences: |
     The number of occurrences of this error.
+
+post_hooks:
+    - "select calitp_itp_id from gtfs_rt.validation_service_alerts limit 1"
+
 dependencies:
     - load_rt_validations
 ---

--- a/airflow/dags/rt_loader/load_rt_validations.yml
+++ b/airflow/dags/rt_loader/load_rt_validations.yml
@@ -1,6 +1,6 @@
 operator: 'operators.PodOperator'
 name: 'gtfs-rt-validation'
-image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.4'
+image: 'ghcr.io/cal-itp/gtfs-rt-validator-api:v0.0.5'
 cmds:
   - python3
 

--- a/airflow/plugins/operators/sql_query_operator.py
+++ b/airflow/plugins/operators/sql_query_operator.py
@@ -10,13 +10,18 @@ class SqlQueryOperator(BaseOperator):
 
     template_fields = ("sql",)
 
-    def __init__(self, sql, **kwargs):
+    def __init__(self, sql, post_hooks=[], **kwargs):
         super().__init__(**kwargs)
 
         self.sql = sql
+        self.post_hooks = post_hooks
 
     def execute(self, context):
         engine = get_engine()
 
         print(f"{engine}\n{self.sql}")
         engine.execute(sql.text(self.sql))
+
+        for hook in self.post_hooks:
+            print(f"{engine}\n{hook}")
+            engine.execute(sql.text(hook))


### PR DESCRIPTION
This image also downloads schedule data _after_ RT, so we will avoid downloading schedule data that has no corresponding RT data.