### PR TITLE
Audit and followups

### DIFF
--- a/airflow/dags/create_external_tables/rt_service_alerts_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_service_alerts_outcomes.yml
@@ -13,6 +13,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: true
   source_uri_prefix: "service_alerts_outcomes/{dt:DATE}/{itp_id:INTEGER}/{url_number:INTEGER}/{hour:INTEGER}/"
 schema_fields:
   - name: step

--- a/airflow/dags/create_external_tables/rt_service_alerts_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_service_alerts_validations_outcomes.yml
@@ -13,6 +13,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: true
   source_uri_prefix: "service_alerts_validations_outcomes/{dt:DATE}/{itp_id:INTEGER}/{url_number:INTEGER}/{hour:INTEGER}/"
 schema_fields:
   - name: step

--- a/airflow/dags/create_external_tables/rt_trip_updates_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_trip_updates_outcomes.yml
@@ -13,6 +13,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: true
   source_uri_prefix: "trip_updates_outcomes/{dt:DATE}/{itp_id:INTEGER}/{url_number:INTEGER}/{hour:INTEGER}/"
 schema_fields:
   - name: step

--- a/airflow/dags/create_external_tables/rt_trip_updates_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_trip_updates_validations_outcomes.yml
@@ -13,6 +13,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: true
   source_uri_prefix: "trip_updates_validations_outcomes/{dt:DATE}/{itp_id:INTEGER}/{url_number:INTEGER}/{hour:INTEGER}/"
 schema_fields:
   - name: step

--- a/airflow/dags/create_external_tables/rt_vehicle_positions_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_vehicle_positions_outcomes.yml
@@ -13,6 +13,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: true
   source_uri_prefix: "vehicle_positions_outcomes/{dt:DATE}/{itp_id:INTEGER}/{url_number:INTEGER}/{hour:INTEGER}/"
 schema_fields:
   - name: step

--- a/airflow/dags/create_external_tables/rt_vehicle_positions_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/rt_vehicle_positions_validations_outcomes.yml
@@ -13,6 +13,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: true
   source_uri_prefix: "vehicle_positions_validations_outcomes/{dt:DATE}/{itp_id:INTEGER}/{url_number:INTEGER}/{hour:INTEGER}/"
 schema_fields:
   - name: step

--- a/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
+++ b/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
@@ -85,6 +85,10 @@ stg_audit__cloudaudit_googleapis_com_data_access AS (
 
         JSON_VALUE(metadata, '$.tableDataRead.jobName') as table_data_read_job_name,
 
+        -- try to parse out the dbt node if we can
+        TRIM(REGEXP_EXTRACT(JSON_VALUE(job, '$.jobConfig.queryConfig.query'), r'\/\*\s.*\s\*\/'), '/* ') AS dbt_header,
+        JSON_VALUE(TRIM(REGEXP_EXTRACT(JSON_VALUE(job, '$.jobConfig.queryConfig.query'), r'\/\*\s.*\s\*\/'), '/* '), '$.node_id') AS dbt_node,
+
         payload,
         metadata,
         job

--- a/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
+++ b/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
@@ -15,10 +15,10 @@
 
 -- Note these two source CTEs use a direct reference instead of source, because a new table is created daily
 WITH latest AS (
-    {% set today = modules.datetime.date.today() %}
+    {% set yesterday = modules.datetime.date.today() - modules.datetime.timedelta(days=1) %}
 
     SELECT *
-    FROM cal-itp-data-infra.audit.cloudaudit_googleapis_com_data_access_{{ today.strftime('%Y%m%d') }}
+    FROM cal-itp-data-infra.audit.cloudaudit_googleapis_com_data_access_{{ yesterday.strftime('%Y%m%d') }}
 ),
 
 everything AS (

--- a/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
+++ b/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
@@ -79,6 +79,7 @@ stg_audit__cloudaudit_googleapis_com_data_access AS (
             SECOND
         ) AS duration_in_seconds,
         JSON_VALUE_ARRAY(job, '$.jobStats.queryStats.referencedTables') as referenced_tables,
+        CAST(JSON_VALUE(job, '$.jobStats.queryStats.totalBilledBytes') AS INT64) AS total_billed_bytes,
         5.0 * CAST(JSON_VALUE(job, '$.jobStats.queryStats.totalBilledBytes') AS INT64) / POWER(2, 40) AS estimated_cost_usd, -- $5/TB
         CAST(JSON_VALUE(job, '$.jobStats.totalSlotMs') AS INT64) / 1000 AS total_slots_seconds,
 

--- a/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
+++ b/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
@@ -9,33 +9,15 @@ sources:
       - name: service_alerts
         description: Unnested service alerts records, hive partitioned in GCS.
       - name: service_alerts_outcomes
-        loaded_at_field: cast(dt as timestamp)
-        freshness:
-          warn_after: { count: 1, period: day }
       - name: service_alerts_validations
       - name: service_alerts_validations_outcomes
-        loaded_at_field: cast(dt as timestamp)
-        freshness:
-          warn_after: { count: 1, period: day }
       - name: trip_updates
         description: Unnested trip updates records, hive partitioned in GCS.
       - name: trip_updates_outcomes
-        loaded_at_field: cast(dt as timestamp)
-        freshness:
-          warn_after: { count: 1, period: day }
       - name: trip_updates_validations
       - name: trip_updates_validations_outcomes
-        loaded_at_field: cast(dt as timestamp)
-        freshness:
-          warn_after: { count: 1, period: day }
       - name: vehicle_positions
         description: Unnested vehicle positions records, hive partitioned in GCS.
       - name: vehicle_positions_outcomes
-        loaded_at_field: cast(dt as timestamp)
-        freshness:
-          warn_after: { count: 1, period: day }
       - name: vehicle_positions_validations
       - name: vehicle_positions_validations_outcomes
-        loaded_at_field: cast(dt as timestamp)
-        freshness:
-          warn_after: { count: 1, period: day }


### PR DESCRIPTION
# Description

This PR makes a couple fixes based on an investigation into high bigquery billing last week.

1. Removes very expensive and largely useless freshness checks on outcomes files. (BigQuery does not efficiently select the pseudo-columns in hive-partitioned external tables.)
2. Fixes the audit table to increment properly and also include more information, including the dbt node name.
3. Requires partition filters for outcomes external tables; they got bigger than expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally via dbt CLI.

## Screenshots (optional)
