### PR TITLE
Airtable operator refactor

### DIFF
--- a/airflow/dags/airtable_loader/california_transit_county_geography.yml
+++ b/airflow/dags/airtable_loader/california_transit_county_geography.yml
@@ -3,7 +3,7 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "county geography"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 
 airtable_options:
   id_name: county_geography_id

--- a/airflow/dags/airtable_loader/california_transit_county_geography.yml
+++ b/airflow/dags/airtable_loader/california_transit_county_geography.yml
@@ -5,4 +5,5 @@ air_table_name: "county geography"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
 
-id_name: county_geography_id
+airtable_options:
+  id_name: county_geography_id

--- a/airflow/dags/airtable_loader/california_transit_county_geography.yml
+++ b/airflow/dags/airtable_loader/california_transit_county_geography.yml
@@ -2,7 +2,7 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "county geography"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_county_geography
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 
 id_name: county_geography_id

--- a/airflow/dags/airtable_loader/california_transit_eligibility_programs.yml
+++ b/airflow/dags/airtable_loader/california_transit_eligibility_programs.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "eligibility programs"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_eligibility_programs
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: eligibility_program_id

--- a/airflow/dags/airtable_loader/california_transit_eligibility_programs.yml
+++ b/airflow/dags/airtable_loader/california_transit_eligibility_programs.yml
@@ -3,7 +3,7 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "eligibility programs"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 
 airtable_options:
   id_name: eligibility_program_id

--- a/airflow/dags/airtable_loader/california_transit_eligibility_programs.yml
+++ b/airflow/dags/airtable_loader/california_transit_eligibility_programs.yml
@@ -4,4 +4,6 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "eligibility programs"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: eligibility_program_id
+
+airtable_options:
+  id_name: eligibility_program_id

--- a/airflow/dags/airtable_loader/california_transit_fare_systems.yml
+++ b/airflow/dags/airtable_loader/california_transit_fare_systems.yml
@@ -3,6 +3,6 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "fare systems"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: fare_system_id

--- a/airflow/dags/airtable_loader/california_transit_fare_systems.yml
+++ b/airflow/dags/airtable_loader/california_transit_fare_systems.yml
@@ -4,4 +4,5 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "fare systems"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: fare_system_id
+airtable_options:
+  id_name: fare_system_id

--- a/airflow/dags/airtable_loader/california_transit_fare_systems.yml
+++ b/airflow/dags/airtable_loader/california_transit_fare_systems.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "fare systems"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_fare_systems
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: fare_system_id

--- a/airflow/dags/airtable_loader/california_transit_funding_programs.yml
+++ b/airflow/dags/airtable_loader/california_transit_funding_programs.yml
@@ -4,4 +4,5 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "funding programs"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: funding_program_id
+airtable_options:
+  id_name: funding_program_id

--- a/airflow/dags/airtable_loader/california_transit_funding_programs.yml
+++ b/airflow/dags/airtable_loader/california_transit_funding_programs.yml
@@ -3,6 +3,6 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "funding programs"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: funding_program_id

--- a/airflow/dags/airtable_loader/california_transit_funding_programs.yml
+++ b/airflow/dags/airtable_loader/california_transit_funding_programs.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "funding programs"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_funding_programs
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: funding_program_id

--- a/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
+++ b/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs datasets"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_gtfs_datasets
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: gtfs_dataset_id

--- a/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
+++ b/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
@@ -4,4 +4,5 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs datasets"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: gtfs_dataset_id
+airtable_options:
+  id_name: gtfs_dataset_id

--- a/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
+++ b/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
@@ -3,6 +3,6 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs datasets"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: gtfs_dataset_id

--- a/airflow/dags/airtable_loader/california_transit_gtfs_service_data.yml
+++ b/airflow/dags/airtable_loader/california_transit_gtfs_service_data.yml
@@ -4,4 +4,5 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs service data"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: gtfs_service_data_id
+airtable_options:
+  id_name: gtfs_service_data_id

--- a/airflow/dags/airtable_loader/california_transit_gtfs_service_data.yml
+++ b/airflow/dags/airtable_loader/california_transit_gtfs_service_data.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs service data"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_gtfs_service_data
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: gtfs_service_data_id

