### PR TITLE
rename column

### DIFF
--- a/airflow/dags/airtable_loader/california_transit_services.yml
+++ b/airflow/dags/airtable_loader/california_transit_services.yml
@@ -9,8 +9,7 @@ id_name: service_id
 
 rename_fields:
   "# Static": num_static
-  # this typo exists in Airtable currently
-  "# Schedule FEeds": num_schedule_feeds
+  "# Schedule Feeds": num_schedule_feeds
   "# TripUpdates": num_trip_updates
   "# Alerts": num_service_alerts
   "# VehiclePositions": num_vehicle_positions

--- a/airflow/dags/airtable_loader/california_transit_services.yml
+++ b/airflow/dags/airtable_loader/california_transit_services.yml
@@ -9,6 +9,8 @@ id_name: service_id
 
 rename_fields:
   "# Static": num_static
+  # this typo exists in Airtable currently
+  "# Schedule FEeds": num_schedule_feeds
   "# TripUpdates": num_trip_updates
   "# Alerts": num_service_alerts
   "# VehiclePositions": num_vehicle_positions


### PR DESCRIPTION
_description added by @lauriemerrell_

# Description

Addresses `google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/cal-itp-data-infra/datasets/airtable/tables?prettyPrint=false: Invalid field name "#_schedule_feeds". Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be at most 300 characters long.` error being thrown by new column name in `services` table in California Transit Airtable base.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? n/a