### PR TITLE
fix(gtfs schedule): suppress API keys in tables

### DIFF
--- a/warehouse/models/gtfs_views_staging/calitp_feeds.sql
+++ b/warehouse/models/gtfs_views_staging/calitp_feeds.sql
@@ -5,6 +5,54 @@ WITH calitp_status AS (
     FROM {{ source('gtfs_schedule_history', 'calitp_status') }}
 ),
 
+raw_feed_urls AS (
+    SELECT
+        *,
+        PARSE_DATE(
+            '%Y-%m-%d',
+            REGEXP_EXTRACT(_FILE_NAME, ".*/([0-9]+-[0-9]+-[0-9]+)")
+        ) AS calitp_extracted_at
+    FROM {{ source('gtfs_schedule_history', 'calitp_feeds_raw') }}
+),
+
+semi_safe_urls AS (
+    -- there are uncensored URLs with API keys
+    -- in the early days of calitp_feeds_raw and before its implementation
+    SELECT
+        T1.itp_id,
+        T1.url_number,
+        T1.calitp_extracted_at,
+        COALESCE(T2.gtfs_schedule_url, T1.gtfs_schedule_url) AS almost_safe_url
+    FROM calitp_status AS T1
+    LEFT JOIN raw_feed_urls AS T2 USING (itp_id, url_number, calitp_extracted_at)
+    ORDER BY calitp_extracted_at
+),
+
+
+safe_urls AS (
+    SELECT
+        itp_id,
+        url_number,
+        calitp_extracted_at,
+        (CASE
+            WHEN (almost_safe_url LIKE r"%api.actransit.org/transit/gtfs/download?token=%")
+                AND (almost_safe_url NOT LIKE r"%api.actransit.org/transit/gtfs/download?token={\%")
+                THEN REGEXP_REPLACE(
+                    almost_safe_url,
+                    "token=[a-zA-Z0-9-]+", {% raw %}"token={{ AC_TRANSIT_API_KEY }}"{% endraw %}
+                )
+            WHEN (almost_safe_url LIKE r"%api.511.org/transit/%?api_key=%")
+                AND (almost_safe_url NOT LIKE r"%api.511.org/transit/%?api_key={\%")
+                THEN REGEXP_REPLACE(
+                    almost_safe_url,
+                    "api_key=[a-zA-Z0-9-]+", {% raw %}"api_key={{ MTC_511_API_KEY }}"{% endraw %}
+                )
+            ELSE almost_safe_url
+            END) AS gtfs_schedule_url
+    FROM semi_safe_urls
+),
+
+-- TODO: can we use raw URL (no API keys) here in the hash too?
 gtfs_schedule_feed_snapshot AS (
     SELECT
         itp_id,
@@ -80,16 +128,18 @@ feed_snapshot_with_removed AS (
 final_data AS (
     SELECT
         TO_BASE64(MD5(
-                CONCAT(calitp_hash, "__", CAST(calitp_extracted_at AS STRING))
+                CONCAT(calitp_hash, "__", CAST(T1.calitp_extracted_at AS STRING))
         ))
         AS feed_key,
-        itp_id AS calitp_itp_id,
-        url_number AS calitp_url_number,
-        agency_name AS calitp_agency_name,
-        gtfs_schedule_url AS calitp_gtfs_schedule_url,
-        calitp_extracted_at,
-        COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
-    FROM feed_snapshot_with_removed
+        T1.itp_id AS calitp_itp_id,
+        T1.url_number AS calitp_url_number,
+        T1.agency_name AS calitp_agency_name,
+        -- the version of URL without API key
+        T2.gtfs_schedule_url AS raw_gtfs_schedule_url,
+        T1.calitp_extracted_at,
+        COALESCE(T1.calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
+    FROM feed_snapshot_with_removed AS T1
+    LEFT JOIN safe_urls AS T2 USING (itp_id, url_number, calitp_extracted_at)
     WHERE NOT is_removed
 ),
 


### PR DESCRIPTION
# Description

This PR changes `gtfs_views_staging.calitp_feeds` to use "safe" URLs with API keys suppressed instead of using URLs with API keys written out. 

I'm changing the name of the accompanying column to `raw_gtfs_schedule_url` in keeping with convention. 

After this merges I will post on Slack notifying people about the changes, but I think it's desirable even if it inconveniences some people. 

Also after this merges I will run the following query to overwrite the defunct `views.gtfs_status_latest` table to suppress its API key values too. 

<details>
<summary>query</summary>

```
WITH old_table AS (
  SELECT *
  FROM `cal-itp-data-infra.views.gtfs_status_latest`
),

raw_feed_urls AS (
    SELECT
        *,
        PARSE_DATE(
            '%Y-%m-%d',
            REGEXP_EXTRACT(_FILE_NAME, ".*/([0-9]+-[0-9]+-[0-9]+)")
        ) AS calitp_extracted_at
    FROM `cal-itp-data-infra.gtfs_schedule_history.calitp_feeds_raw`
),

semi_safe_urls AS (
    -- there are uncensored URLs with API keys
    -- in the early days of calitp_feeds_raw and before its implementation
    SELECT
        T1.itp_id,
        T1.url_number,
        T1.calitp_extracted_at,
        COALESCE(T2.gtfs_schedule_url, T1.gtfs_schedule_url) AS almost_safe_url
    FROM old_table AS T1
    LEFT JOIN raw_feed_urls AS T2 USING (itp_id, url_number, calitp_extracted_at)
    ORDER BY calitp_extracted_at
),


safe_urls AS (
    SELECT
        itp_id,
        url_number,
        calitp_extracted_at,
        (CASE
            WHEN (almost_safe_url LIKE r"%api.actransit.org/transit/gtfs/download?token=%")
                AND (almost_safe_url NOT LIKE r"%api.actransit.org/transit/gtfs/download?token={\%")
                THEN REGEXP_REPLACE(
                    almost_safe_url,
                    "token=[a-zA-Z0-9-]+", {% raw %}"token={{ AC_TRANSIT_API_KEY }}"{% endraw %}
                )
            WHEN (almost_safe_url LIKE r"%api.511.org/transit/%?api_key=%")
                AND (almost_safe_url NOT LIKE r"%api.511.org/transit/%?api_key={\%")
                THEN REGEXP_REPLACE(
                    almost_safe_url,
                    "api_key=[a-zA-Z0-9-]+", {% raw %}"api_key={{ MTC_511_API_KEY }}"{% endraw %}
                )
            ELSE almost_safe_url
            END) AS gtfs_schedule_url
    FROM semi_safe_urls
),

SELECT 
  T1.* EXCEPT gtfs_schedule_url,
  T2.gtfs_schedule_url AS raw_gtfs_schedule_url
FROM old_table AS T1
LEFT JOIN safe_urls AS T2
  USING (itp_id, url_number, calitp_extracted_at)
```
</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- because of column name change, but AFAIK no one is using that field directly -- I will announce on Slack and any changes should be straightforward
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran `dbt run` for this table and its children. Verified it runs successfully and that no null URLs result. I also just went through and checked the results of this query and confirmed that the only discrepancies are URLs that contain API keys:

```
SELECT T1.feed_key,
  T2.feed_key, 
  T1.calitp_itp_id,
  T2.calitp_itp_id,
  T1.calitp_url_number,
  T2.calitp_url_number,
  T1.calitp_gtfs_schedule_url,
  T2.raw_gtfs_schedule_url
FROM `cal-itp-data-infra.views.gtfs_schedule_dim_feeds` AS T1
FULL OUTER JOIN `cal-itp-data-infra-staging.laurie_views.gtfs_schedule_dim_feeds` AS T2
USING(feed_key)
WHERE T1.calitp_gtfs_schedule_url != T2.raw_gtfs_schedule_url
ORDER BY T1.calitp_extracted_at
```
