### PR TITLE
fix(gtfs schedule): handle feed removal gaps in gtfs_views_staging.calitp_feeds

### DIFF
--- a/warehouse/models/gtfs_views_staging/calitp_feeds.sql
+++ b/warehouse/models/gtfs_views_staging/calitp_feeds.sql
@@ -107,7 +107,7 @@ lag_md5_hash AS (
 hash_check AS (
     SELECT
         *,
-        calitp_hash != prev_calitp_hash OR is_first_extraction
+        calitp_hash != COALESCE(prev_calitp_hash, "") OR is_first_extraction
         AS is_changed
     FROM lag_md5_hash
 ),


### PR DESCRIPTION
# Description

Bug fix for #1030 -- see issue for context. Basically, BigQuery didn't correctly handle an equality check where one of the values was null. I had been *not* fixing this issue because the only affected feed was an erroneous feed (Capitol Corridor data that had been downloaded under AC Transit). But now a correct, current Elk Grove Transit feed is also being affected (#1329), so fixing.

Resolves #1030, resolves #1329

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ensured that there are only two new rows in `calitp_feeds`, the two noted (AC Transit and Elk Grove). Ran `dbt test` and ensured that tests passed on all affected data (after running `dbt run --select +calitp_feeds+` so all affected data was up to date)