### PR TITLE
agencies.yml: remove deprecated octa feeds

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -902,10 +902,6 @@ orange-county-transportation-authority:
   agency_name: Orange County Transportation Authority
   feeds:
     - gtfs_schedule_url: https://octa.net/current/google_transit.zip
-      gtfs_rt_vehicle_positions_url: https://api.octa.net/GTFSRealTime/protoBuf/VehiclePositions.aspx
-      gtfs_rt_service_alerts_url: https://api.octa.net/GTFSRealTime/protoBuf/servicealerts.aspx
-      gtfs_rt_trip_updates_url: https://api.octa.net/GTFSRealTime/protoBuf/tripupdates.aspx
-    - gtfs_schedule_url: https://octa.net/current/google_transit.zip
       gtfs_rt_vehicle_positions_url: https://api.goswift.ly/real-time/octa/gtfs-rt-vehicle-positions
       gtfs_rt_service_alerts_url: https://api.goswift.ly/real-time/octa/gtfs-rt-alerts
       gtfs_rt_trip_updates_url: https://api.goswift.ly/real-time/octa/gtfs-rt-trip-updates


### PR DESCRIPTION
**Before merging I want to confirm with @evansiroky, @o-ram, and @edasmalchi that this is appropriate**

# Description

Remove OCTA non-Swiftly URLs; they are deprecated per @edasmalchi (and they have been returning invalid data as of this week).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?
N/A
