### PR TITLE
fix(airflow/gtfs_loader): replace non-utf-8 characters

### DIFF
--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -48,7 +48,9 @@ def _keep_columns(
     # pandas.errors.ParserError, but the responsibility to catch this error is assumed
     # to be implemented in the code that calls this method.
     try:
-        df = pd.read_csv(read_gcfs(src_path), dtype="object", **kwargs)
+        df = pd.read_csv(
+            read_gcfs(src_path), dtype="object", encoding_errors="replace", **kwargs
+        )
     except EmptyDataError:
         # in the rare case of a totally empty data file, create a DataFrame
         # with no rows, and the target columns


### PR DESCRIPTION
# Description

Fixes #1675 by ignoring non-UTF-8 characters in our copy operation (this is the task that copies new GTFS data from one CSV location to a second CSV location with only the known subset of columns.) 

I have chosen to use the `replace` pandas error handling, which replaces the illegal character with a defined unknown.

Alternatives would be:
- Trying to find an encoding that works for the Foothill Transit data on 2022-07-26. 
- Use `ignore` instead of `replace` (see [docs](https://docs.python.org/3/library/codecs.html#error-handlers)); this would replace with an empty space instead of a placeholder character

I liked the placeholder character because it preserves the fact that some data was present. 

Resolves #1675

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

- Tested in a notebook and manually confirmed that this option works for the affected data
- Ran Airflow locally 

## Screenshots 

Notebook:

<img width="721" alt="image" src="https://user-images.githubusercontent.com/55149902/183217869-c94dc1ba-0b93-4fec-903b-e491ab116a69.png">

Airflow:

<img width="1351" alt="image" src="https://user-images.githubusercontent.com/55149902/183217902-b272a0a7-06c0-477a-aa74-9b1b5cf5ba6f.png">

(Production Airflow shows that that exact line is where the issue occurs without this fix:)
<img width="1387" alt="image" src="https://user-images.githubusercontent.com/55149902/183217959-80e11faa-2223-4cb1-b1b6-9182c15b4e35.png">


