### PR TITLE
try to pin a good version of google api core

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -19,3 +19,4 @@ humanize==3.14.0
 backoff==1.11.1
 pydantic==1.9.0
 tabulate==0.8.9
+google-api-core==2.8.0


### PR DESCRIPTION
# Description

The composer requirements github action failed on a recent PR merge https://github.com/cal-itp/data-infra/runs/6557522098?check_suite_focus=true.

This PR pins a version of google-api-core that will hopefully resolve this issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Ran `pip install` to install the latest good version.

## Screenshots (optional)
