### PR TITLE
GTFS downloader v2 - download_feeds task and Pydantic/GCS work!

### DIFF
--- a/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
+++ b/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
@@ -1,0 +1,21 @@
+description: "Download GTFS Schedule feeds as specified in Airtable"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "blake.f@jarv.us"
+      - "evan.siroky@dot.ca.gov"
+      - "hunter.owens@dot.ca.gov"
+      - "jameelah.y@jarv.us"
+      - "laurie.m@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: True

--- a/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
+++ b/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
@@ -12,6 +12,7 @@ default_args:
       - "hunter.owens@dot.ca.gov"
       - "jameelah.y@jarv.us"
       - "laurie.m@jarv.us"
+      - "andrew.v@jarv.us"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -18,7 +18,8 @@ from utils import (
     AirtableGTFSDataExtract,
     AirtableGTFSDataRecord,
     AirtableGTFSDataRecordProcessingOutcome,
-    GTFSFeedExtract,
+    GTFSFeedExtractInfo,
+    GTFSFeedType,
 )
 
 GTFS_FEED_LIST_ERROR_THRESHOLD = 0.95
@@ -48,7 +49,7 @@ def download_feed(
         or "feed.zip"
     )
 
-    extract = GTFSFeedExtract(
+    extract = GTFSFeedExtractInfo(
         filename=filename,
         config=record,
         response_code=resp.status_code,
@@ -75,6 +76,9 @@ def download_all(task_instance, execution_date, **kwargs):
     outcomes: List[AirtableGTFSDataRecordProcessingOutcome] = []
 
     for record in records:
+        if record.data != GTFSFeedType.schedule:
+            continue
+
         try:
             # this is a bit hacky but we need this until we split off auth query params from the URI itself
             jinja_pattern = r"(?P<param_name>\w+)={{\s*(?P<param_lookup_key>\w+)\s*}}"

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -23,6 +23,7 @@ def download_all(task_instance, execution_date, **kwargs):
     with create_session() as session:
         auth_dict = {var.key: var.val for var in session.query(Variable)}
 
+    airtable_records = AirtableGTFSDataExtract.get_latest().records
     # TODO: get these from Airtable or whatever
     feeds: List[GTFSFeed] = [
         GTFSFeed(
@@ -32,6 +33,7 @@ def download_all(task_instance, execution_date, **kwargs):
     ]
 
     exceptions = []
+    outcomes = []
 
     for feed in feeds:
         try:
@@ -76,6 +78,8 @@ def download_all(task_instance, execution_date, **kwargs):
                 traceback.format_exc(),
             )
             exceptions.append(e)
+
+    assert len(outcomes) == len(airtable_records)
 
     if exceptions:
         exc_str = "\n".join(map(str, exceptions))

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -11,10 +11,59 @@ import pendulum
 import re
 from airflow.models import Variable
 from airflow.utils.db import create_session
+from pydantic.networks import HttpUrl
+from pydantic.tools import parse_obj_as
 from requests import Session
-from typing import List
+from typing import List, Dict
 from calitp.storage import get_fs
-from utils import prefix_bucket, GTFSFeed, GTFSFeedType, GTFSExtract
+from utils import (
+    AirtableGTFSDataExtract,
+    AirtableGTFSDataRecord,
+    AirtableGTFSDataRecordProcessingOutcome,
+    GTFSFeedExtract,
+)
+
+GTFS_FEED_LIST_ERROR_THRESHOLD = 0.95
+
+
+def download_feed(
+    record: AirtableGTFSDataRecord, auth_dict: Dict
+) -> AirtableGTFSDataRecordProcessingOutcome:
+    if not record.uri:
+        raise ValueError("")
+
+    parse_obj_as(HttpUrl, record.uri)
+
+    s = Session()
+    r = s.prepare_request(record.build_request(auth_dict))
+    resp = s.send(r)
+    resp.raise_for_status()
+
+    # we can try a few different locations for the filename
+    disp1 = re.search('filename="(.+)"', resp.headers.get("content-disposition", ""))
+    disp2 = re.search('filename="(.+)"', resp.headers.get("Content-Disposition", ""))
+
+    filename = (
+        (disp1.group(0) if disp1 else None)
+        or (disp2.group(0) if disp1 else None)
+        or (os.path.basename(resp.url) if resp.url.endswith(".zip") else None)
+        or "content.zip"
+    )
+
+    extract = GTFSFeedExtract(
+        filename=filename,
+        config=record,
+        response_code=resp.status_code,
+        response_headers=resp.headers,
+        download_time=pendulum.now(),
+    )
+
+    extract.save_content(fs=get_fs(), content=resp.content)
+
+    return AirtableGTFSDataRecordProcessingOutcome(
+        success=True,
+        extract=extract,
+    )
 
 
 def download_all(task_instance, execution_date, **kwargs):
@@ -23,68 +72,38 @@ def download_all(task_instance, execution_date, **kwargs):
     with create_session() as session:
         auth_dict = {var.key: var.val for var in session.query(Variable)}
 
-    airtable_records = AirtableGTFSDataExtract.get_latest().records
-    # TODO: get these from Airtable or whatever
-    feeds: List[GTFSFeed] = [
-        GTFSFeed(
-            type=GTFSFeedType.schedule,
-            url="https://www.bart.gov/dev/schedules/google_transit.zip",
-        ),
-    ]
+    records = AirtableGTFSDataExtract.get_latest().records
+    outcomes: List[AirtableGTFSDataRecordProcessingOutcome] = []
 
-    exceptions = []
-    outcomes = []
-
-    for feed in feeds:
+    for record in records:
         try:
-            s = Session()
-            r = s.prepare_request(feed.build_request(auth_dict))
-            resp = s.send(r)
-
-            # we can try a few different locations for the filename
-            disp1 = re.search(
-                'filename="(.+)"', resp.headers.get("content-disposition", "")
-            )
-            disp2 = re.search(
-                'filename="(.+)"', resp.headers.get("Content-Disposition", "")
-            )
-
-            filename = (
-                (disp1.group(0) if disp1 else None)
-                or (disp2.group(0) if disp1 else None)
-                or (os.path.basename(resp.url) if resp.url.endswith(".zip") else None)
-                or "content.zip"
-            )
-
-            extract = GTFSExtract(
-                feed=feed,
-                filename=filename,
-                response_code=resp.status_code,
-                response_headers=resp.headers,
-                download_time=pendulum.now(),
-            )
-
-            extract.save_content(
-                fs=get_fs(),
-                bucket=prefix_bucket("gtfs-schedule-raw"),
-                content=resp.content,
-            )
-
-            # if resp.headers['content-type'] != 'application/zip':
-
+            # this is a bit hacky but we need this until we split off auth query params from the URI itself
+            jinja_pattern = r"(?P<param_name>\w+)={{\s*(?P<param_lookup_key>\w+)\s*}}"
+            match = re.search(jinja_pattern, record.uri)
+            if match:
+                record.auth_query_param = {
+                    match.group("param_name"): match.group("param_lookup_key")
+                }
+                record.uri = re.sub(jinja_pattern, "", record.uri)
+            outcomes.append(download_feed(record, auth_dict=auth_dict))
         except Exception as e:
             print(
                 f"exception occurred while attempting to download feed: {str(e)}",
                 traceback.format_exc(),
             )
-            exceptions.append(e)
+            raise
+            # outcomes.append(AirtableGTFSDataRecordProcessingOutcome(
+            #
+            # ))
 
-    assert len(outcomes) == len(airtable_records)
+    assert len(records) == len(
+        outcomes
+    ), f"we somehow ended up with {len(outcomes)} from {len(records)}"
 
-    if exceptions:
-        exc_str = "\n".join(map(str, exceptions))
+    success_rate = len([outcome for outcome in outcomes if outcome.success]) / len(
+        records
+    )
+    if success_rate < GTFS_FEED_LIST_ERROR_THRESHOLD:
         raise RuntimeError(
-            f"got {len(exceptions)} exceptions out of {len(feeds)} feeds: {exc_str}"
+            f"Success rate: {success_rate} was below error threshold: {GTFS_FEED_LIST_ERROR_THRESHOLD}"
         )
-    else:
-        print(f"successfully handled all {len(feeds)} feeds!")

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -1,8 +1,6 @@
 # ---
 # python_callable: download_all
 # provide_context: true
-# dependencies:
-#   - generate_provider_list
 # ---
 import traceback
 
@@ -47,7 +45,7 @@ def download_feed(
         (disp1.group(0) if disp1 else None)
         or (disp2.group(0) if disp1 else None)
         or (os.path.basename(resp.url) if resp.url.endswith(".zip") else None)
-        or "content.zip"
+        or "feed.zip"
     )
 
     extract = GTFSFeedExtract(

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -62,6 +62,7 @@ def download_feed(
 
     return AirtableGTFSDataRecordProcessingOutcome(
         success=True,
+        input_record=record,
         extract=extract,
     )
 
@@ -91,10 +92,13 @@ def download_all(task_instance, execution_date, **kwargs):
                 f"exception occurred while attempting to download feed: {str(e)}",
                 traceback.format_exc(),
             )
-            raise
-            # outcomes.append(AirtableGTFSDataRecordProcessingOutcome(
-            #
-            # ))
+            outcomes.append(
+                AirtableGTFSDataRecordProcessingOutcome(
+                    success=False,
+                    exception=e,
+                    input_record=record,
+                )
+            )
 
     assert len(records) == len(
         outcomes

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -68,6 +68,7 @@ def download_feed(
 
 
 def download_all(task_instance, execution_date, **kwargs):
+    start = pendulum.now()
     # TODO: use laurie's method for this
     # https://stackoverflow.com/a/61808755
     with create_session() as session:
@@ -107,14 +108,16 @@ def download_all(task_instance, execution_date, **kwargs):
                 )
             )
 
+    print(f"took {pendulum.now() - start} to process {len(records)} records")
+
     assert len(records) == len(
         outcomes
     ), f"we somehow ended up with {len(outcomes)} from {len(records)}"
 
-    success_rate = len([outcome for outcome in outcomes if outcome.success]) / len(
-        records
-    )
+    successes = len([outcome for outcome in outcomes if outcome.success])
+    print(f"successfully fetched {successes} of {len(records)}")
+    success_rate = successes / len(records)
     if success_rate < GTFS_FEED_LIST_ERROR_THRESHOLD:
         raise RuntimeError(
-            f"Success rate: {success_rate} was below error threshold: {GTFS_FEED_LIST_ERROR_THRESHOLD}"
+            f"Success rate: {success_rate:.1f} was below error threshold: {GTFS_FEED_LIST_ERROR_THRESHOLD}"
         )

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -124,7 +124,7 @@ def download_all(task_instance, execution_date, **kwargs):
 
     assert len(records) == len(
         outcomes
-    ), f"we somehow ended up with {len(outcomes)} from {len(records)}"
+    ), f"we somehow ended up with {len(outcomes)} outcomes from {len(records)} records"
 
     successes = len([outcome for outcome in outcomes if outcome.success])
     print(f"successfully fetched {successes} of {len(records)}")

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -79,7 +79,6 @@ def download_feed(
 
 def download_all(task_instance, execution_date, **kwargs):
     start = pendulum.now()
-    # TODO: use laurie's method for this
     # https://stackoverflow.com/a/61808755
     with create_session() as session:
         auth_dict = {var.key: var.val for var in session.query(Variable)}

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -1,0 +1,86 @@
+# ---
+# python_callable: download_all
+# provide_context: true
+# dependencies:
+#   - generate_provider_list
+# ---
+import traceback
+
+import os
+import pendulum
+import re
+from airflow.models import Variable
+from airflow.utils.db import create_session
+from requests import Session
+from typing import List
+from calitp.storage import get_fs
+from utils import prefix_bucket, GTFSFeed, GTFSFeedType, GTFSExtract
+
+
+def download_all(task_instance, execution_date, **kwargs):
+    # TODO: use laurie's method for this
+    # https://stackoverflow.com/a/61808755
+    with create_session() as session:
+        auth_dict = {var.key: var.val for var in session.query(Variable)}
+
+    # TODO: get these from Airtable or whatever
+    feeds: List[GTFSFeed] = [
+        GTFSFeed(
+            type=GTFSFeedType.schedule,
+            url="https://www.bart.gov/dev/schedules/google_transit.zip",
+        ),
+    ]
+
+    exceptions = []
+
+    for feed in feeds:
+        try:
+            s = Session()
+            r = s.prepare_request(feed.build_request(auth_dict))
+            resp = s.send(r)
+
+            # we can try a few different locations for the filename
+            disp1 = re.search(
+                'filename="(.+)"', resp.headers.get("content-disposition", "")
+            )
+            disp2 = re.search(
+                'filename="(.+)"', resp.headers.get("Content-Disposition", "")
+            )
+
+            filename = (
+                (disp1.group(0) if disp1 else None)
+                or (disp2.group(0) if disp1 else None)
+                or (os.path.basename(resp.url) if resp.url.endswith(".zip") else None)
+                or "content.zip"
+            )
+
+            extract = GTFSExtract(
+                feed=feed,
+                filename=filename,
+                response_code=resp.status_code,
+                response_headers=resp.headers,
+                download_time=pendulum.now(),
+            )
+
+            extract.save_content(
+                fs=get_fs(),
+                bucket=prefix_bucket("gtfs-schedule-raw"),
+                content=resp.content,
+            )
+
+            # if resp.headers['content-type'] != 'application/zip':
+
+        except Exception as e:
+            print(
+                f"exception occurred while attempting to download feed: {str(e)}",
+                traceback.format_exc(),
+            )
+            exceptions.append(e)
+
+    if exceptions:
+        exc_str = "\n".join(map(str, exceptions))
+        raise RuntimeError(
+            f"got {len(exceptions)} exceptions out of {len(feeds)} feeds: {exc_str}"
+        )
+    else:
+        print(f"successfully handled all {len(feeds)} feeds!")

--- a/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_feeds.py
@@ -108,6 +108,8 @@ def download_all(task_instance, execution_date, **kwargs):
                 )
             )
 
+    # TODO: save the outcomes somewhere
+
     print(f"took {pendulum.now() - start} to process {len(records)} records")
 
     assert len(records) == len(
@@ -119,5 +121,5 @@ def download_all(task_instance, execution_date, **kwargs):
     success_rate = successes / len(records)
     if success_rate < GTFS_FEED_LIST_ERROR_THRESHOLD:
         raise RuntimeError(
-            f"Success rate: {success_rate:.1f} was below error threshold: {GTFS_FEED_LIST_ERROR_THRESHOLD}"
+            f"Success rate: {success_rate:.3f} was below error threshold: {GTFS_FEED_LIST_ERROR_THRESHOLD}"
         )

--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -136,6 +136,7 @@ def download_all(task_instance, execution_date, **kwargs):
 
     result = DownloadFeedsResult(
         start_time=start,
+        end_time=pendulum.now(),
         outcomes=outcomes,
         filename="results.jsonl",
     )

--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -146,6 +146,7 @@ def download_all(task_instance, execution_date, **kwargs):
     print(f"successfully fetched {len(result.successes)} of {len(records)}")
 
     if result.failures:
+        print("Failures:", "\n".join(str(f.exception) for f in result.failures))
         # use pandas begrudgingly for email HTML since the old task used it
         html_report = pd.DataFrame(f.dict() for f in result.failures).to_html(
             border=False

--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -93,7 +93,7 @@ def download_all(task_instance, execution_date, **kwargs):
     records = [
         record
         for record in AirtableGTFSDataExtract.get_latest().records
-        if record.data == GTFSFeedType.schedule
+        if record.data_quality_pipeline and record.data == GTFSFeedType.schedule
     ]
     outcomes: List[AirtableGTFSDataRecordProcessingOutcome] = []
 
@@ -146,7 +146,12 @@ def download_all(task_instance, execution_date, **kwargs):
     print(f"successfully fetched {len(result.successes)} of {len(records)}")
 
     if result.failures:
-        print("Failures:", "\n".join(str(f.exception) for f in result.failures))
+        print(
+            "Failures:",
+            "\n".join(
+                str(f.exception) or str(type(f.exception)) for f in result.failures
+            ),
+        )
         # use pandas begrudgingly for email HTML since the old task used it
         html_report = pd.DataFrame(f.dict() for f in result.failures).to_html(
             border=False

--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -147,7 +147,7 @@ def download_all(task_instance, execution_date, **kwargs):
 
     if result.failures:
         print(
-            "Failures:",
+            "Failures:\n",
             "\n".join(
                 str(f.exception) or str(type(f.exception)) for f in result.failures
             ),

--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 from calitp.config import is_development
+from utils import prefix_bucket
 
 # To add a macro, add its definition in the appropriate section
 # And then add it to the dictionary at the bottom of this file
@@ -183,5 +184,5 @@ data_infra_macros = {
     "sql_airtable_mapping": airtable_mapping_generate_sql,
     "is_development": is_development_macro,
     "image_tag": lambda: "development" if is_development() else "latest",
-    "prefix_bucket": lambda s: f"test-{s}" if is_development() else s,
+    "prefix_bucket": prefix_bucket,
 }

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -208,7 +208,7 @@ class AirtableGTFSDataRecord(BaseModel):
         params = {k: auth_dict[v] for k, v in self.auth_query_param.items()}
         headers = {k: auth_dict[v] for k, v in self.auth_header.items()}
 
-        # some web servers
+        # some web servers require user agents or they will throw a 4XX error
         headers[
             "User-Agent"
         ] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0"

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -204,11 +204,20 @@ class AirtableGTFSDataRecord(BaseModel):
         return base64.urlsafe_b64encode(self.uri.encode()).decode()
 
     def build_request(self, auth_dict: dict) -> Request:
-        filled_auth_params = {k: auth_dict[v] for k, v in self.auth_query_param.items()}
-        filled_auth_headers = {k: auth_dict[v] for k, v in self.auth_header.items()}
+        params = {k: auth_dict[v] for k, v in self.auth_query_param.items()}
+        headers = {k: auth_dict[v] for k, v in self.auth_header.items()}
+
+        # some web servers
+        headers[
+            "User-Agent"
+        ] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0"
+
         # inspired by: https://stackoverflow.com/questions/18869074/create-url-without-request-execution
         return Request(
-            "GET", url=self.uri, params=filled_auth_params, headers=filled_auth_headers
+            "GET",
+            url=self.uri,
+            params=params,
+            headers=headers,
         )
 
 

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -17,7 +17,7 @@ from calitp import read_gcfs, save_to_gcfs
 from calitp.config import is_development
 from calitp.storage import get_fs
 from pandas.errors import EmptyDataError
-from pydantic import AnyUrl, validator, Field
+from pydantic import validator, Field, HttpUrl
 from pydantic import BaseModel
 from pydantic.class_validators import root_validator
 from pydantic.tools import parse_obj_as
@@ -188,7 +188,7 @@ class AirtableGTFSDataRecord(BaseModel):
         return v
 
     @property
-    def schedule_url(self) -> Optional[AnyUrl]:
+    def schedule_url(self) -> Optional[HttpUrl]:
         # TODO: implement me
         raise NotImplementedError
 
@@ -410,6 +410,7 @@ def get_latest_file(
         )[0]
 
     children = directory.children(fs)
+    # This is just a convention for us for now; we could also label files with metadata if desired
     if len(children) != 1:
         raise ValueError(
             f"found {len(directory.children(fs))} files rather than 1 in the directory {directory.name}"

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -167,6 +167,7 @@ class AirtableGTFSDataRecord(BaseModel):
     name: str
     uri: Optional[str]
     data: GTFSFeedType
+    data_quality_pipeline: Optional[bool]
     schedule_to_use_for_rt_validation: Optional[List[str]]
     auth_query_param: Dict[str, str] = {}
     # TODO: add auth_headers when available in Airtable!
@@ -466,7 +467,7 @@ class AirtableGTFSDataExtract(PartitionedGCSArtifact):
 class GTFSFeedExtractInfo(PartitionedGCSArtifact):
     # TODO: this should check whether the bucket exists https://stackoverflow.com/a/65628273
     # TODO: this should be named `gtfs-raw` _or_ we make it dynamic
-    bucket: ClassVar[str] = prefix_bucket("gs://calitp-gtfs-raw")
+    bucket: ClassVar[str] = prefix_bucket("gs://calitp-gtfs-schedule-raw")
     partition_names: ClassVar[List[str]] = ["dt", "base64_url", "time"]
     config: AirtableGTFSDataRecord
     response_code: int
@@ -496,7 +497,7 @@ class AirtableGTFSDataRecordProcessingOutcome(ProcessingOutcome):
 
 
 class DownloadFeedsResult(PartitionedGCSArtifact):
-    bucket: ClassVar[str] = prefix_bucket("gs://calitp-gtfs-raw")
+    bucket: ClassVar[str] = prefix_bucket("gs://calitp-gtfs-schedule-raw")
     table: ClassVar[str] = "download_schedule_feed_results"
     partition_names: ClassVar[List[str]] = ["dt", "time"]
     start_time: pendulum.DateTime
@@ -532,7 +533,7 @@ class DownloadFeedsResult(PartitionedGCSArtifact):
 
 # class GTFSDownloadFeeds(PartitionedGCSArtifact):
 #     __root__: List[AirtableGTFSDataRecordProcessingOutcome]
-#     bucket: ClassVar[str] = prefix_bucket("gs://calitp-gtfs-raw")
+#     bucket: ClassVar[str] = prefix_bucket("gs://calitp-gtfs-schedule-raw")
 #     table: ClassVar[str] =
 #     partition_names: ClassVar[List[str]] = ["dt", "base64_url", "time"]
 

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -516,7 +516,7 @@ class DownloadFeedsResult(PartitionedGCSArtifact):
         self.save_content(
             fs=fs,
             content="\n".join(o.json() for o in self.outcomes).encode(),
-            exclude=["outcomes"],
+            exclude={"outcomes"},
         )
 
 

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -11,6 +11,7 @@ from typing import ClassVar, List, Union
 from typing import Optional, Dict
 
 import gcsfs
+import humanize
 import pandas as pd
 import pendulum
 from airflow.models import Variable
@@ -270,7 +271,7 @@ class PartitionedGCSArtifact(BaseModel, abc.ABC):
         )
 
     def save_content(self, fs: gcsfs.GCSFileSystem, content: bytes):
-        logging.info(f"saving {len(content)} bytes to {self.path}")
+        logging.info(f"saving {humanize.naturalsize(len(content))} to {self.path}")
         fs.pipe(path=self.path, value=content)
 
 

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -120,6 +120,20 @@ class GTFSRTFeedType(str, Enum):
 class DuplicateURLError(ValueError):
     pass
 
+class AirtableGTFSDataRecord(BaseModel):
+    pass
+
+class AirtableGTFSDataExtract(BaseModel):
+    records: List[AirtableGTFSDataRecord]
+    timestamp: pendulum.DateTime
+
+    @classmethod
+    def get_latest(cls) -> AirtableGTFSDataExtract:
+        # get the latest jsonl.gz as a dictionary
+        return AirtableGTFSDataExtract(timestamp=latest.timestamp, **dictionary)
+
+    def to_download_list(self) -> GTFSFeedDownloadList:
+        pass
 
 class GTFSFeed(BaseModel):
     _instances: ClassVar[Dict[str, "GTFSFeed"]] = {}

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -491,6 +491,7 @@ class DownloadFeedsResult(PartitionedGCSArtifact):
     table: ClassVar[str] = "download_schedule_feed_results"
     partition_names: ClassVar[List[str]] = ["dt", "time"]
     start_time: pendulum.DateTime
+    end_time: pendulum.DateTime
     outcomes: List[AirtableGTFSDataRecordProcessingOutcome]
 
     @property

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -282,7 +282,6 @@ class PartitionedGCSArtifact(BaseModel, abc.ABC):
         fs.pipe(path=self.path, value=content)
         fs.setxattrs(
             path=self.path,
-            content_type="json",
             # This syntax seems silly but it's so we pass the _value_ of PARTITIONED_ARTIFACT_METADATA_KEY
             **{PARTITIONED_ARTIFACT_METADATA_KEY: self.json()},
         )

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -512,6 +512,7 @@ class AirtableGTFSDataRecordProcessingOutcome(ProcessingOutcome):
 
 
 if __name__ == "__main__":
+    # These snippets are useful for testing/debugging
     print(
         get_latest_file(
             table_path="gs://rt-parsed/service_alerts/",

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -69,7 +69,8 @@ PARTITION_DESERIALIZERS = {
 
 def partition_map(path) -> Dict[str, PartitionType]:
     return {
-        key: value for key, value in re.findall(r"/(\w+)=([\w\-:]+)(?=/)", path.lower())
+        key: value
+        for key, value in re.findall(r"/(\w+)=([\w\-:=]+)(?=/)", path.lower())
     }
 
 
@@ -276,6 +277,7 @@ class PartitionedGCSArtifact(BaseModel, abc.ABC):
 class ProcessingOutcome(BaseModel, abc.ABC):
     success: bool
     exception: Optional[Exception]
+    input_record: BaseModel
 
     class Config:
         arbitrary_types_allowed = True
@@ -448,7 +450,7 @@ class GTFSFeedExtract(PartitionedGCSArtifact):
 
 class AirtableGTFSDataRecordProcessingOutcome(ProcessingOutcome):
     input_type: ClassVar[typing.Type[PartitionedGCSArtifact]] = GTFSFeedExtract
-    extract: GTFSFeedExtract
+    extract: Optional[GTFSFeedExtract]
 
 
 # class GTFSFeedExtractOutcome(PartitionedGCSArtifact):

--- a/airflow/requirements-dev.txt
+++ b/airflow/requirements-dev.txt
@@ -1,1 +1,1 @@
-apache-airflow==2.1.4
+apache-airflow==2.1.4 # pyup: ignore

--- a/airflow/requirements-dev.txt
+++ b/airflow/requirements-dev.txt
@@ -1,0 +1,1 @@
+apache-airflow==2.1.4

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -19,3 +19,4 @@ backoff==1.11.1
 pydantic==1.9.0
 tabulate==0.8.9
 google-api-core==2.8.0
+typing-extensions==4.2.0

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -19,4 +19,4 @@ backoff==1.11.1
 pydantic==1.9.0
 tabulate==0.8.9
 google-api-core==2.8.0
-typing-extensions==4.2.0
+typing-extensions==4.1.1


### PR DESCRIPTION
# Description

Must wait on https://github.com/cal-itp/data-infra/pull/1509!

This PR creates some initial Pydantic models to faciliate easy reading/writing of hive-partitioned artifacts in GCS. It also creates a new DAG `download_gtfs_schedule_v2` with a single task to download GTFS Schedule feeds based on Airtable records.

1. Raw GTFS Schedule zip files are saved in GCS
2. Pydantic bases classes drive the GCS I/O, and the subclasses configure metadata, partitions, etc.
3. GCS files keep metadata (defined in #2) describing the configuration that led to their creation

I've also set up the [Airflow variables](https://o1d2fa0877cf3fb10p-tp.appspot.com/variable/list/) containing our existing secrets.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally! Right now I'm testing with an Airtable extract from 2022-06-10 as that was the last time that task was run in development. With those records, we end up with `successfully fetched 177 of 189` which is just below our 95% threshold. We will be able to test with newer data once https://github.com/cal-itp/data-infra/pull/1509 is merged.

## Screenshots (optional)
