### PR TITLE
Fix monitoring tolerations

### DIFF
--- a/kubernetes/apps/values/promtail.yaml
+++ b/kubernetes/apps/values/promtail.yaml
@@ -1,2 +1,8 @@
 config:
   lokiAddress: http://loki.monitoring-loki.svc.cluster.local:3100/loki/api/v1/push
+
+tolerations:
+
+  # run on all nodes by default
+  - operator: Exists
+    effect: NoSchedule


### PR DESCRIPTION
The prometheus node-exporter instances already run with a wildcard toleration which allows them to run across all node pools. This adds a similar wildcard toleration to promtail instances to do the same for log collection.