### PR TITLE
Reports to warehouse

### DIFF
--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -843,7 +843,8 @@ models:
           - not_null
   - name: reports_daily_service_route_stops
     description: |
-      New table to consolidate and improve metric generation for reports.
+      Table consolidating daily service hours, routes, and stops by feed,
+      filtered to the specific feed used for each monthly report.
       Replaces complex Siuba code in reports notebook and allows for 
       visibility into service hour changes before the report generation process.
       Primary key is composite of service_date, calitp_itp_id, calitp_url_number.

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -845,7 +845,7 @@ models:
     description: |
       Table consolidating daily service hours, routes, and stops by feed,
       filtered to the specific feed used for each monthly report.
-      Replaces complex Siuba code in reports notebook and allows for 
+      Replaces complex Siuba code in reports notebook and allows for
       visibility into service hour changes before the report generation process.
       Primary key is composite of service_date, calitp_itp_id, calitp_url_number.
     tests:
@@ -878,11 +878,11 @@ models:
       - name: last_departure_ts
         description: Time of last departure on date
       - name: n_stops
-        description: | 
+        description: |
          Total number of stops present in active feed
          (not necessarily served on date)
       - name: n_routes
-        description: | 
+        description: |
          Total number of routes present in active feed
          (not necessarily operating on date)
 

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -841,6 +841,49 @@ models:
         description: Field in validation output from GTFS validator
         tests:
           - not_null
+  - name: reports_daily_service_route_stops
+    description: |
+      New table to consolidate and improve metric generation for reports.
+      Replaces complex Siuba code in reports notebook and allows for 
+      visibility into service hour changes before the report generation process.
+      Primary key is composite of service_date, calitp_itp_id, calitp_url_number.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - service_date
+            - calitp_itp_id
+            - calitp_url_number
+    columns:
+      - name: service_date
+        description: Date on which this service level was present
+        tests:
+          - not_null
+      - name: calitp_itp_id
+        description: '{{ doc("column_calitp_itp_id") }}'
+        tests:
+          - not_null
+      - name: calitp_url_number
+        description: '{{ doc("column_calitp_url_number") }}'
+      - name: feed_key
+        tests:
+          - not_null
+        description: feed_key only present with active service on date
+      - name: ttl_service_hours
+        description: Total service hours across entire feed on date, if any
+      - name: n_trips
+        description: Total number of trips ran on date, if any
+      - name: first_departure_ts
+        description: Time of first departure on date
+      - name: last_departure_ts
+        description: Time of last departure on date
+      - name: n_stops
+        description: | 
+         Total number of stops present in active feed
+         (not necessarily served on date)
+      - name: n_routes
+        description: | 
+         Total number of routes present in active feed
+         (not necessarily operating on date)
 
 exposures:
   - name: calitp_map_tile_server
@@ -854,6 +897,27 @@ exposures:
 
     owner:
       email: andrew.v@jarv.us
+  - name: calitp_reports_site
+    type: application
+    maturity: medium
+    url: "reports.calitp.org"
+    description: Cal-ITP reports site
+
+    depends_on:
+      - ref("reports_daily_service_routes_stops")
+      - ref("reports_gtfs_schedule_index")
+      - ref("gtfs_schedule_dim_feeds")
+      - ref("gtfs_schedule_fact_stop_id_changes")
+      - ref("gtfs_schedule_fact_route_id_changes")
+      - source("gtfs_type2", "validation_notices")
+      # ^ hopefully not for long
+      # also gtfs_schedule_history.calitp_files_updates
+      # don't think this is a source in dbt?
+      # could add, but would also like to look at options
+      # to replace reports-side...
+
+    owner:
+      email: eric.d@jarv.us
 
     meta:
       destinations:

