### PR TITLE
jupyter values.yaml: updated oauth_callback_url from hubtest to notebooks.calitp.org

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -37,7 +37,7 @@ jupyterhub:
       GitHubOAuthenticator:
         # client_id:     in existingSecret
         # client_secret: in existingSecret
-        oauth_callback_url: https://hubtest.k8s.calitp.jarv.us/hub/oauth_callback
+        oauth_callback_url: https://notebooks.calitp.org/hub/oauth_callback
         allowed_organizations:
           - cal-itp:warehouse-users
         scope:


### PR DESCRIPTION
# Description

Issue #1480 identified a bug in the new jupyterhub domain introduced by issue #1460 where an `OAuth state missing from cookies` error appears because the URL on the callback URL (hubtest.k8s.calitp.jarv.us) is different from the initial visit (notebooks.calitp.org).

**All analysts and other users of Jupyterhub have been notified to begin using the new notebooks.calitp.org URL starting 5/11/22**

Resolves #1480

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  * Still not sure if this invalidates hubtest.k8s.calitp.jarv.us from being used to oauth to github
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
* Still not sure if this invalidates hubtest.k8s.calitp.jarv.us from being used to oauth to github
* Need to update helm chart after this is merged

## Screenshots (optional)
