### PR TITLE
Add RT VP vs Sched Table

### DIFF
--- a/warehouse/models/rt_views/_rt_views.yml
+++ b/warehouse/models/rt_views/_rt_views.yml
@@ -222,6 +222,13 @@ models:
       Each row represents a comparison of the scheduled versus realtime vehicle positions data
       for each route by day over the course of two months. This data is avalibale for two agenices,
       SamTrans and Big Blue Bus.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date
+            - calitp_itp_id
+            - calitp_url_number
+            - route_id
     columns:
       - name: date
         description: Date for which data was present in our time frame

--- a/warehouse/models/rt_views/_rt_views.yml
+++ b/warehouse/models/rt_views/_rt_views.yml
@@ -225,12 +225,12 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - date
+            - service_date
             - calitp_itp_id
             - calitp_url_number
             - route_id
     columns:
-      - name: date
+      - name: service_date
         description: Date for which data was present in our time frame
       - *calitp_itp_id
       - *calitp_url_number

--- a/warehouse/models/rt_views/_rt_views.yml
+++ b/warehouse/models/rt_views/_rt_views.yml
@@ -221,9 +221,9 @@ models:
     description: |
       Each row represents a comparison of the scheduled versus realtime vehicle positions data
       for each route by day over the course of two months. This data is avalibale for two agenices,
-      SamTrans and Big Blue Bus. 
+      SamTrans and Big Blue Bus.
     columns:
-      - name: service_date
+      - name: date
         description: Date for which data was present in our time frame
       - *calitp_itp_id
       - *calitp_url_number

--- a/warehouse/models/rt_views/_rt_views.yml
+++ b/warehouse/models/rt_views/_rt_views.yml
@@ -217,6 +217,28 @@ models:
         tests:
           - unique
           - not_null
+  - name: gtfs_rt_vs_schedule_trips_sample
+    description: |
+      Each row represents a comparison of the scheduled versus realtime vehicle positions data
+      for each route by day over the course of two months. This data is avalibale for two agenices,
+      SamTrans and Big Blue Bus. 
+    columns:
+      - name: service_date
+        description: Date for which data was present in our time frame
+      - *calitp_itp_id
+      - *calitp_url_number
+      - name: route_id
+        descritpion: Route ID
+      - name: agency_name
+        descritpion: Agency Name
+      - name: route_short_name
+        description: Common route name
+      - name: num_sched
+        description:  Number of trips where GTFS scheduled data is present on given day.
+      - name: num_vp
+        description: Number of trips where GTFS RT vehicle position data is present on given day.
+      - name: pct_w_vp
+        description: Percent of scheduled trips with vehicle positions realtime data for that specific day and route.
 
 exposures:
   - name: rt_speed_maps

