### PR TITLE
fix: transit tech stacks -- fix unnesting

### DIFF
--- a/warehouse/models/mart/transit_database/map_services_x_products.sql
+++ b/warehouse/models/mart/transit_database/map_services_x_products.sql
@@ -30,11 +30,13 @@ unnest_service_components AS (
         ntd_certified,
         product_component_valid,
         notes
-    FROM stg_transit_database__service_components,
-        stg_transit_database__service_components.services AS service_key,
-        stg_transit_database__service_components.product AS product_key,
-        stg_transit_database__service_components.contracts AS contract_key,
-        stg_transit_database__service_components.component AS component_key
+    FROM stg_transit_database__service_components
+    LEFT JOIN UNNEST(stg_transit_database__service_components.services) AS service_key
+    LEFT JOIN UNNEST(stg_transit_database__service_components.product) AS product_key
+    LEFT JOIN UNNEST(stg_transit_database__service_components.contracts) AS contract_key
+    LEFT JOIN UNNEST(stg_transit_database__service_components.component) AS component_key
+    -- check that we have service and product actually defined
+    WHERE (service_key IS NOT NULL) AND (product_key IS NOT NULL)
 ),
 
 map_services_x_products AS (

--- a/warehouse/models/staging/transit_database/stg_transit_database__contracts.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__contracts.sql
@@ -18,9 +18,9 @@ mapped_holder_ids AS (
         map_holder.ct_key AS contract_holder,
         map_vendor.ct_key AS contract_vendor,
         dt
-    FROM latest,
-        latest.contract_holder AS unnested_contract_holder,
-        latest.contract_vendor AS unnested_contract_vendor
+    FROM latest
+    LEFT JOIN UNNEST(latest.contract_holder) AS unnested_contract_holder
+    LEFT JOIN UNNEST(latest.contract_vendor) AS unnested_contract_vendor
     LEFT JOIN int_tts_organizations_ct_organizations_map AS map_holder
         ON unnested_contract_holder = map_holder.tts_key
         AND dt = map_holder.tts_date

--- a/warehouse/models/staging/transit_database/stg_transit_database__service_components.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__service_components.sql
@@ -15,8 +15,9 @@ int_tts_services_ct_services_map AS (
 mapped_service_ids AS (
     SELECT
         service_component_id,
-        ARRAY_AGG(ct_key) AS services
-    FROM latest, UNNEST(services) as tts_service_id
+        ARRAY_AGG(ct_key IGNORE NULLS) AS services
+    FROM latest
+    LEFT JOIN UNNEST(latest.services) as tts_service_id
     LEFT JOIN int_tts_services_ct_services_map AS map
         ON tts_service_id = map.tts_key
         AND dt = map.tts_date


### PR DESCRIPTION
_🚨 merging into feature branch not main_

# Description

Fixes unnesting-- switches from `CROSS JOIN` to `LEFT JOIN` where applicable to stop dropping rows where the unnested array is null. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? Ran `dbt run` and `dbt test` on the affected folders
