### PR TITLE
create full-refresh DAG to run manually as needed; couple other fixes

### DIFF
--- a/airflow/dags/transform_warehouse_full_refresh/METADATA.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/METADATA.yml
@@ -1,4 +1,4 @@
-description: "Builds and tests the warehouse, and uploads artifacts"
+description: "Runs dbt with --full-refresh; use this to refresh/rebuild/backfill incremental models."
 schedule_interval: null
 tags:
   - all_gusty_features

--- a/airflow/dags/transform_warehouse_full_refresh/METADATA.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/METADATA.yml
@@ -1,0 +1,17 @@
+description: "Builds and tests the warehouse, and uploads artifacts"
+schedule_interval: null
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "andrew.v@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 0
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: True

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -6,7 +6,7 @@ cmds:
   - python3
 arguments:
   - '/app/scripts/run_and_upload.py'
-  - '--no-dbt-test'
+  - '--full-refresh'
   - '--dbt-docs'
   - '--save-artifacts'
   - '--deploy-docs'

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -6,6 +6,7 @@ cmds:
   - python3
 arguments:
   - '/app/scripts/run_and_upload.py'
+  - '--no-dbt-test'
   - '--dbt-docs'
   - '--save-artifacts'
   - '--deploy-docs'

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -1,15 +1,16 @@
 operator: 'operators.PodOperator'
-name: 'dbt-run-and-upload-artifacts'
+name: 'dbt-test'
 image: 'ghcr.io/cal-itp/data-infra/warehouse:{{ image_tag() }}'
 
 cmds:
   - python3
 arguments:
   - '/app/scripts/run_and_upload.py'
-  - '--dbt-docs'
-  - '--save-artifacts'
-  - '--deploy-docs'
-  - '--sync-metabase'
+  - '--no-dbt-run'
+  - '--dbt-test'
+
+dependencies:
+  - dbt_run_and_upload_artifacts
 
 is_delete_operator_pod: true
 get_logs: true
@@ -23,24 +24,11 @@ env_vars:
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
   DBT_TARGET: prod_service_account
-  NETLIFY_SITE_ID: cal-itp-dbt-docs
 secrets:
   - deploy_type: volume
     deploy_target: /secrets/jobs-data/
     secret: jobs-data
     key: service-account.json
-  - deploy_type: env
-    deploy_target: METABASE_USER
-    secret: jobs-data
-    key: metabase-user
-  - deploy_type: env
-    deploy_target: METABASE_PASSWORD
-    secret: jobs-data
-    key: metabase-password
-  - deploy_type: env
-    deploy_target: NETLIFY_AUTH_TOKEN
-    secret: jobs-data
-    key: netlify-auth-token
 
 tolerations:
   - key: pod-role

--- a/warehouse/models/gtfs_schedule_latest_only/feed_info.md
+++ b/warehouse/models/gtfs_schedule_latest_only/feed_info.md
@@ -9,9 +9,12 @@ URL of the dataset publishing organization's website. This may be the same as on
 {% enddocs %}
 
 {% docs gtfs_feed_info__feed_lang %}
-Default language used for the text in this dataset. This setting helps GTFS consumers choose capitalization rules and other language-specific settings for the dataset. The file translations.txt can be used if the text needs to be translated into languages other than the default one.
+Default language used for the text in this dataset. This setting helps GTFS consumers choose capitalization rules and other language-specific settings for the dataset.
+The file translations.txt can be used if the text needs to be translated into languages other than the default one.
 
-The default language may be multilingual for datasets with the original text in multiple languages. In such cases, the feed_lang field should contain the language code mul defined by the norm ISO 639-2. The best practice here would be to provide, in translations.txt, a translation for each language used throughout the dataset. If all the original text in the dataset is in the same language, then mul should not be used.Example: Consider a dataset from a multilingual country like Switzerland, with the original stops.stop_name field populated with stop names in different languages. Each stop name is written according to the dominant language in that stop’s geographic location, e.g. Genève for the French-speaking city of Geneva, Zürich for the German-speaking city of Zurich, and Biel/Bienne for the bilingual city of Biel/Bienne. The dataset feed_lang should be mul and translations would be provided in translations.txt, in German: Genf, Zürich and Biel; in French: Genève, Zurich and Bienne; in Italian: Ginevra, Zurigo and Bienna; and in English: Geneva, Zurich and Biel/Bienne.
+The default language may be multilingual for datasets with the original text in multiple languages. In such cases, the feed_lang field should contain the language code mul
+defined by the norm ISO 639-2. The best practice here would be to provide, in translations.txt, a translation for each language used throughout the dataset. If all the
+original text in the dataset is in the same language, then mul should not be used. See https://gtfs.org/reference/static#feed_infotxt for examples.
 {% enddocs %}
 
 {% docs gtfs_feed_info__default_lang %}

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -20,8 +20,9 @@ def run(
     profiles_dir: Path = os.environ.get("DBT_PROFILES_DIR", os.getcwd()),
     target: str = os.environ.get("DBT_TARGET"),
     dbt_run: bool = True,
-    dbt_test: bool = True,
-    dbt_freshness: bool = True,
+    full_refresh: bool = False,
+    dbt_test: bool = False,
+    dbt_freshness: bool = False,
     dbt_docs: bool = False,
     save_artifacts: bool = False,
     deploy_docs: bool = False,
@@ -52,7 +53,11 @@ def run(
         return cmd
 
     if dbt_run:
-        subprocess.run(get_command("run")).check_returncode()
+        args = ["run"]
+
+        if full_refresh:
+            args.append("--full-refresh")
+        subprocess.run(get_command(*args)).check_returncode()
     else:
         typer.echo("skipping run, only compiling")
         subprocess.run(get_command("compile")).check_returncode()


### PR DESCRIPTION
# Description

`gtfs_rt_fact_daily_validation_errors` is our first incremental model, and it currently fails to build as the job is trying to MERGE on a unique key that doesn't exist yet. To create that key, we need to be able to run dbt with `--full-refresh` as needed in Airflow (this is a common pattern). This PR creates a non-scheduled DAG to make this happen.

```
Database Error in model gtfs_rt_fact_daily_validation_errors (models/rt_views/gtfs_rt_fact_daily_validation_errors.sql)
Name key not found inside DBT_INTERNAL_DEST at [68:57]
compiled SQL at target/run/calitp_warehouse/models/rt_views/gtfs_rt_fact_daily_validation_errors.sql
```

It also fixes an issue where `feed_info` throws an error when trying to set the column comments, as the doc-block for `feed_lang` was longer than BigQuery's limit of 1024 characters.

```
400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/cal-itp-data-infra/datasets/gtfs_schedule/tables/feed_info?prettyPrint=false: The description for field feed_lang is too long. The maximum length is 1024 characters.
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally via poetry/Airflow.

## Screenshots (optional)