--- a/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
+++ b/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
@@ -37,7 +37,7 @@ stops_agg AS (
         COUNT(DISTINCT stop_key) AS n_stops
     FROM gtfs_schedule_fact_daily_feed_stops
     -- temporary, test filter
-    WHERE date >= '2022-05-01' AND date <= '2022-06-30'
+    WHERE date >= '2022-04-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -48,7 +48,7 @@ routes_agg AS (
         COUNT(DISTINCT route_key) AS n_routes
     FROM gtfs_schedule_fact_daily_feed_routes
     -- temporary, test filter
-    WHERE date >= '2022-05-01' AND date <= '2022-06-30'
+    WHERE date >= '2022-04-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -78,7 +78,7 @@ date_renamed AS (
     SELECT full_date AS service_date
     FROM dim_date
     -- temporary, test filter
-    WHERE full_date >= '2022-05-01' AND full_date <= '2022-06-30'
+    WHERE full_date >= '2022-04-01' AND full_date <= '2022-06-30'
 ),
 
 reports_feeds_distinct AS (
@@ -97,7 +97,7 @@ date_feed_cross AS (
     CROSS JOIN reports_feeds_distinct AS T2
     WHERE T2.use_for_report
     -- temporary, for testing on a single month...
-    AND T1.service_date >= '2022-05-01' AND T1.service_date <= '2022-06-30'
+    AND T1.service_date >= '2022-04-01' AND T1.service_date <= '2022-06-30'
 ),
 
 for_report AS (

--- a/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
+++ b/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
@@ -37,7 +37,7 @@ stops_agg AS (
         COUNT(DISTINCT stop_key) AS n_stops
     FROM gtfs_schedule_fact_daily_feed_stops
     -- temporary, test filter
-    WHERE date >= '2022-04-01' AND date <= '2022-06-30'
+    -- WHERE date >= '2022-04-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -48,7 +48,7 @@ routes_agg AS (
         COUNT(DISTINCT route_key) AS n_routes
     FROM gtfs_schedule_fact_daily_feed_routes
     -- temporary, test filter
-    WHERE date >= '2022-04-01' AND date <= '2022-06-30'
+    -- WHERE date >= '2022-04-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -78,7 +78,7 @@ date_renamed AS (
     SELECT full_date AS service_date
     FROM dim_date
     -- temporary, test filter
-    WHERE full_date >= '2022-04-01' AND full_date <= '2022-06-30'
+    -- WHERE full_date >= '2022-04-01' AND full_date <= '2022-06-30'
 ),
 
 reports_feeds_distinct AS (
@@ -97,7 +97,7 @@ date_feed_cross AS (
     CROSS JOIN reports_feeds_distinct AS T2
     WHERE T2.use_for_report
     -- temporary, for testing on a single month...
-    AND T1.service_date >= '2022-04-01' AND T1.service_date <= '2022-06-30'
+    -- AND T1.service_date >= '2022-04-01' AND T1.service_date <= '2022-06-30'
 ),
 
 for_report AS (

--- a/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
+++ b/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
@@ -36,8 +36,6 @@ stops_agg AS (
         date AS service_date,
         COUNT(DISTINCT stop_key) AS n_stops
     FROM gtfs_schedule_fact_daily_feed_stops
-    -- temporary, test filter
-    -- WHERE date >= '2022-04-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -47,8 +45,6 @@ routes_agg AS (
         date AS service_date,
         COUNT(DISTINCT route_key) AS n_routes
     FROM gtfs_schedule_fact_daily_feed_routes
-    -- temporary, test filter
-    -- WHERE date >= '2022-04-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -77,8 +73,6 @@ stops_routes_metadata_joined AS (
 date_renamed AS (
     SELECT full_date AS service_date
     FROM dim_date
-    -- temporary, test filter
-    -- WHERE full_date >= '2022-04-01' AND full_date <= '2022-06-30'
 ),
 
 reports_feeds_distinct AS (
@@ -96,8 +90,6 @@ date_feed_cross AS (
     FROM date_renamed AS T1
     CROSS JOIN reports_feeds_distinct AS T2
     WHERE T2.use_for_report
-    -- temporary, for testing on a single month...
-    -- AND T1.service_date >= '2022-04-01' AND T1.service_date <= '2022-06-30'
 ),
 
 for_report AS (

--- a/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
+++ b/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
@@ -7,12 +7,12 @@ WITH gtfs_schedule_fact_daily_service AS (
 
 gtfs_schedule_fact_daily_feed_stops AS (
     SELECT *
-    FROM {{ ref('gtfs_schedule_fact_daily_feed_stops') }} 
+    FROM {{ ref('gtfs_schedule_fact_daily_feed_stops') }}
 ),
 
 gtfs_schedule_fact_daily_feed_routes AS (
     SELECT *
-    FROM {{ ref('gtfs_schedule_fact_daily_feed_routes') }} 
+    FROM {{ ref('gtfs_schedule_fact_daily_feed_routes') }}
 ),
 
 gtfs_schedule_dim_feeds AS (
@@ -27,14 +27,14 @@ dates AS (
 
 reports_gtfs_schedule_index AS (
     SELECT *
-    FROM {{ ref('reports_gtfs_schedule_index') }} 
+    FROM {{ ref('reports_gtfs_schedule_index') }}
 ),
 
 stops_agg AS (
     SELECT
         feed_key,
         date AS service_date,
-        COUNT(DISTINCT stop_key) AS n_stops
+        COUNT(stop_key) AS n_stops
     FROM gtfs_schedule_fact_daily_feed_stops
     GROUP BY 1, 2
 ),
@@ -43,7 +43,7 @@ routes_agg AS (
     SELECT
         feed_key,
         date AS service_date,
-        COUNT(DISTINCT route_key) AS n_routes
+        COUNT(route_key) AS n_routes
     FROM gtfs_schedule_fact_daily_feed_routes
     GROUP BY 1, 2
 ),
@@ -65,7 +65,9 @@ stops_routes_metadata_joined AS (
 ),
 
 reports_feeds_distinct AS (
-    SELECT DISTINCT calitp_itp_id, calitp_url_number
+    SELECT DISTINCT
+        calitp_itp_id,
+        calitp_url_number
     FROM reports_gtfs_schedule_index
 ),
 
@@ -75,28 +77,28 @@ date_feed_cross AS (
         DATE_ADD(LAST_DAY(T1.service_date, MONTH), INTERVAL 1 DAY) AS publish_date,
         -- construct publish_date for all combinations to filter later
         T2.calitp_itp_id,
-        T2.calitp_url_number,
+        T2.calitp_url_number
     FROM dates AS T1
     CROSS JOIN reports_feeds_distinct AS T2
 ),
 
 for_report AS (
     SELECT
-    calitp_itp_id,
-    calitp_url_number,
-    publish_date
+        calitp_itp_id,
+        calitp_url_number,
+        publish_date
     FROM reports_gtfs_schedule_index
     WHERE use_for_report
 ),
 
 date_feed_cross_rejoin AS (
     SELECT
-    T1.*
+        T1.*
     FROM date_feed_cross AS T1
     INNER JOIN for_report AS T2
-    ON T1.publish_date = T2.publish_date
-        AND T1.calitp_itp_id = T2.calitp_itp_id
-        AND T1.calitp_url_number = T2.calitp_url_number
+        ON T1.publish_date = T2.publish_date
+            AND T1.calitp_itp_id = T2.calitp_itp_id
+            AND T1.calitp_url_number = T2.calitp_url_number
 ),
 
 service_agg AS (
@@ -114,19 +116,19 @@ service_agg AS (
         ON T1.service_date = T2.service_date
             AND T1.calitp_itp_id = T2.calitp_itp_id
             AND T1.calitp_url_number = T2.calitp_url_number
-   GROUP BY 1, 2, 3, 4
+    GROUP BY 1, 2, 3, 4
 ),
 
 reports_daily_service_routes_stops AS (
     SELECT
         T1.*,
         T2.n_stops,
-        T2.n_routes,
+        T2.n_routes
     FROM service_agg AS T1
     INNER JOIN stops_routes_metadata_joined AS T2
         ON T1.calitp_itp_id = T2.calitp_itp_id
             AND T1.calitp_url_number = T2.calitp_url_number
             AND T1.service_date = T2.service_date
-) 
+)
 
 SELECT * FROM reports_daily_service_routes_stops

--- a/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
+++ b/warehouse/models/gtfs_views/reports_daily_service_routes_stops.sql
@@ -37,7 +37,7 @@ stops_agg AS (
         COUNT(DISTINCT stop_key) AS n_stops
     FROM gtfs_schedule_fact_daily_feed_stops
     -- temporary, test filter
-    WHERE date >= '2022-05-01' AND date <= '2022-05-31'
+    WHERE date >= '2022-05-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -48,7 +48,7 @@ routes_agg AS (
         COUNT(DISTINCT route_key) AS n_routes
     FROM gtfs_schedule_fact_daily_feed_routes
     -- temporary, test filter
-    WHERE date >= '2022-05-01' AND date <= '2022-05-31'
+    WHERE date >= '2022-05-01' AND date <= '2022-06-30'
     GROUP BY 1, 2
 ),
 
@@ -78,7 +78,7 @@ date_renamed AS (
     SELECT full_date AS service_date
     FROM dim_date
     -- temporary, test filter
-    WHERE full_date >= '2022-05-01' AND full_date <= '2022-05-31'
+    WHERE full_date >= '2022-05-01' AND full_date <= '2022-06-30'
 ),
 
 reports_feeds_distinct AS (
@@ -97,7 +97,7 @@ date_feed_cross AS (
     CROSS JOIN reports_feeds_distinct AS T2
     WHERE T2.use_for_report
     -- temporary, for testing on a single month...
-    AND T1.service_date >= '2022-05-01' AND T1.service_date <= '2022-05-31'
+    AND T1.service_date >= '2022-05-01' AND T1.service_date <= '2022-06-30'
 ),
 
 for_report AS (
@@ -121,7 +121,6 @@ date_feed_cross_rejoin AS (
         AND T1.calitp_url_number = T2.calitp_url_number
 ),
 
--- TODO include dates with zero service...
 service_agg AS (
     SELECT
         T1.service_date,

--- a/warehouse/models/test_general/reports_daily_service_routes_stops.sql
+++ b/warehouse/models/test_general/reports_daily_service_routes_stops.sql
@@ -1,0 +1,155 @@
+{{ config(materialized='table') }}
+
+WITH gtfs_schedule_fact_daily_service AS (
+    SELECT *
+    FROM {{ ref('gtfs_schedule_fact_daily_service') }}
+),
+
+gtfs_schedule_fact_daily_feed_stops AS (
+    SELECT *
+    FROM {{ ref('gtfs_schedule_fact_daily_feed_stops') }} 
+),
+
+gtfs_schedule_fact_daily_feed_routes AS (
+    SELECT *
+    FROM {{ ref('gtfs_schedule_fact_daily_feed_routes') }} 
+),
+
+gtfs_schedule_dim_feeds AS (
+    SELECT *
+    FROM {{ ref('gtfs_schedule_dim_feeds') }}
+),
+
+dim_date AS (
+    SELECT *
+    FROM {{ ref('dim_date') }}
+),
+
+reports_gtfs_schedule_index AS (
+    SELECT *
+    FROM {{ ref('reports_gtfs_schedule_index') }} 
+),
+
+stops_agg AS (
+    SELECT
+        feed_key,
+        date AS service_date,
+        COUNT(DISTINCT stop_key) AS n_stops
+    FROM gtfs_schedule_fact_daily_feed_stops
+    -- temporary, test filter
+    WHERE date >= '2022-05-01' AND date <= '2022-05-31'
+    GROUP BY 1, 2
+),
+
+routes_agg AS (
+    SELECT
+        feed_key,
+        date AS service_date,
+        COUNT(DISTINCT route_key) AS n_routes
+    FROM gtfs_schedule_fact_daily_feed_routes
+    -- temporary, test filter
+    WHERE date >= '2022-05-01' AND date <= '2022-05-31'
+    GROUP BY 1, 2
+),
+
+stops_routes_agg AS (
+    SELECT
+        T1.feed_key,
+        T1.n_stops,
+        T1.service_date,
+        T2.n_routes,
+    FROM stops_agg AS T1
+    INNER JOIN routes_agg AS T2
+        ON T1.service_date = T2.service_date
+            AND T1.feed_key = T2.feed_key
+),
+
+stops_routes_metadata_joined AS (
+    SELECT
+        T1.*,
+        T2.calitp_itp_id,
+        T2.calitp_url_number,
+    FROM stops_routes_agg AS T1
+    INNER JOIN gtfs_schedule_dim_feeds AS T2
+        ON T1.feed_key = T2.feed_key
+),
+
+date_renamed AS (
+    SELECT full_date AS service_date
+    FROM dim_date
+    -- temporary, test filter
+    WHERE full_date >= '2022-05-01' AND full_date <= '2022-05-31'
+),
+
+reports_feeds_distinct AS (
+    SELECT DISTINCT calitp_itp_id, calitp_url_number, use_for_report
+    FROM reports_gtfs_schedule_index
+),
+
+date_feed_cross AS (
+    SELECT
+        T1.service_date,
+        DATE_ADD(LAST_DAY(T1.service_date, MONTH), INTERVAL 1 DAY) AS publish_date,
+        -- construct publish_date for all combinations to filter later
+        T2.calitp_itp_id,
+        T2.calitp_url_number,
+    FROM date_renamed AS T1
+    CROSS JOIN reports_feeds_distinct AS T2
+    WHERE T2.use_for_report
+    -- temporary, for testing on a single month...
+    AND T1.service_date >= '2022-05-01' AND T1.service_date <= '2022-05-31'
+),
+
+for_report AS (
+    SELECT
+    calitp_itp_id,
+    calitp_url_number,
+    date_start,
+    date_end,
+    publish_date
+    FROM reports_gtfs_schedule_index
+    WHERE use_for_report
+),
+
+date_feed_cross_rejoin AS (
+    SELECT
+    T1.*
+    FROM date_feed_cross AS T1
+    INNER JOIN for_report AS T2
+    ON T1.publish_date = T2.publish_date
+        AND T1.calitp_itp_id = T2.calitp_itp_id
+        AND T1.calitp_url_number = T2.calitp_url_number
+),
+
+-- TODO include dates with zero service...
+service_agg AS (
+    SELECT
+        T1.service_date,
+        T1.calitp_itp_id,
+        T1.calitp_url_number,
+        T2.feed_key,
+        SUM(T2.ttl_service_hours) AS ttl_service_hours,
+        SUM(T2.n_trips) AS n_trips,
+        MIN(T2.first_departure_ts) AS first_departure_ts,
+        MAX(T2.last_arrival_ts) AS last_arrival_ts
+    FROM date_feed_cross_rejoin AS T1
+    LEFT JOIN gtfs_schedule_fact_daily_service AS T2
+        ON T1.service_date = T2.service_date
+            AND T1.calitp_itp_id = T2.calitp_itp_id
+            AND T1.calitp_url_number = T2.calitp_url_number
+   GROUP BY 1, 2, 3, 4
+),
+
+reports_daily_service_routes_stops AS (
+    SELECT
+        T1.*,
+        T2.n_stops,
+        T2.n_routes,
+    FROM service_agg AS T1
+    INNER JOIN stops_routes_metadata_joined AS T2
+        ON T1.calitp_itp_id = T2.calitp_itp_id
+            AND T1.calitp_url_number = T2.calitp_url_number
+            AND T1.service_date = T2.service_date
+) 
+
+SELECT * FROM reports_daily_service_routes_stops


### PR DESCRIPTION
# Description

New table to consolidate and improve metric generation for reports. Replaces complex Siuba code in reports notebook and allows for visibility into service hour changes before the report generation process.

Resolves https://github.com/cal-itp/reports/issues/129

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran for 2 months via dbt, that processed 1.4GB.

## Screenshots (optional)
