### PR TITLE
let the prefix_bucket macro also add the gs protocol

### DIFF
--- a/airflow/dags/airtable_loader_v2/california_transit_county_geography.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_county_geography.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "county geography"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_eligibility_programs.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_eligibility_programs.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "eligibility programs"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_fare_systems.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_fare_systems.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "fare systems"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_funding_programs.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_funding_programs.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "funding programs"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_gtfs_datasets.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_gtfs_datasets.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs datasets"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_gtfs_service_data.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_gtfs_service_data.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "gtfs service data"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_ntd_agency_info.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_ntd_agency_info.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "NTD Agency Info"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_organizations.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_organizations.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_base_name: california_transit
 air_table_name: organizations
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_place_geography.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_place_geography.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "place geography"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_rider_requirements.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_rider_requirements.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: "rider requirements"
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/california_transit_services.yml
+++ b/airflow/dags/airtable_loader_v2/california_transit_services.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appPnJWrQ7ui4UmIl
 air_table_name: services
 air_base_name: california_transit
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_components.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_components.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "components"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_contracts.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_contracts.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "contracts"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_data_schemas.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_data_schemas.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "data schemas"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_organizations.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_organizations.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "organizations"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_products.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_products.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "products"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_properties_features.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_properties_features.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "Properties + Features"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_relationships_service_components.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_relationships_service_components.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "relationships service-components"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_service_components.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_service_components.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "service-components"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/airtable_loader_v2/transit_tech_stacks_services.yml
+++ b/airflow/dags/airtable_loader_v2/transit_tech_stacks_services.yml
@@ -3,4 +3,4 @@ operator: operators.AirtableToGCSOperator
 air_base_id: appeVUdmRBi3K9hTS
 air_table_name: "services"
 air_base_name: transit_technology_stacks
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"

--- a/airflow/dags/parse_and_validate_rt/parse_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt/parse_rt_service_alerts.yml
@@ -11,7 +11,7 @@ arguments:
   - "service_alerts"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ get_bucket() }}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
-  - "gs://{{ prefix_bucket('rt-parsed') }}"
+  - "{{ prefix_bucket('rt-parsed') }}"
   - "--parse"
   - "--verbose"
 

--- a/airflow/dags/parse_and_validate_rt/parse_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt/parse_rt_trip_updates.yml
@@ -11,7 +11,7 @@ arguments:
   - "trip_updates"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ get_bucket() }}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
-  - "gs://{{ prefix_bucket('rt-parsed') }}"
+  - "{{ prefix_bucket('rt-parsed') }}"
   - "--parse"
   - "--verbose"
 

--- a/airflow/dags/parse_and_validate_rt/parse_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt/parse_rt_vehicle_positions.yml
@@ -11,7 +11,7 @@ arguments:
   - "vehicle_positions"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ get_bucket() }}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
-  - "gs://{{ prefix_bucket('rt-parsed') }}"
+  - "{{ prefix_bucket('rt-parsed') }}"
   - "--parse"
   - "--verbose"
 

--- a/airflow/dags/parse_and_validate_rt/validate_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt/validate_rt_service_alerts.yml
@@ -11,7 +11,7 @@ arguments:
   - "service_alerts"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ get_bucket() }}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
-  - "gs://{{ prefix_bucket('rt-parsed') }}"
+  - "{{ prefix_bucket('rt-parsed') }}"
   - "--threads=2"
   - "--validate"
   - "--verbose"

--- a/airflow/dags/parse_and_validate_rt/validate_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt/validate_rt_trip_updates.yml
@@ -11,7 +11,7 @@ arguments:
   - "trip_updates"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ get_bucket() }}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
-  - "gs://{{ prefix_bucket('rt-parsed') }}"
+  - "{{ prefix_bucket('rt-parsed') }}"
   - "--threads=2"
   - "--validate"
   - "--verbose"

--- a/airflow/dags/parse_and_validate_rt/validate_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt/validate_rt_vehicle_positions.yml
@@ -11,7 +11,7 @@ arguments:
   - "vehicle_positions"
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ get_bucket() }}/rt/{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH*') }}"
-  - "gs://{{ prefix_bucket('rt-parsed') }}"
+  - "{{ prefix_bucket('rt-parsed') }}"
   - "--threads=2"
   - "--validate"
   - "--verbose"

--- a/airflow/dags/sandbox/load_airtable_child.yml
+++ b/airflow/dags/sandbox/load_airtable_child.yml
@@ -3,7 +3,7 @@ operator: operators.AirtableToGCSOperator
 air_base_id: apphcwzP8cR82NeJo
 air_base_name: sandbox
 air_table_name: child
-bucket: "gs://{{ prefix_bucket('calitp-airtable') }}"
+bucket: "{{ prefix_bucket('calitp-airtable') }}"
 
 dependencies:
   - op_airtable_to_warehouse


### PR DESCRIPTION
# Description

Fixes a bug I introduced around prefix_bucket; in some places, the caller adds the protocol, but we should just let prefix_bucket handle it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally via Airflow.

## Screenshots (optional)
```
...
Downloading airtable data for transit_technology_stacks.services
Uploading to GCS at gs://test-calitp-airtable/transit_technology_stacks__services/dt=2022-07-07/time=14:05:38/services.jsonl.gz
[2022-07-07 14:05:39,611] {taskinstance.py:1219} INFO - Marking task as SUCCESS. dag_id=airtable_loader_v2, task_id=transit_tech_stacks_services, execution_date=20220707T020000, start_date=20220707T140443, end_date=20220707T140539
[2022-07-07 14:05:39,637] {dagrun.py:477} INFO - Marking run <DagRun airtable_loader_v2 @ 2022-07-07T02:00:00+00:00: backfill__2022-07-07T02:00:00+00:00, externally triggered: False> successful
[2022-07-07 14:05:39,641] {backfill_job.py:388} INFO - [backfill progress] | finished run 1 of 1 | tasks waiting: 0 | succeeded: 20 | running: 0 | failed: 0 | skipped: 0 | deadlocked: 0 | not ready: 0
[2022-07-07 14:05:39,644] {backfill_job.py:831} INFO - Backfill done. Exiting.
```