### PR TITLE
Deploy 640Mi limit for gtfs-rt-archiver into production

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -35,7 +35,7 @@ spec:
               memory: 512Mi
               cpu: 5.0
             limits:
-              memory: 512Mi
+              memory: 640Mi
       volumes:
         - name: agencies-data
           secret:


### PR DESCRIPTION
Deploys #1577 into production