--- a/airflow/dags/airtable_loader/california_transit_gtfs_service_data.yml
+++ b/airflow/dags/airtable_loader/california_transit_gtfs_service_data.yml
@@ -3,6 +3,6 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs service data"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: gtfs_service_data_id

--- a/airflow/dags/airtable_loader/california_transit_ntd_agency_info.yml
+++ b/airflow/dags/airtable_loader/california_transit_ntd_agency_info.yml
@@ -3,6 +3,6 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "NTD Agency Info"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: ntd_agency_info_id

--- a/airflow/dags/airtable_loader/california_transit_ntd_agency_info.yml
+++ b/airflow/dags/airtable_loader/california_transit_ntd_agency_info.yml
@@ -4,4 +4,5 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "NTD Agency Info"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: ntd_agency_info_id
+airtable_options:
+  id_name: ntd_agency_info_id

--- a/airflow/dags/airtable_loader/california_transit_ntd_agency_info.yml
+++ b/airflow/dags/airtable_loader/california_transit_ntd_agency_info.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "NTD Agency Info"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_ntd_agency_info
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: ntd_agency_info_id

--- a/airflow/dags/airtable_loader/california_transit_organizations.yml
+++ b/airflow/dags/airtable_loader/california_transit_organizations.yml
@@ -1,6 +1,7 @@
 operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
+air_base_name: california_transit
 air_table_name: organizations
 gcs_path: airtable/california-transit/
 table_name: airtable.california_transit_organizations

--- a/airflow/dags/airtable_loader/california_transit_organizations.yml
+++ b/airflow/dags/airtable_loader/california_transit_organizations.yml
@@ -4,7 +4,8 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_base_name: california_transit
 air_table_name: organizations
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: organization_id
+airtable_options:
+  id_name: organization_id
 
 rename_fields:
   "# Fixed-Route Services w/ Static GTFS": num_fixed_route_services_w_static_gtfs

--- a/airflow/dags/airtable_loader/california_transit_organizations.yml
+++ b/airflow/dags/airtable_loader/california_transit_organizations.yml
@@ -6,14 +6,13 @@ air_table_name: organizations
 bucket: "gs://{{ prefix_bucket('airtable') }}"
 airtable_options:
   id_name: organization_id
-
-rename_fields:
-  "# Fixed-Route Services w/ Static GTFS": num_fixed_route_services_w_static_gtfs
-  "# Fixed-Route or Deviated Fixed-Route Services": num_fixed_route_or_deviated_fixed_route_services
-  "# Fixed-Route or Deviated Fixed-Route Service w/ Static GTFS": num_fixed_route_or_deviated_fixed_route_service_w__static_gtfs
-  "# Services with Missing Static Feed For Fixed-Route or Deviated Fixed-Route": num_services_with_missing_static_feed_for_fixed_route_or_deviated_fixed_route
-  "# of Fixed-Route Services": num_fixed_route_services
-  "# Services w/ Complete RT Status": num_services_w_complete_rt_status
-  ">=1 GTFS feed for any service (1=yes)": "at_least_one_gtfs_feed_for_any_service"
-  ">= 1 complete RT set (1=yes)": "at_least_one_complete_rt_set"
-  "Complete static GTFS coverage (1=yes)": "complete_static_gtfs_coverage"
+  rename_fields:
+    "# Fixed-Route Services w/ Static GTFS": num_fixed_route_services_w_static_gtfs
+    "# Fixed-Route or Deviated Fixed-Route Services": num_fixed_route_or_deviated_fixed_route_services
+    "# Fixed-Route or Deviated Fixed-Route Service w/ Static GTFS": num_fixed_route_or_deviated_fixed_route_service_w__static_gtfs
+    "# Services with Missing Static Feed For Fixed-Route or Deviated Fixed-Route": num_services_with_missing_static_feed_for_fixed_route_or_deviated_fixed_route
+    "# of Fixed-Route Services": num_fixed_route_services
+    "# Services w/ Complete RT Status": num_services_w_complete_rt_status
+    ">=1 GTFS feed for any service (1=yes)": "at_least_one_gtfs_feed_for_any_service"
+    ">= 1 complete RT set (1=yes)": "at_least_one_complete_rt_set"
+    "Complete static GTFS coverage (1=yes)": "complete_static_gtfs_coverage"

