### PR TITLE
grant access to payments_rides for non-agency users

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -10,6 +10,10 @@ grant to (
   {% endfor %}
 )
 filter using (
+  {% if not filter_column and not filter_value %}
+  1 = 1
+  {% else %}
   {{ filter_column }} = '{{ filter_value }}'
+  {% endif %}
 )
 {% endmacro %}

--- a/warehouse/models/payments_views/payments_rides.sql
+++ b/warehouse/models/payments_views/payments_rides.sql
@@ -23,8 +23,9 @@
 " {{ create_row_access_policy(
     principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',
-                  'user:natalie@calitp.org',
-                  'user:eric@calitp.org',
+                  'domain:calitp.org',
+                  'user:angela@compiler.la',
+                  'user:easall@gmail.com',
                   'user:jeremyscottowades@gmail.com',
                  ]
 ) }}",

--- a/warehouse/models/payments_views/payments_rides.sql
+++ b/warehouse/models/payments_views/payments_rides.sql
@@ -1,5 +1,6 @@
 {{ config(
-    post_hook=[" {{ create_row_access_policy(
+    post_hook=[
+" {{ create_row_access_policy(
     filter_column = 'participant_id',
     filter_value = 'mst',
     principals = ['serviceAccount:mst-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
@@ -18,7 +19,15 @@
     filter_column = 'participant_id',
     filter_value = 'clean-air-express',
     principals = ['serviceAccount:clean-air-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
-) }}"
+) }}",
+" {{ create_row_access_policy(
+    principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+                  'group:cal-itp@jarv.us',
+                  'user:natalie@calitp.org',
+                  'user:eric@calitp.org',
+                  'user:jeremyscottowades@gmail.com',
+                 ]
+) }}",
 ]
 
 ) }}


### PR DESCRIPTION
# Description

I didn't realize that row access policies (introduced in https://github.com/cal-itp/data-infra/pull/1697) meant 0 rows were shown if a user failed to match any criteria. This PR restores full access to `payments_rides` to the appropriate users.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
This has already been deployed and I've confirmed in Metabase.

## Screenshots (optional)
