### PR TITLE
vendor jar in github and copy in dockerfile

### DIFF
--- a/jobs/gtfs-rt-parser/Dockerfile
+++ b/jobs/gtfs-rt-parser/Dockerfile
@@ -11,9 +11,8 @@ RUN apt-get update -y \
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
 ENV PATH="${PATH}:/root/.poetry/bin"
 
-RUN wget \
-    https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/gtfs-realtime-validator-lib/1.0.0-SNAPSHOT/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar \
-    -O ${GTFS_RT_VALIDATOR_JAR}
+# formerly the "1.0.0-SNAPSHOT" from S3
+COPY ./rt-validator.jar ${GTFS_RT_VALIDATOR_JAR}
 
 WORKDIR /app
 

--- a/jobs/gtfs-rt-parser/README.md
+++ b/jobs/gtfs-rt-parser/README.md
@@ -17,3 +17,9 @@ combine them.
 This image can be built and tested via local Airflow.
 
 In addition, there is at least one Python test that can be executed via `poetry run pytest`.
+
+## The GTFS-RT validator
+The [validator jar](./rt-validator.jar) is an old snapshot of the GTFS Realtime validator that now lives under
+[MobilityData](https://github.com/MobilityData/gtfs-realtime-validator). We've temporarily vendored an old version
+(specifically "1.0.0-SNAPSHOT") to help make our builds less dependent on external services. We should begin
+using the officially-published [packages](https://github.com/orgs/MobilityData/packages?repo_name=gtfs-realtime-validator) at some point in the future.


### PR DESCRIPTION
The old S3 file location of the RT validator jar is returning 403s, so I'm just vendoring a copy and using it in the Dockerfile.