### PR TITLE
start typing and anchoring important columns

### DIFF
--- a/warehouse/macros/farm_surrogate_key.sql
+++ b/warehouse/macros/farm_surrogate_key.sql
@@ -1,0 +1,10 @@
+{% macro farm_surrogate_key(columns) %}
+FARM_FINGERPRINT(CONCAT(
+{% for column in columns %}
+CAST({{ column }} AS STRING)
+{% if not loop.last %}
+, "___",
+{% endif %}
+{% endfor %}
+))
+{% endmacro %}

--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -32,6 +32,8 @@ models:
         tests: &primary_key_tests
           - not_null
           - unique
+        meta: &pk_meta
+          metabase.semantic_type: type/PK
       - name: agency_id
         description: '{{ doc("gtfs_agency__agency_id") }}'
       - name: agency_name
@@ -71,6 +73,7 @@ models:
       - name: attribution_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: attribution_id
         description: '{{ doc("gtfs_attributions__attribution_id") }}'
       - name: agency_id
@@ -111,6 +114,7 @@ models:
       - name: calendar_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: service_id
         description: '{{ doc("gtfs_calendar__service_id") }}'
         tests:
@@ -192,6 +196,7 @@ models:
       - name: fare_attribute_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: fare_id
         description: '{{ doc("gtfs_fare_attributes__fare_id") }}'
         tests:
@@ -232,6 +237,7 @@ models:
       - name: fare_rule_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: fare_id
         description: '{{ doc("gtfs_fare_rules__fare_id") }}'
         tests:
@@ -260,6 +266,7 @@ models:
       - name: feed_info_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: feed_publisher_name
         description: '{{ doc("gtfs_feed_info__feed_publisher_name") }}'
         tests:
@@ -300,6 +307,7 @@ models:
       - name: frequency_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: trip_id
         description: '{{ doc("gtfs_frequencies__trip_id") }}'
         tests:
@@ -334,6 +342,7 @@ models:
       - name: level_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: level_id
         description: '{{ doc("gtfs_levels__level_id") }}'
         tests:
@@ -360,6 +369,7 @@ models:
       - name: pathway_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: pathway_id
         description: '{{ doc("gtfs_pathways__pathway_id") }}'
         tests:
@@ -410,6 +420,7 @@ models:
       - name: route_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: route_id
         description: '{{ doc("gtfs_routes__route_id") }}'
         tests:
@@ -454,6 +465,7 @@ models:
       - name: shape_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: shape_id
         description: '{{ doc("gtfs_shapes__shape_id") }}'
         tests:
@@ -462,10 +474,14 @@ models:
         description: '{{ doc("gtfs_shapes__shape_pt_lat") }}'
         tests:
         - not_null
+        meta:
+          metabase.semantic_type: type/Latitude
       - name: shape_pt_lon
         description: '{{ doc("gtfs_shapes__shape_pt_lon") }}'
         tests:
         - not_null
+        meta:
+          metabase.semantic_type: type/Longitude
       - name: shape_pt_sequence
         description: '{{ doc("gtfs_shapes__shape_pt_sequence") }}'
         tests:
@@ -489,6 +505,7 @@ models:
       - name: stop_time_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: trip_id
         description: '{{ doc("gtfs_stop_times__trip_id") }}'
         tests:
@@ -537,6 +554,7 @@ models:
       - name: stop_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: stop_id
         description: '{{ doc("gtfs_stops__stop_id") }}'
         tests:
@@ -551,8 +569,12 @@ models:
         description: '{{ doc("gtfs_stops__stop_desc") }}'
       - name: stop_lat
         description: '{{ doc("gtfs_stops__stop_lat") }}'
+        meta:
+          metabase.semantic_type: type/Latitude
       - name: stop_lon
         description: '{{ doc("gtfs_stops__stop_lon") }}'
+        meta:
+          metabase.semantic_type: type/Longitude
       - name: zone_id
         description: '{{ doc("gtfs_stops__zone_id") }}'
       - name: stop_url
