### PR TITLE
disable autodetect if schema is specified

### DIFF
--- a/airflow/plugins/operators/external_table.py
+++ b/airflow/plugins/operators/external_table.py
@@ -36,7 +36,7 @@ def _bq_client_create_external_table(
     # TODO: must be fully qualified table name
     ext = bigquery.ExternalConfig(source_format)
     ext.source_uris = source_objects
-    ext.autodetect = True
+    ext.autodetect = schema_fields is None
     ext.ignore_unknown_values = True
 
     if geojson:


### PR DESCRIPTION
# Description

In the event we provide a schema for a BigQuery external table, we should not also be setting schema autodetection as it will override the provided schema.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Necessary and tested in https://github.com/cal-itp/data-infra/pull/1691

## Screenshots (optional)
