### PR TITLE
Fix: skip amplitude_benefits DAG if 404

### DIFF
--- a/airflow/plugins/operators/amplitude_to_flattened_json.py
+++ b/airflow/plugins/operators/amplitude_to_flattened_json.py
@@ -1,6 +1,7 @@
 """Module for exporting data from Amplitude and adding to the data warehouse"""
 import os
 import gzip
+import logging
 import zipfile
 from io import BytesIO, StringIO
 from datetime import timedelta
@@ -15,6 +16,9 @@ from airflow.exceptions import AirflowSkipException
 from calitp.config import is_development
 
 DATE_FORMAT = "%Y%m%dT%H"
+
+
+logger = logging.getLogger(__name__)
 
 
 def amplitude_to_df(
@@ -61,14 +65,17 @@ def amplitude_to_df(
     secret_key = secret_key or os.environ[secret_key_env]
 
     try:
+        logger.info("Calling Amplitude API")
         response = requests.get(
             url, params=params, auth=(api_key, secret_key), stream=True
         )
         response.raise_for_status()
     except HTTPError as e:
         code = e.response.status_code
+        logger.info(f"Amplitude API returned error code: {code}")
 
         if code == 404:  # 404 just means there was no data
+            logger.info("Skipping the rest of this task")
             raise AirflowSkipException()
         else:
             raise e

--- a/airflow/plugins/operators/amplitude_to_flattened_json.py
+++ b/airflow/plugins/operators/amplitude_to_flattened_json.py
@@ -8,8 +8,10 @@ from datetime import timedelta
 import calitp
 import requests
 import pandas as pd
+from requests import HTTPError
 
 from airflow.models import BaseOperator
+from airflow.exceptions import AirflowSkipException
 from calitp.config import is_development
 
 DATE_FORMAT = "%Y%m%dT%H"
@@ -58,10 +60,18 @@ def amplitude_to_df(
     api_key = api_key or os.environ[api_key_env]
     secret_key = secret_key or os.environ[secret_key_env]
 
-    response = requests.get(url, params=params, auth=(api_key, secret_key), stream=True)
+    try:
+        response = requests.get(
+            url, params=params, auth=(api_key, secret_key), stream=True
+        )
+        response.raise_for_status()
+    except HTTPError as e:
+        code = e.response.status_code
 
-    # raise HTTPError if an error status code was returned
-    response.raise_for_status()
+        if code == 404:  # 404 just means there was no data
+            raise AirflowSkipException()
+        else:
+            raise e
 
     df_list = []
     with zipfile.ZipFile(BytesIO(response.content)) as export:


### PR DESCRIPTION
# Description

This PR makes it so that if the `amplitude_benefits` DAG's `api_to_jsonl` task sees a 404 from the Amplitude API, the task will be marked as Skipped instead of Failed. (A 404 from the API just means that there was no data, and there are valid cases for that, such as the application being down or analytics not being enabled.)

Resolves #1682

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Manually with my local Airflow Docker container (set `start_date` to `2022-08-05` and `end_date` to `2022-08-06`).

## Screenshots (optional)
**Tree view:**
![image](https://user-images.githubusercontent.com/25497886/186242703-24170abd-9a4e-41bb-b8bd-6d1e417cce10.png)

**Task logs:**
![image](https://user-images.githubusercontent.com/25497886/186242670-efd5cb0d-1deb-4fca-a53a-d2937231f1ab.png)