### PR TITLE
limit schedule validation jobs with a pool

### DIFF
--- a/airflow/dags/unzip_and_validate_gtfs_schedule/validate_gtfs_schedule.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/validate_gtfs_schedule.yml
@@ -1,6 +1,7 @@
 operator: operators.PodOperator
 name: 'validate-gtfs-schedule'
 image: 'ghcr.io/cal-itp/data-infra/gtfs-schedule-validator:{{image_tag()}}'
+pool: schedule_validate_pool
 
 cmds:
   - python3


### PR DESCRIPTION
# Description

I forgot to add a pool to control how many schedule pipeline jobs can run at once during the backfill.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/4305366/185976858-dba33a9f-624c-4149-ab22-c7786c2ad449.png)
