### PR TITLE
airtable: rename gtfs dataset columns to be BQ friendly

### DIFF
--- a/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
+++ b/airflow/dags/airtable_loader/california_transit_gtfs_datasets.yml
@@ -6,3 +6,7 @@ gcs_path: airtable/california-transit/
 table_name: airtable.california_transit_gtfs_datasets
 
 id_name: gtfs_dataset_id
+
+rename_fields:
+  "QC: Used Schedule in Referenced Schedule": qc_used_schedule_in_referenced_schedule
+  "QC: Appropriately Deprecated": qc_appropriately_deprecated


### PR DESCRIPTION
# Description

`airtable_loader.california_transit_gtfs_datasets` DAG task is failing in production (and therefore causing the `airtable_views` DAG to fail) because new Airtable columns in the `gtfs datasets` contain illegal punctuation. This PR renames those fields. More structural changes to the Airtable operator to make it slightly more robust are coming in PR #1509, hope to merge ~next week.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran in local Airflow, confirmed updated DAG task runs successfully: 
![image](https://user-images.githubusercontent.com/55149902/170707477-82dbf70d-fcaa-4b18-b0d6-cff92e81ca80.png)