### PR TITLE
docs(audit): identify and fix broken or outdated links, misc quick improvements

### DIFF
--- a/docs/analytics_examples/new_tutorial.md
+++ b/docs/analytics_examples/new_tutorial.md
@@ -12,6 +12,7 @@ kernelspec:
   language: python
   name: python3
 ---
+(complex-queries)=
 # More Complex Queries
 
 ## Introduction

--- a/docs/analytics_examples/overview.md
+++ b/docs/analytics_examples/overview.md
@@ -1,8 +1,11 @@
 (analysis-examples-overview)=
-# Analysis Examples
-The section below provides examples of various elements of the analysis process.
-
-Keep reading below to find demonstrations of:
+# Analysis Tutorials
+This section provides examples of various elements of the analysis process. You will find demonstrations of:
 * Analysis languages and techniques
 * Tables and columns used in common analyses
 * Documents prepared though the analysis process
+
+Tutorials:
+* [Querying GTFS in the Data Warehouse](warehouse-tutorial)
+* [More Complex Queries](complex-queries)
+* [Sample Data Catalog](sample-catalog)

--- a/docs/analytics_examples/warehouse_tutorial.md
+++ b/docs/analytics_examples/warehouse_tutorial.md
@@ -13,7 +13,7 @@ kernelspec:
   name: python3
 ---
 (warehouse-tutorial)=
