### PR TITLE
Change column name to fix run error

### DIFF
--- a/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
@@ -4,7 +4,7 @@ vp_trips AS (
     SELECT DISTINCT
         calitp_itp_id,
         calitp_url_number,
-        date,
+        date AS service_date,
         trip_id AS vp_trip_id
     -- trip_route_id
     -- note: to change when we want to include more operators. trip_route_id and trip_id are optional
@@ -44,7 +44,7 @@ rt_sched_joined AS (
             T1.trip_id = T2.vp_trip_id
             AND T1.calitp_itp_id = T2.calitp_itp_id
             AND T1.calitp_url_number = T2.calitp_url_number
-            AND T1.service_date = T2.date
+            AND T1.service_date = T2.service_date
     GROUP BY 1, 2, 3, 4
 ),
 


### PR DESCRIPTION
# Description

After running the `gtfs_rt_vs_schedule_trips_sample` table with DBT, I received an error for the column name `service_date` for reference table `stg_rt__vehicle_positions` even though it has previously run with no issue. This PR removes the column rename to have the original name `date` so that the table will run without errors. 
 
<img width="909" alt="Screen Shot 2022-08-31 at 9 55 45 AM" src="https://user-images.githubusercontent.com/72096633/187735895-1ad97584-fd6f-46be-8327-8158f927a8d9.png">

Resolves # [issue]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
The table has been tested and rerun successfully. 
<img width="920" alt="Screen Shot 2022-08-31 at 9 58 22 AM" src="https://user-images.githubusercontent.com/72096633/187736484-d94a4235-578d-4d06-a4c6-f68d19f93771.png">

## Screenshots (optional)
<img width="907" alt="Screen Shot 2022-08-31 at 9 58 37 AM" src="https://user-images.githubusercontent.com/72096633/187736546-4a80fe53-9e92-4791-8454-a59bc1859ac2.png">