--- a/airflow/dags/airtable_loader/california_transit_organizations.yml
+++ b/airflow/dags/airtable_loader/california_transit_organizations.yml
@@ -3,9 +3,7 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_base_name: california_transit
 air_table_name: organizations
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_organizations
-
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: organization_id
 
 rename_fields:

--- a/airflow/dags/airtable_loader/california_transit_organizations.yml
+++ b/airflow/dags/airtable_loader/california_transit_organizations.yml
@@ -3,7 +3,7 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_base_name: california_transit
 air_table_name: organizations
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: organization_id
   rename_fields:

--- a/airflow/dags/airtable_loader/california_transit_place_geography.yml
+++ b/airflow/dags/airtable_loader/california_transit_place_geography.yml
@@ -4,4 +4,5 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "place geography"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: place_geography_id
+airtable_options:
+  id_name: place_geography_id

--- a/airflow/dags/airtable_loader/california_transit_place_geography.yml
+++ b/airflow/dags/airtable_loader/california_transit_place_geography.yml
@@ -3,6 +3,6 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "place geography"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: place_geography_id

--- a/airflow/dags/airtable_loader/california_transit_place_geography.yml
+++ b/airflow/dags/airtable_loader/california_transit_place_geography.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "place geography"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_place_geography
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: place_geography_id

--- a/airflow/dags/airtable_loader/california_transit_rider_requirements.yml
+++ b/airflow/dags/airtable_loader/california_transit_rider_requirements.yml
@@ -2,7 +2,6 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "rider requirements"
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_rider_requirements
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: rider_requirement_id

--- a/airflow/dags/airtable_loader/california_transit_rider_requirements.yml
+++ b/airflow/dags/airtable_loader/california_transit_rider_requirements.yml
@@ -3,6 +3,6 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "rider requirements"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: rider_requirement_id

--- a/airflow/dags/airtable_loader/california_transit_rider_requirements.yml
+++ b/airflow/dags/airtable_loader/california_transit_rider_requirements.yml
@@ -4,4 +4,5 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "rider requirements"
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: rider_requirement_id
+airtable_options:
+  id_name: rider_requirement_id

--- a/airflow/dags/airtable_loader/california_transit_services.yml
+++ b/airflow/dags/airtable_loader/california_transit_services.yml
@@ -3,7 +3,7 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: services
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 airtable_options:
   id_name: service_id
   rename_fields:

--- a/airflow/dags/airtable_loader/california_transit_services.yml
+++ b/airflow/dags/airtable_loader/california_transit_services.yml
@@ -2,9 +2,8 @@ operator: operators.AirtableToWarehouseOperator
 
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: services
-gcs_path: airtable/california-transit/
-table_name: airtable.california_transit_services
-
+air_base_name: california_transit
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 id_name: service_id
 
 rename_fields:

--- a/airflow/dags/airtable_loader/california_transit_services.yml
+++ b/airflow/dags/airtable_loader/california_transit_services.yml
@@ -6,11 +6,10 @@ air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
 airtable_options:
   id_name: service_id
-
-rename_fields:
-  "# Static": num_static
-  "# TripUpdates": num_trip_updates
-  "# Alerts": num_service_alerts
-  "# VehiclePositions": num_vehicle_positions
-  "Product: GRaaS": "product_graas"
-  "Product: Payments": "product_payments"
+  rename_fields:
+    "# Static": num_static
+    "# TripUpdates": num_trip_updates
+    "# Alerts": num_service_alerts
+    "# VehiclePositions": num_vehicle_positions
+    "Product: GRaaS": "product_graas"
+    "Product: Payments": "product_payments"

--- a/airflow/dags/airtable_loader/california_transit_services.yml
+++ b/airflow/dags/airtable_loader/california_transit_services.yml
@@ -4,7 +4,8 @@ air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: services
 air_base_name: california_transit
 bucket: "gs://{{ prefix_bucket('airtable') }}"
