### PR TITLE
Run CKAN weekly, with multipart uploads as needed

### DIFF
--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -145,6 +145,6 @@ data_infra_macros = {
     "sql_airtable_mapping": airtable_mapping_generate_sql,
     "is_development": is_development_macro,
     "image_tag": lambda: "development" if is_development() else "latest",
-    "env_var": lambda key: os.getenv(key),
+    "env_var": os.getenv,
     "prefix_bucket": prefix_bucket,
 }

--- a/airflow/dags/publish_open_data/METADATA.yml
+++ b/airflow/dags/publish_open_data/METADATA.yml
@@ -1,0 +1,19 @@
+description: "Publishes data to various open data portals"
+schedule_interval: "0 0 * * 1"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "andrew.v@jarv.us"
+      - "eric.dasmalchi@dot.ca.gov"
+      - "laurie.m@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: True

--- a/airflow/dags/publish_open_data/publish_california_open_data.yml
+++ b/airflow/dags/publish_open_data/publish_california_open_data.yml
@@ -8,9 +8,7 @@ arguments:
   - '/app/scripts/publish.py'
   - 'publish-exposure'
   - 'california_open_data'
-  - '{% if is_development() %}--no-deploy{% else %}--deploy{% endif %}'
-  - '--project'
-  - '{{ get_project_id() }}'
+  - '{% if is_development() %}--no-publish{% else %}--publish{% endif %}'
   - '--bucket'
   - "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   - '--manifest'
@@ -32,11 +30,16 @@ secrets:
     secret: jobs-data
     key: service-account.json
 
+resources:
+  request_memory: 2.0Gi
+  request_cpu: 1
+
 tolerations:
   - key: pod-role
     operator: Equal
     value: computetask
     effect: NoSchedule
+
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/airflow/dags/publish_open_data/publish_california_open_data.yml
+++ b/airflow/dags/publish_open_data/publish_california_open_data.yml
@@ -5,15 +5,14 @@ image: 'ghcr.io/cal-itp/data-infra/warehouse:{{ image_tag() }}'
 cmds:
   - python3
 arguments:
-  - '/app/scripts/run_and_upload.py'
+  - '/app/scripts/publish.py'
   - 'publish-exposure'
   - 'california_open_data'
-  - '--deploy'
-  - '--sync-metabase'
+  - '{% if is_development() %}--no-deploy{% else %}--deploy{% endif %}'
   - '--project'
-  - 'cal-itp-data-infra'
+  - '{{ get_project_id() }}'
   - '--bucket'
-  - 'gs://calitp-publish/'
+  - "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   - '--manifest'
   - "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}/latest/manifest.json"
 
@@ -25,8 +24,7 @@ cluster_name: data-infra-apps
 namespace: airflow-jobs
 
 env_vars:
-  BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
-  CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
+  GOOGLE_APPLICATION_CREDENTIALS: /secrets/jobs-data/service_account.json
 
 secrets:
   - deploy_type: volume

--- a/airflow/dags/publish_open_data/publish_california_open_data.yml
+++ b/airflow/dags/publish_open_data/publish_california_open_data.yml
@@ -1,0 +1,50 @@
+operator: 'operators.PodOperator'
+name: 'publish-california-open-data'
+image: 'ghcr.io/cal-itp/data-infra/warehouse:{{ image_tag() }}'
+
+cmds:
+  - python3
+arguments:
+  - '/app/scripts/run_and_upload.py'
+  - 'publish-exposure'
+  - 'california_open_data'
+  - '--deploy'
+  - '--sync-metabase'
+  - '--project'
+  - 'cal-itp-data-infra'
+  - '--bucket'
+  - 'gs://calitp-publish/'
+  - '--manifest'
+  - "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}/latest/manifest.json"
+
+is_delete_operator_pod: true
+get_logs: true
+is_gke: true
+pod_location: us-west1
+cluster_name: data-infra-apps
+namespace: airflow-jobs
+
+env_vars:
+  BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
+  CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
+
+secrets:
+  - deploy_type: volume
+    deploy_target: /secrets/jobs-data/
+    secret: jobs-data
+    key: service-account.json
+
+tolerations:
+  - key: pod-role
+    operator: Equal
+    value: computetask
+    effect: NoSchedule
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: pod-role
+          operator: In
+          values:
+          - computetask

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -19,11 +19,13 @@ cluster_name: data-infra-apps
 namespace: airflow-jobs
 
 env_vars:
