### PR TITLE
gtfs-rt-archive/app.yaml: remove memory request

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -32,7 +32,6 @@ spec:
               mountPath: /secrets/gcs-upload-svcacct
           resources:
             requests:
-              memory: 512Mi
               cpu: 5.0
       volumes:
         - name: agencies-data


### PR DESCRIPTION
If a workload balloons to somewhere around 10x its requested limit, the
control plane will evict it. We want this workload to stay put through
the bitter end.