--- a/warehouse/models/rt_views/gtfs_rt_vs_sched_routes.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_sched_routes.sql
@@ -1,0 +1,74 @@
+WITH 
+gtfs_rt_vp_distinct_trips AS (
+    SELECT DISTINCT
+     calitp_itp_id,
+     calitp_url_number,
+     date,
+     trip_id,
+     trip_route_id,
+     vehicle_id
+    FROM {{ ref('stg_rt__vehicle_positions') }}
+    WHERE calitp_itp_id = 300
+        AND date between '2022-04-01' AND '2022-06-30'
+),
+
+vp_trips AS(
+SELECT 
+  date AS service_date, 
+  trip_id AS vp_trip_id, 
+  calitp_itp_id, 
+  calitp_url_number
+FROM gtfs_rt_vp_distinct_trips
+WHERE date BETWEEN '2022-04-01' AND '2022-06-30'
+),
+
+sched_trips AS(
+SELECT 
+  trip_id, 
+  route_id,
+  service_date, 
+  calitp_itp_id, 
+  calitp_url_number
+FROM {{ref('gtfs_schedule_fact_daily_trips')}}
+WHERE (calitp_itp_id=300
+    AND service_date BETWEEN '2022-04-01' AND '2022-06-30'
+    AND is_in_service = True)
+),
+rt_sched_joined AS(
+  SELECT
+  T1.calitp_itp_id,
+  T1.calitp_url_number,
+  T1.route_id,
+  T1.service_date,
+    COUNT(T1.trip_id) AS num_sched,
+    COUNT(T2.vp_trip_id) AS num_vp,
+    -- num_vp/num_sched AS pct_w_vp
+  FROM sched_trips AS T1
+  LEFT JOIN vp_trips AS T2
+    ON
+      T1.trip_id = T2.vp_trip_id
+      AND T1.calitp_itp_id = T2.calitp_itp_id
+      AND T1.calitp_url_number = T2.calitp_url_number
+      AND T1.service_date = T2.service_date
+  GROUP BY 1, 2, 3, 4
+),
+with_percent AS(
+  SELECT
+  T1.calitp_itp_id,
+  T2.agency_name,
+  T1.calitp_url_number,
+  T1.route_id,
+  T2.route_short_name,
+  T1.service_date,
+  T1.num_sched,
+  T1.num_vp,
+  num_vp/num_sched AS pct_w_vp
+  FROM rt_sched_joined AS T1
+  LEFT JOIN {{ref('gtfs_schedule_dim_routes')}} AS T2
+    ON
+      T1.route_id = T2.route_id
+      AND T1.calitp_itp_id = T2.calitp_itp_id
+      AND T1.calitp_url_number = T2.calitp_url_number
+)
+SELECT * 
+FROM with_percent

--- a/warehouse/models/rt_views/gtfs_rt_vs_sched_routes.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_sched_routes.sql
@@ -1,27 +1,18 @@
 WITH 