+  CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_TARGET: prod_service_account
+  DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   NETLIFY_SITE_ID: cal-itp-dbt-docs
+
 secrets:
   - deploy_type: volume
     deploy_target: /secrets/jobs-data/

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -6,7 +6,6 @@ cmds:
   - python3
 arguments:
   - '/app/scripts/run_and_upload.py'
-  - '--no-dbt-run'
   - '--dbt-docs'
   - '--save-artifacts'
   - '--deploy-docs'

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -6,6 +6,7 @@ cmds:
   - python3
 arguments:
   - '/app/scripts/run_and_upload.py'
+  - '--no-dbt-run'
   - '--dbt-docs'
   - '--save-artifacts'
   - '--deploy-docs'
@@ -44,11 +45,16 @@ secrets:
     secret: jobs-data
     key: netlify-auth-token
 
+resources:
+  request_memory: 2.0Gi
+  request_cpu: 1
+
 tolerations:
   - key: pod-role
     operator: Equal
     value: computetask
     effect: NoSchedule
+
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/airflow/dags/transform_warehouse/dbt_test.yml
+++ b/airflow/dags/transform_warehouse/dbt_test.yml
@@ -24,7 +24,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_TARGET: prod_service_account
+  DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
 
 secrets:
   - deploy_type: volume

--- a/airflow/dags/transform_warehouse/dbt_test.yml
+++ b/airflow/dags/transform_warehouse/dbt_test.yml
@@ -25,17 +25,23 @@ env_vars:
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
   DBT_TARGET: prod_service_account
+
 secrets:
   - deploy_type: volume
     deploy_target: /secrets/jobs-data/
     secret: jobs-data
     key: service-account.json
 
+resources:
+  request_memory: 2.0Gi
+  request_cpu: 1
+
 tolerations:
   - key: pod-role
     operator: Equal
     value: computetask
     effect: NoSchedule
+
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -23,7 +23,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_TARGET: prod_service_account
+  DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   NETLIFY_SITE_ID: cal-itp-dbt-docs
 secrets:
   - deploy_type: volume

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -23,7 +23,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_TARGET: prod_service_account
+  DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
 secrets:
   - deploy_type: volume
     deploy_target: /secrets/jobs-data/

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -80,12 +80,15 @@ x-airflow-common:
     GOOGLE_CLOUD_PROJECT: cal-itp-data-infra
 
     CALITP_BUCKET__AIRTABLE: "gs://test-calitp-airtable"
+    CALITP_BUCKET__DBT_ARTIFACTS: "gs://test-calitp-dbt-artifacts"
     CALITP_BUCKET__GTFS_RT_RAW: "gs://test-calitp-gtfs-rt-raw"
     CALITP_BUCKET__GTFS_RT_PARSED: "gs://test-calitp-gtfs-rt-parsed"
     CALITP_BUCKET__GTFS_RT_VALIDATION: "gs://test-calitp-gtfs-rt-validation"
     CALITP_BUCKET__GTFS_SCHEDULE_RAW: "gs://test-calitp-gtfs-schedule-raw"
     CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION: "gs://test-calitp-gtfs-schedule-validation"
     CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED: "gs://test-calitp-gtfs-schedule-unzipped"
