### PR TITLE
Update Tri-Valley Wheels GTFS Schedule link

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1375,7 +1375,7 @@ tri-delta-transit:
 tri-valley-wheels:
   agency_name: Tri-Valley Wheels
   feeds:
-    - gtfs_schedule_url: https://www.wheelsbus.com/wp-content/uploads/2020/06/google_transit1.zip?read_comply=
+    - gtfs_schedule_url: http://webwatch.lavta.org/tmgtfsrealtimewebservice/gtfs-static/google_transit.zip
       gtfs_rt_vehicle_positions_url: null
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null


### PR DESCRIPTION
# Description

Updates to the correct Tri-Valley Wheels GTFS Schedule link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Saw new URL on transit agency's website: https://www.wheelsbus.com/about/developer/

Downloaded locally to verify that it is current.
