### PR TITLE
Replace loki-stack with current loki and promtail charts

### DIFF
--- a/.holo/branches/release-candidate/kubernetes/apps/charts/loki.toml
+++ b/.holo/branches/release-candidate/kubernetes/apps/charts/loki.toml
@@ -1,4 +1,4 @@
 [holomapping]
 holosource = "jarvus-cluster-template=>k8s-blueprint"
-root       = "loki-stack/helm-chart"
+root       = "loki/helm-chart"
 files      = "**"

--- a/.holo/branches/release-candidate/kubernetes/apps/charts/promtail.toml
+++ b/.holo/branches/release-candidate/kubernetes/apps/charts/promtail.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "jarvus-cluster-template=>k8s-blueprint"
+root       = "promtail/helm-chart"
+files      = "**"

--- a/.holo/sources/jarvus-cluster-template.toml
+++ b/.holo/sources/jarvus-cluster-template.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/cluster-template"
-ref = "refs/tags/v0.18.1"
+ref = "refs/tags/v0.20.2"

--- a/ci/vars/releases/prod-loki.env
+++ b/ci/vars/releases/prod-loki.env
@@ -1,5 +1,5 @@
 RELEASE_DRIVER=helm
 RELEASE_NAMESPACE=monitoring-loki
 RELEASE_HELM_NAME=loki
-RELEASE_HELM_CHART=kubernetes/apps/charts/loki-stack
+RELEASE_HELM_CHART=kubernetes/apps/charts/loki
 RELEASE_HELM_VALUES=

--- a/ci/vars/releases/prod-promtail
+++ b/ci/vars/releases/prod-promtail
@@ -1,0 +1,5 @@
+RELEASE_DRIVER=helm
+RELEASE_NAMESPACE=monitoring-loki
+RELEASE_HELM_NAME=promtail
+RELEASE_HELM_CHART=kubernetes/apps/charts/promtail
+RELEASE_HELM_VALUES=


### PR DESCRIPTION
The current deployment stack for loki is outdated, which causes labels to not properly parse. This change pulls in more current versions of the components of the loki stack to enable its full log parsing power.