### PR TITLE
Create SFTP ingest component for Elavon data

### DIFF
--- a/ci/vars/releases/prod-sftp-ingest-elavon.env
+++ b/ci/vars/releases/prod-sftp-ingest-elavon.env
@@ -1,0 +1,2 @@
+RELEASE_DRIVER=kustomize
+RELEASE_KUSTOMIZE_DIR=kubernetes/apps/overlays/prod-sftp-ingest-elavon

--- a/kubernetes/apps/manifests/sftp-server/intranet-service.yaml
+++ b/kubernetes/apps/manifests/sftp-server/intranet-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sftp-intranet
+  labels:
+    component: sftp-server
+spec:
+  ports:
+    - port: 22
+      name: sftp
+  clusterIP: None
+  selector:
+    component: sftp-server

--- a/kubernetes/apps/manifests/sftp-server/kustomization.yaml
+++ b/kubernetes/apps/manifests/sftp-server/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- workload.yaml

--- a/kubernetes/apps/manifests/sftp-server/kustomization.yaml
+++ b/kubernetes/apps/manifests/sftp-server/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - workload.yaml
+- intranet-service.yaml
 
 configMapGenerator:
   - name: sftp-sshd

--- a/kubernetes/apps/manifests/sftp-server/kustomization.yaml
+++ b/kubernetes/apps/manifests/sftp-server/kustomization.yaml
@@ -1,2 +1,7 @@
 resources:
 - workload.yaml
+
+configMapGenerator:
+  - name: sftp-sshd
+    files:
+      - sshd_config

