### PR TITLE
kubernetes: gtfs-rt-archive: lower memory limit and add cpu request

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -32,9 +32,10 @@ spec:
               mountPath: /secrets/gcs-upload-svcacct
           resources:
             requests:
-              memory: 2.0Gi
+              memory: 512Mi
+              cpu: 5.0
             limits:
-              memory: 2.0Gi
+              memory: 512Mi
       volumes:
         - name: agencies-data
           secret:


### PR DESCRIPTION
The memory limit of 2 GB is well above normal operating range, and in
fact tends to indicate that there is already a problem well underway. A
review of grafana data suggests that normal operation should remain
under the 512 MB mark.

The lack of CPU requests also means that both the preprod and the prod
archiver instances may end up scheduled on the same node, which in the
event of a utilization spike over 4 cores, could cause transaction
failures. This CPU request reflects more than half of the capacity of
any given node in the gtfsrt-v1 pool, reasonably ensuring that preprod
and prod instances will not be co-scheduled on a node.