@@ -585,6 +607,7 @@ models:
       - name: transfer_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: from_stop_id
         description: '{{ doc("gtfs_transfers__from_stop_id") }}'
         tests:
@@ -615,6 +638,7 @@ models:
       - name: translation_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: table_name
         description: '{{ doc("gtfs_translations__table_name") }}'
         tests:
@@ -653,6 +677,7 @@ models:
       - name: trip_key
         description: '{{ doc("column_schedule_key") }}'
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: route_id
         description: '{{ doc("gtfs_trips__route_id") }}'
         tests:

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -174,6 +174,13 @@ models:
       Slowly-changing dimension table of shapes created from shapes.txt
       data. Each row is a shape. Primary key is composite of
       calitp_itp_id, calitp_url_number, calitp_extracted_at, and shape_id.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - calitp_extracted_at
+            - calitp_itp_id
+            - calitp_url_number
+            - shape_id
     columns:
       - &calitp_itp_id
         name: calitp_itp_id

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -5,6 +5,14 @@ models:
     description: |
       Each row is a date.
     columns:
+      - &key
+        name: key
+        description: Surrogate primary key for the table.
+        tests:
+          - not_null
+          - unique
+        meta:
+          metabase.semantic_type: type/PK
       - name: id
         description: Date formatted as string for identification, in "YYYY-MM-DD" format, ex. "2022-03-31".
         tests:
@@ -166,19 +174,16 @@ models:
       Each row is a cleaned row from a shapes.txt file.
       Definitions for the original GTFS fields are available at:
       https://gtfs.org/reference/static#shapestxt.
+    columns:
+      - *key
+
   - name: gtfs_schedule_dim_shapes_geo
     description: |
       Slowly-changing dimension table of shapes created from shapes.txt
       data. Each row is a shape. Primary key is composite of
       calitp_itp_id, calitp_url_number, calitp_extracted_at, and shape_id.
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - calitp_extracted_at
-            - calitp_itp_id
-            - calitp_url_number
-            - shape_id
     columns:
+      - *key
       - &calitp_itp_id
         name: calitp_itp_id
         description: '{{ doc("column_calitp_itp_id") }}'
@@ -211,6 +216,7 @@ models:
         description: Ordered array of WKT points that make up the shape.
         tests:
           - not_null
+
   - name: gtfs_schedule_dim_stop_times
     description: |
       Slowly-changing dimension table of stop_times.txt data.

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -179,15 +179,27 @@ models:
             - calitp_url_number
             - shape_id
     columns:
-      - name: calitp_itp_id
+      - &calitp_itp_id
+        name: calitp_itp_id
         description: '{{ doc("column_calitp_itp_id") }}'
-      - name: calitp_url_number
+        tests:
+          - not_null
+        meta:
+          metabase.semantic_type: type/FK
+      - &calitp_url_number
+        name: calitp_url_number
         description: '{{ doc("column_calitp_url_number") }}'
-      - name: calitp_extracted_at
+        tests:
+          - not_null
+        meta:
+          metabase.semantic_type: type/FK
+      - &calitp_extracted_at
+        name: calitp_extracted_at
         description: '{{ doc("column_schedule_calitp_extracted_at") }}'
         tests:
           - not_null
-      - name: calitp_deleted_at
+      - &calitp_deleted_at
+        name: calitp_deleted_at
         description: '{{ doc("column_schedule_calitp_deleted_at") }}'
         tests:
           - not_null
@@ -418,14 +430,8 @@ models:
             - day_name
             - calitp_extracted_at
     columns:
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-        tests:
-          - not_null
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
-        tests:
-          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: service_id
         description: service_id value from calendar.txt
         tests:
@@ -436,14 +442,8 @@ models:
           (from calendar.txt columns)
         tests:
           - not_null
-      - name: calitp_extracted_at
-        description: '{{ doc("column_schedule_calitp_extracted_at") }}'
-        tests:
-          - not_null
-      - name: calitp_deleted_at
-        description: '{{ doc("column_schedule_calitp_extracted_at") }}'
-        tests:
-          - not_null
+      - *calitp_extracted_at
+      - *calitp_deleted_at
   - name: gtfs_schedule_stg_daily_service
     description: |
       Each row indicates whether a given service_id was
