### PR TITLE
use new version of caltip py with good gcsfs

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.8.18a0
+calitp==2022.8.18
 intake==0.6.1
 ipdb==0.13.4
 gusty==0.6.0

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.8.17
+calitp==2022.8.18a0
 intake==0.6.1
 ipdb==0.13.4
 gusty==0.6.0


### PR DESCRIPTION
# Description

The new version of gcsfs has a [regression](https://github.com/fsspec/gcsfs/issues/486) that is affecting our Airflow jobs. I've deployed a [new version](https://github.com/cal-itp/calitp-py/pull/73) of calitp-py that pins us to an older gcsfs version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
```
Installing collected packages: gcsfs
Successfully installed gcsfs-2022.5.0
```

## Screenshots (optional)
