### PR TITLE
Expand GTFS schedule data published to CKAN

### DIFF
--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -769,6 +769,7 @@ exposures:
             frequencies: 48542c8f-8ce1-43e3-a965-6c68771d6fe5
             levels: 288a08cd-7929-479e-aa88-08b677a08510
             pathways: a01484af-c460-40a4-ac8a-896b0196e8c2
+            # TODO: add shapes when the size limit has been lifted
 #            shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
             transfers: f8dcda5d-0c6d-4c70-b5f5-6716adcf6ffc
             translations: 7abe9256-6cd2-4c1f-9b6a-72108022a382

--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -754,8 +754,20 @@ exposures:
           format: csv
           url: https://data.ca.gov/api/3/action/resource_update
           ids:
-            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
-            routes: c6bbb637-988f-431c-8444-aef7277297f8
-            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
-            stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
-            trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
+#            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
+#            routes: c6bbb637-988f-431c-8444-aef7277297f8
+#            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
+#            stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
+#            trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
+            attributions: 038b7354-06e8-4082-a4a1-40debd3110d5
+            calendar: a79f10b8-b322-43f3-b3f4-ba46a8dbe9ab
+            calendar_dates: 06a21a8e-dba3-4e7e-8726-f2e992cc1a80
+            fare_attributes: 9db51dfa-fd6d-481b-b655-96e8af722ab5
+            fare_rules: 4fb1fa39-0ef9-457d-97b1-bb7e9e848312
+            feed_info: 50d12559-635e-4222-ac25-3706c066902d
+            frequencies: 48542c8f-8ce1-43e3-a965-6c68771d6fe5
+            levels: 288a08cd-7929-479e-aa88-08b677a08510
+            pathways: a01484af-c460-40a4-ac8a-896b0196e8c2
+            shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
+            transfers: f8dcda5d-0c6d-4c70-b5f5-6716adcf6ffc
+            translations: 7abe9256-6cd2-4c1f-9b6a-72108022a382

--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -748,6 +748,7 @@ exposures:
         Cal-ITP collects the GTFS feeds from a statewide list [link] every night and aggegrates it into a statewide table
         for analysis purposes only. Do not use for trip planner ingestation, rather is meant to be used for statewide
         analytics and other use cases. Note: These data may or may or may not have passed GTFS-Validation.
+      coordinate_system_espg: "EPSG:4326"
       destinations:
         - type: ckan
           bucket: gs://calitp-publish
@@ -768,6 +769,6 @@ exposures:
             frequencies: 48542c8f-8ce1-43e3-a965-6c68771d6fe5
             levels: 288a08cd-7929-479e-aa88-08b677a08510
             pathways: a01484af-c460-40a4-ac8a-896b0196e8c2
-            shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
+#            shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
             transfers: f8dcda5d-0c6d-4c70-b5f5-6716adcf6ffc
             translations: 7abe9256-6cd2-4c1f-9b6a-72108022a382

--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -755,11 +755,11 @@ exposures:
           format: csv
           url: https://data.ca.gov/api/3/action/resource_update
           ids:
-#            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
-#            routes: c6bbb637-988f-431c-8444-aef7277297f8
-#            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
-#            stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
-#            trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
+            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
+            routes: c6bbb637-988f-431c-8444-aef7277297f8
+            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
+            stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
+            trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
             attributions: 038b7354-06e8-4082-a4a1-40debd3110d5
             calendar: a79f10b8-b322-43f3-b3f4-ba46a8dbe9ab
             calendar_dates: 06a21a8e-dba3-4e7e-8726-f2e992cc1a80

--- a/warehouse/scripts/dbt_artifacts.py
+++ b/warehouse/scripts/dbt_artifacts.py
@@ -263,6 +263,7 @@ Destination = Annotated[
 
 class ExposureMeta(BaseModel):
     methodology: Optional[str]
+    coordinate_system_espg: Optional[str]
     destinations: List[Destination] = []
 
 

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -106,6 +106,9 @@ def _publish_exposure(
                             }
                         )
 