-# Tutorial - Querying the Data Warehouse
+# Querying GTFS in the Data Warehouse
 
 ## Introduction
 

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -21,13 +21,14 @@
 **Dashboards & Notebooks:**
 
 - [ ]  [**Metabase**](https://dashboards.calitp.org/) - Business Insights & Dashboards | ([Docs](metabase))
-- [ ]  [**JupyterHub**](https://hubtest.k8s.calitp.jarv.us/) - Cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
+- [ ]  [**JupyterHub**](https://notebooks.calitp.org/) - Cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
 - [ ]  [**Google BigQuery**](https://console.cloud.google.com/bigquery) - Viewing the data warehouse and querying SQL
 
 **Python Libraries:**
 
 - [ ]  **calitp** - Cal-ITP's internal Python library | ([Docs](calitp))
 - [ ]  **siuba** - Recommended data analysis library | ([Docs](siuba))
+- [ ]  **shared_utils** - A shared analytics team utilities library | ([Docs](shared-utils))
 
 &nbsp;
 (get-help)=

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -20,10 +20,10 @@
 
 **Analytics Tools:**
 
-- [ ]  **Metabase** - [dashboards.calitp.org](https://dashboards.calitp.org/) - Business Insights & Dashboards | ([Docs](metabase))
-- [ ]  **JupyterHub** - [notebooks.calitp.org](https://notebooks.calitp.org/) - Cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
-- [ ]  **Analytics Portfolio Site** - [analysis.calitp.org](https://analysis.calitp.org/) - The landing page for the Cal-ITP analytics portfolio website. | (Docs WIP)
-- [ ]  **DBT Warehouse Documentation** - [dbt-docs.calitp.org](https://dbt-docs.calitp.org/) - Documentation for the Cal-ITP data warehouse. | ([See also](intro-warehouse))
+- [ ]  **[notebooks.calitp.org](https://notebooks.calitp.org/)** - Cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
+- [ ]  **[dashboards.calitp.org](https://dashboards.calitp.org/)** - Metabase business insights & dashboards | ([Docs](metabase))
+- [ ]  **[dbt-docs.calitp.org](https://dbt-docs.calitp.org/)** - Documentation for the Cal-ITP data warehouse. | ([See also](intro-warehouse))
+- [ ]  **[analysis.calitp.org](https://analysis.calitp.org/)** - The Cal-ITP analytics portfolio website. | (Docs WIP)
 - [ ]  [**Google BigQuery**](https://console.cloud.google.com/bigquery) - Viewing the data warehouse and querying SQL
 
 **Python Libraries:**

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -22,7 +22,7 @@
 
 - [ ]  **[notebooks.calitp.org](https://notebooks.calitp.org/)** - JupyterHub cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
 - [ ]  **[dashboards.calitp.org](https://dashboards.calitp.org/)** - Metabase business insights & dashboards | ([Docs](metabase))
-- [ ]  **[dbt-docs.calitp.org](https://dbt-docs.calitp.org/)** - Documentation for the Cal-ITP data warehouse. | ([See also](intro-warehouse))
+- [ ]  **[dbt-docs.calitp.org](https://dbt-docs.calitp.org/)** - Documentation for the Cal-ITP data warehouse. | ([See also](datasets-tables))
 - [ ]  **[analysis.calitp.org](https://analysis.calitp.org/)** - The Cal-ITP analytics portfolio website. | (Docs WIP)
 - [ ]  [**Google BigQuery**](https://console.cloud.google.com/bigquery) - Viewing the data warehouse and querying SQL
 

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -20,7 +20,7 @@
 
 **Analytics Tools:**
 
-- [ ]  **[notebooks.calitp.org](https://notebooks.calitp.org/)** - Cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
+- [ ]  **[notebooks.calitp.org](https://notebooks.calitp.org/)** - JupyterHub cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
 - [ ]  **[dashboards.calitp.org](https://dashboards.calitp.org/)** - Metabase business insights & dashboards | ([Docs](metabase))
 - [ ]  **[dbt-docs.calitp.org](https://dbt-docs.calitp.org/)** - Documentation for the Cal-ITP data warehouse. | ([See also](intro-warehouse))
 - [ ]  **[analysis.calitp.org](https://analysis.calitp.org/)** - The Cal-ITP analytics portfolio website. | (Docs WIP)

--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -18,17 +18,19 @@
 - [ ]  [**Analyst Project Board**](https://github.com/cal-itp/data-analyses/projects/1) | ([Docs](analytics-project-board))
 - [ ]  [**Google Cloud Storage**](https://console.cloud.google.com/storage/browser/calitp-analytics-data) | ([Docs](storing-new-data))
 
-**Dashboards & Notebooks:**
+**Analytics Tools:**
 
-- [ ]  [**Metabase**](https://dashboards.calitp.org/) - Business Insights & Dashboards | ([Docs](metabase))
-- [ ]  [**JupyterHub**](https://notebooks.calitp.org/) - Cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
+- [ ]  **Metabase** - [dashboards.calitp.org](https://dashboards.calitp.org/) - Business Insights & Dashboards | ([Docs](metabase))
+- [ ]  **JupyterHub** - [notebooks.calitp.org](https://notebooks.calitp.org/) - Cloud-based notebooks for querying Python, SQL, R | ([Docs](jupyterhub))
+- [ ]  **Analytics Portfolio Site** - [analysis.calitp.org](https://analysis.calitp.org/) - The landing page for the Cal-ITP analytics portfolio website. | (Docs WIP)
+- [ ]  **DBT Warehouse Documentation** - [dbt-docs.calitp.org](https://dbt-docs.calitp.org/) - Documentation for the Cal-ITP data warehouse. | ([See also](intro-warehouse))
 - [ ]  [**Google BigQuery**](https://console.cloud.google.com/bigquery) - Viewing the data warehouse and querying SQL
 
 **Python Libraries:**
 
 - [ ]  **calitp** - Cal-ITP's internal Python library | ([Docs](calitp))
 - [ ]  **siuba** - Recommended data analysis library | ([Docs](siuba))
-- [ ]  **shared_utils** - A shared analytics team utilities library | ([Docs](shared-utils))
+- [ ]  [**shared_utils**](https://github.com/cal-itp/data-analyses/tree/main/_shared_utils) - A shared utilities library for the analytics team | ([Docs](shared-utils))
 
 &nbsp;
 (get-help)=

--- a/docs/analytics_publishing/where_reports_live.md
+++ b/docs/analytics_publishing/where_reports_live.md
@@ -1,3 +1,3 @@
 (where-reports-live)=
-# Where Reports Live (WIP)
-To-do
+# Where Reports Live
+You can find the Cal-ITP Analytics Portfolio at [analysis.calitp.org](https://analysis.calitp.org).

--- a/docs/analytics_tools/data_catalogs.md
+++ b/docs/analytics_tools/data_catalogs.md
@@ -79,7 +79,7 @@ df = catalog.ca_open_data.cdcr_population_covid_tracking.read()
 
 When putting GCS files into the catalog, note that geospatial datasets (zipped shapefiles, GeoJSONs) require the additional `use_fsspec: true` argument compared to tabular datasets (parquets, CSVs). Geoparquets, the exception, are catalogued like tabular datasets.
 
-Opening geospatial datasets through `intake` is the easiest way to import these datasets within a Jupyter Notebook. Otherwise, `geopandas` can read the geospatial datasets that are locally saved or downloaded first from the bucket, but not directly with a GCS file path. Refer to [storing data](connecting-to-warehouse) to set up your Google authentication.
+Opening geospatial datasets through `intake` is the easiest way to import these datasets within a Jupyter Notebook. Otherwise, `geopandas` can read the geospatial datasets that are locally saved or downloaded first from the bucket, but not directly with a GCS file path. Refer to [storing data](Connecting to the Warehouse) to set up your Google authentication.
 
 ```yaml
 lehd_federal_jobs_by_tract:

--- a/docs/analytics_tools/knowledge_sharing.md
+++ b/docs/analytics_tools/knowledge_sharing.md
@@ -125,7 +125,7 @@ def add_tooltip(chart, tooltip1, tooltip2):
 * [Styling dataframes with HTML.](https://pandas.pydata.org/pandas-docs/stable/user_guide/style.html)
 * [After styling a DataFrame, you will have to access the underlying data with .data](https://stackoverflow.com/questions/56647813/perform-operations-after-styling-in-a-dataframe).
 
-### Ipywidgets
+### ipywidgets
 #### Tabs
 * Create tabs to switch between different views.
 * [Stack Overflow Help.](https://stackoverflow.com/questions/50842160/how-to-display-matplotlib-plots-in-a-jupyter-tab-widget)

--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -6,7 +6,7 @@ Jupyterhub is a web application that allows users to analyze and create reports 
 
 Analyses on JupyterHub are accomplished using notebooks, which allow users to mix narrative with analysis code.
 
-**You can access JuypterHub [using this link](https://hubtest.k8s.calitp.jarv.us/)**.
+**You can access JuypterHub using this link:[notebooks.calitp.org](https://notebooks.calitp.org/)**.
 
 ## Table of Contents
 1. [Using JupyterHub](#using-jupyterhub)
@@ -25,7 +25,7 @@ This avoids the need to set up a local environment, provides dedicated storage, 
 
 ### Logging in to JupyterHub
 
-JupyterHub currently lives at [hubtest.k8s.calitp.jarv.us/hub](https://hubtest.k8s.calitp.jarv.us/hub/).
+JupyterHub currently lives at [notebooks.calitp.org](https://notebooks.calitp.org/).
 
 Note: you will need to have been added to the Cal-ITP organization on GitHub to obtain access. If you have yet to be added to the organization and need to be, DM Charlie on Cal-ITP Slack <a href="https://cal-itp.slack.com/team/U027GAVHFST" target="_blank">using this link</a>.
 

--- a/docs/analytics_tools/overview.md
+++ b/docs/analytics_tools/overview.md
@@ -3,6 +3,7 @@
 Welcome to the Analytics Tools section! If you're here, you're ready to begin conducting analyses.
 
 **What you should know after reading**:
+* [Where to easily acccess links to team tools](tools-quick-links)
 * [How to use our BI & dashboarding tool](metabase)
 * [How to use our cloud notebook](jupyterhub)
 * [How to query the warehouse with SQL](querying-sql-jupyterhub)

--- a/docs/analytics_tools/python_libraries.md
+++ b/docs/analytics_tools/python_libraries.md
@@ -23,7 +23,7 @@ The following libraries are available and recommended for use by Cal-ITP data an
 <br> - [Collect Query Results](#collect-query-results)
 <br> - [Show Query SQL](#show-query-sql)
 <br> - [More siuba Resources](more-siuba-resources)
-1. [shared utils](#shared-utils)
+1. [shared utils](shared-utils)
 1. [pandas](pandas-resources)
 1. [Add New Packages](#add-new-packages)
 
@@ -123,8 +123,9 @@ Note that here the pandas Series method `str.contains` corresponds to `regexp_co
 * [siuba docs](https://siuba.readthedocs.io)
 * ['Tidy Tuesday' live analyses with siuba](https://www.youtube.com/playlist?list=PLiQdjX20rXMHc43KqsdIowHI3ouFnP_Sf)
 
+(shared-utils)=
 ## shared utils
-A set of shared utility functions can also be installed, similarly to any Python library. The [shared_utils](https://github.com/cal-itp/data-analyses/shared_utils) are stored here. Generalized functions for analysis are added as collaborative work evolves so we aren't constantly reinventing the wheel.
+A set of shared utility functions can also be installed, similarly to any Python library. The [shared_utils](https://github.com/cal-itp/data-analyses/tree/main/_shared_utils) are stored here. Generalized functions for analysis are added as collaborative work evolves so we aren't constantly reinventing the wheel.
 
 ```python
 # In terminal:

--- a/docs/analytics_tools/tools_quick_links.md
+++ b/docs/analytics_tools/tools_quick_links.md
@@ -4,8 +4,8 @@
 
 | Tool | Purpose |
 | -------- | -------- |
-| [**Analytics Repo**](https://github.com/cal-itp/data-analyses) | GitHub |
-| [**Analytics Project Board**](https://github.com/cal-itp/data-analyses/projects/1) | GitHub |
+| [**Analytics Repo**](https://github.com/cal-itp/data-analyses) | Analytics team code repository. |
+| [**Analytics Project Board**](https://github.com/cal-itp/data-analyses/projects/1) | Analytics team work management. |
 | [**notebooks.calitp.org**](https://notebooks.calitp.org/) | JupyterHub cloud-based notebooks |
 | [**dashboards.calitp.org**](https://dashboards.calitp.org/) | Metabase dashboards & Business Insights |
 | [**dbt-docs.calitp.org**](https://dbt-docs.calitp.org/) | DBT warehouse documentation |

--- a/docs/analytics_tools/tools_quick_links.md
+++ b/docs/analytics_tools/tools_quick_links.md
@@ -6,10 +6,10 @@
 | -------- | -------- |
 | [**Analytics Repo**](https://github.com/cal-itp/data-analyses) | GitHub |
 | [**Analytics Project Board**](https://github.com/cal-itp/data-analyses/projects/1) | GitHub |
-| **JupyterHub** - [notebooks.calitp.org](https://notebooks.calitp.org/) | Cloud-based notebooks |
-| **Metabase** - [dashboards.calitp.org](https://dashboards.calitp.org/) | Dashboards & Business Insights |
-| **DBT Warehouse Documentation** - [dbt-docs.calitp.org](https://dbt-docs.calitp.org/) | Warehouse documentation |
-| **Analytics Portfolio Site** - [analysis.calitp.org](https://analysis.calitp.org/) | Analytics portfolio landing page |
+| [**notebooks.calitp.org**](https://notebooks.calitp.org/) | JupyterHub cloud-based notebooks |
+| [**dashboards.calitp.org**](https://dashboards.calitp.org/) | Metabase dashboards & Business Insights |
+| [**dbt-docs.calitp.org**](https://dbt-docs.calitp.org/) | DBT warehouse documentation |
+| [**analysis.calitp.org**](https://analysis.calitp.org/) | Analytics portfolio landing page |
 | [**Google BigQuery**](https://console.cloud.google.com/bigquery) | Our warehouse and SQL Querying |
 | [**Google Cloud Storage**](https://console.cloud.google.com/storage/browser/calitp-analytics-data) | Cloud file storage |
 

--- a/docs/analytics_tools/tools_quick_links.md
+++ b/docs/analytics_tools/tools_quick_links.md
@@ -1,3 +1,4 @@
+(tools-quick-links)=
 # Tools Quick Links
 **Lost a link?** Find quick access to our tools below.
 
@@ -6,7 +7,7 @@
 | [**Analytics Repo**](https://github.com/cal-itp/data-analyses) | GitHub |
 | [**Analytics Project Board**](https://github.com/cal-itp/data-analyses/projects/1) | GitHub |
 | [**Metabase**](https://dashboards.calitp.org/) | Dashboards & Business Insights |
-| [**JupyterHub**](https://hubtest.k8s.calitp.jarv.us/) | Cloud-based notebooks |
+| [**JupyterHub**](https://notebooks.calitp.org/) | Cloud-based notebooks |
 | [**Google BigQuery**](https://console.cloud.google.com/bigquery) | Our warehouse and SQL Querying |
 | [**Google Cloud Storage**](https://console.cloud.google.com/storage/browser/calitp-analytics-data) | Cloud file storage |
 

--- a/docs/analytics_tools/tools_quick_links.md
+++ b/docs/analytics_tools/tools_quick_links.md
@@ -6,8 +6,10 @@
 | -------- | -------- |
 | [**Analytics Repo**](https://github.com/cal-itp/data-analyses) | GitHub |
 | [**Analytics Project Board**](https://github.com/cal-itp/data-analyses/projects/1) | GitHub |
-| [**Metabase**](https://dashboards.calitp.org/) | Dashboards & Business Insights |
-| [**JupyterHub**](https://notebooks.calitp.org/) | Cloud-based notebooks |
+| **JupyterHub** - [notebooks.calitp.org](https://notebooks.calitp.org/) | Cloud-based notebooks |
+| **Metabase** - [dashboards.calitp.org](https://dashboards.calitp.org/) | Dashboards & Business Insights |
+| **DBT Warehouse Documentation** - [dbt-docs.calitp.org](https://dbt-docs.calitp.org/) | Warehouse documentation |
+| **Analytics Portfolio Site** - [analysis.calitp.org](https://analysis.calitp.org/) | Analytics portfolio landing page |
 | [**Google BigQuery**](https://console.cloud.google.com/bigquery) | Our warehouse and SQL Querying |
 | [**Google Cloud Storage**](https://console.cloud.google.com/storage/browser/calitp-analytics-data) | Cloud file storage |
 

--- a/docs/analytics_welcome/how_we_work.md
+++ b/docs/analytics_welcome/how_we_work.md
@@ -10,7 +10,7 @@ The section below outlines our team's primary meetings and their purposes, as we
 | **Technical Onboarding** | Week 1 <br/> 40 Mins | To ensure access to tools and go over best practices. |
 | **Data Services All-Hands** | Every other Monday <br/> 1 Hour | A team-wide data services sync. |
 | **Analyst Roundtable** | Tues & Thurs <br/> 45 Mins | An opportunity to share your screen and discuss what you've been working on. |
-| **Lunch n' Learn** | Tuesdays <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/> Access recordings of **previous Lunch n' Learns** [at this link](https://youtube.com/playlist?list=PLJA3syyg1ijm36JFZ95v79zAuv-5c8hfZ). |
+| **Lunch n' Learn** | Every other Tuesday <br/> 1 Hour | A weekly opportunity to cover a specific topic, learn something new, and gain visibility into projects and across teams. <br/> Access recordings of **previous Lunch n' Learns** [at this link](https://youtube.com/playlist?list=PLJA3syyg1ijm36JFZ95v79zAuv-5c8hfZ). |
 
 (slack-intro)=
 ## Communication Channels
@@ -41,7 +41,7 @@ The screencast below introduces:
 ### GitHub Analytics Repo
 
 #### Using the data-analyses Repo
-This is our main data analysis repository, for sharing quick reports and works in progress. Get set up on GitHub and clone the data-analyses repository [using this link](github-setup).
+This is our main data analysis repository, for sharing quick reports and works in progress. Get set up on GitHub and clone the data-analyses repository [using this link](committing-from-jupyterhub).
 
 For collaborative short-term tasks, create a new folder and work off a separate branch.
 

--- a/docs/analytics_welcome/overview.md
+++ b/docs/analytics_welcome/overview.md
@@ -16,6 +16,7 @@ After you've read through this section, continue reading through the remaining s
 **Other Analytics Sections**:
 * [Technical Onboarding](technical-onboarding)
 * [Introduction to Analytics Tools](intro-analytics-tools)
+* [Tutorials for New Python Users](beginner_analysts_tutorials)
 * [Introduction to the Warehouse](intro-warehouse)
 * [Datasets & Tables](datasets-tables)
 * [Analysis Examples](analysis-examples-overview)

--- a/docs/architecture/architecture_overview.md
+++ b/docs/architecture/architecture_overview.md
@@ -1,5 +1,5 @@
+(architecture-overview)=
 # Architecture Overview
-
 Here is a high-level summary of the Cal-ITP data services architecture.
 
 ```{mermaid}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -7,5 +7,5 @@ This resource serves as an opportunity to learn more about how the data services
 Use the links below to access dedicated chapters for the following users:
 
 * [Analysts](analysts-welcome)
-* [Developers](airflow)
+* [Developers](architecture-overview)
 * [Contribute to the Docs!](contribute-overview)

--- a/docs/warehouse/adding_oneoff_data.md
+++ b/docs/warehouse/adding_oneoff_data.md
@@ -1,3 +1,4 @@
+(adding-data-to-warehouse)=
 # Adding Data to the Warehouse
 To work with data in our BI tool ([Metabase](https://dashboards.calitp.org/)) we first have to add the data to our warehouse ([BigQuery](https://console.cloud.google.com/bigquery)). To add data to BigQuery for use in Metabase follow the instructions below.
 

--- a/docs/warehouse/overview.md
+++ b/docs/warehouse/overview.md
@@ -2,7 +2,6 @@
 # Introduction to the Warehouse
 The section serves as an introduction to the Cal-ITP warehouse through conventions, best practices, and tips and tricks to better understand the Cal-ITP data warehouse.
 * [Table Naming](warehouse-table-naming)
-* [Agency GTFS Feeds](agency-gtfs-feeds)
-* [Creating New Tables (Views)](creating-new-views)
+* [Adding Data to the Warehouse](adding-data-to-warehouse)
 * [Metric Views](metric-views)
 * [Helpful SQL Snippets](helpful-sql-snippets)

--- a/docs/warehouse/sql_snippets.md
+++ b/docs/warehouse/sql_snippets.md
@@ -14,7 +14,7 @@ kernelspec:
 ---
 (helpful-sql-snippets)=
 # Helpful SQL Snippets
-
+For information on how to query SQL in JupyterHub notebooks, refer to [this documentation](querying-sql-jupyterhub).
 ## Fetching historical data for specific dates
 
 Some tables in the warehouse--like those in `gtfs_schedule_type2`--capture the full


### PR DESCRIPTION
# Description

With the new analytics tool URLs, taking the time to replace the old URLs in the docs as well as any others outdated or broken. Also making small misc improvements/edits as I see them.

Also adding `analysis.calitp.org` to docs in several places

Resolves #1502 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?
Also running tests in command line to verify all URLs in the jupyterbook resolve

