### PR TITLE
only request 0.5 cpu so we can fit more jobs on a node

### DIFF
--- a/airflow/dags/parse_rt/parse_rt_service_alerts.yml
+++ b/airflow/dags/parse_rt/parse_rt_service_alerts.yml
@@ -32,7 +32,7 @@ secrets:
 
 resources:
   request_memory: 2.0Gi
-  request_cpu: 1
+  request_cpu: 0.5
 
 tolerations:
   - key: pod-role

--- a/airflow/dags/parse_rt/parse_rt_trip_updates.yml
+++ b/airflow/dags/parse_rt/parse_rt_trip_updates.yml
@@ -32,7 +32,7 @@ secrets:
 
 resources:
   request_memory: 2.0Gi
-  request_cpu: 1
+  request_cpu: 0.5
 
 tolerations:
   - key: pod-role

--- a/airflow/dags/parse_rt/parse_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_rt/parse_rt_vehicle_positions.yml
@@ -32,7 +32,7 @@ secrets:
 
 resources:
   request_memory: 2.0Gi
-  request_cpu: 1
+  request_cpu: 0.5
 
 tolerations:
   - key: pod-role


### PR DESCRIPTION
After watching the new RT jobs run in production, I want to reduce the CPU request from 1 to 0.5 as they don't consume very much at all. (Lots of network, not so much CPU.)

![image](https://user-images.githubusercontent.com/4305366/165319085-3040ec5d-0c9d-4fb4-a9f2-17329a40e7ec.png)
