### PR TITLE
remove mem limit on archiver

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -34,8 +34,6 @@ spec:
             requests:
               memory: 512Mi
               cpu: 5.0
-            limits:
-              memory: 640Mi
       volumes:
         - name: agencies-data
           secret:


### PR DESCRIPTION
# Description

We want to test uncapping the memory limit for the RT archiver.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