+                    typer.secho(
+                        f"saving intermediate file to {fpath}", fg=typer.colors.GREEN
+                    )
                     df.to_csv(fpath, index=False)
                     typer.secho(
                         f"selected {len(df)} rows ({humanize.naturalsize(os.stat(fpath).st_size)}) from {node.schema_table}"
@@ -263,8 +266,8 @@ class MetadataRow(BaseModel):
     data_standard: Literal["https://developers.google.com/transit/gtfs"]
     notes: None
     gis_theme: None
-    gis_horiz_accuracy: Literal["4m"]
-    gis_vert_accuracy: Literal["4m"]
+    gis_horiz_accuracy: Optional[Literal["4m"]]
+    gis_vert_accuracy: Optional[Literal["4m"]]
     gis_coordinate_system_epsg: Optional[str]
     gis_vert_datum_epsg: None
 
@@ -370,9 +373,7 @@ def generate_exposure_documentation(
                         gis_theme=None,
                         gis_horiz_accuracy="4m",
                         gis_vert_accuracy="4m",
-                        gis_coordinate_system_epsg=node.meta.get(
-                            "publish.gis_coordinate_system_epsg"
-                        ),
+                        gis_coordinate_system_epsg=exposure.meta.coordinate_system_espg,
                         gis_vert_datum_epsg=None,
                     ).json(models_as_dict=False)
                 )

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -118,6 +118,8 @@ def _publish_exposure(
                                     headers={"Authorization": API_KEY},
                                     files={"upload": fp},
                                 ).raise_for_status()
+                        else:
+                            typer.secho(f"would be {upload_msg} if --deploy", fg=typer.colors.MAGENTA)
 
             elif isinstance(destination, TilesDestination):
                 layer_geojson_paths: Dict[str, Path] = {}

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -148,7 +148,7 @@ def _publish_exposure(
                     geojsonl_fpath = os.path.join(tmpdir, f"{node.name}.geojsonl")
 
                     client = bigquery.Client(project=project)
-                    print(f"querying {node.schema_table}")
+                    typer.secho(f"querying {node.schema_table}")
                     # TODO: this is not great but we have to work around how BigQuery removes overlapping line segments
                     df = client.query(
                         f"select * from {node.schema_table}"
@@ -311,6 +311,11 @@ def generate_exposure_documentation(
         manifest = Manifest(**json.load(f))
 
     exposure = manifest.exposures[f"exposure.calitp_warehouse.{exposure.value}"]
+
+    typer.secho(
+        f"writing out {metadata_output} and {dictionary_output}",
+        fg=typer.colors.MAGENTA,
+    )
 
     with open(metadata_output, "w", newline="") as mf, open(
         dictionary_output, "w", newline=""

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -90,6 +90,22 @@ def _publish_exposure(
                         project_id=node.database,
                         progress_bar_type="tqdm",
                     )
+
+                    if model_name == "stops":
+                        df = df.round(
+                            {
+                                "stop_lat": 5,
+                                "stop_lon": 5,
+                            }
+                        )
+                    elif model_name == "shapes":
+                        df = df.round(
+                            {
+                                "shape_pt_lat": 5,
+                                "shape_pt_lon": 5,
+                            }
+                        )
+
                     df.to_csv(fpath, index=False)
                     typer.secho(
                         f"selected {len(df)} rows ({humanize.naturalsize(os.stat(fpath).st_size)}) from {node.schema_table}"
@@ -119,7 +135,10 @@ def _publish_exposure(
                                     files={"upload": fp},
                                 ).raise_for_status()
                         else:
-                            typer.secho(f"would be {upload_msg} if --deploy", fg=typer.colors.MAGENTA)
+                            typer.secho(
+                                f"would be {upload_msg} if --deploy",
+                                fg=typer.colors.MAGENTA,
+                            )
 
             elif isinstance(destination, TilesDestination):
                 layer_geojson_paths: Dict[str, Path] = {}
@@ -244,8 +263,8 @@ class MetadataRow(BaseModel):
     data_standard: Literal["https://developers.google.com/transit/gtfs"]
     notes: None
     gis_theme: None
-    gis_horiz_accuracy: None
-    gis_vert_accuracy: None
+    gis_horiz_accuracy: Literal["4m"]
+    gis_vert_accuracy: Literal["4m"]
     gis_coordinate_system_epsg: Optional[str]
     gis_vert_datum_epsg: None
 
@@ -344,8 +363,8 @@ def generate_exposure_documentation(
                         data_standard="https://developers.google.com/transit/gtfs",
                         notes=None,
                         gis_theme=None,
-                        gis_horiz_accuracy=None,
-                        gis_vert_accuracy=None,
+                        gis_horiz_accuracy="4m",
+                        gis_vert_accuracy="4m",
                         gis_coordinate_system_epsg=node.meta.get(
                             "publish.gis_coordinate_system_epsg"
                         ),


### PR DESCRIPTION
# Description

Adds additional CKAN IDs for the GTFS Schedule data set. Also updates dictionary and rounds lat/lon to 5 digits as required by the open data portal precision guidelines.

Resolves https://github.com/cal-itp/data-infra/issues/284

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Running locally for now.
## Screenshots (optional)