@@ -459,14 +459,8 @@ models:
             - service_id
             - service_date
     columns:
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-        tests:
-          - not_null
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
-        tests:
-          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: service_id
         description: |
           service_id value from calendar.txt or calendar_dates.txt
@@ -498,10 +492,8 @@ models:
         description: '{{ doc("column_schedule_key") }}'
         tests:
           - not_null
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: service_id
         description: |
           service_id value from calendar.txt / calendar_dates.txt /
@@ -555,10 +547,8 @@ models:
         description: '{{ doc("column_schedule_key") }}'
         tests:
           - not_null
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: service_id
         description: |
           service_id value from calendar.txt / calendar_dates.txt /
@@ -586,14 +576,8 @@ models:
             - metric_month
             - metric_year
     columns:
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-        tests:
-          - not_null
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
-        tests:
-          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: metric_year
         description: |
           The year of the month for which the month-over-month ratio is
@@ -644,10 +628,8 @@ models:
             - metric_date
             - change_status
     columns:
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: feed_key
         description: |
           feed_key for the feed from this calitp_itp_id + calitp_url_number
@@ -676,10 +658,8 @@ models:
             - metric_date
             - change_status
     columns:
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: feed_key
         description: |
           feed_key for the feed from this calitp_itp_id + calitp_url_number
