### PR TITLE
Full RT backfill, separate pools, and a couple tweaks

### DIFF
--- a/airflow/dags/create_external_tables/rt_service_alerts_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_service_alerts_outcomes.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct step
+  from `{{ get_project_id() }}`.external_gtfs_rt.service_alerts_outcomes;
+
 source_objects:
   - "service_alerts_outcomes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.service_alerts_outcomes"

--- a/airflow/dags/create_external_tables/rt_service_alerts_validations.yml
+++ b/airflow/dags/create_external_tables/rt_service_alerts_validations.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct errorMessage.validationRule.errorDescription
+  from `{{ get_project_id() }}`.external_gtfs_rt.service_alerts_validations;
+
 source_objects:
   - "service_alerts_validations/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.service_alerts_validations"

--- a/airflow/dags/create_external_tables/rt_service_alerts_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_service_alerts_validations_outcomes.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct step
+  from `{{ get_project_id() }}`.external_gtfs_rt.service_alerts_validations_outcomes;
+
 source_objects:
   - "service_alerts_validations_outcomes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.service_alerts_validations_outcomes"

--- a/airflow/dags/create_external_tables/rt_trip_updates_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_trip_updates_outcomes.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct step
+  from `{{ get_project_id() }}`.external_gtfs_rt.trip_updates_outcomes;
+
 source_objects:
   - "trip_updates_outcomes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.trip_updates_outcomes"

--- a/airflow/dags/create_external_tables/rt_trip_updates_validations.yml
+++ b/airflow/dags/create_external_tables/rt_trip_updates_validations.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct errorMessage.validationRule.errorDescription
+  from `{{ get_project_id() }}`.external_gtfs_rt.trip_updates_validations;
+
 source_objects:
   - "trip_updates_validations/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.trip_updates_validations"

--- a/airflow/dags/create_external_tables/rt_trip_updates_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_trip_updates_validations_outcomes.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct step
+  from `{{ get_project_id() }}`.external_gtfs_rt.trip_updates_validations_outcomes;
+
 source_objects:
   - "trip_updates_validations_outcomes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.trip_updates_validations_outcomes"

--- a/airflow/dags/create_external_tables/rt_vehicle_positions_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_vehicle_positions_outcomes.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct step
+  from `{{ get_project_id() }}`.external_gtfs_rt.vehicle_positions_outcomes;
+
 source_objects:
   - "vehicle_positions_outcomes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.vehicle_positions_outcomes"

--- a/airflow/dags/create_external_tables/rt_vehicle_positions_validations.yml
+++ b/airflow/dags/create_external_tables/rt_vehicle_positions_validations.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct errorMessage.validationRule.errorDescription
+  from `{{ get_project_id() }}`.external_gtfs_rt.vehicle_positions_validations;
+
 source_objects:
   - "vehicle_positions_validations/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.vehicle_positions_validations"

--- a/airflow/dags/create_external_tables/rt_vehicle_positions_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_vehicle_positions_validations_outcomes.yml
@@ -1,7 +1,11 @@
 operator: operators.ExternalTable
 bucket: gs://rt-parsed
 prefix_bucket: true
-test: true
+
+post_hook: |
+  select distinct step
+  from `{{ get_project_id() }}`.external_gtfs_rt.vehicle_positions_validations_outcomes;
+
 source_objects:
   - "vehicle_positions_validations_outcomes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_rt.vehicle_positions_validations_outcomes"

--- a/airflow/dags/parse_and_validate_rt/METADATA.yml
+++ b/airflow/dags/parse_and_validate_rt/METADATA.yml
@@ -5,8 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    # TODO: don't forget to change me back to "2021-07-09"
-    start_date: "2022-05-01"
+    start_date: "2021-07-09"
     email:
       - "blake.f@jarv.us"
       - "evan.siroky@dot.ca.gov"

--- a/airflow/dags/parse_and_validate_rt/METADATA.yml
+++ b/airflow/dags/parse_and_validate_rt/METADATA.yml
@@ -15,7 +15,6 @@ default_args:
     email_on_retry: False
     max_active_dag_runs: 6
     retries: 1
-    pool: rt_parse_pool
     retry_delay: !timedelta 'minutes: 2'
     concurrency: 5
     #sla: !timedelta 'hours: 2'

--- a/airflow/dags/parse_and_validate_rt/parse_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt/parse_rt_service_alerts.yml
@@ -1,6 +1,7 @@
 operator: operators.PodOperator
 name: 'parse-rt-service-alerts'
 image: 'ghcr.io/cal-itp/data-infra/gtfs-rt-parser:{{image_tag()}}'
+pool: rt_parse_pool
 
 cmds:
   - python3

--- a/airflow/dags/parse_and_validate_rt/parse_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt/parse_rt_trip_updates.yml
@@ -1,6 +1,7 @@
 operator: operators.PodOperator
 name: 'parse-rt-trip-updates'
 image: 'ghcr.io/cal-itp/data-infra/gtfs-rt-parser:{{image_tag()}}'
+pool: rt_parse_pool
 
 cmds:
   - python3

--- a/airflow/dags/parse_and_validate_rt/parse_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt/parse_rt_vehicle_positions.yml
@@ -1,6 +1,7 @@
 operator: operators.PodOperator
 name: 'parse-rt-vehicle-positions'
 image: 'ghcr.io/cal-itp/data-infra/gtfs-rt-parser:{{image_tag()}}'
+pool: rt_parse_pool
 
 cmds:
   - python3

