### PR TITLE
warehouse: changed itp_id from FLOAT to FLOAT64 in schema declaration

### DIFF
--- a/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/external_airtable_california_transit_fare_systems.yml
@@ -103,7 +103,7 @@ schema_fields:
     type: STRING
   - name: itp_id
     mode: NULLABLE
-    type: FLOAT
+    type: FLOAT64
   - name: bike_fee
     mode: NULLABLE
     type: STRING


### PR DESCRIPTION
# Description
We changed `itp_id` from `FLOAT` to `FLOAT64` to address the dbt error in the `transform_warehouse` airflow dag:

`Error while reading table: cal-itp-data-infra.external_airtable.california_transit__fare_systems, error message: JSON parsing error in row starting at position 0: Could not convert value 'number_value: 	 "415.0"' to integer. Field: itp_id; Value: 415.0`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml