### PR TITLE
docs(datasets and tables): added markdown table with new links to dbt docs

### DIFF
--- a/docs/datasets_and_tables/views.md
+++ b/docs/datasets_and_tables/views.md
@@ -2,12 +2,44 @@
 
 ## Data
 
-| dataset | description | examples |
-| ------- | ----------- | -------- |
-| `views.gtfs_agency_names` | One row per GTFS Static data feed, with `calitp_itp_id`, `calitp_url_number`, and `agency_name` | |
-| `views.gtfs_schedule_service_daily` | `calendar.txt` data from GTFS Static unpacked and joined with `calendar_dates.txt` to reflect service schedules on a given day. Critically, it uses the data that was current on `service_date`. For `service_date` values in the future, uses most recent data in warehouse. | |
-| `views.validation_notices` | One line per specific validation violation (e.g. each invalid phone number). See `validation_code_descriptions` for human friendly code labels, and `validation_notice_fields` for looking up what columns in `validation_notices` different codes have data for (e.g. the code `"invalid_phone_number"` sets the `fieldValue` column). | |
-
-## DAGs Maintenance
-
-You can find further information on DAGs maintenance for Views [on this page](views-dags).
+|Table                                                    |Description|Link                                                                                                                         |
+|---------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------|
+|dim_date                                                 |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_date)                                                 |
+|dim_metric_date                                          |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_metric_date)                                          |
+|gtfs_rt_fact_daily_feeds                                 |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_rt_fact_daily_feeds)                                 |
+|gtfs_rt_fact_daily_validation_errors                     |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_rt_fact_daily_validation_errors)                     |
+|gtfs_rt_fact_extraction_errors                           |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_rt_fact_extraction_errors)                           |
+|gtfs_rt_fact_files                                       |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_rt_fact_files)                                       |
+|gtfs_rt_fact_files_wide_hourly                           |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_rt_fact_files_wide_hourly)                           |
+|gtfs_rt_validation_code_descriptions                     |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_rt_validation_code_descriptions)                     |
+|gtfs_schedule_data_feed_trip_stops_latest                |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_data_feed_trip_stops_latest)                |
+|gtfs_schedule_dim_feeds                                  |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_feeds)                                  |
+|gtfs_schedule_dim_files                                  |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_files)                                  |
+|gtfs_schedule_dim_pathways                               |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_pathways)                               |
+|gtfs_schedule_dim_routes                                 |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_routes)                                 |
+|gtfs_schedule_dim_shapes                                 |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_shapes)                                 |
+|gtfs_schedule_dim_shapes_geo                             |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_shapes_geo)                             |
+|gtfs_schedule_dim_shapes_geo_latest                      |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_shapes_geo_latest)                      |
+|gtfs_schedule_dim_stop_times                             |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_stop_times)                             |
+|gtfs_schedule_dim_stops                                  |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_stops)                                  |
+|gtfs_schedule_dim_trips                                  |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_dim_trips)                                  |
+|gtfs_schedule_fact_daily                                 |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily)                                 |
+|gtfs_schedule_fact_daily_feed_files                      |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily_feed_files)                      |
+|gtfs_schedule_fact_daily_feed_routes                     |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily_feed_routes)                     |
+|gtfs_schedule_fact_daily_feed_stops                      |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily_feed_stops)                      |
+|gtfs_schedule_fact_daily_feeds                           |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily_feeds)                           |
+|gtfs_schedule_fact_daily_pathways                        |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily_pathways)                        |
+|gtfs_schedule_fact_daily_service                         |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily_service)                         |
+|gtfs_schedule_fact_daily_trips                           |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_daily_trips)                           |
+|gtfs_schedule_fact_day_of_week_service_monthly_comparison|           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_day_of_week_service_monthly_comparison)|
+|gtfs_schedule_fact_route_id_changes                      |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_route_id_changes)                      |
+|gtfs_schedule_fact_stop_id_changes                       |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_fact_stop_id_changes)                       |
+|gtfs_schedule_index_feed_trip_stops                      |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_index_feed_trip_stops)                      |
+|gtfs_schedule_stg_calendar_long                          |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_stg_calendar_long)                          |
+|gtfs_schedule_stg_daily_service                          |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.gtfs_schedule_stg_daily_service)                          |
+|reports_gtfs_schedule_index                              |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.reports_gtfs_schedule_index)                              |
+|reports_weekly_file_checks                               |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.reports_weekly_file_checks)                               |
+|validation_code_descriptions                             |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.validation_code_descriptions)                             |
+|validation_dim_codes                                     |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.validation_dim_codes)                                     |
+|validation_fact_daily_feed_codes                         |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.validation_fact_daily_feed_codes)                         |
+|validation_fact_daily_feed_notices                       |           |[link](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.validation_fact_daily_feed_notices)                       |


### PR DESCRIPTION
# Description

As part of deploying dbt we benefit from new, automatically generated, table-level documentation that is easier to maintain, lives close to the code, and serves as our source of truth.

To make this useful, we need to remove the current documentation (keeping what doesn't yet live in dbt) and link out to the dbt site.

It is important to note that **there are some docs that should not yet be deprecated** including airtable, transit database, and anything not yet in dbt.

Datasets included in this PR:
* external_gtfs_rt
* gtfs_rt
* gtfs_rt_logs
* gtfs_schedule
* gtfs_schedule_history
* gtfs_schedule_type2
* gtfs_views_staging
* information_schema
* staging
* views

Resolves #1499 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
