### PR TITLE
headers.yml: fix octa header reference

### DIFF
--- a/airflow/data/headers.yml
+++ b/airflow/data/headers.yml
@@ -56,7 +56,7 @@
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
     - itp_id: 235 # OCTA
-      url_number: 1
+      url_number: 0
       rt_urls:
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url


### PR DESCRIPTION
# Description

In #1520, I didn't realize I had to also update `headers.yml` because the OCTA Swiftly feeds use header-based authorization and that relationship was based on URL number (.... argh!) We didn't get OCTA data yesterday because we're getting an invalid header (`401`) response.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml (technically headers.yml but essentially the same)

## How has this been tested? N/A