### PR TITLE
agencies.yml: add FCRTA and Escalon Transit

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1639,7 +1639,7 @@ elk-grove:
 fresno-county:
   agency_name: Fresno County Rural Transit Agency
   feeds:
-  - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/fresnocounty-ca-us/fresnocounty-ca-us.zip
+  - gtfs_schedule_url: https://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/7869/google_transit.zip
     gtfs_rt_vehicle_positions_url: null
     gtfs_rt_service_alerts_url: null
     gtfs_rt_trip_updates_url: null
@@ -1700,3 +1700,11 @@ treasure-island-ferry:
       gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
       gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=TF
   itp_id: 485
+escalon-transit:
+  agency_name: Escalon Transit
+  feeds:
+    - gtfs_schedule_url: https://data.trilliumtransit.com/gtfs/escalon-ca-us/escalon-ca-us.zip
+      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_service_alerts_url: null
+      gtfs_rt_trip_updates_url: null
+  itp_id: 107

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1700,8 +1700,8 @@ treasure-island-ferry:
       gtfs_rt_service_alerts_url: http://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
       gtfs_rt_trip_updates_url: http://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=TF
   itp_id: 485
-escalon-transit:
-  agency_name: Escalon Transit
+etrans:
+  agency_name: eTrans
   feeds:
     - gtfs_schedule_url: https://data.trilliumtransit.com/gtfs/escalon-ca-us/escalon-ca-us.zip
       gtfs_rt_vehicle_positions_url: null


### PR DESCRIPTION
# Description

Update FCRTA and add Escalon Transit information in agencies.yml

Resolves #1672 

**Question for @evansiroky and @o-ram:** In #1672, Olivia said to list the agency_name as `Escalon Transit`. In `agency.txt` and on their website it seems that they always use the `eTrans` branding. Do we want to list the `calitp_agency_name` (the `agency_name` field in agencies.yml) as `eTrans`, or leave it as `Escalon Transit`?

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

* Tried each download link, verified they work
* Checked `gtfs_schedule_dim_feeds` to confirm that ITP ID `107` has never been used
