### PR TITLE
Fix CA Open Data Columns

### DIFF
--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -14,19 +14,21 @@ models:
         description: '{{ doc("column_calitp_itp_id") }}'
         meta:
           metabase.semantic_type: type/FK
-          publish.ignore: true
       - &calitp_url_number
         name: calitp_url_number
         description: '{{ doc("column_calitp_url_number") }}'
         meta:
           metabase.semantic_type: type/FK
-          publish.ignore: true
       - &calitp_extracted_at
         name: calitp_extracted_at
         description: '{{ doc("column_schedule_calitp_extracted_at") }}'
+        meta:
+          publish.ignore: true
       - &calitp_hash
         name: calitp_hash
         description: '{{ doc("column_schedule_calitp_hash") }}'
+        meta:
+          publish.ignore: true
       - name: agency_key
         description: '{{ doc("column_schedule_key") }}'
         tests: &primary_key_tests
@@ -34,6 +36,7 @@ models:
           - unique
         meta: &pk_meta
           metabase.semantic_type: type/PK
+          publish.ignore: true
       - name: agency_id
         description: '{{ doc("gtfs_agency__agency_id") }}'
       - name: agency_name

--- a/warehouse/scripts/dbt_artifacts.py
+++ b/warehouse/scripts/dbt_artifacts.py
@@ -168,7 +168,10 @@ class TestMetadata(BaseModel):
 
 class Test(BaseNode):
     resource_type: Literal[DbtResourceType.test]
-    test_metadata: TestMetadata
+    # test_metadata is optional because singular tests (custom defined) do not have test_metadata attribute
+    # for example: https://github.com/dbt-labs/dbt-docs/blob/main/src/app/services/graph.service.js#L340
+    # ^ singular test is specifically identified by not having the test_metadata attribute
+    test_metadata: Optional[TestMetadata]
 
 
 Node = Annotated[


### PR DESCRIPTION
# Description

## Issue
Per email from Conveyal, the [latest GTFS open dataset on the CA open data portal](https://data.ca.gov/dataset/cal-itp-gtfs-ingest-pipeline-dataset) is missing the `calitp_itp_id` and `calitp_url_number` attributes. Upon inspection we were also publishing the `calitp_hash` and `<file name>_key` fields, which are not in the data dictionary and not intended to be published. 

## Resolution

This PR:
* Updates the column metadata so that `calitp_itp_id` and `calitp_url_number` *will* be published, and `calitp_hash` and `<file name>_key` will *not*
* Updates the Pydantic dbt Manifest parsing to make the `TestMetadata` attribute optional -- when I tried to dry-run the publish workflow, it failed because some [newly-defined](https://github.com/cal-itp/data-infra/pull/1418) [singular tests](https://docs.getdbt.com/docs/building-a-dbt-project/tests#singular-tests) lacked the `test_metadata` attribute which was defined as required in the Pydantic model. Per things like [this](https://github.com/dbt-labs/dbt-docs/blob/main/src/app/services/graph.service.js#L340), it appears that singular tests are like specifically identifiable by their lack of the `test_metadata` attribute. So I make that optional here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

* Ran `dbt run` & `dbt test` and confirmed success
* Did a dry run (`poetry run python scripts/publish.py publish-exposure california_open_data --dry-run`) of the publish workflow and confirmed that the resulting files have only the desired columns -- at time of PR writing, this is still running because it's kind of slow, but I confirmed that two files were written with the correct columns

Once this merges, I will run the actual publish workflow to fix on the portal. 
