### PR TITLE
jupyter(helm): re-updating the heml oauth_callback to point to notebooks.calitp.org

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -37,7 +37,7 @@ jupyterhub:
       GitHubOAuthenticator:
         # client_id:     in existingSecret
         # client_secret: in existingSecret
-        oauth_callback_url: https://hubtest.k8s.calitp.jarv.us/hub/oauth_callback
+        oauth_callback_url: https://notebooks.calitp.org/hub/oauth_callback
         allowed_organizations:
           - cal-itp:warehouse-users
         scope:


### PR DESCRIPTION
# Description

Re-updating the JupyterHub heml oauth_callback to point to notebooks.calitp.org

Resolves #1492 #1489 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