-id_name: service_id
+airtable_options:
+  id_name: service_id
 
 rename_fields:
   "# Static": num_static

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
@@ -1,6 +1,10 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__county_geography
+  LIMIT 1;
 source_objects:
   - "california_transit__county_geography/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__county_geography"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__county_geography/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__county_geography"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__county_geography/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_county_geography.yml
@@ -2,9 +2,9 @@ operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
 source_objects:
-  - "california_transit__county_geography/*.csv"
+  - "california_transit__county_geography/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__county_geography"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_eligibility_programs.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_eligibility_programs.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_eligibility_programs.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_eligibility_programs.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__eligibility_programs/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__eligibility_programs"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__eligibility_programs/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_eligibility_programs.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_eligibility_programs.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__eligibility_programs
+  LIMIT 1;
 source_objects:
-  - "california_transit__eligibility_programs/*.csv"
+  - "california_transit__eligibility_programs/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__eligibility_programs"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__fare_systems
+  LIMIT 1;
 source_objects:
-  - "california_transit__fare_systems/*.csv"
+  - "california_transit__fare_systems/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__fare_systems"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__fare_systems/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__fare_systems"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__fare_systems/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_funding_programs.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_funding_programs.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__funding_programs/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__funding_programs"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__funding_programs/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_funding_programs.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__funding_programs
+  LIMIT 1;
 source_objects:
-  - "california_transit__funding_programs/*.csv"
+  - "california_transit__funding_programs/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__funding_programs"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_datasets.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_datasets.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__gtfs_datasets
+  LIMIT 1;
 source_objects:
-  - "california_transit__gtfs_datasets/*.csv"
+  - "california_transit__gtfs_datasets/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__gtfs_datasets"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_datasets.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__gtfs_datasets/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__gtfs_datasets"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__gtfs_datasets/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_service_data.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_service_data.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_service_data.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_service_data.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__gtfs_service_data
+  LIMIT 1;
 source_objects:
-  - "california_transit__gtfs_service_data/*.csv"
+  - "california_transit__gtfs_service_data/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__gtfs_service_data"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_service_data.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_gtfs_service_data.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__gtfs_service_data/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__gtfs_service_data"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__gtfs_service_data/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_ntd_agency_info.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_ntd_agency_info.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_ntd_agency_info.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_ntd_agency_info.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__ntd_agency_info/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__ntd_agency_info"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__ntd_agency_info/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_ntd_agency_info.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_ntd_agency_info.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__ntd_agency_info
+  LIMIT 1;
 source_objects:
-  - "california_transit__ntd_agency_info/*.csv"
+  - "california_transit__ntd_agency_info/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__ntd_agency_info"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_organizations.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_organizations.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__organizations
+  LIMIT 1;
 source_objects:
-  - "california_transit__organizations/*.csv"
+  - "california_transit__organizations/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__organizations"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_organizations.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__organizations/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__organizations"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__organizations/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_place_geography.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_place_geography.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_place_geography.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_place_geography.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__place_geography/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__place_geography"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__place_geography/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_place_geography.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_place_geography.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__place_geography
+  LIMIT 1;
 source_objects:
-  - "california_transit__place_geography/*.csv"
+  - "california_transit__place_geography/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__place_geography"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_rider_requirements.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_rider_requirements.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_rider_requirements.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_rider_requirements.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__rider_requirements
+  LIMIT 1;
 source_objects:
-  - "california_transit__rider_requirements/*.csv"
+  - "california_transit__rider_requirements/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__rider_requirements"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_rider_requirements.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_rider_requirements.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__rider_requirements/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__rider_requirements"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__rider_requirements/"

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_services.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: gs://airtable
+bucket: gs://calitp-airtable
 prefix_bucket: true
 post_hook: |
   SELECT *

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_services.yml
@@ -1,10 +1,14 @@
 operator: operators.ExternalTable
 bucket: gs://airtable
 prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_airtable.california_transit__services
+  LIMIT 1;
 source_objects:
-  - "california_transit__services/*.csv"
+  - "california_transit__services/*.jsonl.gz"
 destination_project_dataset_table: "external_airtable.california_transit__services"
-source_format: CSV
+source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO

--- a/airflow/dags/create_external_tables/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_services.yml
@@ -1,0 +1,11 @@
+operator: operators.ExternalTable
+bucket: gs://airtable
+prefix_bucket: true
+source_objects:
+  - "california_transit__services/*.csv"
+destination_project_dataset_table: "external_airtable.california_transit__services"
+source_format: CSV
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  source_uri_prefix: "california_transit__services/"

--- a/airflow/dags/sandbox/load_airtable_child.yml
+++ b/airflow/dags/sandbox/load_airtable_child.yml
@@ -3,10 +3,11 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: apphcwzP8cR82NeJo
 air_base_name: sandbox
 air_table_name: child
-bucket: "gs://{{ prefix_bucket('airtable') }}"
+bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
 
-id_name: "child_id"
-column_prefix: "child_"
+airtable_options:
+  id_name: "child_id"
+  column_prefix: "child_"
 
 
 dependencies:

--- a/airflow/dags/sandbox/load_airtable_child.yml
+++ b/airflow/dags/sandbox/load_airtable_child.yml
@@ -1,11 +1,13 @@
 operator: operators.AirtableToWarehouseOperator
 
 air_base_id: apphcwzP8cR82NeJo
+air_base_name: sandbox
 air_table_name: child
-table_name: sandbox.airtable_child
+bucket: "gs://{{ prefix_bucket('airtable') }}"
 
 id_name: "child_id"
 column_prefix: "child_"
+
 
 dependencies:
   - op_airtable_to_warehouse

--- a/airflow/dags/sandbox/op_airtable_to_warehouse.yml
+++ b/airflow/dags/sandbox/op_airtable_to_warehouse.yml
@@ -3,11 +3,12 @@ operator: operators.AirtableToWarehouseOperator
 air_base_id: apphcwzP8cR82NeJo
 air_base_name: sandbox
 air_table_name: parent
-bucket: "{{ prefix_bucket('airtable') }}"
-id_name: "parent_id"
-rename_fields:
-  child: child_id
-column_prefix: "parent_"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"
+airtable_options:
+  id_name: "parent_id"
+  rename_fields:
+    child: child_id
+  column_prefix: "parent_"
 
 dependencies:
   - create_dataset

--- a/airflow/dags/sandbox/op_airtable_to_warehouse.yml
+++ b/airflow/dags/sandbox/op_airtable_to_warehouse.yml
@@ -1,10 +1,9 @@
 operator: operators.AirtableToWarehouseOperator
 
 air_base_id: apphcwzP8cR82NeJo
+air_base_name: sandbox
 air_table_name: parent
-gcs_path: sandbox/airtable
-table_name: sandbox.airtable_parent
-
+bucket: "{{ prefix_bucket('airtable') }}"
 id_name: "parent_id"
 rename_fields:
   child: child_id

--- a/airflow/plugins/operators/airtable_to_warehouse.py
+++ b/airflow/plugins/operators/airtable_to_warehouse.py
@@ -103,7 +103,7 @@ class AirtableExtract(BaseModel):
             raise ValueError(
                 "An extract time must be set before a hive path can be generated."
             )
-        safe_air_table_name = "_".join(self.air_table_name.split(" "))
+        safe_air_table_name = str.lower("_".join(self.air_table_name.split(" ")))
         return os.path.join(
             bucket,
             f"{self.air_base_name}__{safe_air_table_name}",
@@ -115,7 +115,7 @@ class AirtableExtract(BaseModel):
     def save_to_gcs(self, fs, bucket):
         hive_path = self.make_hive_path(bucket)
         print(f"Uploading to GCS at {hive_path}")
-        assert self.data, "data does not exist, cannot save"
+        assert self.data.any(None), "data does not exist, cannot save"
         fs.pipe(
             hive_path,
             gzip.compress(self.data.to_json(orient="records", lines=True).encode()),

--- a/airflow/plugins/operators/airtable_to_warehouse.py
+++ b/airflow/plugins/operators/airtable_to_warehouse.py
@@ -21,24 +21,14 @@ def process_arrays_for_nulls(arr):
     Therefore we need to manually replace nulls with falsy values according
     to the type of data in the array.
     """
-    # check whether there are any non-null values in the array
-    # can't look at NoneType directly in Python 3: https://bugs.python.org/issue19438
-    types = {type(entry) for entry in {arr}} - {type(None)}
-    if len(types) > 0:
-        if types <= {int, float}:
-            new_array = [x if x is not None else -1 for x in arr]
-        # use empty string for all non-numeric types
-        # may need to expand this over time
-        else:
-            new_array = [x if x is not None else "" for x in arr]
-    else:
-        # if array only has null values, just return an empty array --
-        # this collapses the distinction between [null] and []
-        # which may be meaningful in cases where the array is the
-        # result of a lookup in Airtable, but the distinction
-        # should be recoverable by checking the lookup relation directly
-        new_array = []
-    return new_array
+    types = set(type(entry) for entry in arr if entry is not None)
+
+    if not types:
+        return []
+    # use empty string for all non-numeric types
+    # may need to expand this over time
+    filler = -1 if types <= {int, float} else ""
+    return [x if x is not None else filler for x in arr]
 
 
 def make_arrays_bq_safe(raw_data):

--- a/airflow/plugins/operators/airtable_to_warehouse.py
+++ b/airflow/plugins/operators/airtable_to_warehouse.py
@@ -3,74 +3,74 @@ import re
 import os
 
 from pyairtable import Table
+from pydantic import BaseModel
+from typing import Optional
 from calitp import save_to_gcfs, to_snakecase, write_table
 
 from airflow.models import BaseOperator
 
+AIRTABLE_API_KEY = os.environ["CALITP_AIRTABLE_API_KEY"]
 
-def airtable_to_df(
-    air_base_id,
-    air_table_name,
-    id_name="__id",
-    rename_fields=None,
-    column_prefix=None,
-    api_key=None,
-):
-    """Download an airtable as a DataFrame.
 
-    Note that airtable records have rows structured as follows:
-        [{"id", "fields": {colname: value, ...}, ...]
+class AirtableExtract(BaseModel):
+    api_key: str
+    air_base_id: str
+    air_table_name: str
+    id_name = "__id"
+    rename_fields = {}
+    column_prefix: Optional[str] = None
 
-    This function applies renames in the following order.
+    def airtable_to_df(self):
+        """Download an Airtable table as a DataFrame.
 
-        1. rename id
-        2. rename fields
-        3. apply column prefix (to columns not renamed by 1 or 2)
-    """
+        Note that airtable records have rows structured as follows:
+            [{"id", "fields": {colname: value, ...}, ...]
 
-    api_key = os.environ["CALITP_AIRTABLE_API_KEY"] if not api_key else api_key
+        This function applies renames in the following order.
 
-    if rename_fields:
-        if not isinstance(rename_fields, dict):
-            raise TypeError("rename fields must be a dictionary")
-    else:
-        rename_fields = {}
+            1. rename id
+            2. rename fields
+            3. apply column prefix (to columns not renamed by 1 or 2)
+        """
 
-    print(f"Downloading airtable data for {air_base_id}.{air_table_name}")
-    all_rows = Table(api_key, air_base_id, air_table_name).all()
-    raw_df = pd.DataFrame([{id_name: row["id"], **row["fields"]} for row in all_rows])
-
-    # rename fields follows format new_name: old_name
-    final_df = raw_df.rename(columns={k: v for k, v in rename_fields.items()}).pipe(
-        to_snakecase
-    )
-
-    if column_prefix:
-        new_field_names = rename_fields.values()
-        return final_df.rename(
-            columns=lambda s: s
-            if (s in new_field_names or s == id_name)
-            else f"{column_prefix}{s}"
+        print(f"Downloading airtable data for {self.air_base_id}.{self.air_table_name}")
+        all_rows = Table(self.api_key, self.air_base_id, self.air_table_name).all()
+        raw_df = pd.DataFrame(
+            [{self.id_name: row["id"], **row["fields"]} for row in all_rows]
         )
 
-    return final_df
+        # rename fields follows format new_name: old_name
+        final_df = raw_df.rename(
+            columns={k: v for k, v in self.rename_fields.items()}
+        ).pipe(to_snakecase)
+
+        if self.column_prefix:
+            new_field_names = self.rename_fields.values()
+            return final_df.rename(
+                columns=lambda s: s
+                if (s in new_field_names or s == self.id_name)
+                else f"{self.column_prefix}{s}"
+            )
+        return final_df
+
+    def make_hive_path(self, bucket):
+        pass
 
 
 class AirtableToWarehouseOperator(BaseOperator):
     def __init__(
         self,
+        api_key,
         air_base_id,
         air_table_name,
-        table_name,
-        id_name="__id",
-        gcs_path=None,
-        rename_fields=None,
-        column_prefix=None,
-        api_key=None,
+        id_name,
+        rename_fields,
+        column_prefix,
+        gcs_path,
         **kwargs,
     ):
-        """An operator that will download data from an airtable and load it into
-            BigQuery and/or save it as a CSV file with the current date in Google Cloud
+        """An operator that downloads data from an Airtable base and loads it into
+            and saves it as a CSV file hive-partitioned by date in Google Cloud
             Storage (GCS).
 
         Args:
@@ -78,11 +78,11 @@ class AirtableToWarehouseOperator(BaseOperator):
             air_table_name (str): The table name that should be extracted from the
                 airtable base
             table_name (str): The name of the table to save to in Big Query
-            id_name (str, optional): The name to give the ID column. Defaults to "__id".
             gcs_path (str, optional): A GCS path prefix. If not provided, no uploading
                 to GCS will occur. The resulting item gets saved to GCS at the following
                 path:
                     `{base_calitp_bucket}/{gcs_path}/{execution_date}/{table_name}.csv`.
+            id_name (str, optional): The name to give the ID column. Defaults to "__id".
             rename_fields (dict, optional): A mapping new desired column name (string)
                 to current airtable column name (string) respectively. Defaults to None.
             column_prefix (str, optional): A string prefix to rename all columns with.
@@ -94,24 +94,20 @@ class AirtableToWarehouseOperator(BaseOperator):
         """
         self.air_base_id = air_base_id
         self.air_table_name = air_table_name
-        self.table_name = table_name
         self.id_name = id_name
         self.rename_fields = rename_fields
         self.column_prefix = column_prefix
         self.api_key = api_key
         self.gcs_path = gcs_path
 
+        self.extract = AirtableExtract(
+            air_base_id, air_table_name, id_name, rename_fields, column_prefix, api_key
+        )
+
         super().__init__(**kwargs)
 
     def execute(self, context):
-        df = airtable_to_df(
-            self.air_base_id,
-            self.air_table_name,
-            self.id_name,
-            self.rename_fields,
-            self.column_prefix,
-            self.api_key,
-        )
+        df = self.extract.airtable_to_df()
 
         if self.table_name:
             print(f"Writing table with shape: {df.shape}")

--- a/airflow/plugins/operators/airtable_to_warehouse.py
+++ b/airflow/plugins/operators/airtable_to_warehouse.py
@@ -48,9 +48,9 @@ def fix_array_containing_null(arr):
 def make_arrays_bq_safe(raw_data):
     safe_data = {}
     for k, v in raw_data.items():
-        if type(v) == dict:
+        if isinstance(v, dict):
             make_arrays_bq_safe(v)
-        elif type(v) == list:
+        elif isinstance(v, list):
             if None in v:
                 safe_data[k] = fix_array_containing_null(v)
             else:

--- a/airflow/plugins/operators/airtable_to_warehouse.py
+++ b/airflow/plugins/operators/airtable_to_warehouse.py
@@ -126,7 +126,6 @@ class AirtableToWarehouseOperator(BaseOperator):
                 This can be someone's personal API key. If not provided, the environment
                 variable of `CALITP_AIRTABLE_API_KEY` is used.
         """
-
         self.extract = AirtableExtract(
             air_base_id=air_base_id,
             air_base_name=air_base_name,

--- a/airflow/plugins/operators/airtable_to_warehouse.py
+++ b/airflow/plugins/operators/airtable_to_warehouse.py
@@ -24,6 +24,11 @@ class AirtableExtract(BaseModel):
     data: Optional[pd.DataFrame]
     extract_time: Optional[pendulum.DateTime]
 
+    # pydantic doesn't know dataframe
+    # see https://stackoverflow.com/a/69200069
+    class Config:
+        arbitrary_types_allowed = True
+
     def fetch_from_airtable(self, api_key):
         """Download an Airtable table as a DataFrame.
 

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -4,13 +4,12 @@ ipdb==0.13.4
 pandas==1.1.4
 gusty==0.6.0
 pandas-gbq==0.14.1
-sqlalchemy-bigquery==1.4.3
+pybigquery==0.7.0
 google-cloud-bigquery==2.34.3
-calitp==0.0.16
+calitp==0.0.12
 google-auth==1.32.1
 gtfs-realtime-bindings==0.0.7
-geopandas
-shapely
+geopandas==0.9.0
 pyairtable==1.0.0
 black==22.3.0
 structlog==21.5.0
@@ -18,4 +17,4 @@ typer==0.4.0
 humanize==3.14.0
 backoff==1.11.1
 pydantic==1.9.0
-python-slugify[unidecode]==6.1.2
+python-slugify==6.1.2

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -17,4 +17,3 @@ typer==0.4.0
 humanize==3.14.0
 backoff==1.11.1
 pydantic==1.9.0
-python-slugify==6.1.2

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -18,4 +18,4 @@ typer==0.4.0
 humanize==3.14.0
 backoff==1.11.1
 pydantic==1.9.0
-slugify==0.0.1
+python-slugify==5.0.0

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -17,3 +17,5 @@ structlog==21.5.0
 typer==0.4.0
 humanize==3.14.0
 backoff==1.11.1
+pydantic==1.9.0
+slugify==0.0.1

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -4,7 +4,7 @@ ipdb==0.13.4
 pandas==1.1.4
 gusty==0.6.0
 pandas-gbq==0.14.1
-pybigquery==0.7.0
+sqlalchemy-bigquery==1.4.3
 google-cloud-bigquery==2.34.3
 calitp==0.0.16
 google-auth==1.32.1
@@ -18,4 +18,4 @@ typer==0.4.0
 humanize==3.14.0
 backoff==1.11.1
 pydantic==1.9.0
-python-slugify==5.0.0
+python-slugify[unidecode]==6.1.2

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,7 +6,7 @@ gusty==0.6.0
 pandas-gbq==0.14.1
 pybigquery==0.7.0
 google-cloud-bigquery==2.34.3
-calitp==0.0.12
+calitp==0.0.16
 google-auth==1.32.1
 gtfs-realtime-bindings==0.0.7
 geopandas


### PR DESCRIPTION
🚨 _This is merging into the `airtable-updates` branch, not `main`, to prepare for a bundle of related changes_

# Description

This PR establishes the groundwork for the "new" Airtable pattern, in line with the RT pipeline and to prepare for #1159.

It refactors the Airtable operator to:
* Stop writing simultaneously to GCS & BigQuery and instead only write to hive-partitioned GCS buckets 
* Use Pydantic typing to enforce data types

In doing so, I had to add a bunch of handling for arrays that contain nulls because BigQuery does not allow them. Specifically, if an array only has null values, this just return an empty array -- this collapses the distinction between [null] and [] which may be meaningful in cases where the array is the result of a lookup in Airtable, but the distinction should be recoverable by checking the lookup relation directly.

It also adds external table creation to the `create_external_tables` DAG. 

@atvaccaro -- Would appreciate particular review on: https://github.com/cal-itp/data-infra/blob/d2e52c06f92308867d59c95c5cf1cd4d28226e71/airflow/plugins/operators/airtable_to_warehouse.py#L18 -- this is where I do the null handling that we discussed. 

**Upcoming follow-ups to be handled in following PRs:**
* Rewrite `airtable_views` in dbt (this will include latest-only logic for the new external tables)
* Extract Transit Stacks

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- breaks Airtable
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

- Ran the updated Airflow tasks locally
- Manually spot checked data & new BQ tables
