### PR TITLE
docs(ssh): added information on persisting SSH keys clarified creating SSH keys

### DIFF
--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -100,9 +100,9 @@ LIMIT 10
 (saving-code-jupyter)=
 ### Saving Code to Github
 Use [this link](committing-from-jupyterhub) to navigate to the `Saving Code` section of the docs to learn how to commit code to GitHub from the Jupyter terminal. You will need to complete the following sections to begin:
-    * [Adding a GitHub SSH Key to Jupyter](adding-ssh-to-jupyter)
-    * [Persisting your SSH Key and Enabling Extensions](persisting-ssh-and-extensions)
-    * [Cloning a Repository](cloning-a-repository)
+* [Adding a GitHub SSH Key to Jupyter](adding-ssh-to-jupyter)
+* [Persisting your SSH Key and Enabling Extensions](persisting-ssh-and-extensions)
+* [Cloning a Repository](cloning-a-repository)
 
 ### Environment Variables
 

--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -4,7 +4,7 @@
 ## Introduction to JupyterHub
 Jupyterhub is a web application that allows users to analyze and create reports on warehouse data (or a number of data sources).
 
-Analyses on JupyterHub are done using notebooks, which allow users to mix narrative with analysis code.
+Analyses on JupyterHub are accomplished using notebooks, which allow users to mix narrative with analysis code.
 
 **You can access JuypterHub [using this link](https://hubtest.k8s.calitp.jarv.us/)**.
 
@@ -19,7 +19,7 @@ Analyses on JupyterHub are done using notebooks, which allow users to mix narrat
 1. [Jupyter Notebook Best Practices](notebook-shortcuts)
 
 ## Using JupyterHub
-For Python users, we have deployed a cloud-based instance of JupyterHub to creating, using, and sharing notebooks easy.
+For Python users, we have deployed a cloud-based instance of JupyterHub to make creating, using, and sharing notebooks easy.
 
 This avoids the need to set up a local environment, provides dedicated storage, and allows you to push to GitHub.
 
@@ -32,8 +32,8 @@ Note: you will need to have been added to the Cal-ITP organization on GitHub to 
 (connecting-to-warehouse)=
 ### Connecting to the Warehouse
 
-Connecting to the warehouse requires a bit of setup after logging in to JupyterHub.
-Users need to download and install the gcloud commandline tool from the app.
+Connecting to the warehouse requires a bit of setup after logging in to JupyterHub, but allows users to query data in the warehouse directly.
+To do this, you will need to download and install the gcloud commandline tool from the app.
 
 See the screencast below for a full walkthrough.
 
@@ -55,7 +55,7 @@ gcloud auth application-default login
 
 ### Increasing the Query Limit
 
-By default, there is a query limit set within the Jupyter Notebook. Most queries should be within that limit, and running into `DatabaseError: 500 Query exceeded limit for bytes billed` should be a red flag to investigate whether such a large query is needed for the analysis. To increase the query limit:
+By default, there is a query limit set within the Jupyter Notebook. Most queries should be within that limit, and running into `DatabaseError: 500 Query exceeded limit for bytes billed` should be a red flag to investigate whether such a large query is needed for the analysis. To increase the query limit, add and execute the following in your notebook:
 
 ```python
 from calitp.tables import tbl
@@ -71,7 +71,7 @@ tbl._init()
 
 JupyterHub makes it easy to query SQL in the notebooks.
 
-To query SQL, simply import the library below at the top of your notebook:
+To query SQL, simply import the below at the top of your notebook:
 
 ```python
 import calitp.magics
@@ -99,7 +99,10 @@ LIMIT 10
 ```
 (saving-code-jupyter)=
 ### Saving Code to Github
-Use [this link](committing-from-jupyterhub) to navigate to the `Saving Code` section of the docs to learn how to commit code to GitHub from the Jupyter terminal.
+Use [this link](committing-from-jupyterhub) to navigate to the `Saving Code` section of the docs to learn how to commit code to GitHub from the Jupyter terminal. You will need to complete the following sections to begin:
+    * [Adding a GitHub SSH Key to Jupyter](adding-ssh-to-jupyter)
+    * [Persisting your SSH Key and Enabling Extensions](persisting-ssh-and-extensions)
+    * [Cloning a Repository](cloning-a-repository)
 
 ### Environment Variables
 

--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -99,7 +99,7 @@ LIMIT 10
 ```
 (saving-code-jupyter)=
 ### Saving Code to Github
-Use [this link](committing-from-jupyterhub) to navigate to the `Saving Code` section of the docs to learn how to commit code to GitHub from the Jupyter terminal. You will need to complete the following sections to begin:
+Use [this link](committing-from-jupyterhub) to navigate to the `Saving Code` section of the docs to learn how to commit code to GitHub from the Jupyter terminal. Once there, you will need to complete the instructions in the following sections:
 * [Adding a GitHub SSH Key to Jupyter](adding-ssh-to-jupyter)
 * [Persisting your SSH Key and Enabling Extensions](persisting-ssh-and-extensions)
 * [Cloning a Repository](cloning-a-repository)

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -23,55 +23,59 @@ Doing work locally and pushing directly from the command line is a similar workf
 
 ### Onboarding Setup
 
-We'll work through getting set up with GitHub on JupyterHub and cloning one GitHub repo. Repeat the steps in [Cloning a Repository](cloning-a-repository) for other repos
+We'll work through getting set up with SSH and GitHub on JupyterHub and cloning one GitHub repo. Repeat the steps in [Cloning a Repository](cloning-a-repository) for other repos
 
 (adding-ssh-to-jupyter)=
 #### Adding a GitHub SSH Key to Jupyter
 (github-setup)=
-For more information on what's below, you can naviagte to the GitHub [directions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) and follow the Linux directions for each step.
+For more information on what's below, you can navigate to the [GitHub directions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) and follow the Linux instructions for each step.
 1. Create a GitHub username if necessary and ensure you're added to the appropriate Cal-ITP teams on GitHub. You'll be committing directly into the Cal-ITP repos!
 1. Open a terminal in JupyterHub. All of our commands will be typed in this terminal.
 1. Set up SSH by following these directions:
-    * Run the following command in the terminal, replacing what's inside the quotes with the email address your GitHub account is associated with
+    * Run the following command in the terminal, replacing what's inside the quotes with the email address your GitHub account is associated with:
         * `ssh-keygen -t ed25519 -C "your_email@example.com"`
     * Select `enter` to store it in the default location, and select `enter` twice more to bypass creating a passphrase
-    * Run the following command to "start" ssh key in the background
+    * Run the following command to "start" ssh key in the background, which should return a response similar to `Agent pid 258`
         * `eval "$(ssh-agent -s)"`
-    Which should return a response similar to this: `Agent pid 258`
-    * Add the ssh key to ssh agent with this command
+    * Add the ssh key to the ssh agent with this command
         * `ssh-add ~/.ssh/id_ed25519`
     * From here we will copy the contents of your public ssh file, which we will first do by viewing it's contents. To view:
         * `cat ~/.ssh/id_ed25519.pub`
-    Now select and copy the entire contents of the file that display, which should begin with `ssh-ed25519` and end with your GitHub email address (beware of copyting white spaces which may cause an issue)
+    * Now select and copy the entire contents of the file that display, which should begin with `ssh-ed25519` and end with your GitHub email address (beware of copying white spaces, which may cause errors in the following steps)
 
 
     * Once copied, navigate to GitHub
-    * In the top right corner, select settings and find `SSH and GPC Keys` in the left sidebar
+    * In the top right corner, select `settings` and find `SSH and GPC Keys` in the left sidebar
     * Select `Add New SSH Key`
         * For the title add something like ‘JupyterHub’
         * Paste the key that you copied into key field
-    * Click add ssh key and if necessary enter password
+    * Click `Add SSH Key`, and, if necessary, enter password
 
 
-    * After you've added your SSH key to your GitHub account, open a new Jupyter terminal window and you'll be able to test your connection with: `ssh -T git@github.com`
+    * After you've added your SSH key to your GitHub account, open a new Jupyter terminal window and you'll be able to test your connection with:
+        * `ssh -T git@github.com`
 
-After completing the steps above, be sure to complete the section below to persist your SSH key between sessions and enable extensions.
+After completing the steps above be sure to complete the section below to persist your SSH key between sessions and enable extensions.
 
 (persisting-ssh-and-extensions)=
 #### Persisting your SSH Key and Enabling Extensions
-To ensure that your SSH key settings persist between your sessions, run the following commands in the Jupyter terminal.
+To ensure that your SSH key settings persist between your sessions, run the following command in the Jupyter terminal.
 * `echo "source .profile" >> .bashrc`
-Restart your Jupyter server by selecting:
+
+
+Now, restart your Jupyter server by selecting:
 * `File` -> `Hub Control Panel` -> `Stop Server` + `Start Server`
-Now, when you open a new Jupyter terminal you should see the notification:
+
+
+From here, wwhen you open a new Jupyter terminal you should see the notification:
 * `ssh-add: Identities added: /home/jovyan/.ssh/id_ed25519`
 
 
 If the above doesn't work, try:
 * Closing your terminal and opening a new one
 * Following the instructions to restart your Jupyter server above
-* Substituting the following for the command above
-`echo "source .profile" >> .bash_profile`
+* Substituting the following for the command above:
+    * `echo "source .profile" >> .bash_profile`
 
 After completing this section, you will also enjoy various extensions in Jupyter, such as `black` hotkey auto-formatting with `ctrl+shft+k`, and the ability to see your current git branch in the Jupyter terminal.
 

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -34,19 +34,22 @@ For more information on what's below, you can navigate to the [GitHub directions
 1. Set up SSH by following these directions:
     * Run the following command in the terminal, replacing what's inside the quotes with the email address your GitHub account is associated with:
         * `ssh-keygen -t ed25519 -C "your_email@example.com"`
-    * Select `enter` to store it in the default location, and select `enter` twice more to bypass creating a passphrase
+    * After that, select `enter` to store it in the default location, and select `enter` twice more to bypass creating a passphrase
     * Run the following command to "start" ssh key in the background, which should return a response similar to `Agent pid 258`
         * `eval "$(ssh-agent -s)"`
     * Add the ssh key to the ssh agent with this command
         * `ssh-add ~/.ssh/id_ed25519`
-    * From here we will copy the contents of your public ssh file, which we will first do by viewing it's contents. To view:
-        * `cat ~/.ssh/id_ed25519.pub`
-    * Now select and copy the entire contents of the file that display, which should begin with `ssh-ed25519` and end with your GitHub email address (beware of copying white spaces, which may cause errors in the following steps)
+    * From here we will copy the contents of your public ssh file, which we will first do by viewing it's contents.
+        * To view:
+            * `cat ~/.ssh/id_ed25519.pub`
+        * Then, select and copy the entire contents of the file that display
+            * The text should begin with `ssh-ed25519` and end with your GitHub email address
+            * Beware of copying white spaces, which may cause errors in the following steps
 
 
     * Once copied, navigate to GitHub
-    * In the top right corner, select `settings` and find `SSH and GPC Keys` in the left sidebar
-    * Select `Add New SSH Key`
+    * In the top right corner, select `Settings` and then select `SSH and GPC Keys` in the left sidebar
+    * Select `New SSH Key`
         * For the title add something like ‘JupyterHub’
         * Paste the key that you copied into key field
     * Click `Add SSH Key`, and, if necessary, enter password
@@ -64,17 +67,17 @@ To ensure that your SSH key settings persist between your sessions, run the foll
 
 
 Now, restart your Jupyter server by selecting:
-* `File` -> `Hub Control Panel` -> `Stop Server` + `Start Server`
+* `File` -> `Hub Control Panel` -> `Stop Server`, then `Start Server`
 
 
-From here, wwhen you open a new Jupyter terminal you should see the notification:
+From here, after opening a new Jupyter terminal you should see the notification:
 * `ssh-add: Identities added: /home/jovyan/.ssh/id_ed25519`
 
 
 If the above doesn't work, try:
 * Closing your terminal and opening a new one
 * Following the instructions to restart your Jupyter server above
-* Substituting the following for the command above:
+* Substituting the following for the `echo` command above and re-attempting:
     * `echo "source .profile" >> .bash_profile`
 
 After completing this section, you will also enjoy various extensions in Jupyter, such as `black` hotkey auto-formatting with `ctrl+shft+k`, and the ability to see your current git branch in the Jupyter terminal.

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -33,23 +33,25 @@ For more information on what's below, you can naviagte to the GitHub [directions
 1. Open a terminal in JupyterHub. All of our commands will be typed in this terminal.
 1. Set up SSH by following these directions:
     * Run the following command in the terminal, replacing what's inside the quotes with the email address your GitHub account is associated with
-    `ssh-keygen -t ed25519 -C "your_email@example.com"`
+        * `ssh-keygen -t ed25519 -C "your_email@example.com"`
     * Select `enter` to store it in the default location, and select `enter` twice more to bypass creating a passphrase
     * Run the following command to "start" ssh key in the background
-    `eval "$(ssh-agent -s)"`
+        * `eval "$(ssh-agent -s)"`
     Which should return a response similar to this: `Agent pid 258`
     * Add the ssh key to ssh agent with this command
-    `ssh-add ~/.ssh/id_ed25519`
+        * `ssh-add ~/.ssh/id_ed25519`
     * From here we will copy the contents of your public ssh file, which we will first do by viewing it's contents. To view:
-    `cat ~/.ssh/id_ed25519.pub`
+        * `cat ~/.ssh/id_ed25519.pub`
     Now select and copy the entire contents of the file that display, which should begin with `ssh-ed25519` and end with your GitHub email address (beware of copyting white spaces which may cause an issue)
+
 
     * Once copied, navigate to GitHub
     * In the top right corner, select settings and find `SSH and GPC Keys` in the left sidebar
     * Select `Add New SSH Key`
-        * For the title add something like ‘jupyter lab’
+        * For the title add something like ‘JupyterHub’
         * Paste the key that you copied into key field
     * Click add ssh key and if necessary enter password
+
 
     * After you've added your SSH key to your GitHub account, open a new Jupyter terminal window and you'll be able to test your connection with: `ssh -T git@github.com`
 
@@ -58,11 +60,12 @@ After completing the steps above, be sure to complete the section below to persi
 (persisting-ssh-and-extensions)=
 #### Persisting your SSH Key and Enabling Extensions
 To ensure that your SSH key settings persist between your sessions, run the following commands in the Jupyter terminal.
-`echo "source .profile" >> .bashrc`
+* `echo "source .profile" >> .bashrc`
 Restart your Jupyter server by selecting:
-`File` -> `Hub Control Panel` -> `Stop Server` + `Start Server`
+* `File` -> `Hub Control Panel` -> `Stop Server` + `Start Server`
 Now, when you open a new Jupyter terminal you should see the notification:
-`ssh-add: Identities added: /home/jovyan/.ssh/id_ed25519`
+* `ssh-add: Identities added: /home/jovyan/.ssh/id_ed25519`
+
 
 If the above doesn't work, try:
 * Closing your terminal and opening a new one

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -1,13 +1,16 @@
 (saving-code)=
 # Saving Code
 
-Most Cal-ITP analysts should opt for working directly from JupyterHub. Leveraging this cloud-based, standardized environment should alleviate many of the pain points associated with creating reproducible, collaborative work.
+Most Cal-ITP analysts should opt for working and committing code directly from JupyterHub. Leveraging this cloud-based, standardized environment should alleviate many of the pain points associated with creating reproducible, collaborative work.
 
 Doing work locally and pushing directly from the command line is a similar workflow, but replace the JupyterHub terminal with your local terminal.
 
 ## Table of Contents
 1. [Committing from JupyterHub](#pushing-from-jupyterhub)
     * [Onboarding Setup](#onboarding-setup)
+        * [Adding a GitHub SSH Key to Jupyter](adding-ssh-to-jupyter)
+        * [Persisting your SSH Key and Enabling Extensions](persisting-ssh-and-extensions)
+        * [Cloning a Repository](cloning-a-repository)
     * What's a typical [project workflow](#project-workflow)?
     * Someone is collaborating on my branch, how do we [stay in sync](#pulling-and-pushing-changes)?
     * The `main` branch is ahead, and I want to [sync my branch with `main`](rebase-and-merge)
@@ -20,14 +23,57 @@ Doing work locally and pushing directly from the command line is a similar workf
 
 ### Onboarding Setup
 
-We'll work through getting set up with GitHub on JupyterHub and cloning one GitHub repo. Repeat steps 6-10 for other repos.
+We'll work through getting set up with GitHub on JupyterHub and cloning one GitHub repo. Repeat the steps in [Cloning a Repository](cloning-a-repository) for other repos
+
+(adding-ssh-to-jupyter)=
+#### Adding a GitHub SSH Key to Jupyter
 (github-setup)=
-1. Create a GitHub username, get added to the various Cal-ITP teams. You'll be committing directly into the Cal-ITP repos!
-1. Open a terminal in JupyterHub. All our commands will be typed in this terminal.
-1. Set up SSH by following these [directions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
-    * Follow the Linux directions for each step
-    * The key may be created with permissions too open for the ssh client. Run `chmod 600 /home/jovyan/.ssh/id_ed25519` (default key file location, change if necessary) to avoid future issues
-1. After you've added your SSH key to your GitHub account, you can test your connection: `ssh -T git@github.com`
+For more information on what's below, you can naviagte to the GitHub [directions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) and follow the Linux directions for each step.
+1. Create a GitHub username if necessary and ensure you're added to the appropriate Cal-ITP teams on GitHub. You'll be committing directly into the Cal-ITP repos!
+1. Open a terminal in JupyterHub. All of our commands will be typed in this terminal.
+1. Set up SSH by following these directions:
+    * Run the following command in the terminal, replacing what's inside the quotes with the email address your GitHub account is associated with
+    `ssh-keygen -t ed25519 -C "your_email@example.com"`
+    * Select `enter` to store it in the default location, and select `enter` twice more to bypass creating a passphrase
+    * Run the following command to "start" ssh key in the background
+    `eval "$(ssh-agent -s)"`
+    Which should return a response similar to this: `Agent pid 258`
+    * Add the ssh key to ssh agent with this command
+    `ssh-add ~/.ssh/id_ed25519`
+    * From here we will copy the contents of your public ssh file, which we will first do by viewing it's contents. To view:
+    `cat ~/.ssh/id_ed25519.pub`
+    Now select and copy the entire contents of the file that display, which should begin with `ssh-ed25519` and end with your GitHub email address (beware of copyting white spaces which may cause an issue)
+
+    * Once copied, navigate to GitHub
+    * In the top right corner, select settings and find `SSH and GPC Keys` in the left sidebar
+    * Select `Add New SSH Key`
+        * For the title add something like ‘jupyter lab’
+        * Paste the key that you copied into key field
+    * Click add ssh key and if necessary enter password
+
+    * After you've added your SSH key to your GitHub account, open a new Jupyter terminal window and you'll be able to test your connection with: `ssh -T git@github.com`
+
+After completing the steps above, be sure to complete the section below to persist your SSH key between sessions and enable extensions.
+
+(persisting-ssh-and-extensions)=
+#### Persisting your SSH Key and Enabling Extensions
+To ensure that your SSH key settings persist between your sessions, run the following commands in the Jupyter terminal.
+`echo "source .profile" >> .bashrc`
+Restart your Jupyter server by selecting:
+`File` -> `Hub Control Panel` -> `Stop Server` + `Start Server`
+Now, when you open a new Jupyter terminal you should see the notification:
+`ssh-add: Identities added: /home/jovyan/.ssh/id_ed25519`
+
+If the above doesn't work, try:
+* Closing your terminal and opening a new one
+* Following the instructions to restart your Jupyter server above
+* Substituting the following for the command above
+`echo "source .profile" >> .bash_profile`
+
+After completing this section, you will also enjoy various extensions in Jupyter, such as `black` hotkey auto-formatting with `ctrl+shft+k`, and the ability to see your current git branch in the Jupyter terminal.
+
+(cloning-a-repository)=
+#### Cloning a Repository
 1. Navigate to the GitHub repository to clone. We'll work our way through the `data-analyses` [repo here](https://github.com/cal-itp/data-analyses). Click on the green `Code` button, select "SSH" and copy the URL.
 1. Clone the Git repo: `git clone git@github.com:cal-itp/data-analyses.git`
 1. Double check  with `ls` to list and see that the remote repo was successfully cloned into your "local" (cloud-based) filesystem.


### PR DESCRIPTION
# Overall Description
Added new information on how to persist SSH keys, clarified information on generating adding SSH key and adding to GitHub, restructured the 'Saving Code' page, linked to 'Saving Code' page from 'Notebooks' page and added additional detail

  

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes

## Docs changes checklist

- [x] Make sure the preview website was able to be generated
- [x] Fill out the following section describing what docs were added/updated

## Files effected
`Analytics Tools/ Notebooks`
* Added new description with link to `Saving Code` page

`Analytics Tools/ Saving Code`
* Added information on perisisting SSH keys and enabling extensions
* Clarified process for generating SSH key and adding to GitHub
* Revised page structure to make more sense, created internal references, added new sections to top page TOC