### PR TITLE
Max_service_date and days_from_service_date columns added to gtfs_schedule_fact_daily_feeds

### DIFF
--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -301,6 +301,12 @@ models:
         description: |
           Days since the feed's contents (the contents of any loadable file
           within the feed) have changed, relative to date
+      - name: max_service_date
+        description: |
+          Maximum service date by feed
+      - name: days_from_last_service
+        description: |
+          Days since the last service date by feed
   - name: gtfs_schedule_fact_daily_feed_files
     description: |
       Each row of this table is a file extracted from a feed on a given day. Note that on days where


### PR DESCRIPTION
# Description
To help generate the metabase dashboard request for https://github.com/cal-itp/data-infra/issues/1206, max_service_date and days_from_service_date columns were added to `gtfs_schedule_fact_daily_feeds`

Resolves # [ihttps://github.com/cal-itp/data-infra/issues/1206]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
tested in big query

## Screenshots (optional)
