### PR TITLE
fix args for pod operators

### DIFF
--- a/airflow/dags/parse_rt/parse_rt_service_alerts.yml
+++ b/airflow/dags/parse_rt/parse_rt_service_alerts.yml
@@ -8,7 +8,6 @@ cmds:
 arguments:
   - "gtfs_rt_parser.py"
   - "service_alerts"
-  - "--glob"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{get_bucket()}}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
   - "--dst-bucket"

--- a/airflow/dags/parse_rt/parse_rt_trip_updates.yml
+++ b/airflow/dags/parse_rt/parse_rt_trip_updates.yml
@@ -8,7 +8,6 @@ cmds:
 arguments:
   - "gtfs_rt_parser.py"
   - "trip_updates"
-  - "--glob"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{get_bucket()}}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
   - "--dst-bucket"

--- a/airflow/dags/parse_rt/parse_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_rt/parse_rt_vehicle_positions.yml
@@ -8,7 +8,6 @@ cmds:
 arguments:
   - "gtfs_rt_parser.py"
   - "vehicle_positions"
-  - "--glob"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{get_bucket()}}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
   - "--dst-bucket"


### PR DESCRIPTION
Real quick fix. I had removed the default `glob` value, so we don't use the option flag anymore.