--- a/kubernetes/apps/manifests/sftp-server/sshd_config
+++ b/kubernetes/apps/manifests/sftp-server/sshd_config
@@ -1,0 +1,6 @@
+Port 22
+Include /etc/ssh/sshd_config.d/*.conf
+AuthorizedKeysFile      .ssh/authorized_keys
+Subsystem       sftp    internal-sftp
+ForceCommand internal-sftp
+ChrootDirectory /sftp

--- a/kubernetes/apps/manifests/sftp-server/workload.yaml
+++ b/kubernetes/apps/manifests/sftp-server/workload.yaml
@@ -47,6 +47,11 @@ spec:
               cp /config/server/sshd_config /etc/ssh/sshd_config
               ssh-keygen -A
               exec /usr/sbin/sshd -e -D
+          readinessProbe:
+            tcpSocket:
+              port: 22
+            initialDelaySeconds: 5
+            periodSeconds: 5
       securityContext:
         fsGroup: 1000
       volumes:

--- a/kubernetes/apps/manifests/sftp-server/workload.yaml
+++ b/kubernetes/apps/manifests/sftp-server/workload.yaml
@@ -24,29 +24,38 @@ spec:
               name: sftp
           volumeMounts:
             - name: data
-              mountPath: /data
-            - name: config
-              mountPath: /config
+              mountPath: /sftp/data
+            - name: user-config
+              mountPath: /config/user
+            - name: server-config
+              mountPath: /config/server
           command: [ /bin/bash ]
           args:
             - -c
             - |
-              test "$SFTP_USER"               || { echo "fatal: SFTP_USER not defined "; exit 1; }
-              test -e /config/authorized_keys || { echo "fatal: /config/authorized_keys not present"; }
+              test "$SFTP_USER" || { echo "fatal: SFTP_USER not defined "; exit 1; }
               dnf install -y openssh-server
               groupadd -g 1000 $SFTP_USER
               useradd  -g 1000 -md /home/$SFTP_USER -s /bin/bash $SFTP_USER
               mkdir -m 0700 /home/$SFTP_USER/.ssh
-              (umask 077; cp /config/authorized_keys /home/$SFTP_USER/.ssh/authorized_keys)
+              if [[ -e /config/user/authorized_keys ]]; then
+                (umask 077; cp /config/user/authorized_keys /home/$SFTP_USER/.ssh/authorized_keys)
+              else
+                echo "warn: no /config/user/authorized_keys file; user $SFTP_USER may not be able to login"
+              fi
               chown -R $SFTP_USER:$SFTP_USER /home/$SFTP_USER/.ssh
+              cp /config/server/sshd_config /etc/ssh/sshd_config
               ssh-keygen -A
-              exec /usr/sbin/sshd -D
+              exec /usr/sbin/sshd -e -D
       securityContext:
         fsGroup: 1000
       volumes:
-        - name: config
+        - name: user-config
           configMap:
             name: sftp-user-config
+        - name: server-config
+          configMap:
+            name: sftp-sshd
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/kubernetes/apps/manifests/sftp-server/workload.yaml
+++ b/kubernetes/apps/manifests/sftp-server/workload.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sftp-server
+spec:
+  selector:
+    matchLabels:
+      component: sftp-server
+  serviceName: sftp-intranet
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: sftp-server
+    spec:
+      containers:
+        - name: server
+          image: fedora:latest
+          envFrom:
+            - configMapRef:
+                name: sftp-user
+          ports:
+            - containerPort: 22
+              name: sftp
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config
+          command: [ /bin/bash ]
+          args:
+            - -c
+            - |
+              test "$SFTP_USER"               || { echo "fatal: SFTP_USER not defined "; exit 1; }
+              test -e /config/authorized_keys || { echo "fatal: /config/authorized_keys not present"; }
+              dnf install -y openssh-server
+              groupadd -g 1000 $SFTP_USER
+              useradd  -g 1000 -md /home/$SFTP_USER -s /bin/bash $SFTP_USER
+              mkdir -m 0700 /home/$SFTP_USER/.ssh
+              (umask 077; cp /config/authorized_keys /home/$SFTP_USER/.ssh/authorized_keys)
+              chown -R $SFTP_USER:$SFTP_USER /home/$SFTP_USER/.ssh
+              ssh-keygen -A
+              exec /usr/sbin/sshd -D
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: config
+          configMap:
+            name: sftp-user-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ 'ReadWriteOnce' ]
+        resources:
+          requests:
+            storage: 1Gi

--- a/kubernetes/apps/manifests/sftp-server/workload.yaml
+++ b/kubernetes/apps/manifests/sftp-server/workload.yaml
@@ -16,6 +16,13 @@ spec:
       containers:
         - name: server
           image: fedora:latest
+          env:
+            - name: SFTP_UID
+              value: '1000'
+            - name: SFTP_AUTHORIZED_KEYS_SRC
+              value: /config/user/authorized_keys
+            - name: SFTP_SSHD_CONFIG_SRC
+              value: /config/server/sshd_config
           envFrom:
             - configMapRef:
                 name: sftp-user
@@ -33,18 +40,20 @@ spec:
           args:
             - -c
             - |
-              test "$SFTP_USER" || { echo "fatal: SFTP_USER not defined "; exit 1; }
+              test "$SFTP_USER"          || SFTP_USER=sftp
+              test "$SFTP_USER_HOME"     || SFTP_USER_HOME=/home/$SFTP_USER
+              test "$SFTP_USER_SSH_HOME" || SFTP_USER_SSH_HOME=$SFTP_USER_HOME/.ssh
               dnf install -y openssh-server
-              groupadd -g 1000 $SFTP_USER
-              useradd  -g 1000 -md /home/$SFTP_USER -s /bin/bash $SFTP_USER
-              mkdir -m 0700 /home/$SFTP_USER/.ssh
-              if [[ -e /config/user/authorized_keys ]]; then
-                (umask 077; cp /config/user/authorized_keys /home/$SFTP_USER/.ssh/authorized_keys)
+              groupadd -g $SFTP_UID $SFTP_USER
+              useradd  -g $SFTP_UID -md $SFTP_USER_HOME -s /bin/bash $SFTP_USER
+              mkdir -p -m 0700 "$SFTP_USER_SSH_HOME"
+              if [[ -e $SFTP_AUTHORIZED_KEYS_SRC ]]; then
+                (umask 077; cp $SFTP_AUTHORIZED_KEYS_SRC "$SFTP_USER_SSH_HOME"/authorized_keys)
               else
-                echo "warn: no /config/user/authorized_keys file; user $SFTP_USER may not be able to login"
+                echo "warn: no $SFTP_AUTHORIZED_KEYS_SRC file; user $SFTP_USER may not be able to login"
               fi
-              chown -R $SFTP_USER:$SFTP_USER /home/$SFTP_USER/.ssh
-              cp /config/server/sshd_config /etc/ssh/sshd_config
+              chown -R $SFTP_USER:$SFTP_USER "$SFTP_USER_SSH_HOME"
+              cp "$SFTP_SSHD_CONFIG_SRC" /etc/ssh/sshd_config
               ssh-keygen -A
               exec /usr/sbin/sshd -e -D
           readinessProbe:

--- a/kubernetes/apps/overlays/base-sftp-ingest-elavon/kustomization.yaml
+++ b/kubernetes/apps/overlays/base-sftp-ingest-elavon/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../manifests/sftp-server
+- sftp-user.yaml

--- a/kubernetes/apps/overlays/base-sftp-ingest-elavon/sftp-user.yaml
+++ b/kubernetes/apps/overlays/base-sftp-ingest-elavon/sftp-user.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sftp-user
+data:
+  SFTP_USER: elavon

--- a/kubernetes/apps/overlays/dev-sftp-ingest-elavon/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev-sftp-ingest-elavon/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dev-sftp-ingest-elavon
+
+resources:
+- ../base-sftp-ingest-elavon
+- ns.yaml
+- sftp-user-config.yaml

--- a/kubernetes/apps/overlays/dev-sftp-ingest-elavon/ns.yaml
+++ b/kubernetes/apps/overlays/dev-sftp-ingest-elavon/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev-sftp-ingest-elavon

--- a/kubernetes/apps/overlays/dev-sftp-ingest-elavon/sftp-user-config.yaml
+++ b/kubernetes/apps/overlays/dev-sftp-ingest-elavon/sftp-user-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sftp-user-config
+data:
+  authorized_keys: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvdNntkalKcXm7lkZzSZlsEtXVyPfQIu/D5HXZbpXIkF1qMr5vGehACgoqe1IeZY/Y/u5M4uJVcrc5S7OZc5rX6E+A30Zjhck4HPfoHjPf8jRfwvZ9EmV5BncJuqCytkWx6oDi1boS8IchKh5H+YslRKe9DYD38igB5aMfrTLjsTHfAm76qD4VtuqhPuNMwK2C66cMVFhIqm8g6BcurncdiVWyP8OcekZw+A527N5FeGw989ZPRhS/AMeZpCKed2z8n04wFgXezIeA6aWMKbh5WEKEe8/O8xFnUTVR1JPuGGZ8OFDXNVUBegiZo3XvaH/RGiBQPMdXUU14Sf6+vrqx' # jlott

--- a/kubernetes/apps/overlays/prod-sftp-ingest-elavon/internet-service.yaml
+++ b/kubernetes/apps/overlays/prod-sftp-ingest-elavon/internet-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sftp-internet
+  labels:
+    component: sftp-server
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 22
+      name: sftp
+  selector:
+    statefulset.kubernetes.io/pod-name: sftp-server-0

--- a/kubernetes/apps/overlays/prod-sftp-ingest-elavon/kustomization.yaml
+++ b/kubernetes/apps/overlays/prod-sftp-ingest-elavon/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../base-sftp-ingest-elavon
 - ns.yaml
 - sftp-user-config.yaml
+- internet-service.yaml
 
 patches:
 - path: patch-volume-size.json

--- a/kubernetes/apps/overlays/prod-sftp-ingest-elavon/kustomization.yaml
+++ b/kubernetes/apps/overlays/prod-sftp-ingest-elavon/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prod-sftp-ingest-elavon
+
+resources:
+- ../base-sftp-ingest-elavon
+- ns.yaml
+- sftp-user-config.yaml
+
+patches:
+- path: patch-volume-size.json
+  target:
+    kind: StatefulSet
+    name: sftp-server

--- a/kubernetes/apps/overlays/prod-sftp-ingest-elavon/ns.yaml
+++ b/kubernetes/apps/overlays/prod-sftp-ingest-elavon/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod-sftp-ingest-elavon

--- a/kubernetes/apps/overlays/prod-sftp-ingest-elavon/patch-volume-size.json
+++ b/kubernetes/apps/overlays/prod-sftp-ingest-elavon/patch-volume-size.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/spec/volumeClaimTemplates/0/spec/resources/requests/storage",
+    "value": "50Gi"
+  }
+]

--- a/kubernetes/apps/overlays/prod-sftp-ingest-elavon/sftp-user-config.yaml
+++ b/kubernetes/apps/overlays/prod-sftp-ingest-elavon/sftp-user-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sftp-user-config
+data:
+  authorized_keys: ''


### PR DESCRIPTION
# Description

This changeset introduces an SFTP server infrastructure component which is then exposed on a stable public IP and port to receive enriched data from Elavon.

Resolves #1667 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Locally, using a kind cluster
