### PR TITLE
fix(jupyter): removed service key gcloud-auth for jupyter users in values.yml

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -17,18 +17,6 @@ jupyterhub:
     cpu:
       limit: 1
       guarantee: 0.5
-    storage:
-      extraVolumes:
-      - name: gcloud-auth
-        projected:
-          sources:
-            - secret:
-                name: jupyterhub-gcloud-service-key
-      extraVolumeMounts:
-        - name: gcloud-auth
-          mountPath: /usr/local/secrets
-    extraEnv:
-      CALITP_SERVICE_KEY_PATH: /usr/local/secrets/service-key.json
     lifecycleHooks:
       postStart:
         exec:


### PR DESCRIPTION
# Overall Description
`kubernetes/apps/charts/jupyterhub/values.yaml`
* removed service key gcloud-auth for jupyter users to in `values.yml` disassociate jupyter from the warehouse and facilitate use by a larger group of caltrans users

closes #1376 

## Checklist for all PRs

- [x] Run `pre-commit run --all-files` to make sure markdown/lint passes
- [x] Link this pull request to all issues that it will close using keywords (see GitHub docs about [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)). Also mention any issues that are partially addressed or are related.