### PR TITLE
Gtfs schedule unzip v2

### DIFF
--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -19,7 +19,7 @@ from calitp.storage import (
     get_fs,
     AirtableGTFSDataExtract,
     AirtableGTFSDataRecord,
-    GTFSFeedExtractInfo,
+    GTFSScheduleFeedExtract,
     GTFSFeedType,
     download_feed,
     ProcessingOutcome,
@@ -34,7 +34,7 @@ GTFS_FEED_LIST_ERROR_THRESHOLD = 0.95
 
 class AirtableGTFSDataRecordProcessingOutcome(ProcessingOutcome):
     airtable_record: AirtableGTFSDataRecord
-    extract: Optional[GTFSFeedExtractInfo]
+    extract: Optional[GTFSScheduleFeedExtract]
 
 
 class DownloadFeedsResult(PartitionedGCSArtifact):

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
@@ -1,0 +1,137 @@
+# ---
+# python_callable: unzip
+# provide_context: true
+# ---
+import os
+import pendulum
+import zipfile
+
+from typing import ClassVar, List, Optional
+from pydantic import Field
+
+from calitp.storage import (
+    fetch_all_in_partition,
+    GTFSFeedExtractInfo,
+    get_fs,
+    GTFSFeedType,
+    PartitionedGCSArtifact,
+    ProcessingOutcome,
+)
+
+SCHEDULE_UNZIPPED_BUCKET = os.getenv("CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED")
+
+
+class GTFSScheduleFeedFile(PartitionedGCSArtifact):
+    bucket: ClassVar[str] = SCHEDULE_UNZIPPED_BUCKET
+    partition_names: ClassVar[List[str]] = ["dt", "base64_url", "ts"]
+    ts: pendulum.DateTime
+    base64_url: str
+    zipfile_path: str
+    original_filename: str
+
+    # if you try to set table directly, you get an error because it "shadows a BaseModel attribute"
+    # so set as a property instead
+    @property
+    def table(self) -> str:
+        # only replace slashes so that this is a mostly GCS-filepath-safe string
+        # if we encounter something else, we will address: https://cloud.google.com/storage/docs/naming-objects
+        return self.original_filename.replace("/", "__")
+
+    @property
+    def dt(self) -> pendulum.Date:
+        return self.ts.date()
+
+
+class GTFSScheduleFeedExtractUnzipOutcome(ProcessingOutcome):
+    extract: GTFSFeedExtractInfo = Field(..., exclude={"config"})
+    zipfile_files: Optional[List[str]]
+    zipfile_dirs: Optional[List[str]]
+    extracted_files: Optional[List[GTFSScheduleFeedFile]]
+
+
+class ScheduleUnzipResult(PartitionedGCSArtifact):
+    bucket: ClassVar[str] = SCHEDULE_UNZIPPED_BUCKET
+    table: ClassVar[str] = "unzipping_results"
+    partition_names: ClassVar[List[str]] = ["dt", "ts"]
+    dt: pendulum.Date
+    ts: pendulum.DateTime
+    outcomes: List[GTFSScheduleFeedExtractUnzipOutcome]
+
+    @property
+    def successes(self) -> List[GTFSScheduleFeedExtractUnzipOutcome]:
+        return [outcome for outcome in self.outcomes if outcome.success]
+
+    @property
+    def failures(self) -> List[GTFSScheduleFeedExtractUnzipOutcome]:
+        return [outcome for outcome in self.outcomes if not outcome.success]
+
+    def save(self, fs):
+        self.save_content(
+            fs=fs,
+            content="\n".join(o.json() for o in self.outcomes).encode(),
+            exclude={"outcomes"},
+        )
+
+
+def summarize_zip(zip: zipfile.ZipFile, at: str = ""):
+    # check for directories
+    type_map = {True: "directory", False: "file"}
+    return {
+        item.name: type_map(item.is_dir())
+        for item in zipfile.Path(root=zip, at=at).iterdir()
+    }
+
+
+def unzip_individual_feed(zip: zipfile.ZipFile):
+    """If zip contains a directory and nothing else at top level or files at top level,
+    we return the contents of the top level or the unique directory as the feed.
+    If there's a directory *and* other files at top level within zip, or if
+    there are nested directories, say we can't parse."""
+
+    top_level_objects = summarize_zip(zip)
+
+    if "directory" in top_level_objects.values():
+        # can only process directory if it's the only item in the zip
+        if len(top_level_objects) != 1:
+            return GTFSScheduleFeedExtractUnzipOutcome(
+                success=False,
+                contained_directory=True,
+            )
+    # TODO: finish implementing
+    # need to check for nested directories -- at which point we say unzipping failed
+    # if there is exactly one top level directory, we return an indicator of such
+    # decide return structure
+
+    return top_level_objects
+
+
+def unzip_extracts(day=pendulum.today()):
+    fs = get_fs()
+
+    day = pendulum.instance(day).date()
+    extracts = fetch_all_in_partition(
+        cls=GTFSFeedExtractInfo,
+        table=GTFSFeedType.schedule,
+        fs=get_fs(),
+        partitions={
+            "dt": day,
+        },
+        verbose=True,
+    )
+
+    outcomes = []
+    for extract in extracts[0:1]:
+        try:
+            with fs.open(extract.path) as f:
+                zip = zipfile.ZipFile(f)
+            # print(zip.infolist())
+            item_check = unzip_individual_feed(zip)
+            print(item_check)
+        except Exception as e:
+            outcomes.append(
+                GTFSScheduleFeedExtractUnzipOutcome(
+                    success=False,
+                    extract=extract,
+                    exception=e,
+                )
+            )

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
@@ -44,8 +44,8 @@ class GTFSScheduleFeedFile(PartitionedGCSArtifact):
 
 
 class GTFSScheduleFeedExtractUnzipOutcome(ProcessingOutcome):
-    extract_path: str
-    extract_md5hash: str
+    zipfile_extract_path: str
+    zipfile_extract_md5hash: str
     zipfile_files: Optional[List[str]]
     zipfile_dirs: Optional[List[str]]
     extracted_files: Optional[List[str]]
@@ -128,8 +128,8 @@ def unzip_individual_feed(
     except Exception as e:
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=False,
-            extract_md5hash=zipfile_md5_hash,
-            extract_path=extract.path,
+            zipfile_extract_md5hash=zipfile_md5_hash,
+            zipfile_extract_path=extract.path,
             exception=e,
         )
     # more than one directory --> invalid zip
@@ -137,8 +137,8 @@ def unzip_individual_feed(
         logging.info(f"Invalid zip {extract.path}: Multiple directories found")
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=False,
-            extract_md5hash=zipfile_md5_hash,
-            extract_path=extract.path,
+            zipfile_extract_md5hash=zipfile_md5_hash,
+            zipfile_extract_path=extract.path,
             zipfile_files=files,
             zipfile_dirs=directories,
         )
@@ -150,8 +150,8 @@ def unzip_individual_feed(
         logging.info(f"Invalid zip {extract.path}: Mix of directories and files found")
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=False,
-            extract_md5hash=zipfile_md5_hash,
-            extract_path=extract.path,
+            zipfile_extract_md5hash=zipfile_md5_hash,
+            zipfile_extract_path=extract.path,
             zipfile_files=files,
             zipfile_dirs=directories,
         )
@@ -163,8 +163,8 @@ def unzip_individual_feed(
         zipfile_files = process_feed_files(fs, extract, feed_directory)
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=True,
-            extract_md5hash=zipfile_md5_hash,
-            extract_path=extract.path,
+            zipfile_extract_md5hash=zipfile_md5_hash,
+            zipfile_extract_path=extract.path,
             zipfile_files=files,
             zipfile_dirs=directories,
             extracted_files=[file.path for file in zipfile_files],
@@ -174,8 +174,8 @@ def unzip_individual_feed(
         zipfile_files = process_feed_files(fs, extract)
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=True,
-            extract_md5hash=zipfile_md5_hash,
-            extract_path=extract.path,
+            zipfile_extract_md5hash=zipfile_md5_hash,
+            zipfile_extract_path=extract.path,
             zipfile_files=files,
             zipfile_dirs=directories,
             extracted_files=[file.path for file in zipfile_files],

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
@@ -84,7 +84,8 @@ def summarize_zip_contents(
         if zipfile.Path(zip, at=entry).is_dir():
             directories.append(entry)
     logging.info(f"Found files: {files} and directories: {directories}")
-    # the only valid case for any directory inside the zipfile is if it's the only item at the root of the zipfile
+    # the only valid case for any directory inside the zipfile is if there's exactly one and it's the only item at the root of the zipfile
+    # (in which case we can treat that directory's contents as the feed)
     is_valid = (not directories) or (
         (len(directories) == 1)
         and ([item.is_dir() for item in zipfile.Path(zip, at="").iterdir()] == [True])
@@ -107,7 +108,7 @@ def process_feed_files(
         )
 
     for file in files:
-        # make a proper path so to access the .name attribute later
+        # make a proper path to access the .name attribute later
         file_path = zipfile.Path(zip, at=file)
         with zip.open(file) as f:
             file_content = f.read()

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
@@ -11,23 +11,20 @@ from pydantic import Field
 
 from calitp.storage import (
     fetch_all_in_partition,
-    GTFSFeedExtractInfo,
+    GTFSScheduleFeedExtract,
     get_fs,
     GTFSFeedType,
     PartitionedGCSArtifact,
     ProcessingOutcome,
 )
 
-# SCHEDULE_UNZIPPED_BUCKET = os.environ["CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED"]
-# SCHEDULE_RAW_BUCKET = os.environ["CALITP_BUCKET__GTFS_SCHEDULE_RAW"]
-# for testing:
-SCHEDULE_RAW_BUCKET = "test-calitp-gtfs-schedule-raw"
-SCHEDULE_UNZIPPED_BUCKET = "test-calitp-gtfs-schedule-unzipped"
+SCHEDULE_UNZIPPED_BUCKET = os.environ["CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED"]
+SCHEDULE_RAW_BUCKET = os.environ["CALITP_BUCKET__GTFS_SCHEDULE_RAW"]
 
 
 class GTFSScheduleFeedFile(PartitionedGCSArtifact):
     bucket: ClassVar[str] = SCHEDULE_UNZIPPED_BUCKET
-    partition_names: ClassVar[List[str]] = GTFSFeedExtractInfo.partition_names
+    partition_names: ClassVar[List[str]] = GTFSScheduleFeedExtract.partition_names
     ts: pendulum.DateTime
     base64_url: str
     zipfile_path: str
@@ -47,7 +44,8 @@ class GTFSScheduleFeedFile(PartitionedGCSArtifact):
 
 
 class GTFSScheduleFeedExtractUnzipOutcome(ProcessingOutcome):
-    extract: GTFSFeedExtractInfo = Field(..., exclude={"config"})
+    extract: GTFSScheduleFeedExtract = Field(..., exclude={"config"})
+    extract_md5hash: str
     zipfile_files: Optional[List[str]]
     zipfile_dirs: Optional[List[str]]
     extracted_files: Optional[List[GTFSScheduleFeedFile]]
@@ -87,9 +85,9 @@ def summarize_zip_contents(zip: zipfile.ZipFile, at: str = ""):
     return files, directories
 
 
-def process_feed_files(fs, extract_path, extract, feed_directory: str = ""):
+def process_feed_files(fs, extract, feed_directory: str = ""):
     zipfile_files = []
-    with fs.open(extract_path) as f:
+    with fs.open(extract.path) as f:
         zip = zipfile.ZipFile(f)
         for file in zipfile.Path(zip, at=feed_directory).iterdir():
             with zip.open(file.name) as f:
@@ -97,7 +95,7 @@ def process_feed_files(fs, extract_path, extract, feed_directory: str = ""):
             file_extract = GTFSScheduleFeedFile(
                 ts=extract.ts,
                 base64_url=extract.base64_url,
-                zipfile_path=extract_path,
+                zipfile_path=extract.path,
                 original_filename=file.name,
                 # TODO: do we need to make this safe?
                 filename=file.name,
@@ -108,25 +106,25 @@ def process_feed_files(fs, extract_path, extract, feed_directory: str = ""):
 
 
 def unzip_individual_feed(
-    fs, extract: GTFSFeedExtractInfo
+    fs, extract: GTFSScheduleFeedExtract
 ) -> GTFSScheduleFeedExtractUnzipOutcome:
     """If zip contains a directory and nothing else at top level or files at top level,
     we return the contents of the top level or the unique directory as the feed.
     If there's a directory *and* other files at top level within zip, or if
     there are nested directories, say we can't parse."""
 
-    # TODO: figure out why this isn't working? should be accessible via just extract.path
-    # need to update all refs once it's working again
-    extract_path = os.path.join(SCHEDULE_RAW_BUCKET, extract.name)
     print(f"Processing {extract.name}")
+    zipfile_md5_hash = ""
     try:
-        with fs.open(extract_path) as f:
+        with fs.open(extract.path) as f:
+            zipfile_md5_hash = f.info()["md5Hash"]
             zip = zipfile.ZipFile(f)
         files, directories = summarize_zip_contents(zip)
-        print(f"Found: {files} and {directories}")
+        print(f"Found files: {files} and directories: {directories}")
     except Exception as e:
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=False,
+            extract_md5hash=zipfile_md5_hash,
             extract=extract,
             exception=e,
         )
@@ -134,6 +132,7 @@ def unzip_individual_feed(
     if len(directories) > 1:
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=False,
+            extract_md5hash=zipfile_md5_hash,
             extract=extract,
             zipfile_files=files,
             zipfile_dirs=directories,
@@ -142,18 +141,20 @@ def unzip_individual_feed(
     # we can treat the contents of that directory as if they were the feed
     elif [item.is_dir() for item in zipfile.Path(zip, at="").iterdir()] == [True]:
         feed_directory = directories[0]
-        zipfile_files = process_feed_files(fs, extract_path, extract, feed_directory)
+        zipfile_files = process_feed_files(fs, extract, feed_directory)
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=True,
+            extract_md5hash=zipfile_md5_hash,
             extract=extract,
             zipfile_files=files,
             zipfile_dirs=directories,
             extracted_files=zipfile_files,
         )
     else:
-        zipfile_files = zipfile_files = process_feed_files(fs, extract_path, extract)
+        zipfile_files = process_feed_files(fs, extract)
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=True,
+            extract_md5hash=zipfile_md5_hash,
             extract=extract,
             zipfile_files=files,
             zipfile_dirs=directories,
@@ -166,7 +167,7 @@ def unzip_extracts(day=pendulum.today()):
 
     day = pendulum.instance(day).date()
     extracts = fetch_all_in_partition(
-        cls=GTFSFeedExtractInfo,
+        cls=GTFSScheduleFeedExtract,
         bucket=SCHEDULE_RAW_BUCKET,
         table=GTFSFeedType.schedule,
         fs=get_fs(),
@@ -177,10 +178,16 @@ def unzip_extracts(day=pendulum.today()):
     )
     print(f"Identified {len(extracts)} records for {day}")
     outcomes = []
-    # TODO: extract all not just first one
-    for extract in extracts[0:1]:
+    for extract in extracts:
         outcome = unzip_individual_feed(fs, extract)
-        print(f"Outcome: {outcome}")
+        print(f"Processing success: {outcome.success}")
         outcomes.append(outcome)
 
-        # TODO: actually save out outcomes file
+    print("Saving results")
+    result = ScheduleUnzipResult(filename="results.jsonl", dt=day, outcomes=outcomes)
+
+    result.save(fs)
+
+    assert len(extracts) == len(
+        result.outcomes
+    ), f"ended up with {len(outcomes)} outcomes from {len(extracts)} extracts"

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -85,6 +85,7 @@ x-airflow-common:
 #    CALITP_BUCKET__GTFS_RT_VALIDATION: "gs://test-calitp-gtfs-rt-validation"
     CALITP_BUCKET__GTFS_SCHEDULE_RAW: "gs://test-calitp-gtfs-schedule-raw"
     CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION: "gs://test-calitp-gtfs-schedule-validation"
+    CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED: "gs://test-calitp-gtfs-schedule-unzipped"
 
     # TODO: this can be removed once we've confirmed it's no longer in Airtable
     GRAAS_SERVER_URL: $GRAAS_SERVER_URL

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.8.18.1
+calitp==2022.8.23
 fsspec==2022.5.0
 intake==0.6.1
 ipdb==0.13.4

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.8.23
+calitp==2022.8.25
 fsspec==2022.5.0
 intake==0.6.1
 ipdb==0.13.4


### PR DESCRIPTION
# Description

This PR partially addresses #1533 -- it takes a zipfile, extracts its constituent files, and writes those files to GCS in hive-partitioned paths. This PR does **not** cover converting the raw data to JSONL. That will be a subsequent task/PR. 

Stray notes about implementation / PR contents:
* @atvaccaro also updated the new downloader to use the latest (as of 8/25) version of `calitp`
* In general here I am saving only the **path** of the prior / subsequent artifacts and not their entire metadata

Example outputs from this new DAG task:
* [Results file](https://console.cloud.google.com/storage/browser/_details/test-calitp-gtfs-schedule-unzipped/unzipping_results/dt%3D1901-01-01/results.jsonl;tab=live_object?project=cal-itp-data-infra&supportedpurview=project)
* [stops.txt file](https://console.cloud.google.com/storage/browser/_details/test-calitp-gtfs-schedule-unzipped/stops.txt/dt%3D1901-01-01/base64_url%3DaHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA%3D/ts%3D1901-01-01T12:43:06.265686%2B00:00/stops.txt;tab=live_object?project=cal-itp-data-infra&supportedpurview=project)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tested by running in local Airflow & inspecting results. Logging output attached below.

<details>
<summary>Airflow logs from successful local DAG run</summary>

```
[2022-08-25 15:31:05,491] {taskinstance.py:1115} INFO - Executing <Task(PythonOperator): unzip_gtfs_schedule> on 1901-01-01T00:00:00+00:00
[2022-08-25 15:31:05,568] {taskinstance.py:1252} INFO - Exporting the following env vars:
AIRFLOW_CTX_DAG_EMAIL=laurie.m@jarv.us,andrew.v@jarv.us,jameelah.y@jarv.us
AIRFLOW_CTX_DAG_OWNER=airflow
AIRFLOW_CTX_DAG_ID=unzip_and_validate_gtfs_schedule
AIRFLOW_CTX_TASK_ID=unzip_gtfs_schedule
AIRFLOW_CTX_EXECUTION_DATE=1901-01-01T00:00:00+00:00
listing all files in gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/
[2022-08-25 15:31:07,749] {unzip_gtfs_schedule.py:199} INFO - Identified 4 records for 1901-01-01
[2022-08-25 15:31:07,749] {unzip_gtfs_schedule.py:120} INFO - Processing schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/valid_dir.zip
[2022-08-25 15:31:09,328] {unzip_gtfs_schedule.py:127} INFO - Found files: ['dir/fare_attributes.txt', 'dir/agency.txt', 'dir/fare_rules.txt', 'dir/stop_times.txt', 'dir/shapes.txt', 'dir/trips.txt', 'dir/feed_info.txt', 'dir/stops.txt', 'dir/calendar.txt', 'dir/routes.txt'] and directories: ['dir/']
[2022-08-25 15:31:09,328] {unzip_gtfs_schedule.py:161} INFO - Valid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/valid_dir.zip: One toplevel directory found
[2022-08-25 15:31:11,149] {storage.py:320} INFO - saving 112 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_attributes.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/fare_attributes.txt
[2022-08-25 15:31:12,013] {storage.py:320} INFO - saving 236 Bytes to gs://test-calitp-gtfs-schedule-unzipped/agency.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/agency.txt
[2022-08-25 15:31:13,020] {storage.py:320} INFO - saving 75 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_rules.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/fare_rules.txt
[2022-08-25 15:31:13,617] {storage.py:320} INFO - saving 2.0 MB to gs://test-calitp-gtfs-schedule-unzipped/stop_times.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/stop_times.txt
[2022-08-25 15:31:16,871] {storage.py:320} INFO - saving 5.4 MB to gs://test-calitp-gtfs-schedule-unzipped/shapes.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/shapes.txt
[2022-08-25 15:31:21,803] {storage.py:320} INFO - saving 77.8 kB to gs://test-calitp-gtfs-schedule-unzipped/trips.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/trips.txt
[2022-08-25 15:31:23,245] {storage.py:320} INFO - saving 240 Bytes to gs://test-calitp-gtfs-schedule-unzipped/feed_info.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/feed_info.txt
[2022-08-25 15:31:24,271] {storage.py:320} INFO - saving 40.3 kB to gs://test-calitp-gtfs-schedule-unzipped/stops.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/stops.txt
[2022-08-25 15:31:25,309] {storage.py:320} INFO - saving 467 Bytes to gs://test-calitp-gtfs-schedule-unzipped/calendar.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/calendar.txt
[2022-08-25 15:31:26,275] {storage.py:320} INFO - saving 1.3 kB to gs://test-calitp-gtfs-schedule-unzipped/routes.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/routes.txt
[2022-08-25 15:31:27,260] {unzip_gtfs_schedule.py:203} INFO - Processing success: True
[2022-08-25 15:31:27,260] {unzip_gtfs_schedule.py:120} INFO - Processing schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T13:43:06.265686+00:00/invalid_dir_toplevel.zip
[2022-08-25 15:31:28,705] {unzip_gtfs_schedule.py:127} INFO - Found files: ['dir/fare_attributes.txt', 'dir/agency.txt', 'dir/fare_rules.txt', 'dir/stop_times.txt', 'dir/shapes.txt', 'dir/trips.txt', 'dir/feed_info.txt', 'dir/stops.txt', 'dir/calendar.txt', 'dir/routes.txt', 'routes.txt', 'shapes.txt', 'stop_times.txt', 'stops.txt', 'trips.txt'] and directories: ['dir/']
[2022-08-25 15:31:28,705] {unzip_gtfs_schedule.py:150} INFO - Invalid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T13:43:06.265686+00:00/invalid_dir_toplevel.zip: Mix of directories and files found
[2022-08-25 15:31:28,706] {unzip_gtfs_schedule.py:203} INFO - Processing success: False
[2022-08-25 15:31:28,706] {unzip_gtfs_schedule.py:120} INFO - Processing schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T14:43:06.265686+00:00/invalid_dir_nested.zip
[2022-08-25 15:31:30,205] {unzip_gtfs_schedule.py:127} INFO - Found files: ['dir/second_dir/fare_attributes.txt', 'dir/second_dir/agency.txt', 'dir/second_dir/fare_rules.txt', 'dir/second_dir/stop_times.txt', 'dir/second_dir/shapes.txt', 'dir/second_dir/trips.txt', 'dir/second_dir/feed_info.txt', 'dir/second_dir/stops.txt', 'dir/second_dir/calendar.txt', 'dir/second_dir/routes.txt'] and directories: ['dir/', 'dir/second_dir/']
[2022-08-25 15:31:30,205] {unzip_gtfs_schedule.py:137} INFO - Invalid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T14:43:06.265686+00:00/invalid_dir_nested.zip: Multiple directories found
[2022-08-25 15:31:30,205] {unzip_gtfs_schedule.py:203} INFO - Processing success: False
[2022-08-25 15:31:30,205] {unzip_gtfs_schedule.py:120} INFO - Processing schedule/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/google_transit.zip
[2022-08-25 15:31:31,669] {unzip_gtfs_schedule.py:127} INFO - Found files: ['agency.txt', 'shapes.txt', 'trips.txt', 'stop_times.txt', 'stops.txt', 'routes.txt', 'calendar.txt', 'feed_info.txt', 'fare_attributes.txt', 'fare_rules.txt'] and directories: []
[2022-08-25 15:31:31,670] {unzip_gtfs_schedule.py:173} INFO - Valid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/google_transit.zip
[2022-08-25 15:31:33,401] {storage.py:320} INFO - saving 236 Bytes to gs://test-calitp-gtfs-schedule-unzipped/agency.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/agency.txt
[2022-08-25 15:31:34,818] {storage.py:320} INFO - saving 5.4 MB to gs://test-calitp-gtfs-schedule-unzipped/shapes.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/shapes.txt
[2022-08-25 15:31:39,949] {storage.py:320} INFO - saving 77.8 kB to gs://test-calitp-gtfs-schedule-unzipped/trips.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/trips.txt
[2022-08-25 15:31:41,331] {storage.py:320} INFO - saving 2.0 MB to gs://test-calitp-gtfs-schedule-unzipped/stop_times.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/stop_times.txt
[2022-08-25 15:31:43,626] {storage.py:320} INFO - saving 40.3 kB to gs://test-calitp-gtfs-schedule-unzipped/stops.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/stops.txt
[2022-08-25 15:31:44,700] {storage.py:320} INFO - saving 1.3 kB to gs://test-calitp-gtfs-schedule-unzipped/routes.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/routes.txt
[2022-08-25 15:31:45,685] {storage.py:320} INFO - saving 467 Bytes to gs://test-calitp-gtfs-schedule-unzipped/calendar.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/calendar.txt
[2022-08-25 15:31:46,693] {storage.py:320} INFO - saving 240 Bytes to gs://test-calitp-gtfs-schedule-unzipped/feed_info.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/feed_info.txt
[2022-08-25 15:31:47,735] {storage.py:320} INFO - saving 112 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_attributes.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/fare_attributes.txt
[2022-08-25 15:31:48,533] {storage.py:320} INFO - saving 75 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_rules.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/fare_rules.txt
[2022-08-25 15:31:49,345] {unzip_gtfs_schedule.py:203} INFO - Processing success: True
[2022-08-25 15:31:49,347] {storage.py:320} INFO - saving 6.4 kB to gs://test-calitp-gtfs-schedule-unzipped/unzipping_results/dt=1901-01-01/results.jsonl
[2022-08-25 15:31:50,338] {python.py:151} INFO - Done. Returned value was: None
[2022-08-25 15:31:50,346] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=unzip_and_validate_gtfs_schedule, task_id=unzip_gtfs_schedule, execution_date=19010101T000000, start_date=20220824T222338, end_date=20220825T153150
```

</details>
