### PR TITLE
Hotfix gcsfs version

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,5 @@
-calitp==2022.8.18
+calitp==2022.8.18.1
+fsspec==2022.5.0
 intake==0.6.1
 ipdb==0.13.4
 gusty==0.6.0


### PR DESCRIPTION
# Description

Deploys https://github.com/cal-itp/calitp-py/pull/74 but also pins a specific fsspec directly in the Composer requirements file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
```
(.venv) ➜  airflow git:(hotfix-gcsfs-version) ✗ gcloud composer environments update calitp-airflow2-prod --update-pypi-packages-from-file requirements.txt --location us-west2 --project cal-itp-data-infra
Waiting for [projects/cal-itp-data-infra/locations/us-west2/environments/calitp-airflow2-prod] to be updated with [projects/cal-itp-data-infra/locations/us-west2/operations/b7fb32bf-6b3b-4fbb-9d8e-9b4c62bf8dca]...done.
```
## Screenshots (optional)
