### PR TITLE
agencies.yml: long beach transit rt urls

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -666,9 +666,9 @@ long-beach-transit:
   agency_name: Long Beach Transit
   feeds:
     - gtfs_schedule_url: https://lbtransit.box.com/shared/static/aoyeskwmsa9g7pyg78q3xuioi0lgqe4f.zip
-      gtfs_rt_vehicle_positions_url: http://206.128.158.171/TMGTFSRealTimeWebService/Vehicle/VehiclePositions.pb
-      gtfs_rt_service_alerts_url: http://206.128.158.171/TMGTFSRealTimeWebService/Alert/Alerts.pb
-      gtfs_rt_trip_updates_url: http://206.128.158.171/TMGTFSRealTimeWebService/TripUpdate/TripUpdates.pb
+      gtfs_rt_vehicle_positions_url: https://lbtgtfs.lbtransit.com/TMGTFSRealTimeWebService/Vehicle/VehiclePositions.pb
+      gtfs_rt_service_alerts_url: https://lbtgtfs.lbtransit.com/TMGTFSRealTimeWebService/Alert/Alerts.pb
+      gtfs_rt_trip_updates_url: https://lbtgtfs.lbtransit.com/TMGTFSRealTimeWebService/TripUpdate/TripUpdates.pb
   itp_id: 170
 madera-area-express:
   agency_name: Madera Area Express


### PR DESCRIPTION
# Description

Same deal as MST yesterday -- Long Beach Transit RT URLs have been updated on [their website
](https://ridelbt.com/gtfs-feed/). Old URLs stopped working yesterday. 

Note that they also provide a few additional data sets that don't seem to be traditional GTFS-RT? 
![image](https://user-images.githubusercontent.com/55149902/173078166-a1dffc06-928f-43ed-bf42-04f22389ad2f.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested? 

Manually checked that each of the new URLs returns valid GTFS-RT data.

## Screenshots (optional)

Updated Airtable with the new URLs:
![image](https://user-images.githubusercontent.com/55149902/173078381-b0464477-2847-48e2-b0c9-8302de5f8aef.png)

