### PR TITLE
gtfs-rt-archive: increase memory limit to 640Mi

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -35,7 +35,7 @@ spec:
               memory: 512Mi
               cpu: 5.0
             limits:
-              memory: 512Mi
+              memory: 640Mi
       volumes:
         - name: agencies-data
           secret:


### PR DESCRIPTION
The limit of 512Mi was causing restarts at an interval which resulted in
over-collection of data, downgrading quality. This modest increase
provides more headroom while still attempting to bludgeon runaway memory
spikes as early as possible.