### PR TITLE
jinja templated tml strings have to be double quoted

### DIFF
--- a/warehouse/models/staging/transit_database/_src_airtable.yml
+++ b/warehouse/models/staging/transit_database/_src_airtable.yml
@@ -4,7 +4,7 @@ sources:
   - name: airtable
     description: |
       Data from Airtable.
-    database: {{ target.database }}
+    database: "{{ target.database }}"
     schema: external_airtable
     tables:
       - name: california_transit__county_geography


### PR DESCRIPTION
Quick fix, I think non-quoted strings with curly braces are invalid in YML. dbt doesn't do the templating until after the YML has already been parsed.