### PR TITLE
Created new payments_rides tables filtered for participants

### DIFF
--- a/warehouse/models/payments_views/_payments_views.yml
+++ b/warehouse/models/payments_views/_payments_views.yml
@@ -116,3 +116,443 @@ models:
         description: The latitude of the second tap transaction (if there is one)
       - name: off_longitude
         description: The longitude of the second tap transaction (if there is one)
+
+  - name: payments_rides__clean_air_express
+    description: Clean Air Express payments data from Cal-ITP's `payments_rides` table.
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: micropayment_id
+        description: From payments.micropayments.micropayment_id
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: funding_source_vault_id
+        description: From payments.micropayments.funding_source_vault_id
+      - name: customer_id
+        description: From payments.micropayments.customer_id
+      - name: principal_customer_id
+        description: From payments.customer_funding_source.principal_customer_id
+      - name: bin
+        description: From payments.customer_funding_source.bin
+      - name: masked_pan
+        description: From payments.customer_funding_source.masked_pan
+      - name: card_scheme
+        description: From payments.customer_funding_source.card_scheme
+      - name: issuer
+        description: From payments.customer_funding_source.issuer
+      - name: issuer_country
+        description: From payments.customer_funding_source.issuer_country
+      - name: form_factor
+        description: From payments.customer_funding_source.form_factor
+      - name: charge_amount
+        description: From payments.micropayments.charge_amount
+      - name: refund_amount
+        description: If there is a refund micropayment associated with the trip, the charge_amount on that refund
+      - name: nominal_amount
+        description: From payments.micropayments.nominal_amount
+      - name: charge_type
+        description: From payments.micropayments.charge_type
+      - name: adjustment_id
+        description: From payments.micropayments.adjustment_id
+      - name: adjustment_type
+        description: From payments.micropayment_adjustments.type
+      - name: adjustment_time_period_type
+        description: From payments.micropayment_adjustments.time_period_type
+      - name: adjustment_description
+        description: From payments.micropayment_adjustments.description
+      - name: adjustment_amount
+        description: From payments.micropayment_adjustments.amount
+      - name: product_id
+        description: From payments.micropayment_adjustments.product_id
+      - name: product_code
+        description: From payments.product_data.product_code
+      - name: product_description
+        description: From payments.product_data.product_description
+      - name: product_type
+        description: From payments.product_data.product_type
+      - name: route_id
+        description: The route_id of the first tap transaction with a non-unknown route_id, else unknown ('Route Z')
+      - name: route_long_name
+        description: The route_long_name of the first tap transaction
+      - name: route_short_name
+        description: The route_short_name of the first tap transaction
+      - name: direction
+        description: The direction of the first tap transaction
+      - name: vehicle_id
+        description: The vehicle_id of the first tap transaction
+      - name: littlepay_transaction_id
+        description: The littlepay_transaction_id of the first tap transaction
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: device_id
+        description: The device_id of the first tap transaction
+      - name: transaction_type
+        description: The transaction_type of the first tap transaction
+      - name: transaction_outcome
+        description: The transaction_outcome of the first tap transaction
+      - name: transaction_date_time_utc
+        description: The transaction_date_time_utc of the first tap transaction
+      - name: transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the first tap transaction
+      - name: location_id
+        description: The location_id of the first tap transaction
+      - name: location_name
+        description: The location_name of the first tap transaction
+      - name: latitude
+        description: The latitude of the first tap transaction
+      - name: longitude
+        description: The longitude of the first tap transaction
+      - name: off_littlepay_transaction_id
+        description: The littlepay_transaction_id of the second tap transaction (if there is one)
+      - name: off_device_id
+        description: The device_id of the second tap transaction (if there is one)
+      - name: off_transaction_type
+        description: The transaction_type of the second tap transaction (if there is one)
+      - name: off_transaction_outcome
+        description: The transaction_outcome of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_utc
+        description: The transaction_date_time_utc of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the second tap transaction (if there is one)
+      - name: off_location_id
+        description: The location_id of the second tap transaction (if there is one)
+      - name: off_location_name
+        description: The location_name of the second tap transaction (if there is one)
+      - name: off_latitude
+        description: The latitude of the second tap transaction (if there is one)
+      - name: off_longitude
+        description: The longitude of the second tap transaction (if there is one)
+
+  - name: payments_rides__mst
+    description: MST payments data from Cal-ITP's `payments_rides` table.
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: micropayment_id
+        description: From payments.micropayments.micropayment_id
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: funding_source_vault_id
+        description: From payments.micropayments.funding_source_vault_id
+      - name: customer_id
+        description: From payments.micropayments.customer_id
+      - name: principal_customer_id
+        description: From payments.customer_funding_source.principal_customer_id
+      - name: bin
+        description: From payments.customer_funding_source.bin
+      - name: masked_pan
+        description: From payments.customer_funding_source.masked_pan
+      - name: card_scheme
+        description: From payments.customer_funding_source.card_scheme
+      - name: issuer
+        description: From payments.customer_funding_source.issuer
+      - name: issuer_country
+        description: From payments.customer_funding_source.issuer_country
+      - name: form_factor
+        description: From payments.customer_funding_source.form_factor
+      - name: charge_amount
+        description: From payments.micropayments.charge_amount
+      - name: refund_amount
+        description: If there is a refund micropayment associated with the trip, the charge_amount on that refund
+      - name: nominal_amount
+        description: From payments.micropayments.nominal_amount
+      - name: charge_type
+        description: From payments.micropayments.charge_type
+      - name: adjustment_id
+        description: From payments.micropayments.adjustment_id
+      - name: adjustment_type
+        description: From payments.micropayment_adjustments.type
+      - name: adjustment_time_period_type
+        description: From payments.micropayment_adjustments.time_period_type
+      - name: adjustment_description
+        description: From payments.micropayment_adjustments.description
+      - name: adjustment_amount
+        description: From payments.micropayment_adjustments.amount
+      - name: product_id
+        description: From payments.micropayment_adjustments.product_id
+      - name: product_code
+        description: From payments.product_data.product_code
+      - name: product_description
+        description: From payments.product_data.product_description
+      - name: product_type
+        description: From payments.product_data.product_type
+      - name: route_id
+        description: The route_id of the first tap transaction with a non-unknown route_id, else unknown ('Route Z')
+      - name: route_long_name
+        description: The route_long_name of the first tap transaction
+      - name: route_short_name
+        description: The route_short_name of the first tap transaction
+      - name: direction
+        description: The direction of the first tap transaction
+      - name: vehicle_id
+        description: The vehicle_id of the first tap transaction
+      - name: littlepay_transaction_id
+        description: The littlepay_transaction_id of the first tap transaction
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: device_id
+        description: The device_id of the first tap transaction
+      - name: transaction_type
+        description: The transaction_type of the first tap transaction
+      - name: transaction_outcome
+        description: The transaction_outcome of the first tap transaction
+      - name: transaction_date_time_utc
+        description: The transaction_date_time_utc of the first tap transaction
+      - name: transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the first tap transaction
+      - name: location_id
+        description: The location_id of the first tap transaction
+      - name: location_name
+        description: The location_name of the first tap transaction
+      - name: latitude
+        description: The latitude of the first tap transaction
+      - name: longitude
+        description: The longitude of the first tap transaction
+      - name: off_littlepay_transaction_id
+        description: The littlepay_transaction_id of the second tap transaction (if there is one)
+      - name: off_device_id
+        description: The device_id of the second tap transaction (if there is one)
+      - name: off_transaction_type
+        description: The transaction_type of the second tap transaction (if there is one)
+      - name: off_transaction_outcome
+        description: The transaction_outcome of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_utc
+        description: The transaction_date_time_utc of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the second tap transaction (if there is one)
+      - name: off_location_id
+        description: The location_id of the second tap transaction (if there is one)
+      - name: off_location_name
+        description: The location_name of the second tap transaction (if there is one)
+      - name: off_latitude
+        description: The latitude of the second tap transaction (if there is one)
+      - name: off_longitude
+        description: The longitude of the second tap transaction (if there is one)
+
+  - name: payments_rides__sacrt
+    description: SacRT payments data from Cal-ITP's `payments_rides` table.
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: micropayment_id
+        description: From payments.micropayments.micropayment_id
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: funding_source_vault_id
+        description: From payments.micropayments.funding_source_vault_id
+      - name: customer_id
+        description: From payments.micropayments.customer_id
+      - name: principal_customer_id
+        description: From payments.customer_funding_source.principal_customer_id
+      - name: bin
+        description: From payments.customer_funding_source.bin
+      - name: masked_pan
+        description: From payments.customer_funding_source.masked_pan
+      - name: card_scheme
+        description: From payments.customer_funding_source.card_scheme
+      - name: issuer
+        description: From payments.customer_funding_source.issuer
+      - name: issuer_country
+        description: From payments.customer_funding_source.issuer_country
+      - name: form_factor
+        description: From payments.customer_funding_source.form_factor
+      - name: charge_amount
+        description: From payments.micropayments.charge_amount
+      - name: refund_amount
+        description: If there is a refund micropayment associated with the trip, the charge_amount on that refund
+      - name: nominal_amount
+        description: From payments.micropayments.nominal_amount
+      - name: charge_type
+        description: From payments.micropayments.charge_type
+      - name: adjustment_id
+        description: From payments.micropayments.adjustment_id
+      - name: adjustment_type
+        description: From payments.micropayment_adjustments.type
+      - name: adjustment_time_period_type
+        description: From payments.micropayment_adjustments.time_period_type
+      - name: adjustment_description
+        description: From payments.micropayment_adjustments.description
+      - name: adjustment_amount
+        description: From payments.micropayment_adjustments.amount
+      - name: product_id
+        description: From payments.micropayment_adjustments.product_id
+      - name: product_code
+        description: From payments.product_data.product_code
+      - name: product_description
+        description: From payments.product_data.product_description
+      - name: product_type
+        description: From payments.product_data.product_type
+      - name: route_id
+        description: The route_id of the first tap transaction with a non-unknown route_id, else unknown ('Route Z')
+      - name: route_long_name
+        description: The route_long_name of the first tap transaction
+      - name: route_short_name
+        description: The route_short_name of the first tap transaction
+      - name: direction
+        description: The direction of the first tap transaction
+      - name: vehicle_id
+        description: The vehicle_id of the first tap transaction
+      - name: littlepay_transaction_id
+        description: The littlepay_transaction_id of the first tap transaction
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: device_id
+        description: The device_id of the first tap transaction
+      - name: transaction_type
+        description: The transaction_type of the first tap transaction
+      - name: transaction_outcome
+        description: The transaction_outcome of the first tap transaction
+      - name: transaction_date_time_utc
+        description: The transaction_date_time_utc of the first tap transaction
+      - name: transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the first tap transaction
+      - name: location_id
+        description: The location_id of the first tap transaction
+      - name: location_name
+        description: The location_name of the first tap transaction
+      - name: latitude
+        description: The latitude of the first tap transaction
+      - name: longitude
+        description: The longitude of the first tap transaction
+      - name: off_littlepay_transaction_id
+        description: The littlepay_transaction_id of the second tap transaction (if there is one)
+      - name: off_device_id
+        description: The device_id of the second tap transaction (if there is one)
+      - name: off_transaction_type
+        description: The transaction_type of the second tap transaction (if there is one)
+      - name: off_transaction_outcome
+        description: The transaction_outcome of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_utc
+        description: The transaction_date_time_utc of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the second tap transaction (if there is one)
+      - name: off_location_id
+        description: The location_id of the second tap transaction (if there is one)
+      - name: off_location_name
+        description: The location_name of the second tap transaction (if there is one)
+      - name: off_latitude
+        description: The latitude of the second tap transaction (if there is one)
+      - name: off_longitude
+        description: The longitude of the second tap transaction (if there is one)
+
+  - name: payments_rides__sbmtd
+    description: SBMTD payments data from Cal-ITP's `payments_rides` table.
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: micropayment_id
+        description: From payments.micropayments.micropayment_id
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: funding_source_vault_id
+        description: From payments.micropayments.funding_source_vault_id
+      - name: customer_id
+        description: From payments.micropayments.customer_id
+      - name: principal_customer_id
+        description: From payments.customer_funding_source.principal_customer_id
+      - name: bin
+        description: From payments.customer_funding_source.bin
+      - name: masked_pan
+        description: From payments.customer_funding_source.masked_pan
+      - name: card_scheme
+        description: From payments.customer_funding_source.card_scheme
+      - name: issuer
+        description: From payments.customer_funding_source.issuer
+      - name: issuer_country
+        description: From payments.customer_funding_source.issuer_country
+      - name: form_factor
+        description: From payments.customer_funding_source.form_factor
+      - name: charge_amount
+        description: From payments.micropayments.charge_amount
+      - name: refund_amount
+        description: If there is a refund micropayment associated with the trip, the charge_amount on that refund
+      - name: nominal_amount
+        description: From payments.micropayments.nominal_amount
+      - name: charge_type
+        description: From payments.micropayments.charge_type
+      - name: adjustment_id
+        description: From payments.micropayments.adjustment_id
+      - name: adjustment_type
+        description: From payments.micropayment_adjustments.type
+      - name: adjustment_time_period_type
+        description: From payments.micropayment_adjustments.time_period_type
+      - name: adjustment_description
+        description: From payments.micropayment_adjustments.description
+      - name: adjustment_amount
+        description: From payments.micropayment_adjustments.amount
+      - name: product_id
+        description: From payments.micropayment_adjustments.product_id
+      - name: product_code
+        description: From payments.product_data.product_code
+      - name: product_description
+        description: From payments.product_data.product_description
+      - name: product_type
+        description: From payments.product_data.product_type
+      - name: route_id
+        description: The route_id of the first tap transaction with a non-unknown route_id, else unknown ('Route Z')
+      - name: route_long_name
+        description: The route_long_name of the first tap transaction
+      - name: route_short_name
+        description: The route_short_name of the first tap transaction
+      - name: direction
+        description: The direction of the first tap transaction
+      - name: vehicle_id
+        description: The vehicle_id of the first tap transaction
+      - name: littlepay_transaction_id
+        description: The littlepay_transaction_id of the first tap transaction
+        tests:
+          - unique:
+              config:
+                store_failures: true
+      - name: device_id
+        description: The device_id of the first tap transaction
+      - name: transaction_type
+        description: The transaction_type of the first tap transaction
+      - name: transaction_outcome
+        description: The transaction_outcome of the first tap transaction
+      - name: transaction_date_time_utc
+        description: The transaction_date_time_utc of the first tap transaction
+      - name: transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the first tap transaction
+      - name: location_id
+        description: The location_id of the first tap transaction
+      - name: location_name
+        description: The location_name of the first tap transaction
+      - name: latitude
+        description: The latitude of the first tap transaction
+      - name: longitude
+        description: The longitude of the first tap transaction
+      - name: off_littlepay_transaction_id
+        description: The littlepay_transaction_id of the second tap transaction (if there is one)
+      - name: off_device_id
+        description: The device_id of the second tap transaction (if there is one)
+      - name: off_transaction_type
+        description: The transaction_type of the second tap transaction (if there is one)
+      - name: off_transaction_outcome
+        description: The transaction_outcome of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_utc
+        description: The transaction_date_time_utc of the second tap transaction (if there is one)
+      - name: off_transaction_date_time_pacific
+        description: The transaction_date_time_pacific of the second tap transaction (if there is one)
+      - name: off_location_id
+        description: The location_id of the second tap transaction (if there is one)
+      - name: off_location_name
+        description: The location_name of the second tap transaction (if there is one)
+      - name: off_latitude
+        description: The latitude of the second tap transaction (if there is one)
+      - name: off_longitude
+        description: The longitude of the second tap transaction (if there is one)

