### PR TITLE
More RT refactor fixes

### DIFF
--- a/jobs/gtfs-rt-parser/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser/gtfs_rt_parser.py
@@ -109,7 +109,8 @@ class RTFile(BaseModel):
         return os.path.join(
             get_bucket(),
             "schedule",
-            str(self.tick.replace(hour=0, minute=0, second=0)),
+            # we timestamp with Airflow _execution date_ currently which is fun
+            str(self.tick.subtract(days=1).replace(hour=0, minute=0, second=0)),
             f"{self.itp_id}_{self.url}",
         )
 


### PR DESCRIPTION
# Description

This PR fixes two problems that popped up during the backfill.

1. Sometimes, there are no validation notices output for a given hour of RT data (usually service alerts). Currently we upload empty files, but BigQuery fails when parsing these. Instead, we should write a single newline character since the data is JSONL.
2. Our schedule data is keyed via Airflow logical execution date in GCS, so we have to subtract a day from the RT ticks to find it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally via docker-compose.

## Screenshots (optional)
