### PR TITLE
Point promtail instances to loki server

### DIFF
--- a/ci/vars/releases/prod-promtail.env
+++ b/ci/vars/releases/prod-promtail.env
@@ -2,4 +2,4 @@ RELEASE_DRIVER=helm
 RELEASE_NAMESPACE=monitoring-loki
 RELEASE_HELM_NAME=promtail
 RELEASE_HELM_CHART=kubernetes/apps/charts/promtail
-RELEASE_HELM_VALUES=
+RELEASE_HELM_VALUES=kubernetes/apps/values/promtail.yaml

--- a/kubernetes/apps/values/promtail.yaml
+++ b/kubernetes/apps/values/promtail.yaml
@@ -1,0 +1,2 @@
+config:
+  lokiAddress: http://loki.monitoring-loki.svc.cluster.local


### PR DESCRIPTION
The default loki server value for promtail instances does not work in the context of the data-infra-apps cluster