### PR TITLE
Max_service_date and days_from_service_date columns added to gtfs_schedule_fact_daily_feeds

### DIFF
--- a/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
@@ -35,7 +35,7 @@ gtfs_schedule_service AS (
 dim_date AS (
     SELECT *
     FROM {{ ref('dim_date') }}
-)
+),
 
 
 -- create underlying dimensions: daily feeds
@@ -72,7 +72,7 @@ daily_service AS (
     SELECT
         gtfs_schedule_service.feed_key,
         MAX(gtfs_schedule_service.service_date) AS max_service_date,
-        MIN(gtfs_schedule_service.service_date) AS min_service_date,
+        MIN(gtfs_schedule_service.service_date) AS min_service_date
 
 
     FROM gtfs_schedule_service
@@ -90,7 +90,7 @@ daily_feed_join AS (
         (daily_service.min_service_date <= daily_feeds.date AND daily_service.max_service_date >= daily_feeds.date)
         AS is_service_date_valid,
 
-          -- how long until this service ends?
+        -- how long until this service ends?
         DATE_DIFF(daily_service.max_service_date, daily_feeds.date, DAY)
         AS days_until_service_end_date,
 


### PR DESCRIPTION
# Description
To help generate the metabase dashboard request for https://github.com/cal-itp/data-infra/issues/1206, max_service_date and days_from_service_date columns were added to `gtfs_schedule_fact_daily_feeds`. Origional merge was missing a comma which caused dbt to fail. The PR was reverted by https://github.com/cal-itp/data-infra/pull/1543. 

Resolves # [https://github.com/cal-itp/data-infra/issues/1206]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
tested in big query

## Screenshots (optional)