### PR TITLE
Initial dbt models to support GTFS guidelines checks

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -65,3 +65,5 @@ models:
     mart:
       transit_database:
         schema: mart_transit_database
+      gtfs_guidelines:
+        schema: mart_gtfs_guidelines

--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -1,0 +1,13 @@
+-- declare checks
+{% macro static_feed_downloaded_successfully() %}
+"Static GTFS feed downloads successfully"
+{% endmacro %}
+
+{% macro no_validation_errors_in_last_30_days() %}
+"No validation errors in last 30 days"
+{% endmacro %}
+
+-- declare features
+{% macro compliant_on_the_map() %}
+"Compliant / On the Map"
+{% endmacro %}

--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -11,3 +11,15 @@
 {% macro compliant_on_the_map() %}
 "Compliant / On the Map"
 {% endmacro %}
+
+
+-- columns
+{% macro gtfs_guidelines_columns() %}
+date,
+calitp_itp_id,
+calitp_url_number,
+calitp_agency_name,
+check,
+status,
+feature
+{% endmacro %}

--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -9,7 +9,7 @@
 
 -- declare features
 {% macro compliant_on_the_map() %}
-"Compliant / On the Map"
+"Compliance"
 {% endmacro %}
 
 

--- a/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
+++ b/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: gtfs_schedule_fact_daily_guideline_checks
+  - name: fact_daily_guideline_checks
     description: |
       Each row represents a date/guideline check/feed combination, with pass/fail information
       indicating whether that feed complied with that check on that date.
@@ -40,6 +40,8 @@ models:
         description: |
           Either "PASS" or "FAIL", indicating check status on the given date for the
           given feed.
+        tests:
+          - not_null
       - name: feature
         description: |
           A string label for the GTFS "feature" associated with the given check. For example,

--- a/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
+++ b/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
@@ -1,0 +1,14 @@
+version: 2
+
+# models:
+  # - name: dim_date
+  #   description: |
+  #     Each row is a date.
+  #   columns:
+  #     - name: id
+  #       description: Date formatted as string for identification, in "YYYY-MM-DD" format, ex. "2022-03-31".
+  #       tests:
+  #         - not_null
+  #         - unique
+  #       meta:
+  #         metabase.semantic_type: type/PK

--- a/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
+++ b/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
@@ -30,6 +30,8 @@ models:
           metabase.semantic_type: type/FK
       - name: calitp_agency_name
         description: Human readable agency name, provided for convenience.
+        meta:
+          metabase.semantic_type: type/Title
       - name: check
         description: |
           A string description of the GTFS guideline check being performed. For example,

--- a/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
+++ b/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
@@ -1,14 +1,44 @@
 version: 2
 
-# models:
-  # - name: dim_date
-  #   description: |
-  #     Each row is a date.
-  #   columns:
-  #     - name: id
-  #       description: Date formatted as string for identification, in "YYYY-MM-DD" format, ex. "2022-03-31".
-  #       tests:
-  #         - not_null
-  #         - unique
-  #       meta:
-  #         metabase.semantic_type: type/PK
+models:
+  - name: gtfs_schedule_fact_daily_guideline_checks
+    description: |
+      Each row represents a date/guideline check/feed combination, with pass/fail information
+      indicating whether that feed complied with that check on that date.
+
+      Note that this table is only partially implemented; can use "SELECT DISTINCT check"
+      to see the list of checks that are evaluated herein.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date
+            - calitp_itp_id
+            - calitp_url_number
+            - check
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('stg_gtfs_guidelines__feed_guideline_index')
+    columns:
+      - name: date
+        description: Date on which the check is being evaluated.
+      - name: calitp_itp_id
+        description: '{{ doc("column_calitp_itp_id") }}'
+        meta:
+          metabase.semantic_type: type/FK
+      - name: calitp_url_number
+        description: '{{ doc("column_calitp_url_number") }}'
+        meta:
+          metabase.semantic_type: type/FK
+      - name: calitp_agency_name
+        description: Human readable agency name, provided for convenience.
+      - name: check
+        description: |
+          A string description of the GTFS guideline check being performed. For example,
+          "Static GTFS feed downloads successfully".
+      - name: status
+        description: |
+          Either "PASS" or "FAIL", indicating check status on the given date for the
+          given feed.
+      - name: feature
+        description: |
+          A string label for the GTFS "feature" associated with the given check. For example,
+          "Compliant / On the Map".

