### PR TITLE
feat(schedule): days in status -- refactor status_since

### DIFF
--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -316,7 +316,7 @@ models:
         description: |
           Number of days between date and service end date. if is_service_valid is False, this may be negative
           indicating that feed is not yet valid as of date. Service end date is the last day on which service occurs on any service in this feed. Is a feed-wide summary.
-      - name: days_in_status
+      - name: days_in_extraction_status
         description: |
           The number of days for which this feed has continuously had
           the same `extraction_status`.

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -316,12 +316,10 @@ models:
         description: |
           Number of days between date and service end date. if is_service_valid is False, this may be negative
           indicating that feed is not yet valid as of date. Service end date is the last day on which service occurs on any service in this feed. Is a feed-wide summary.
-      - name: status_since
+      - name: days_in_status
         description: |
-          This field indicates the date since which this feed has continuously
-          had the same `extraction_status`; i.e., the feed has
-          had the same extraction_status every day (inclusive)
-          between `status_since` and `date`.
+          The number of days for which this feed has continuously had
+          the same `extraction_status`.
   - name: gtfs_schedule_fact_daily_feed_files
     description: |
       Each row of this table is a file extracted from a feed on a given day. Note that on days where

--- a/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
@@ -183,14 +183,14 @@ status_since AS (
             OVER (PARTITION BY feed_key, extraction_status
                 ORDER BY date DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
-            DAY) AS days_in_status
+            DAY) AS days_in_extraction_status
     FROM feed_updated
 ),
 
 gtfs_schedule_fact_daily_feeds AS (
     SELECT
         t1.* EXCEPT(calitp_itp_id, calitp_url_number),
-        t2.days_in_status
+        t2.days_in_extraction_status
     FROM feed_updated AS t1
     LEFT JOIN status_since AS t2
         USING (feed_key, date)

--- a/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_feeds.sql
@@ -178,18 +178,19 @@ status_since AS (
     SELECT
         feed_key,
         date,
-        LAST_VALUE(date)
-        OVER (PARTITION BY feed_key, extraction_status
-            ORDER BY date DESC
-            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-        AS status_since
+        DATE_DIFF(date,
+            LAST_VALUE(date)
+            OVER (PARTITION BY feed_key, extraction_status
+                ORDER BY date DESC
+                ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+            DAY) AS days_in_status
     FROM feed_updated
 ),
 
 gtfs_schedule_fact_daily_feeds AS (
     SELECT
         t1.* EXCEPT(calitp_itp_id, calitp_url_number),
-        t2.status_since
+        t2.days_in_status
     FROM feed_updated AS t1
     LEFT JOIN status_since AS t2
         USING (feed_key, date)


### PR DESCRIPTION
# Description

While we preferred the implementation in #1590, Metabase limitations (can't do `DATE_DIFF`) have led us to need to do the date subtraction requested in #1205 directly in the warehouse. So this PR refactors #1590 to instead return the `DATE_DIFF` directly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? `dbt run` and `dbt test` succeed locally; manually inspected results 
