### PR TITLE
Add WeHo RT URLs

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1680,9 +1680,9 @@ city-of-west-hollywood:
   agency_name: City of West Hollywood
   feeds:
     - gtfs_schedule_url: https://www.weho.org/home/showdocument?id=53383&t=637901042129473913
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://webservices.umoiq.com/api/gtfs-rt/v1/vehicle-positions/west-hollywood
+      gtfs_rt_service_alerts_url: https://webservices.umoiq.com/api/gtfs-rt/v1/service-alerts/west-hollywood
+      gtfs_rt_trip_updates_url: https://webservices.umoiq.com/api/gtfs-rt/v1/trip-updates/west-hollywood
   itp_id: 367
 south-san-fransisco-shuttle:
   agency_name: South San Francisco Shuttle

--- a/airflow/data/headers.yml
+++ b/airflow/data/headers.yml
@@ -78,3 +78,12 @@
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
+- header-data:
+    x-umo-iq-api-key: {{ WEHO_RT_KEY }}
+  URLs:
+    - itp_id: 367 # City of West Hollywood
+      url_number: 0
+      rt_urls:
+        - gtfs_rt_vehicle_positions_url
+        - gtfs_rt_service_alerts_url
+        - gtfs_rt_trip_updates_url


### PR DESCRIPTION
# Description

Adds new RT URLs and associated header info for City of West Hollywood.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Downloading RT feeds locally.
