### PR TITLE
fix(build-docs): reverting workflow to fix docs build on merge issue

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,11 +1,10 @@
 name: Publish docs to gh-pages
 
 on:
-  pull_request:
+  push:
     paths:
       - 'docs/**'
-  push:
-    branches: [ main ]
+  pull_request:
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/analytics_welcome/overview.md
+++ b/docs/analytics_welcome/overview.md
@@ -1,7 +1,7 @@
 (analysts-welcome)=
 # Welcome!
 
-Welcome to the Analysts chapter of our Cal-ITP Data Services documentation!
+Welcome to the Analysts section of our Cal-ITP Data Services documentation!
 
 Here you will be introduced to the resources and best practices that make our analytics team work.
 


### PR DESCRIPTION
@lauriemerrell noticed that her docs updates weren't building on merge from main, so I'm reverting to the previous workflow settings

We can revisit this and try to address the duplicate build process again soon

Files effected:
`.github/workflows/publish-docs.yml`
* reverted previous workflow settings

`docs/analytics_welcome/overview`
* trivial change to get docs to build on merge