@@ -723,14 +703,8 @@ models:
             - calitp_itp_id
             - calitp_url_number
     columns:
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-        tests:
-          - not_null
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
-        tests:
-          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: publish_date
         description: |
           Date a report will be published (e.g. June 1st reports

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -127,6 +127,8 @@ models:
         tests:
           - not_null
           - unique
+        meta:
+          metabase.semantic_type: type/PK
   - name: gtfs_schedule_dim_files
     description: |
       Dimension table of all files that have been encountered in Cal-ITP
@@ -139,6 +141,8 @@ models:
         tests:
           - not_null
           - unique
+        meta:
+          metabase.semantic_type: type/PK
   - name: gtfs_schedule_dim_pathways
     description: |
       Slowly-changing dimension table of pathways.txt data.
@@ -162,6 +166,8 @@ models:
         tests:
           - not_null
           - unique
+        meta:
+          metabase.semantic_type: type/PK
   - name: gtfs_schedule_dim_shapes
     description: |
       Slowly-changing dimension table of shapes.txt data.
@@ -370,6 +376,8 @@ models:
         tests:
           - not_null
           - unique
+        meta:
+          metabase.semantic_type: type/PK
   - name: gtfs_schedule_fact_daily_feed_routes
     description: |
       Each row of this table is a feed/route/day combination, showing

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -5,19 +5,13 @@ models:
     description: |
       Each row is a date.
     columns:
-      - &key
-        name: key
-        description: Surrogate primary key for the table.
-        tests:
-          - not_null
-          - unique
-        meta:
-          metabase.semantic_type: type/PK
       - name: id
         description: Date formatted as string for identification, in "YYYY-MM-DD" format, ex. "2022-03-31".
         tests:
           - not_null
           - unique
+        meta:
+          metabase.semantic_type: type/PK
       - name: full_date
         description: Date formatted as a date; formatted as YYYY-MM-DD, ex. 2022-03-31.
         tests:
@@ -174,8 +168,6 @@ models:
       Each row is a cleaned row from a shapes.txt file.
       Definitions for the original GTFS fields are available at:
       https://gtfs.org/reference/static#shapestxt.
-    columns:
-      - *key
 
   - name: gtfs_schedule_dim_shapes_geo
     description: |
@@ -183,7 +175,6 @@ models:
       data. Each row is a shape. Primary key is composite of
       calitp_itp_id, calitp_url_number, calitp_extracted_at, and shape_id.
     columns:
-      - *key
       - &calitp_itp_id
         name: calitp_itp_id
         description: '{{ doc("column_calitp_itp_id") }}'

--- a/warehouse/models/gtfs_views/dim_date.sql
+++ b/warehouse/models/gtfs_views/dim_date.sql
@@ -12,7 +12,6 @@ WITH raw_dates AS (
 dim_date AS (
     SELECT
         FORMAT_DATE('%F', d) AS id,
-        {{ farm_surrogate_key(["FORMAT_DATE('%F', d)"]) }} AS key,
         d AS full_date,
         EXTRACT(YEAR FROM d) AS year,
         EXTRACT(WEEK FROM d) AS year_week,

--- a/warehouse/models/gtfs_views/dim_date.sql
+++ b/warehouse/models/gtfs_views/dim_date.sql
@@ -12,6 +12,7 @@ WITH raw_dates AS (
 dim_date AS (
     SELECT
         FORMAT_DATE('%F', d) AS id,
+        {{ farm_surrogate_key(["FORMAT_DATE('%F', d)"]) }} AS key,
         d AS full_date,
         EXTRACT(YEAR FROM d) AS year,
         EXTRACT(WEEK FROM d) AS year_week,

--- a/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes.sql
@@ -6,14 +6,7 @@ WITH shapes_clean AS (
 ),
 
 gtfs_schedule_dim_shapes AS (
-    SELECT
-        *,
-        {{ farm_surrogate_key([
-            'calitp_itp_id',
-            'calitp_url_number',
-            'calitp_extracted_at',
-            'shape_id',
-        ]) }} AS key
+    SELECT *
     FROM shapes_clean
 )
 

--- a/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes.sql
@@ -6,7 +6,15 @@ WITH shapes_clean AS (
 ),
 
 gtfs_schedule_dim_shapes AS (
-    SELECT * FROM shapes_clean
+    SELECT
+        *,
+        {{ farm_surrogate_key([
+            'calitp_itp_id',
+            'calitp_url_number',
+            'calitp_extracted_at',
+            'shape_id',
+        ]) }} AS key
+    FROM shapes_clean
 )
 
 SELECT * FROM gtfs_schedule_dim_shapes

--- a/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes_geo.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes_geo.sql
@@ -132,7 +132,14 @@ initial_pt_array AS (
 ),
 
 gtfs_schedule_dim_shapes_geo AS (
-    SELECT * EXCEPT(ct)
+    SELECT
+        * EXCEPT(ct),
+        {{ farm_surrogate_key([
+            'calitp_itp_id',
+            'calitp_url_number',
+            'calitp_extracted_at',
+            'shape_id',
+        ]) }} AS key
     FROM initial_pt_array
     -- drop shapes that had nulls
     WHERE ARRAY_LENGTH(pt_array) = ct

--- a/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes_geo.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_dim_shapes_geo.sql
@@ -132,14 +132,7 @@ initial_pt_array AS (
 ),
 
 gtfs_schedule_dim_shapes_geo AS (
-    SELECT
-        * EXCEPT(ct),
-        {{ farm_surrogate_key([
-            'calitp_itp_id',
-            'calitp_url_number',
-            'calitp_extracted_at',
-            'shape_id',
-        ]) }} AS key
+    SELECT * EXCEPT(ct)
     FROM initial_pt_array
     -- drop shapes that had nulls
     WHERE ARRAY_LENGTH(pt_array) = ct

--- a/warehouse/models/gtfs_views_staging/agency_clean.sql
+++ b/warehouse/models/gtfs_views_staging/agency_clean.sql
@@ -22,7 +22,7 @@ agency_clean AS (
         TRIM(agency_email) AS agency_email,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS agency_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS agency_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM agency
 )

--- a/warehouse/models/gtfs_views_staging/attributions_clean.sql
+++ b/warehouse/models/gtfs_views_staging/attributions_clean.sql
@@ -26,7 +26,7 @@ attributions_clean AS (
         TRIM(attribution_phone) AS attribution_phone,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS attribution_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS attribution_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM attributions
 )

--- a/warehouse/models/gtfs_views_staging/calendar_clean.sql
+++ b/warehouse/models/gtfs_views_staging/calendar_clean.sql
@@ -25,8 +25,7 @@ calendar_clean AS (
         PARSE_DATE("%Y%m%d", TRIM(end_date)) AS end_date,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
-        AS calendar_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS calendar_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM calendar
 )

--- a/warehouse/models/gtfs_views_staging/fare_attributes_clean.sql
+++ b/warehouse/models/gtfs_views_staging/fare_attributes_clean.sql
@@ -22,7 +22,7 @@ fare_attributes_clean AS (
         TRIM(transfer_duration) AS transfer_duration,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS fare_attribute_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS fare_attribute_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM fare_attributes
 )

--- a/warehouse/models/gtfs_views_staging/fare_rules_clean.sql
+++ b/warehouse/models/gtfs_views_staging/fare_rules_clean.sql
@@ -20,10 +20,7 @@ fare_rules_clean AS (
         TRIM(contains_id) AS contains_id,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(
-            CONCAT(CAST(calitp_hash AS STRING), "___",
-                CAST(calitp_extracted_at AS STRING)))
-        AS fare_rule_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS fare_rule_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM fare_rules
 )

--- a/warehouse/models/gtfs_views_staging/feed_info_clean.sql
+++ b/warehouse/models/gtfs_views_staging/feed_info_clean.sql
@@ -26,7 +26,7 @@ feed_info_clean AS (
         calitp_hash,
         PARSE_DATE("%Y%m%d", TRIM(feed_start_date)) AS feed_start_date,
         PARSE_DATE("%Y%m%d", TRIM(feed_end_date)) AS feed_end_date,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }}
         AS feed_info_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM feed_info

--- a/warehouse/models/gtfs_views_staging/frequencies_clean.sql
+++ b/warehouse/models/gtfs_views_staging/frequencies_clean.sql
@@ -20,7 +20,7 @@ frequencies_clean AS (
         TRIM(exact_times) AS exact_times,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS frequency_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS frequency_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM frequencies
 )

--- a/warehouse/models/gtfs_views_staging/levels_clean.sql
+++ b/warehouse/models/gtfs_views_staging/levels_clean.sql
@@ -18,7 +18,7 @@ levels_clean AS (
         TRIM(level_name) AS level_name,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS level_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS level_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM levels
 )

--- a/warehouse/models/gtfs_views_staging/pathways_clean.sql
+++ b/warehouse/models/gtfs_views_staging/pathways_clean.sql
@@ -27,7 +27,7 @@ pathways_clean AS (
         TRIM(reversed_signposted_as) AS reversed_signposted_as,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS pathway_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS pathway_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM pathways
 )

--- a/warehouse/models/gtfs_views_staging/routes_clean.sql
+++ b/warehouse/models/gtfs_views_staging/routes_clean.sql
@@ -27,7 +27,7 @@ routes_clean AS (
         TRIM(continuous_drop_off) AS continuous_drop_off,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }}
         AS route_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM routes

--- a/warehouse/models/gtfs_views_staging/shapes_clean.sql
+++ b/warehouse/models/gtfs_views_staging/shapes_clean.sql
@@ -20,7 +20,7 @@ shapes_clean AS (
         SAFE_CAST(TRIM(shape_dist_traveled) AS FLOAT64) AS shape_dist_traveled,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS shape_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS shape_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM shapes
 )

--- a/warehouse/models/gtfs_views_staging/stop_times_clean.sql
+++ b/warehouse/models/gtfs_views_staging/stop_times_clean.sql
@@ -27,7 +27,7 @@ stop_times_clean AS (
         TRIM(timepoint) AS timepoint,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING)))
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }}
         AS stop_time_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM stop_times

--- a/warehouse/models/gtfs_views_staging/stops_clean.sql
+++ b/warehouse/models/gtfs_views_staging/stops_clean.sql
@@ -30,7 +30,7 @@ stops_clean AS (
         TRIM(platform_code) AS platform_code,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS stop_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS stop_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM stops
 )

--- a/warehouse/models/gtfs_views_staging/transfers_clean.sql
+++ b/warehouse/models/gtfs_views_staging/transfers_clean.sql
@@ -18,7 +18,7 @@ transfers_clean AS (
         TRIM(transfer_type) AS transfer_type,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS transfer_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS transfer_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM transfers
 )

--- a/warehouse/models/gtfs_views_staging/translations_clean.sql
+++ b/warehouse/models/gtfs_views_staging/translations_clean.sql
@@ -23,7 +23,7 @@ translations_clean AS (
         TRIM(field_value) AS field_value,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS translation_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS translation_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM translations
 )

--- a/warehouse/models/gtfs_views_staging/trips_clean.sql
+++ b/warehouse/models/gtfs_views_staging/trips_clean.sql
@@ -25,7 +25,7 @@ trips_clean AS (
         TRIM(bikes_allowed) AS bikes_allowed,
         calitp_extracted_at,
         calitp_hash,
-        FARM_FINGERPRINT(CONCAT(CAST(calitp_hash AS STRING), "___", CAST(calitp_extracted_at AS STRING))) AS trip_key,
+        {{ farm_surrogate_key(['calitp_hash', 'calitp_extracted_at']) }} AS trip_key,
         COALESCE(calitp_deleted_at, "2099-01-01") AS calitp_deleted_at
     FROM trips
 )

--- a/warehouse/models/rt_views/_rt_views.yml
+++ b/warehouse/models/rt_views/_rt_views.yml
@@ -42,14 +42,20 @@ models:
         description: Timestamp when this file was extracted
         tests:
           - not_null
-      - name: calitp_itp_id
+      - &calitp_itp_id
+        name: calitp_itp_id
         description: '{{ doc("column_calitp_itp_id") }}'
         tests:
           - not_null
-      - name: calitp_url_number
+        meta:
+          metabase.semantic_type: type/FK
+      - &calitp_url_number
+        name: calitp_url_number
         description: '{{ doc("column_calitp_url_number") }}'
         tests:
           - not_null
+        meta:
+          metabase.semantic_type: type/FK
       - name: name
         description: File type (service_alerts, trip_updates, or vehicle_positions)
         tests:
@@ -94,14 +100,8 @@ models:
         description: Date extracted from calitp_extracted_at
         tests:
           - not_null
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-        tests:
-          - not_null
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
-        tests:
-          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: name
         description: File type (service_alerts, trip_updates, or vehicle_positions)
         tests:
@@ -129,14 +129,8 @@ models:
         description: Date for which this feed was present in our extraction list
         tests:
           - not_null
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-        tests:
-          - not_null
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
-        tests:
-          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: url
         description: Feed URL
         tests:
@@ -162,14 +156,8 @@ models:
         description: Date for which this feed was present in our extraction list
         tests:
           - not_null
-      - name: calitp_itp_id
-        description: '{{ doc("column_calitp_itp_id") }}'
-        tests:
-          - not_null
-      - name: calitp_url_number
-        description: '{{ doc("column_calitp_url_number") }}'
-        tests:
-          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
       - name: rt_feed_type
         description: GTFS realtime type (service_alerts, trip_updates, or vehicle_positions)
         tests:
@@ -197,11 +185,15 @@ models:
         tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.95
+        meta:
+          metabase.semantic_type: type/FK
       - name: calitp_url_number
         description: '{{ doc("column_calitp_url_number") }}'
         tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.95
+        meta:
+          metabase.semantic_type: type/FK
       - name: error
         description: |
           Download error encountered.


### PR DESCRIPTION
# Description

Adds a bunch of semantic types! We should be using non-specific FKs to prevent auto-binning of numerical identifiers such as `calitp_itp_id`.

One opinion in this PR: every table should have an explicit primary key column with not-null and unique tests, rather than just a unique-combination-of-columns test. This is useful when using YAML anchors.

Resolves https://github.com/cal-itp/data-infra/issues/1107

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