--- a/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
@@ -9,12 +9,14 @@ stg_gtfs_guidelines__no_validation_errors_in_last_30_days AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__no_validation_errors_in_last_30_days') }}
 ),
 
-gtfs_schedule_fact_daily_guideline_checks AS (
-    SELECT {{ gtfs_guidelines_columns() }}
+fact_daily_guideline_checks AS (
+    SELECT
+        {{ gtfs_guidelines_columns() }}
     FROM stg_gtfs_guidelines__schedule_downloaded_successfully
     UNION ALL
-        SELECT {{ gtfs_guidelines_columns() }}
-        FROM stg_gtfs_guidelines__no_validation_errors_in_last_30_days
+    SELECT
+        {{ gtfs_guidelines_columns() }}
+    FROM stg_gtfs_guidelines__no_validation_errors_in_last_30_days
 )
 
-SELECT * FROM gtfs_schedule_fact_daily_guideline_checks
+SELECT * FROM fact_daily_guideline_checks

--- a/warehouse/models/mart/gtfs_guidelines/gtfs_schedule_fact_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_guidelines/gtfs_schedule_fact_daily_guideline_checks.sql
@@ -1,0 +1,18 @@
+{{ config(materialized='table') }}
+
+-- start query
+WITH stg_gtfs_guidelines__schedule_downloaded_successfully AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__schedule_downloaded_successfully') }}
+),
+
+stg_gtfs_guidelines__no_validation_errors_in_last_30_days AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__no_validation_errors_in_last_30_days') }}
+),
+
+gtfs_schedule_fact_daily_guideline_checks AS (
+    SELECT * FROM stg_gtfs_guidelines__schedule_downloaded_successfully
+    UNION ALL
+    SELECT * FROM stg_gtfs_guidelines__no_validation_errors_in_last_30_days
+)
+
+SELECT * FROM gtfs_schedule_fact_daily_guideline_checks