+
+    DBT_TARGET: staging_service_account
 
     # TODO: this can be removed once we've confirmed it's no longer in Airtable
     GRAAS_SERVER_URL: $GRAAS_SERVER_URL

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -87,6 +87,7 @@ x-airflow-common:
     CALITP_BUCKET__GTFS_SCHEDULE_RAW: "gs://test-calitp-gtfs-schedule-raw"
     CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION: "gs://test-calitp-gtfs-schedule-validation"
     CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED: "gs://test-calitp-gtfs-schedule-unzipped"
+    CALITP_BUCKET__PUBLISH: "gs://test-calitp-publish"
 
     DBT_TARGET: staging_service_account
 

--- a/docs/publishing/sections/8_ckan.md
+++ b/docs/publishing/sections/8_ckan.md
@@ -56,15 +56,20 @@ update the `meta` field to map the dbt models to the appropriate UUIDs.
 
 An example from the latest-only GTFS data exposure.
 ```yaml
-meta:
-  destinations:
-    - type: ckan
-      bucket: gs://calitp-publish
-      format: csv
-      url: https://data.ca.gov/api/3/action/resource_update
-      ids:
-        agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
-        routes: c6bbb637-988f-431c-8444-aef7277297f8
+    meta:
+      methodology: |
+        Cal-ITP collects the GTFS feeds from a statewide list [link] every night and aggegrates it into a statewide table
+        for analysis purposes only. Do not use for trip planner ingestation, rather is meant to be used for statewide
+        analytics and other use cases. Note: These data may or may or may not have passed GTFS-Validation.
+      coordinate_system_espg: "EPSG:4326"
+      destinations:
+        - type: ckan
+          bucket: gs://calitp-publish
+          format: csv
+          url: https://data.ca.gov
+          ids:
+            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
+            routes: c6bbb637-988f-431c-8444-aef7277297f8
 ```
 
 ### Publish the data!
@@ -79,7 +84,7 @@ poetry run python scripts/publish.py publish-exposure california_open_data --dry
 
 Example production deployment:
 ```bash
-poetry run python scripts/publish.py publish-exposure california_open_data --project=cal-itp-data-infra --bucket="gs://calitp-publish" --deploy
+poetry run python scripts/publish.py publish-exposure california_open_data --project=cal-itp-data-infra --bucket="gs://calitp-publish" --publish
 ```
 
 

--- a/warehouse/.dockerignore
+++ b/warehouse/.dockerignore
@@ -1,0 +1,5 @@
+.user.yml
+
+target/
+dbt_packages/
+logs/

--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -760,7 +760,7 @@ exposures:
           ids:
             agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
             routes: c6bbb637-988f-431c-8444-aef7277297f8
-            # stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
+            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
             stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
             trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
             attributions: 038b7354-06e8-4082-a4a1-40debd3110d5

--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -758,22 +758,20 @@ exposures:
           format: csv
           url: https://data.ca.gov
           ids:
