### PR TITLE
Reports feed info optional

### DIFF
--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -841,7 +841,7 @@ models:
         description: Field in validation output from GTFS validator
         tests:
           - not_null
-  - name: reports_daily_service_route_stops
+  - name: reports_daily_service_routes_stops
     description: |
       Table consolidating daily service hours, routes, and stops by feed,
       filtered to the specific feed used for each monthly report.

--- a/warehouse/models/gtfs_views/reports_gtfs_schedule_index.sql
+++ b/warehouse/models/gtfs_views/reports_gtfs_schedule_index.sql
@@ -79,7 +79,8 @@ reports_gtfs_schedule_index AS (
         has_feed_info,
         is_private_feed,
         (calitp_url_number = 0
-            AND has_feed_info
+            -- try making optional for June reports
+            -- AND has_feed_info
             AND NOT is_private_feed
         ) AS use_for_report
     FROM agency_feeds_on_end_date AS AF


### PR DESCRIPTION
# Description

Removes the requirement that `feed_info.txt` be present to generate the `use_for_report` flag in `reports_gtfs_schedule_index`. 

Will be accompanied with a content change to the report to highlight the importance of `feed_info.txt` if missing.

Resolves [reports #153](https://github.com/cal-itp/reports/issues/153)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran via dbt in staging, works as intended.

## Screenshots (optional)
