### PR TITLE
Chore: remove pyup configuration

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,5 +1,0 @@
-# pyup.io config file
-# see https://pyup.io/docs/configuration/ for all available options
-
-schedule: ''
-update: insecure

--- a/airflow/requirements-dev.txt
+++ b/airflow/requirements-dev.txt
@@ -1,2 +1,2 @@
-apache-airflow==2.1.4 # pyup: ignore
+apache-airflow==2.1.4
 black==22.3.0


### PR DESCRIPTION
[pyup.io](https://pyup.io) is no longer used for scanning; Dependabot handles dependency updates now.

# Description

Removing the configuration file and any mention of pyup elsewhere in the repo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Dependabot is already working, pyup has not been working for some time (the app was removed from the Cal-ITP GitHub org).