-#            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
-            # routes: c6bbb637-988f-431c-8444-aef7277297f8
-            # TODO: add stop_times back in once size limit lifted
-            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
-            # stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
-            # trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
-            # attributions: 038b7354-06e8-4082-a4a1-40debd3110d5
-            # calendar: a79f10b8-b322-43f3-b3f4-ba46a8dbe9ab
-            # calendar_dates: 06a21a8e-dba3-4e7e-8726-f2e992cc1a80
-            # fare_attributes: 9db51dfa-fd6d-481b-b655-96e8af722ab5
-            # fare_rules: 4fb1fa39-0ef9-457d-97b1-bb7e9e848312
-            # feed_info: 50d12559-635e-4222-ac25-3706c066902d
-            # frequencies: 48542c8f-8ce1-43e3-a965-6c68771d6fe5
-            # levels: 288a08cd-7929-479e-aa88-08b677a08510
-            # pathways: a01484af-c460-40a4-ac8a-896b0196e8c2
-            # TODO: add shapes when the size limit has been lifted
-            # shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
-            # transfers: f8dcda5d-0c6d-4c70-b5f5-6716adcf6ffc
-            # translations: 7abe9256-6cd2-4c1f-9b6a-72108022a382
+            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
+            routes: c6bbb637-988f-431c-8444-aef7277297f8
+            # stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
+            stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
+            trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
+            attributions: 038b7354-06e8-4082-a4a1-40debd3110d5
+            calendar: a79f10b8-b322-43f3-b3f4-ba46a8dbe9ab
+            calendar_dates: 06a21a8e-dba3-4e7e-8726-f2e992cc1a80
+            fare_attributes: 9db51dfa-fd6d-481b-b655-96e8af722ab5
+            fare_rules: 4fb1fa39-0ef9-457d-97b1-bb7e9e848312
+            feed_info: 50d12559-635e-4222-ac25-3706c066902d
+            frequencies: 48542c8f-8ce1-43e3-a965-6c68771d6fe5
+            levels: 288a08cd-7929-479e-aa88-08b677a08510
+            pathways: a01484af-c460-40a4-ac8a-896b0196e8c2
+            shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
+            transfers: f8dcda5d-0c6d-4c70-b5f5-6716adcf6ffc
+            translations: 7abe9256-6cd2-4c1f-9b6a-72108022a382

--- a/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
+++ b/warehouse/models/gtfs_schedule_latest_only/_gtfs_schedule_latest_only.yml
@@ -756,24 +756,24 @@ exposures:
         - type: ckan
           bucket: gs://calitp-publish
           format: csv
-          url: https://data.ca.gov/api/3/action/resource_update
+          url: https://data.ca.gov
           ids:
-            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
-            routes: c6bbb637-988f-431c-8444-aef7277297f8
+#            agency: e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
+            # routes: c6bbb637-988f-431c-8444-aef7277297f8
             # TODO: add stop_times back in once size limit lifted
-            # stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
-            stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
-            trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
-            attributions: 038b7354-06e8-4082-a4a1-40debd3110d5
-            calendar: a79f10b8-b322-43f3-b3f4-ba46a8dbe9ab
-            calendar_dates: 06a21a8e-dba3-4e7e-8726-f2e992cc1a80
-            fare_attributes: 9db51dfa-fd6d-481b-b655-96e8af722ab5
-            fare_rules: 4fb1fa39-0ef9-457d-97b1-bb7e9e848312
-            feed_info: 50d12559-635e-4222-ac25-3706c066902d
-            frequencies: 48542c8f-8ce1-43e3-a965-6c68771d6fe5
-            levels: 288a08cd-7929-479e-aa88-08b677a08510
-            pathways: a01484af-c460-40a4-ac8a-896b0196e8c2
+            stop_times: d31eef2f-e223-4ca4-a86b-170acc6b2590
+            # stops: 8c876204-e12b-48a2-8299-10f6ae3d4f2b
+            # trips: 0e4da89e-9330-43f8-8de9-305cb7d4918f
+            # attributions: 038b7354-06e8-4082-a4a1-40debd3110d5
+            # calendar: a79f10b8-b322-43f3-b3f4-ba46a8dbe9ab
+            # calendar_dates: 06a21a8e-dba3-4e7e-8726-f2e992cc1a80
+            # fare_attributes: 9db51dfa-fd6d-481b-b655-96e8af722ab5
+            # fare_rules: 4fb1fa39-0ef9-457d-97b1-bb7e9e848312
+            # feed_info: 50d12559-635e-4222-ac25-3706c066902d
+            # frequencies: 48542c8f-8ce1-43e3-a965-6c68771d6fe5
+            # levels: 288a08cd-7929-479e-aa88-08b677a08510
+            # pathways: a01484af-c460-40a4-ac8a-896b0196e8c2
             # TODO: add shapes when the size limit has been lifted
