### PR TITLE
Fix port number in lokiAddress

### DIFF
--- a/kubernetes/apps/values/promtail.yaml
+++ b/kubernetes/apps/values/promtail.yaml
@@ -1,2 +1,2 @@
 config:
-  lokiAddress: http://loki.monitoring-loki.svc.cluster.local
+  lokiAddress: http://loki.monitoring-loki.svc.cluster.local:3100


### PR DESCRIPTION
no assumptions are made regarding loki's default port number; it must be explicitly specified