### PR TITLE
Fact daily trips incremental

### DIFF
--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -513,13 +513,49 @@ models:
       Each row is a trip / day combination, where the given trip is
       active on the given day, enriched with route and stop_time
       information to give a daily summary. Primary key is composite
-      of trip_key, service_date, and service_id.
+      of feed_key, trip_key, and service_date.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - trip_key
             - service_date
-            - service_id
+            - feed_key
+    columns:
+      - name: feed_key
+        description: '{{ doc("column_schedule_key") }}'
+        tests:
+          - not_null
+      - name: trip_key
+        description: '{{ doc("column_schedule_key") }}'
+        tests:
+          - not_null
+      - *calitp_itp_id
+      - *calitp_url_number
+      - name: service_id
+        description: |
+          service_id value from calendar.txt / calendar_dates.txt /
+          trips.txt
+        tests:
+          - not_null
+      - name: service_date
+        description: |
+          Service date
+        tests:
+          - not_null
+  - name: gtfs_schedule_fact_daily_trips_inc
+    description: |
+      Each row is a trip / day combination, where the given trip is
+      active on the given day, enriched with route and stop_time
+      information to give a daily summary. Primary key is composite
+      of feed_key, trip_key, and service_date. **Incremental version
+      of gtfs_schedule_fact_daily_trips; currently testing incremental
+      implementation.**
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - trip_key
+            - service_date
+            - feed_key
     columns:
       - name: feed_key
         description: '{{ doc("column_schedule_key") }}'

--- a/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_trips_inc.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_trips_inc.sql
@@ -25,15 +25,15 @@ gtfs_schedule_dim_stop_times AS (
     FROM {{ ref('gtfs_schedule_dim_stop_times') }}
     {% if is_incremental() or target.name == 'dev' %}
         WHERE
-            (calitp_extracted_at >=
+            (calitp_extracted_at >= --noqa
                 (SELECT MAX(calitp_extracted_at)
-                FROM {{ this }})
+                    FROM {{ this }})
             )
-            OR
-            (calitp_deleted_at >=
+            OR --noqa
+            (calitp_deleted_at >= --noqa
                 (SELECT MAX(calitp_deleted_at)
-                FROM {{ this }}
-                WHERE calitp_deleted_at != '2099-01-01')
+                    FROM {{ this }}
+                    WHERE calitp_deleted_at != '2099-01-01')
             )
     {% endif %}
 ),

--- a/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_trips_inc.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_fact_daily_trips_inc.sql
@@ -23,7 +23,7 @@ gtfs_schedule_stg_daily_service AS (
 gtfs_schedule_dim_stop_times AS (
     SELECT *
     FROM {{ ref('gtfs_schedule_dim_stop_times') }}
-    {% if is_incremental() or target.name == 'dev' %}
+    {% if is_incremental() %}
         WHERE
             (calitp_extracted_at >= --noqa
                 (SELECT MAX(calitp_extracted_at)


### PR DESCRIPTION
# Description

Makes a test version of the `gtfs_schedule_fact_daily_trips` table that is incrementally materialized. We will let this run for about a week in test to confirm it is accurately replicating the current behavior and, if so, replace the old table (which currently takes 20+ minutes to run every day and causes our dbt run DAG task to fail.)

This also updates the documentation & tests on the main `gtfs_schedule_fact_daily_trips` table to:

1. Fix the failing uniqueness test -- this partially addresses #1471, though not entirely. 
2. Correctly identify the (composite) primary key 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? 
`dbt run` and `dbt test` both pass locally for this new table

## Screenshots (optional)
