### PR TITLE
use newer version of schedule validator api

### DIFF
--- a/airflow/dags/gtfs_downloader/validate_gcs_bucket.yml
+++ b/airflow/dags/gtfs_downloader/validate_gcs_bucket.yml
@@ -1,6 +1,6 @@
 operator: 'operators.PodOperator'
 name: 'pod-ex-minimum2'
-image: 'ghcr.io/cal-itp/gtfs-validator-api:v0.0.5'
+image: 'ghcr.io/cal-itp/gtfs-validator-api:v0.0.7'
 cmds: ["sh", "-c"]
 arguments:
   - >-


### PR DESCRIPTION
deploys https://github.com/cal-itp/gtfs-validator-api/pull/3 and _actually_ closes https://github.com/cal-itp/data-infra/issues/1078 (oops)