### PR TITLE
add missing columnName column to schedule validation notices schema

### DIFF
--- a/airflow/dags/gtfs_schedule_history/validation_report.yml
+++ b/airflow/dags/gtfs_schedule_history/validation_report.yml
@@ -29,6 +29,8 @@ schema_fields:
       fields:
         - name: csvRowNumber
           type: INTEGER
+        - name: columnName
+          type: STRING
         - name: oldCsvRowNumber
           type: INTEGER
         - name: newCsvRowNumber


### PR DESCRIPTION
# Description

We had a failure last night in `validation_notices_load` due to bad JSON parsing. A new schedule feed is resulting in a new validation notice (specifically, a non-ASCII character) which has a field called `columnName` which we haven't used before. I'm unsure how this differs from `fieldName`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
tbd

## Screenshots (optional)