--- a/airflow/dags/parse_and_validate_rt/validate_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt/validate_rt_service_alerts.yml
@@ -1,6 +1,7 @@
 operator: operators.PodOperator
 name: 'validate-rt-service-alerts'
 image: 'ghcr.io/cal-itp/data-infra/gtfs-rt-parser:{{image_tag()}}'
+pool: rt_validate_pool
 
 cmds:
   - python3

--- a/airflow/dags/parse_and_validate_rt/validate_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt/validate_rt_trip_updates.yml
@@ -1,6 +1,7 @@
 operator: operators.PodOperator
 name: 'validate-rt-trip-updates'
 image: 'ghcr.io/cal-itp/data-infra/gtfs-rt-parser:{{image_tag()}}'
+pool: rt_validate_pool
 
 cmds:
   - python3

--- a/airflow/dags/parse_and_validate_rt/validate_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt/validate_rt_vehicle_positions.yml
@@ -1,6 +1,7 @@
 operator: operators.PodOperator
 name: 'validate-rt-vehicle-positions'
 image: 'ghcr.io/cal-itp/data-infra/gtfs-rt-parser:{{image_tag()}}'
+pool: rt_validate_pool
 
 cmds:
   - python3

--- a/jobs/gtfs-rt-parser/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser/gtfs_rt_parser.py
@@ -69,6 +69,7 @@ def upload_if_records(
             fg=typer.colors.YELLOW,
             pbar=pbar,
         )
+        return
 
     log(
         f"writing {len(records)} lines to {out_path}",

--- a/jobs/gtfs-rt-parser/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser/gtfs_rt_parser.py
@@ -58,21 +58,25 @@ def upload_if_records(
     pbar=None,
     verbose=False,
 ):
+    # BigQuery fails when trying to parse empty files, so shouldn't write them
+    if not records:
+        log(
+            f"WARNING: no records found for {out_path}, skipping upload",
+            fg=typer.colors.YELLOW,
+            pbar=pbar,
+        )
+
     log(
         f"writing {len(records)} lines to {out_path}",
         pbar=pbar,
     )
     with tempfile.NamedTemporaryFile(mode="wb", delete=False, dir=tmp_dir) as f:
         gzipfile = gzip.GzipFile(mode="wb", fileobj=f)
-        if records:
-            if isinstance(records[0], BaseModel):
-                encoded = (r.json() for r in records)
-            else:
-                encoded = (json.dumps(r) for r in records)
-            gzipfile.write("\n".join(encoded).encode("utf-8"))
+        if isinstance(records[0], BaseModel):
+            encoded = (r.json() for r in records)
         else:
-            # BigQuery fails when trying to parse empty files, so we include a single newline character
-            gzipfile.write("\n".encode("utf-8"))
+            encoded = (json.dumps(r) for r in records)
+        gzipfile.write("\n".join(encoded).encode("utf-8"))
         gzipfile.close()
 
     put_with_retry(fs, f.name, out_path)

--- a/jobs/gtfs-rt-parser/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser/gtfs_rt_parser.py
@@ -21,7 +21,11 @@ from zipfile import ZipFile
 import backoff
 import pendulum
 import typer
-from aiohttp.client_exceptions import ClientResponseError, ClientOSError
+from aiohttp.client_exceptions import (
+    ClientResponseError,
+    ClientOSError,
+    ServerDisconnectedError,
+)
 from calitp.config import get_bucket
 from calitp.storage import get_fs
 from google.protobuf import json_format
@@ -200,7 +204,7 @@ def fatal_code(e):
 
 @backoff.on_exception(
     backoff.expo,
-    exception=(ClientOSError, ClientResponseError),
+    exception=(ClientOSError, ClientResponseError, ServerDisconnectedError),
     max_tries=3,
     giveup=fatal_code,
 )
@@ -209,7 +213,9 @@ def get_with_retry(fs, *args, **kwargs):
 
 
 @backoff.on_exception(
-    backoff.expo, exception=(ClientOSError, ClientResponseError), max_tries=3
+    backoff.expo,
+    exception=(ClientOSError, ClientResponseError, ServerDisconnectedError),
+    max_tries=3,
 )
 def put_with_retry(fs, *args, **kwargs):
     return fs.put(*args, **kwargs)


### PR DESCRIPTION
# Description

The new RT pipeline has been running for a few days now successfully! We only backfilled to the beginning of May, so we could catch up quickly and keep new data flowing in roughly realtime. Now, we are ready to backfill back to the start of RT data in July.

This PR also has a few small tweaks.
1. It splits up parsing and validation into separate pools. We can run much more parsing at once than validation, so we can get historical RT _data_ backfilled much more quickly by having a larger pool.
2. It skips uploading single-newline gzip files to represent zero validation notices; BigQuery does not like these.
3. Adds a retry on ServerDisconnectedError, which we didn't before.
4. It uses post-hooks to test that external tables are queryable after creation.

Resolves https://github.com/cal-itp/data-infra/issues/1482

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

I removed the empty-ish files from `gs://rt-parsed/` and can now run the following type of query on all 3 types of validations.

```sql
select distinct errorMessage.validationRule.errorDescription
from `cal-itp-data-infra`.external_gtfs_rt.trip_updates_validations
;
```

In addition, all external tables can be created and queried properly. https://o1d2fa0877cf3fb10p-tp.appspot.com/tree?dag_id=create_external_tables

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/4305366/167472125-216767d1-d55a-42ba-b17f-6b63e50f79ea.png)
