### PR TITLE
load this from a secret

### DIFF
--- a/airflow/dags/publish_open_data/publish_california_open_data.yml
+++ b/airflow/dags/publish_open_data/publish_california_open_data.yml
@@ -29,6 +29,10 @@ secrets:
     deploy_target: /secrets/jobs-data/
     secret: jobs-data
     key: service-account.json
+  - deploy_type: env
+    deploy_target: CALITP_CKAN_GTFS_SCHEDULE_KEY
+    secret: jobs-data
+    key: calitp-ckan-gtfs-schedule-key
 
 resources:
   request_memory: 2.0Gi


### PR DESCRIPTION
# Description

I missed loading the CKAN API key from secrets in the pod operator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally.

## Screenshots (optional)
```
[2022-08-29 18:45:43,736] {pod_launcher.py:198} INFO - Event: publish-california-open-data.86737792f3cd4288b68a2bd5e7f9b1f1 had an event of type Running
[2022-08-29 18:45:43,882] {pod_launcher.py:149} INFO - fetching manifest from gs://test-calitp-dbt-artifacts/latest/manifest.json
[2022-08-29 18:45:43,885] {pod_launcher.py:149} INFO - handling agency e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
Downloading: 100%|██████████| 346/346 [00:00<00:00, 2750.52rows/s]
[2022-08-29 18:45:45,486] {pod_launcher.py:149} INFO - saving intermediate file to /tmp/tmpu47aztkg/agency.csv
[2022-08-29 18:45:45,490] {pod_launcher.py:149} INFO - selected 346 rows (42.9 kB) from staging_gtfs_schedule.agency
[2022-08-29 18:45:45,491] {pod_launcher.py:149} INFO - writing agency to gs://calitp-publish/california_open_data__agency/dt=2022-08-29/agency.csv
[2022-08-29 18:45:45,706] {pod_launcher.py:149} INFO - uploading to https://data.ca.gov e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
[2022-08-29 18:45:45,706] {pod_launcher.py:149} INFO - uploading 42.9 kB to e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
```