### PR TITLE
dbt-metabase updates

### DIFF
--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -111,19 +111,23 @@ models:
       - name: aggregated_to_gtfs_dataset_key
         description: |
           Key for another GTFS dataset record to which this record is aggregated.
-        tests:
-          - relationships:
-             to: ref('dim_gtfs_datasets')
-             field: key
+        # self relationship test breaks metabase connector: https://github.com/JarvusInnovations/dbt-metabase/blob/master/dbtmetabase/parsers/dbt_manifest.py#L202
+        # TODO: make an aliased version of the relationship test
+        # tests:
+        #   - relationships:
+        #      to: ref('dim_gtfs_datasets')
+        #      field: key
       - name: schedule_to_use_for_rt_validation_gtfs_dataset_key
         description: |
           For realtime datasets, the key of the schedule dataset that should
           be used for validation (i.e., the given realtime dataset should reference
           identifiers from the schedule dataset listed here.)
-        tests:
-          - relationships:
-             to: ref('dim_gtfs_datasets')
-             field: key
+        # self relationship test breaks metabase connector: https://github.com/JarvusInnovations/dbt-metabase/blob/master/dbtmetabase/parsers/dbt_manifest.py#L202
+        # TODO: make an aliased version of the relationship test
+        # tests:
+        #   - relationships:
+        #      to: ref('dim_gtfs_datasets')
+        #      field: key
   - name: dim_gtfs_service_data
     description: |
       Each record links together a single `gtfs dataset` and one (if possible)
@@ -188,10 +192,12 @@ models:
         description: |
           For realtime dataset / service relationships,
           the associated schedule dataset / service relationship.
-        tests:
-          - relationships:
-             to: ref('dim_gtfs_service_data')
-             field: key
+        # self relationship test breaks metabase connector: https://github.com/JarvusInnovations/dbt-metabase/blob/master/dbtmetabase/parsers/dbt_manifest.py#L202
+        # TODO: make an aliased version of the relationship test
+        # tests:
+        #   - relationships:
+        #      to: ref('dim_gtfs_service_data')
+        #      field: key
   - name: dim_service_components
     description: |
       Each row is a unique service / product / component combination.

--- a/warehouse/poetry.lock
+++ b/warehouse/poetry.lock
@@ -396,7 +396,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "dbt-metabase"
-version = "0.8.6.dev6+g480611a"
+version = "0.8.6.dev7+g6a255db"
 description = "Model synchronization from dbt to Metabase."
 category = "main"
 optional = false
@@ -416,7 +416,7 @@ test = ["setuptools (>=45)", "wheel", "pylint", "mypy", "types-requests", "types
 type = "git"
 url = "https://github.com/JarvusInnovations/dbt-metabase"
 reference = "master"
-resolved_reference = "480611acf5855ffbfbfd15a69af523ab63b6cadf"
+resolved_reference = "6a255db58d681806b00867a36b9074d04844177a"
 
 [[package]]
 name = "debugpy"


### PR DESCRIPTION
# Description

* Comments out relationship tests that were causing the dbt-Metabase connection to fail for the `mart_transit_database` dataset -- planning to reinstate these next week via an alias or similar, but they are not critical 
* Updates the dbt-Metabase version to address a bug 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) -- more bug suppression
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran dbt-Metabase exposures locally, verified that error that was occurring before has stopped
