### PR TITLE
feat(schedule): track continuous download errors

### DIFF
--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -284,6 +284,8 @@ models:
           indicating that feed is not yet valid as of date
       - name: extraction_status
         description: Indicates whether extraction was successful ('success') or not ('error')
+        tests:
+          - not_null
       - name: parse_error_encountered
         description: |
           Whether a fatal error occurred while parsing the feed; only populated
@@ -314,12 +316,12 @@ models:
         description: |
           Number of days between date and service end date. if is_service_valid is False, this may be negative
           indicating that feed is not yet valid as of date. Service end date is the last day on which service occurs on any service in this feed. Is a feed-wide summary.
-      - name: erroring_since
+      - name: status_since
         description: |
-          If `extraction_status` is "error", this field indicates the date since which this
-          feed has been continuously experiencing extraction errors; i.e., the feed has
-          had extraction_status of "error" every day (inclusive)
-          between `erroring_since` and `date`.
+          This field indicates the date since which this feed has continuously
+          had the same `extraction_status`; i.e., the feed has
+          had the same extraction_status every day (inclusive)
+          between `status_since` and `date`.
   - name: gtfs_schedule_fact_daily_feed_files
     description: |
       Each row of this table is a file extracted from a feed on a given day. Note that on days where

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -314,6 +314,12 @@ models:
         description: |
           Number of days between date and service end date. if is_service_valid is False, this may be negative
           indicating that feed is not yet valid as of date. Service end date is the last day on which service occurs on any service in this feed. Is a feed-wide summary.
+      - name: erroring_since
+        description: |
+          If `extraction_status` is "error", this field indicates the date since which this
+          feed has been continuously experiencing extraction errors; i.e., the feed has
+          had extraction_status of "error" every day (inclusive)
+          between `erroring_since` and `date`.
   - name: gtfs_schedule_fact_daily_feed_files
     description: |
       Each row of this table is a file extracted from a feed on a given day. Note that on days where

--- a/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
@@ -173,10 +173,26 @@ feed_updated AS (
 
 ),
 
+errors_erroring_since AS (
+    SELECT
+        feed_key,
+        date,
+        LAST_VALUE(date)
+        OVER (PARTITION BY feed_key, extraction_status
+            ORDER BY date DESC
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+        AS erroring_since
+    FROM feed_updated
+    WHERE extraction_status = "error"
+),
+
 gtfs_schedule_fact_daily_feeds AS (
     SELECT
-        * EXCEPT(calitp_itp_id, calitp_url_number)
-    FROM feed_updated
+        t1.* EXCEPT(calitp_itp_id, calitp_url_number),
+        t2.erroring_since
+    FROM feed_updated AS t1
+    LEFT JOIN errors_erroring_since AS t2
+        USING (feed_key, date)
 )
 
 SELECT * FROM gtfs_schedule_fact_daily_feeds

--- a/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
@@ -173,7 +173,8 @@ feed_updated AS (
 
 ),
 
-errors_erroring_since AS (
+-- check how long feed has had the same extraction_status
+status_since AS (
     SELECT
         feed_key,
         date,
@@ -181,17 +182,16 @@ errors_erroring_since AS (
         OVER (PARTITION BY feed_key, extraction_status
             ORDER BY date DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-        AS erroring_since
+        AS status_since
     FROM feed_updated
-    WHERE extraction_status = "error"
 ),
 
 gtfs_schedule_fact_daily_feeds AS (
     SELECT
         t1.* EXCEPT(calitp_itp_id, calitp_url_number),
-        t2.erroring_since
+        t2.status_since
     FROM feed_updated AS t1
-    LEFT JOIN errors_erroring_since AS t2
+    LEFT JOIN status_since AS t2
         USING (feed_key, date)
 )
 


### PR DESCRIPTION
# Description

_updated 6/27 based on discussing the original implementation with @atvaccaro_
Add a `status_since` column to `gtfs_schedule_fact_daily_feeds` so we can track continuous errors to address #1205.

~**🚨 Question for reviewers:**~
* ~Should it just be `status_since` and track continuous success OR failure? I wasn't sure if we have a reason to potentially want to track both. The request in the motivating ticket is specific to failures but I guess we could want to track successes too or make the column more generic?~
* ^ yes, done

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? `dbt run` & `dbt test` both succeed 