### PR TITLE
feat(jupyter):add notebooks.calitp.org to ingress

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -63,7 +63,7 @@ jupyterhub:
     tls:
       - secretName: jupyterhub-tls
         hosts:
-          - notebooks.calipt.org
+          - notebooks.calitp.org
           - hubtest.k8s.calitp.jarv.us
   proxy:
     service:

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -58,10 +58,12 @@ jupyterhub:
       cert-manager.io/cluster-issuer: letsencrypt-prod
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
     hosts:
+      - notebooks.calitp.org
       - hubtest.k8s.calitp.jarv.us
     tls:
       - secretName: jupyterhub-tls
         hosts:
+          - notebooks.calipt.org
           - hubtest.k8s.calitp.jarv.us
   proxy:
     service:


### PR DESCRIPTION
# Description

Add notebooks.calitp.org ingress to the jupyterhub cluster.

Resolves #[675](https://github.com/cal-itp/data-infra/issues/675)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Recommendations are very welcome

## Screenshots (optional)
