### PR TITLE
Update to stable URL for Culver City

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -361,7 +361,7 @@ cudahy-area-rapid-transit:
 culver-citybus:
   agency_name: Culver CityBus
   feeds:
-    - gtfs_schedule_url: https://www.culvercity.org/files/assets/public/documents/information-technology/maps/gtfsexport12-28-21.zip
+    - gtfs_schedule_url: https://www.culvercity.org/files/assets/public/documents/information-technology/maps/gtfsexport.zip
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null


### PR DESCRIPTION
# Description

Per conversation with staff at the City of Culver City, this is the proper stable URL to be fetching their GTFS Schedule from.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Downloaded locally.