### PR TITLE
Clean up RT outcomes

### DIFF
--- a/jobs/gtfs-rt-parser-v2/.dockerignore
+++ b/jobs/gtfs-rt-parser-v2/.dockerignore
@@ -1,0 +1,3 @@
+out.log
+.mypy_cache
+.pytest_cache

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -230,7 +230,7 @@ class RTHourlyAggregation(PartitionedGCSArtifact):
 
 
 class RTFileProcessingOutcome(ProcessingOutcome):
-    extract: GTFSRTFeedExtract
+    extract_path: str
     aggregation: Optional[RTHourlyAggregation]
 
 
@@ -399,7 +399,7 @@ def validate_and_upload(
                     step=hour.step,
                     success=False,
                     exception=e,
-                    extract=extract,
+                    extract_path=extract.path,
                 )
             )
             continue
@@ -419,7 +419,7 @@ def validate_and_upload(
             RTFileProcessingOutcome(
                 step=hour.step,
                 success=True,
-                extract=extract,
+                extract_path=extract.path,
             )
         )
 
@@ -471,7 +471,7 @@ def parse_and_upload(
                         step="parse",
                         success=False,
                         exception=e,
-                        extract=extract,
+                        extract_path=extract.path,
                     )
                 )
                 continue
@@ -489,7 +489,7 @@ def parse_and_upload(
                         step="parse",
                         success=False,
                         exception=ValueError(msg),
-                        extract=extract,
+                        extract_path=extract.path,
                     )
                 )
                 continue
@@ -513,7 +513,7 @@ def parse_and_upload(
                 RTFileProcessingOutcome(
                     step="parse",
                     success=True,
-                    extract=extract,
+                    extract_path=extract.path,
                 )
             )
             del parsed
@@ -560,7 +560,7 @@ def parse_and_validate(
                 RTFileProcessingOutcome(
                     step=hour.step,
                     success=False,
-                    extract=extract,
+                    extract_path=extract.path,
                     exception=NoScheduleDataSpecified(),
                 )
                 for extract in hour.extracts
@@ -588,7 +588,7 @@ def parse_and_validate(
                 RTFileProcessingOutcome(
                     step=hour.step,
                     success=False,
-                    extract=extract,
+                    extract_path=extract.path,
                     exception=e,
                 )
                 for extract in hour.extracts

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -190,13 +190,6 @@ class RTHourlyAggregation(PartitionedGCSArtifact):
     base64_url: str
     extracts: List[GTFSRTFeedExtract] = Field(..., exclude=True)
 
-    class Config:
-        json_encoders = {
-            List[GTFSRTFeedExtract]: lambda extracts: [
-                extract.path for extract in extracts
-            ],
-        }
-
     @property
     def bucket(self) -> str:
         if self.step == RTProcessingStep.parse:


### PR DESCRIPTION
# Description

Brings the RT outcomes in alignment with https://github.com/cal-itp/data-infra/pull/1696; in general, we're moving towards just saving paths to source data instead of the entire source data container pydantic type.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally.

## Screenshots (optional)
```
saving 8939 outcomes to gs://test-calitp-gtfs-rt-validation/service_alerts_validation_outcomes/dt=2022-08-15/hour=2022-08-15T16:00:00+00:00/service_alerts.jsonl
fin.
```