### PR TITLE
fix(open data): suppress publishing stop_times because of size limit

### DIFF
--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -760,7 +760,8 @@ exposures:
           ids:
             agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
             routes: c6bbb637-988f-431c-8444-aef7277297f8
-            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
+            # TODO: add stop_times back in once size limit lifted
+            # stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
             stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
             trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
             attributions: 038b7354-06e8-4082-a4a1-40debd3110d5


### PR DESCRIPTION
# Description

When attempting to publish an updated version of the GTFS latest-only data, my upload failed because the stop_times data is too large for the CKAN API. We will need to reach out to the CKAN admin folks for support (already have one inquiry out to them); in the meantime I am suppressing stop_times so we can re-publish everything else with the correct columns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? 

See #1669; we actually successfully re-published agency and routes but then stop_times failed because of data size. 
