### PR TITLE
fix(ckan publishing): only add columns to data dictionary if they're supposed to be published

### DIFF
--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -380,30 +380,31 @@ def generate_exposure_documentation(
             )
 
             for name, column in node.columns.items():
-                dictionary_writer.writerow(
-                    json.loads(
-                        DictionaryRow(
-                            system_name="Cal-ITP GTFS-Ingest Pipeline",
-                            table_name=node.name,
-                            field_name=column.name,
-                            field_alias=None,
-                            field_description=column.description,
-                            field_description_authority="",
-                            confidential="N",
-                            sensitive="N",
-                            pii="N",
-                            pci="N",
-                            field_type=column.meta.get("publish.type", "STRING"),
-                            field_length=column.meta.get("publish.length", 1024),
-                            field_precision=None,
-                            units=None,
-                            domain_type="Unrepresented",
-                            allowable_min_value=None,
-                            allowable_max_value=None,
-                            usage_notes=None,
-                        ).json()
+                if not column.meta.get("publish.ignore", False):
+                    dictionary_writer.writerow(
+                        json.loads(
+                            DictionaryRow(
+                                system_name="Cal-ITP GTFS-Ingest Pipeline",
+                                table_name=node.name,
+                                field_name=column.name,
+                                field_alias=None,
+                                field_description=column.description,
+                                field_description_authority="",
+                                confidential="N",
+                                sensitive="N",
+                                pii="N",
+                                pci="N",
+                                field_type=column.meta.get("publish.type", "STRING"),
+                                field_length=column.meta.get("publish.length", 1024),
+                                field_precision=None,
+                                units=None,
+                                domain_type="Unrepresented",
+                                allowable_min_value=None,
+                                allowable_max_value=None,
+                                usage_notes=None,
+                            ).json()
+                        )
                     )
-                )
 
 
 @app.command()


### PR DESCRIPTION
# Description

I noticed that when running `poetry run python scripts/publish.py generate-exposure-documentation california_open_data`, fields that had `publish.ignore = True` were still being included in the data dictionary. This PR fixes that by adding a check that a field is supposed to be published before adding it to the data dictionary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? 
Tested by running `poetry run python scripts/publish.py generate-exposure-documentation california_open_data` and confirming that resulting files do not contain `calitp_hash` and other fields that were suppressed in #1669.
