### PR TITLE
Update AVTA URL

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -49,7 +49,7 @@ amtrak:
 antelope-valley-transit-authority:
   agency_name: Antelope Valley Transit Authority
   feeds:
-    - gtfs_schedule_url: https://www.avta.com/userfiles/files/AVTA%20GTFS.zip
+    - gtfs_schedule_url: https://www.avta.com/userfiles/files/AVTA_GTFS.zip
       gtfs_rt_vehicle_positions_url: https://track-it.avta.com/InfoPoint/GTFS-Realtime.ashx?Type=VehiclePosition
       gtfs_rt_service_alerts_url: https://track-it.avta.com/InfoPoint/GTFS-Realtime.ashx?Type=Alert
       gtfs_rt_trip_updates_url: https://track-it.avta.com/InfoPoint/GTFS-Realtime.ashx?Type=TripUpdate

--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -39,7 +39,12 @@ def main():
         if changed_urls is not None and url not in changed_urls:
             continue
         try:
-            result = requests.get(url, headers=headers.get(key, {}))
+            h = {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0",
+                **headers.get(key, {}),
+            }
+
+            result = requests.get(url, headers=h, timeout=10)
             result.raise_for_status()
         except Exception as e:
             print(f"Failed to download {url}")


### PR DESCRIPTION
# Description

Updates the AVTA URL to a new URL that is on their website. (See https://www.avta.com/gtfs.php).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Received communication to use the URL found on the referenced page, downloaded locally.