-#            shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
-            transfers: f8dcda5d-0c6d-4c70-b5f5-6716adcf6ffc
-            translations: 7abe9256-6cd2-4c1f-9b6a-72108022a382
+            # shapes: 2f5e7bdb-33e8-4633-b163-6bab42ad0951
+            # transfers: f8dcda5d-0c6d-4c70-b5f5-6716adcf6ffc
+            # translations: 7abe9256-6cd2-4c1f-9b6a-72108022a382

--- a/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
+++ b/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
@@ -10,4 +10,3 @@ stop_times AS (
 )
 
 SELECT * FROM stop_times
-LIMIT 1040900

--- a/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
+++ b/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
@@ -10,4 +10,3 @@ stop_times AS (
 )
 
 SELECT * FROM stop_times
-LIMIT 1740900

--- a/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
+++ b/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
@@ -10,3 +10,4 @@ stop_times AS (
 )
 
 SELECT * FROM stop_times
+LIMIT 1040900

--- a/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
+++ b/warehouse/models/gtfs_schedule_latest_only/stop_times.sql
@@ -10,3 +10,4 @@ stop_times AS (
 )
 
 SELECT * FROM stop_times
+LIMIT 1740900

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -529,7 +529,7 @@ def publish_exposure(
 
     if manifest.startswith("gs://"):
         typer.secho(f"fetching manifest from {manifest}", fg=typer.colors.GREEN)
-        fs = gcsfs.GCSFileSystem()
+        fs = gcsfs.GCSFileSystem(project=project)
         with fs.open(manifest) as f:
             actual_manifest = Manifest(**json.load(f))
 

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -8,7 +8,7 @@ from typing import List
 import gcsfs
 import typer
 
-BUCKET = "calitp-dbt-artifacts"
+BUCKET = os.environ["CALITP_BUCKET__DBT_ARTIFACTS"]
 
 artifacts = map(
     Path, ["index.html", "catalog.json", "manifest.json", "run_results.json"]
@@ -87,7 +87,7 @@ def run(
             _from = str(project_dir / Path("target") / artifact)
 
             if save_artifacts:
-                _to = f"gs://{BUCKET}/latest/{artifact}"
+                _to = f"{BUCKET}/latest/{artifact}"
                 typer.echo(f"writing {_from} to {_to}")
                 fs.put(lpath=_from, rpath=_to)
             else:

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -79,7 +79,8 @@ def run(
         os.mkdir("docs/")
 
         fs = gcsfs.GCSFileSystem(
-            project="cal-itp-data-infra", token=os.getenv("BIGQUERY_KEYFILE_LOCATION")
+            project="cal-itp-data-infra",
+            token=os.getenv("BIGQUERY_KEYFILE_LOCATION"),
         )
 
         for artifact in artifacts:


### PR DESCRIPTION
# Description

Finally gets large files uploading to CKAN and defines an Airflow task to run weekly! The task uses the latest manifest artifact in GCS to pick the tables to select and upload. I don't think we can automate metadata unfortunately, as that's a manual process with human review.

Closes https://github.com/cal-itp/data-infra/issues/283
Progress towards https://github.com/cal-itp/data-infra/issues/427, I think we need to get the updated metadata/dictionary sent first.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally... lots.

## Screenshots (optional)
```
[2022-08-26 20:26:27,203] {pod_launcher.py:311} INFO - Event with job id publish-california-open-data.cfb34c7982874d3fb9191dcd70c66297 Succeeded
[2022-08-26 20:26:27,301] {pod_launcher.py:198} INFO - Event: publish-california-open-data.cfb34c7982874d3fb9191dcd70c66297 had an event of type Succeeded
[2022-08-26 20:26:27,301] {pod_launcher.py:311} INFO - Event with job id publish-california-open-data.cfb34c7982874d3fb9191dcd70c66297 Succeeded
[2022-08-26 20:26:27,464] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=publish_open_data, task_id=publish_california_open_data, execution_date=20220822T000000, start_date=20220826T173842, end_date=20220826T202627
```