### PR TITLE
fix bad type usage

### DIFF
--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -82,7 +82,7 @@ def run(
 
             # avoid copying run_results is unnecessary for the docs site
             # so just skip to avoid any potential information leakage
-            if "run_results" not in artifact:
+            if "run_results" not in str(artifact):
                 shutil.copy(_from, "docs/")
 
         if deploy_docs:


### PR DESCRIPTION
Pathlib is super useful, but unfortunately path objects don't implement `__iter__` so we can't do checks like `if some_str in path`. I failed to test this properly prior to deploying https://github.com/cal-itp/data-infra/pull/1383.