-gtfs_rt_vp_distinct_trips AS (
+-- selecting the distinct trips from GTFS Vehicle Postions for two operators (SamTrans and Big Blue Bus) and two months
+vp_trips AS (
     SELECT DISTINCT
      calitp_itp_id,
      calitp_url_number,
-     date,
-     trip_id,
+     date AS service_date,
+     trip_id AS vp_trip_id,
      trip_route_id,
      vehicle_id
     FROM {{ ref('stg_rt__vehicle_positions') }}
-    WHERE calitp_itp_id = 300
-        AND date between '2022-04-01' AND '2022-06-30'
-),
-
-vp_trips AS(
-SELECT 
-  date AS service_date, 
-  trip_id AS vp_trip_id, 
-  calitp_itp_id, 
-  calitp_url_number
-FROM gtfs_rt_vp_distinct_trips
-WHERE date BETWEEN '2022-04-01' AND '2022-06-30'
-),
-
+    WHERE date between '2022-05-01' AND '2022-06-30' 
+      AND (calitp_itp_id in (300, 290)
+)),
+-- selecting GTFS schedule data for the same two operators and two months
 sched_trips AS(
 SELECT 
   trip_id, 
@@ -30,10 +21,12 @@ SELECT
   calitp_itp_id, 
   calitp_url_number
 FROM {{ref('gtfs_schedule_fact_daily_trips')}}
-WHERE (calitp_itp_id=300
-    AND service_date BETWEEN '2022-04-01' AND '2022-06-30'
+WHERE service_date BETWEEN '2022-05-01' AND '2022-06-30' 
+    AND (calitp_itp_id in (300, 290)
     AND is_in_service = True)
 ),
+
+-- joining Vehicle Position data and Scheduled data on service date, trip id and itp id and url number
 rt_sched_joined AS(
   SELECT
   T1.calitp_itp_id,
@@ -52,6 +45,8 @@ rt_sched_joined AS(
       AND T1.service_date = T2.service_date
   GROUP BY 1, 2, 3, 4
 ),
+
+-- getting the percent of scheduled trips with vehicle position data and adding the common route name
 with_percent AS(
   SELECT
   T1.calitp_itp_id,

--- a/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
@@ -1,73 +1,75 @@
-WITH 
+WITH
 -- selecting the distinct trips from GTFS Vehicle Postions for two operators (SamTrans 290 and Big Blue Bus 300) and two months
 vp_trips AS (
     SELECT DISTINCT
-     calitp_itp_id,
-     calitp_url_number,
-     date AS service_date,
-     trip_id AS vp_trip_id,
-     -- trip_route_id
-     -- note: to change when we want to include more operators. trip_route_id and trip_id are optional
-     -- https://gtfs.org/realtime/reference/#message-vehicleposition
+        calitp_itp_id,
+        calitp_url_number,
+        date AS service_date,
+        trip_id AS vp_trip_id
+    -- trip_route_id
+    -- note: to change when we want to include more operators. trip_route_id and trip_id are optional
+    -- https://gtfs.org/realtime/reference/#message-vehicleposition
     FROM {{ ref('stg_rt__vehicle_positions') }}
-    WHERE date between '2022-05-01' AND '2022-06-30' 
-      AND (calitp_itp_id in (300, 290)
-)),
+    WHERE date BETWEEN '2022-05-01' AND '2022-06-30'
+        AND (calitp_itp_id IN (300, 290)
+        )
+),
+
 --- selecting GTFS schedule data for the same two operators and two months
-sched_trips AS(
-SELECT 
-  trip_id, 
-  route_id,
-  service_date, 
-  calitp_itp_id, 
-  calitp_url_number
-FROM {{ref('gtfs_schedule_fact_daily_trips')}}
-WHERE service_date BETWEEN '2022-05-01' AND '2022-06-30' 
-    AND (calitp_itp_id in (300, 290)
-    AND is_in_service = True)
+sched_trips AS (
+    SELECT
+        trip_id,
+        route_id,
+        service_date,
+        calitp_itp_id,
+        calitp_url_number
+    FROM {{ ref('gtfs_schedule_fact_daily_trips') }}
+    WHERE service_date BETWEEN '2022-05-01' AND '2022-06-30'
+        AND (calitp_itp_id IN (300, 290) AND is_in_service = True)
 ),
 
 -- joining Vehicle Position data and Scheduled data on service date, trip id and itp id and url number
-rt_sched_joined AS(
-  SELECT
-  T1.calitp_itp_id,
-  T1.calitp_url_number,
-  T1.route_id,
-  T1.service_date,
-    COUNT(T1.trip_id) AS num_sched,
-    COUNT(T2.vp_trip_id) AS num_vp,
+rt_sched_joined AS (
+    SELECT
+        T1.calitp_itp_id,
+        T1.calitp_url_number,
+        T1.route_id,
+        T1.service_date,
+        COUNT(T1.trip_id) AS num_sched,
+        COUNT(T2.vp_trip_id) AS num_vp
     -- num_vp/num_sched AS pct_w_vp
-  FROM sched_trips AS T1
-  LEFT JOIN vp_trips AS T2
-    ON
-      T1.trip_id = T2.vp_trip_id
-      AND T1.calitp_itp_id = T2.calitp_itp_id
-      AND T1.calitp_url_number = T2.calitp_url_number
-      AND T1.service_date = T2.service_date
-  GROUP BY 1, 2, 3, 4
+    FROM sched_trips AS T1
+    LEFT JOIN vp_trips AS T2
+        ON
+            T1.trip_id = T2.vp_trip_id
+            AND T1.calitp_itp_id = T2.calitp_itp_id
+            AND T1.calitp_url_number = T2.calitp_url_number
+            AND T1.service_date = T2.service_date
+    GROUP BY 1, 2, 3, 4
 ),
 
 -- getting the percent of scheduled trips with vehicle position data and adding the common route name
-gtfs_rt_vs_schedule_trips_sample AS(
-  SELECT
-  T1.calitp_itp_id,
-  T2.agency_name,
-  T1.calitp_url_number,
-  T1.route_id,
-  T2.route_short_name,
-  T1.service_date,
-  T2.calitp_extracted_at,
-  T2.calitp_deleted_at,
-  T1.num_sched,
-  T1.num_vp,
-  num_vp/num_sched AS pct_w_vp
-  FROM rt_sched_joined AS T1
-  LEFT JOIN {{ref('gtfs_schedule_dim_routes')}} AS T2
-    ON
-      T1.route_id = T2.route_id
-      AND T1.calitp_itp_id = T2.calitp_itp_id
-      AND T1.calitp_url_number = T2.calitp_url_number
-      AND T1.service_date BETWEEN T2.calitp_extracted_at AND T2.calitp_deleted_at
+gtfs_rt_vs_schedule_trips_sample AS (
+    SELECT
+        T1.calitp_itp_id,
+        T2.agency_name,
+        T1.calitp_url_number,
+        T1.route_id,
+        T2.route_short_name,
+        T1.service_date AS date,
+        T2.calitp_extracted_at,
+        T2.calitp_deleted_at,
+        T1.num_sched,
+        T1.num_vp,
+        num_vp / num_sched AS pct_w_vp
+    FROM rt_sched_joined AS T1
+    LEFT JOIN {{ ref('gtfs_schedule_dim_routes') }} AS T2
+        ON
+            T1.route_id = T2.route_id
+            AND T1.calitp_itp_id = T2.calitp_itp_id
+            AND T1.calitp_url_number = T2.calitp_url_number
+            AND T1.date BETWEEN T2.calitp_extracted_at AND T2.calitp_deleted_at
 )
-SELECT * 
+
+SELECT *
 FROM gtfs_rt_vs_schedule_trips_sample

--- a/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
@@ -10,7 +10,7 @@ vp_trips AS (
     -- note: to change when we want to include more operators. trip_route_id and trip_id are optional
     -- https://gtfs.org/realtime/reference/#message-vehicleposition
     FROM {{ ref('stg_rt__vehicle_positions') }}
-    WHERE date BETWEEN '2022-05-01' AND '2022-06-30'
+    WHERE service_date BETWEEN '2022-05-01' AND '2022-06-30'
         AND (calitp_itp_id IN (300, 290)
         )
 ),
@@ -56,7 +56,7 @@ gtfs_rt_vs_schedule_trips_sample AS (
         T1.calitp_url_number,
         T1.route_id,
         T2.route_short_name,
-        T1.service_date AS date,
+        T1.service_date,
         T2.calitp_extracted_at,
         T2.calitp_deleted_at,
         T1.num_sched,
@@ -68,7 +68,7 @@ gtfs_rt_vs_schedule_trips_sample AS (
             T1.route_id = T2.route_id
             AND T1.calitp_itp_id = T2.calitp_itp_id
             AND T1.calitp_url_number = T2.calitp_url_number
-            AND T1.date BETWEEN T2.calitp_extracted_at AND T2.calitp_deleted_at
+            AND T1.service_date BETWEEN T2.calitp_extracted_at AND T2.calitp_deleted_at
 )
 
 SELECT *


### PR DESCRIPTION
# Description

Adding a table that looks at the number of scheduled trips and trips with vehicle position data. This table currently has two operators (ITP_ID 300 Big Blue Bus and ITP_ID 290 SamTrans) and compares data for two months. 

The table currently lives in rt_views but can be changed! 

To come after GTFS rewrite: additional operators and more dates - NOT urgent. 

Works towards #[263](https://github.com/cal-itp/data-analyses/issues/263) in data-analyses

*note:* column agency_name not always merging right. looking into this. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tested using dbt tables in natalie_views

## Screenshots (optional)
<img width="1050" alt="Screen Shot 2022-08-30 at 11 20 38 AM" src="https://user-images.githubusercontent.com/72096633/187513709-6a34e959-5189-42d5-a002-4e8c70bbdb90.png">