--- a/warehouse/models/mart/gtfs_guidelines/gtfs_schedule_fact_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_guidelines/gtfs_schedule_fact_daily_guideline_checks.sql
@@ -10,9 +10,11 @@ stg_gtfs_guidelines__no_validation_errors_in_last_30_days AS (
 ),
 
 gtfs_schedule_fact_daily_guideline_checks AS (
-    SELECT * FROM stg_gtfs_guidelines__schedule_downloaded_successfully
+    SELECT {{ gtfs_guidelines_columns() }}
+    FROM stg_gtfs_guidelines__schedule_downloaded_successfully
     UNION ALL
-    SELECT * FROM stg_gtfs_guidelines__no_validation_errors_in_last_30_days
+        SELECT {{ gtfs_guidelines_columns() }}
+        FROM stg_gtfs_guidelines__no_validation_errors_in_last_30_days
 )
 
 SELECT * FROM gtfs_schedule_fact_daily_guideline_checks

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -11,7 +11,8 @@ gtfs_schedule_dim_feeds AS (
 -- list all the checks that have been implemented
 checks_implemented AS (
     SELECT {{ static_feed_downloaded_successfully() }} AS check, {{ compliant_on_the_map() }} AS feature
-    UNION ALL SELECT {{ no_validation_errors_in_last_30_days() }}, {{ compliant_on_the_map() }}
+    UNION ALL
+    SELECT {{ no_validation_errors_in_last_30_days() }}, {{ compliant_on_the_map() }}
 ),
 
 -- create an index: all feed/date/check combinations

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -1,0 +1,33 @@
+{{ config(materialized='table') }}
+
+WITH gtfs_schedule_fact_daily_feeds AS (
+    SELECT * FROM {{ ref('gtfs_schedule_fact_daily_feeds') }}
+),
+
+gtfs_schedule_dim_feeds AS (
+    SELECT * FROM {{ ref('gtfs_schedule_dim_feeds') }}
+),
+
+-- list all the checks that have been implemented
+checks_implemented AS (
+    SELECT {{ static_feed_downloaded_successfully() }} AS check, {{ compliant_on_the_map() }} AS feature
+    UNION ALL SELECT {{ no_validation_errors_in_last_30_days() }}, {{ compliant_on_the_map() }}
+),
+
+-- create an index: all feed/date/check combinations
+stg_gtfs_guidelines__feed_check_index AS (
+    SELECT
+        t2.calitp_itp_id,
+        t2.calitp_url_number,
+        t2.calitp_agency_name,
+        t1.date,
+        t1.feed_key,
+        t3.check,
+        t3.feature
+    FROM gtfs_schedule_fact_daily_feeds AS t1
+    LEFT JOIN gtfs_schedule_dim_feeds AS t2
+        USING (feed_key)
+    CROSS JOIN checks_implemented AS t3
+)
+
+SELECT * FROM stg_gtfs_guidelines__feed_check_index

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_validation_errors_in_last_30_days.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_validation_errors_in_last_30_days.sql
@@ -1,0 +1,60 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ no_validation_errors_in_last_30_days() }}
+),
+
+validation_fact_daily_feed_codes AS (
+    SELECT * FROM {{ ref('validation_fact_daily_feed_codes') }}
+),
+
+validation_dim_codes AS (
+    SELECT * FROM {{ ref('validation_dim_codes') }}
+),
+
+validation_errors_by_day AS (
+    SELECT
+        feed_key,
+        date,
+        SUM(n_notices) as validation_errors
+    FROM validation_fact_daily_feed_codes
+    LEFT JOIN validation_dim_codes USING(code)
+    WHERE severity = "error"
+    GROUP BY feed_key, date
+),
+
+validation_errors_in_last_30_days_check AS (
+    SELECT
+        date,
+        calitp_itp_id,
+        calitp_url_number,
+        calitp_agency_name,
+        check,
+        feature,
+        SUM(validation_errors)
+            OVER (
+                PARTITION BY
+                    calitp_itp_id,
+                    calitp_url_number
+                ORDER BY date
+                ROWS BETWEEN 30 PRECEDING AND CURRENT ROW
+        ) AS errors_last_30_days
+    FROM feed_guideline_index
+    LEFT JOIN validation_errors_by_day USING (feed_key, date)
+),
+
+validation_errors_in_last_30_days_idx AS (
+    SELECT
+        date,
+        calitp_itp_id,
+        calitp_url_number,
+        calitp_agency_name,
+        check,
+        CASE
+            WHEN errors_last_30_days > 0 THEN "FAIL"
+            ELSE "PASS"
+        END AS status,
+        feature
+    FROM validation_errors_in_last_30_days_check
+)
+
+SELECT * FROM validation_errors_in_last_30_days_idx

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_validation_errors_in_last_30_days.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_validation_errors_in_last_30_days.sql
@@ -18,7 +18,7 @@ validation_errors_by_day AS (
         SUM(n_notices) as validation_errors
     FROM validation_fact_daily_feed_codes
     LEFT JOIN validation_dim_codes USING(code)
-    WHERE severity = "error"
+    WHERE severity = "ERROR"
     GROUP BY feed_key, date
 ),
 
