### PR TITLE
agencies.yml: add/update Anaheim and Santa Maria agency info

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1135,8 +1135,8 @@ santa-cruz-metropolitan-transit-district:
 santa-maria-area-transit:
   agency_name: Santa Maria Area Transit
   feeds:
-    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/smat-ca-us/smat-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
+    - gtfs_schedule_url: https://smrt.tripshot.com/v1/gtfs.zip?regionId=CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+      gtfs_rt_vehicle_positions_url: https://smrt.tripshot.com/v1/gtfs/realtime/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 298
@@ -1660,3 +1660,11 @@ lax-flyaway:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 165
+anaheim-regional:
+  agency_name: Anaheim Regional Transportation
+  feeds:
+    - gtfs_schedule_url: https://art.tripshot.com/v1/gtfs.zip?regionId=CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+      gtfs_rt_vehicle_positions_url: https://art.tripshot.com/v1/gtfs/realtime/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+      gtfs_rt_service_alerts_url: null
+      gtfs_rt_trip_updates_url: null
+  itp_id: 14


### PR DESCRIPTION
# Description

Per #1514, updates `agencies.yml` information for Anaheim and Santa Maria agencies.

**Questions for @evansiroky and @o-ram:**
* I am using the name `Anaheim Regional Transportation` here because that's what's in the new feed's `agency.txt`. Formerly (and in Airtable) we have used `Anaheim Resort Transportation`. 
* Just to fully confirm -- I am **replacing** the Santa Maria Trillium schedule link with the new link. 

Resolves #1514

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?
- Manually hit each new URL and confirmed that they work and return the expected type of data
- Confirmed that the trip IDs matched between the VP feeds and their respective schedules 
