### PR TITLE
Fix cleanup-release-candidates workflow failures

### DIFF
--- a/.github/workflows/cleanup-release-candidates.yml
+++ b/.github/workflows/cleanup-release-candidates.yml
@@ -22,6 +22,7 @@ jobs:
     - name: 'Delete orphaned release candidates'
       run: |
         while read candidate_sha1 candidate_ref; do
+          test "$candidate_ref" || continue
           source_branch=${candidate_ref#refs/heads/candidates/}
           source_ref=refs/heads/$source_branch
           if ! [[ $(git ls-remote "$REPO_URL" "$source_ref") ]]; then


### PR DESCRIPTION
This workflow would previously fail when there were no candidate branches returned from the `git ls-remote` command due to an attempt to iterate once with empty values.