@@ -51,7 +51,7 @@ validation_errors_in_last_30_days_idx AS (
         check,
         CASE
             WHEN errors_last_30_days > 0 THEN "FAIL"
-            ELSE "PASS"
+            WHEN errors_last_30_days = 0 THEN "PASS"
         END AS status,
         feature
     FROM validation_errors_in_last_30_days_check

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__schedule_downloaded_successfully.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__schedule_downloaded_successfully.sql
@@ -1,0 +1,37 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ static_feed_downloaded_successfully() }}
+),
+
+gtfs_schedule_fact_daily_feeds AS (
+    SELECT * FROM {{ ref('gtfs_schedule_fact_daily_feeds') }}
+),
+
+static_feed_downloaded_successfully_check AS (
+    SELECT
+        feed_key,
+        date,
+        CASE
+            WHEN extraction_status = "success" THEN "PASS"
+            WHEN extraction_status = "error" THEN "FAIL"
+        ELSE null
+        END AS status,
+        {{ static_feed_downloaded_successfully() }} AS check
+    FROM gtfs_schedule_fact_daily_feeds
+),
+
+static_feed_downloaded_successfully_check_idx AS (
+    SELECT
+        t1.date,
+        t1.calitp_itp_id,
+        t1.calitp_url_number,
+        t1.calitp_agency_name,
+        t1.check,
+        t2.status,
+        t1.feature,
+    FROM feed_guideline_index AS t1
+    LEFT JOIN static_feed_downloaded_successfully_check AS t2
+        USING (feed_key, date, check)
+)
+
+SELECT * FROM static_feed_downloaded_successfully_check_idx

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -114,6 +114,7 @@ def run(
             ("views", "Data Marts (formerly Warehouse Views)"),
             ("gtfs_schedule", "GTFS Schedule Feeds Latest"),
             ("mart_transit_database", "Data Marts (formerly Warehouse Views)"),
+            ("mart_gtfs_guidelines", "Data Marts (formerly Warehouse Views)"),
         ]:
             subprocess.run(
                 [


### PR DESCRIPTION
# Description

This PR addresses #1688 by creating an initial table following [the schema](https://docs.google.com/spreadsheets/d/1v5nPowMi0EzQpfDd9d0ZluWnKX8JKm8E2nGMmuUvDRE/edit#gid=1164332414) requested, with slight modification -- `agency-id` is implemented as the combination of `calitp_itp_id`, `calitp_url_number`, and `calitp_agency_name` (for readability).

Specifically, this table implements two guideline checks:
* GTFS schedule downloaded successfully: checks whether there was a download error for a given GTFS schedule feed 
* No validation errors in last 30 days: checks for number of validation notices with "error" severity in the last 30 days -- >0, fail, if 0, pass 

I'd like both @atvaccaro and @owades to review before merging. 

TODO after merge:
* Sync the `mart_gtfs_guidelines` dataset to Metabase in `Data Marts`. 

Notes for reviewers:
* The way I have this, each individual `check` is implemented as a staging table, and then the `mart` table just unions all those staging tables together. Does that seem appropriate? Do we want each individual check as its own mart table? 
* [As I noted](https://github.com/cal-itp/data-infra/issues/1688#issuecomment-1220038182) on the initial issue, we will definitely need to refactor a bit on the rewrite. Most particularly: right now, `dim_feeds` treats a given ITP ID's schedule and RT feeds as part of one shared entity (i.e., one "feed" has a schedule URL, a trip updates URL, a vehicle positions URL, and a service alerts URL), so right now the granularity of checks is `date/check/itp_id/url_number`, which means we can assess schedule and RT on the same "index". Post-rewrite, we won't necessarily have that same fully-native concept of a shared identifier across all four feed types. We can definitely reconstruct such a concept if needed. But I do think there's a question of what is the entity that is being assessed here -- is is the `service`, the `organization`, or just the `dataset`? If it's just the `dataset`, how do we want to link the 3 RT feed types together in the future?

NOTE: Currently, the uniqueness test on this table fails because of the two-row feed_info (#1471). I would like to leave the test and just fix #1471 separately.

Resolves #1688

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Run locally (`dbt run` and `dbt test`). Have also manually inspected the resulting table, see below for screenshot. 

## Screenshot
![image](https://user-images.githubusercontent.com/55149902/187312281-8a63fded-c6b4-41a6-bda4-c5d8fe800794.png)

Here is an example dashboard I made (don't want to open access in Metabase too much to avoid confusion -- this is populated by my namespaced staging version of the table):

![image](https://user-images.githubusercontent.com/55149902/187463747-61f1ed9d-c637-46b8-bfb9-65bbf0dbf137.png)