--- a/warehouse/models/payments_views/payments_rides__clean_air_express.sql
+++ b/warehouse/models/payments_views/payments_rides__clean_air_express.sql
@@ -1,0 +1,10 @@
+WITH filter_by_clean_air_express AS (
+
+    SELECT *
+    FROM {{ ref('payments_rides') }}
+    WHERE
+        participant_id = "clean-air-express"
+
+)
+
+SELECT * FROM filter_by_clean_air_express

--- a/warehouse/models/payments_views/payments_rides__mst.sql
+++ b/warehouse/models/payments_views/payments_rides__mst.sql
@@ -1,0 +1,10 @@
+WITH filter_by_mst AS (
+
+    SELECT *
+    FROM {{ ref('payments_rides') }}
+    WHERE
+        participant_id = "mst"
+
+)
+
+SELECT * FROM filter_by_mst

--- a/warehouse/models/payments_views/payments_rides__sacrt.sql
+++ b/warehouse/models/payments_views/payments_rides__sacrt.sql
@@ -1,0 +1,10 @@
+WITH filter_by_sacrt AS (
+
+    SELECT *
+    FROM {{ ref('payments_rides') }}
+    WHERE
+        participant_id = "sacrt"
+
+)
+
+SELECT * FROM filter_by_sacrt

--- a/warehouse/models/payments_views/payments_rides__sbmtd.sql
+++ b/warehouse/models/payments_views/payments_rides__sbmtd.sql
@@ -1,0 +1,10 @@
+WITH filter_by_sbmtd AS (
+
+    SELECT *
+    FROM {{ ref('payments_rides') }}
+    WHERE
+        participant_id = "sbmtd"
+
+)
+
+SELECT * FROM filter_by_sbmtd


### PR DESCRIPTION
# Description
Creates single-participant tables from `payments_rides` so as to limit participant warehouse access to only their data

* Created four new tables filtered by distinct `participant_id` from `payments_rides`
  * payments_rides__clean_air_express
  * payments_rides__mst
  * payments_rides__sbmtd
  * payments_rides__sacrt
* Added documentation for these tables in `_payments_views.yml`

TO-DO: 
- [ ] revise docs to not include references to other warehouse tables, include Littlepay column descriptions instead 
- [ ] coordinate and communicate service account access for participants in gcp

Resolves #1680 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?
`charlie_views` testing schema in staging warehouse, served dbt docs locally