### PR TITLE
Timestamp hive partitions

### DIFF
--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -72,7 +72,7 @@ def download_feed(
         config=record,
         response_code=resp.status_code,
         response_headers=resp.headers,
-        download_time=pendulum.now(),
+        ts=pendulum.now(),
     )
 
     extract.save_content(fs=get_fs(), content=resp.content)
@@ -135,8 +135,8 @@ def download_all(task_instance, execution_date, **kwargs):
     ), f"we somehow ended up with {len(outcomes)} outcomes from {len(records)} records"
 
     result = DownloadFeedsResult(
-        start_time=start,
-        end_time=pendulum.now(),
+        ts=start,
+        end=pendulum.now(),
         outcomes=outcomes,
         filename="results.jsonl",
     )

--- a/airflow/plugins/operators/airtable_to_gcs.py
+++ b/airflow/plugins/operators/airtable_to_gcs.py
@@ -97,7 +97,7 @@ class AirtableExtract(BaseModel):
             bucket,
             f"{self.air_base_name}__{safe_air_table_name}",
             f"dt={self.extract_time.to_date_string()}",
-            f"ts={self.extract_time}",
+            f"ts={self.extract_time.to_iso8601_string()}",
             f"{safe_air_table_name}.jsonl.gz",
         )
 

--- a/airflow/plugins/operators/airtable_to_gcs.py
+++ b/airflow/plugins/operators/airtable_to_gcs.py
@@ -97,7 +97,7 @@ class AirtableExtract(BaseModel):
             bucket,
             f"{self.air_base_name}__{safe_air_table_name}",
             f"dt={self.extract_time.to_date_string()}",
-            f"time={self.extract_time.to_time_string()}",
+            f"ts={self.extract_time}",
             f"{safe_air_table_name}.jsonl.gz",
         )
 

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.7.13a9
+calitp==2022.7.14a0
 intake==0.6.1
 ipdb==0.13.4
 gusty==0.6.0

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.7.14a0
+calitp==2022.7.14a2
 intake==0.6.1
 ipdb==0.13.4
 gusty==0.6.0


### PR DESCRIPTION
# Description

Refactoring GTFS schedule and Airtable to use timestamps in partitions instead of "time" strings. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- we are doing a backfill so that the external tables will continue to work
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Local Airflow. 

```
tY2EtdXMvYmVsbGZsb3dlci1jYS11cy56aXA=/ts=2022-07-14T19:26:22.469787+00:00/bellflower-ca-us.zip
took 6 minutes ago to process 178 records
[2022-07-14 19:26:23,734] {storage.py:255} INFO - saving 581.4 kB to gs://test-calitp-gtfs-schedule-raw/download_schedule_feed_results/dt=2022-07-14/ts=2022-07-14T19:19:28.126183+00:00/results.jsonl
successfully fetched 177 of 178
Failures:
 404 Client Error: Not Found for url: http://data.trilliumtransit.com/gtfs/taft-co-us/taft-ca-us.zip
Skipping since in development mode! Would have emailed 1 failures.
[2022-07-14 19:26:24,872] {python.py:151} INFO - Done. Returned value was: None
[2022-07-14 19:26:24,878] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=download_gtfs_schedule_v2, task_id=download_schedule_feeds, execution_date=20220401T000000, start_date=20220630T160127, end_date=20220714T192624
```