### PR TITLE
Deploy unlimited archiver memory into production

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archive/app.yaml
@@ -32,7 +32,6 @@ spec:
               mountPath: /secrets/gcs-upload-svcacct
           resources:
             requests:
-              memory: 512Mi
               cpu: 5.0
       volumes:
         - name: agencies-data


### PR DESCRIPTION
We want to hand memory management issues directly to the kernel and remove them entirely from the purview of the control plane