### PR TITLE
(analyst_docs): update gcloud commands

### DIFF
--- a/docs/analytics_tools/notebooks.md
+++ b/docs/analytics_tools/notebooks.md
@@ -42,15 +42,26 @@ See the screencast below for a full walkthrough.
 
 The commands required:
 ```python
+# in the main directory (outside of data-analyses and data-infra)
+
 # initial setup (in terminal) ----
-curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-361.0.0-linux-x86_64.tar.gz
-tar -zxvf google-cloud-sdk-361.0.0-linux-x86_64.tar.gz
+curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-396.0.0-linux-x86_64.tar.gz
+tar -zxvf google-cloud-sdk-396.0.0-linux-x86_64.tar.gz
 ./google-cloud-sdk/install.sh
 ./google-cloud-sdk/bin/gcloud init
 
 # log in to project ----
 gcloud auth login
+
+# Authenticate ---- paste URL into browser, copy/paste the authorization code
+
 gcloud auth application-default login
+
+# When it asks for the path:
+/home/jovyan/.bash_profile
+
+# If the default project ID is None, change it
+gcloud config set project cal-itp-data-infra
 ```
 
 ### Increasing the Query Limit


### PR DESCRIPTION
# Description

Bug: While onboarding to JupyterHub and granting GCS permissions, the gcloud commands are out of date and can't successfully install. 
Resolves [Slack convo](https://cal-itp.slack.com/archives/C02KH3DGZL7/p1659551211529189)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
