### PR TITLE
Use new Airtable fields for building GTFS requests, and getting auth from secrets

### DIFF
--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -87,7 +87,9 @@ def download_all(task_instance, execution_date, **kwargs):
     logging.info(f"processing {len(records)} records")
 
     for i, record in enumerate(records, start=1):
-        logging.info(f"attempting to fetch {i}/{len(records)} {record.uri}")
+        logging.info(
+            f"attempting to fetch {i}/{len(records)} {record.name}({record.pipeline_url})"
+        )
 
         try:
             extract, content = download_feed(
@@ -107,7 +109,7 @@ def download_all(task_instance, execution_date, **kwargs):
             )
         except Exception as e:
             logging.error(
-                f"exception occurred while attempting to download feed {record.uri}: {str(e)}\n{traceback.format_exc()}"
+                f"exception occurred while attempting to download feed {record.name}({record.pipeline_url}): {str(e)}\n{traceback.format_exc()}"
             )
             outcomes.append(
                 AirtableGTFSDataRecordProcessingOutcome(

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.8.25
+calitp==2022.9.1a2
 fsspec==2022.5.0
 intake==0.6.1
 ipdb==0.13.4

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.9.1a2
+calitp==2022.9.1a3
 fsspec==2022.5.0
 intake==0.6.1
 ipdb==0.13.4

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-dev/archiver-channel-vars.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-dev/archiver-channel-vars.yaml
@@ -6,4 +6,4 @@ data:
   AIRFLOW_ENV: development
   CALITP_BUCKET__AIRTABLE: "gs://test-calitp-airtable"
   CALITP_BUCKET__GTFS_RT_RAW: "gs://test-calitp-gtfs-rt-raw"
-  HUEY_CONSUMER_WORKERS: "16"
+  HUEY_CONSUMER_WORKERS: "12"

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-dev/consumer.patch.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-dev/consumer.patch.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: gtfs-rt-archiver-consumer
 spec:
-  replicas: 1
+  replicas: 2
   template:
     spec:
       containers:

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-dev/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-dev/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.1.7'
+  newTag: '3.1.8'

--- a/services/gtfs-rt-archiver-v3/Dockerfile
+++ b/services/gtfs-rt-archiver-v3/Dockerfile
@@ -2,19 +2,16 @@ FROM python:3.9
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN apt-get update -y \
-    && apt-get install -y python3 python3-pip
-RUN pip install memray
-
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-ENV PATH="${PATH}:/root/.poetry/bin"
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+ENV PATH="/root/.local/bin:${PATH}"
 
 WORKDIR /app
 
 COPY ./pyproject.toml /app/pyproject.toml
 COPY ./poetry.lock /app/poetry.lock
-RUN poetry config virtualenvs.create false
-RUN poetry install
+RUN poetry export -f requirements.txt --without-hashes --output requirements.txt \
+    && pip install -r requirements.txt
+RUN pip install memray
 
 COPY . /app
 

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -5,6 +5,7 @@ Huey's startup hooks are per _worker_ and not the overall consumer process.
 import typer
 import os
 
+from calitp.auth import load_secrets
 from huey.constants import WORKER_THREAD
 
 import logging
@@ -13,7 +14,7 @@ import sys
 from huey.consumer_options import ConsumerConfig
 from prometheus_client import start_http_server
 
-from .tasks import huey, load_secrets
+from .tasks import huey
 
 
 def main(

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
@@ -2,7 +2,7 @@ from prometheus_client import Counter, Gauge, Histogram
 
 standard_labels = (
     "record_name",
-    "record_uri",
+    "record_pipeline_url",
     "record_feed_type",
 )
 AIRTABLE_CONFIGURATION_AGE = Gauge(

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from datetime import datetime
 from typing import Dict, Any
 
@@ -97,19 +98,25 @@ def fetch(tick: datetime, record: AirtableGTFSDataRecord):
                 "unexpected HTTP response code from feed request",
                 code=e.response.status_code,
                 content=e.response.text,
+                exc=str(e),
                 exc_type=type(e).__name__,
+                traceback=traceback.format_exc(),
             )
             raise
         except RequestException as e:
             logger.error(
                 "request exception occurred from feed request",
+                exc=str(e),
                 exc_type=type(e).__name__,
+                traceback=traceback.format_exc(),
             )
             raise
         except Exception as e:
             logger.error(
                 "other non-request exception occurred during download_feed",
+                exc=str(e),
                 exc_type=type(e).__name__,
+                traceback=traceback.format_exc(),
             )
             raise
 

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/ticker.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/ticker.py
@@ -8,11 +8,12 @@ import pendulum
 import schedule
 import typer
 from cachetools.func import ttl_cache
+from calitp.auth import load_secrets
 from calitp.storage import AirtableGTFSDataExtract, GTFSFeedType, AirtableGTFSDataRecord
 from prometheus_client import start_http_server
 
 from .metrics import TICKS, AIRTABLE_CONFIGURATION_AGE
-from .tasks import fetch, huey, load_secrets
+from .tasks import fetch, huey
 
 
 @ttl_cache(ttl=300)

--- a/services/gtfs-rt-archiver-v3/poetry.lock
+++ b/services/gtfs-rt-archiver-v3/poetry.lock
@@ -91,17 +91,19 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "calitp"
-version = "2022.8.12a2"
+version = "2022.9.1a3"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
 python-versions = ">=3.8,<3.11"
 
 [package.dependencies]
-gcsfs = ">=2022.5.0,<2023.0.0"
+fsspec = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
+gcsfs = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
 google-api-core = ">=1.32.0,<2.0.0dev"
 google-cloud-bigquery = ">=1.15.0,<3.0.0dev"
 google-cloud-bigquery-storage = "2.14.1"
+google-cloud-secret-manager = ">=2.12.4,<3.0.0"
 gtfs-realtime-bindings = ">=0.0.7,<0.0.8"
 humanize = ">=4.2.3,<5.0.0"
 Jinja2 = "<3.1.0"
@@ -172,7 +174,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["pytest-cov", "pytest", "PyTest-Cov (<2.6)", "PyTest (<5)", "zipp (<2)", "sphinxcontrib-websupport (<2)", "configparser (<5)", "importlib-resources (<4)", "importlib-metadata (<3)", "sphinx (<2)", "bump2version (<1)", "tox"]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "frozenlist"
@@ -280,9 +282,9 @@ rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
 six = ">=1.9.0"
 
 [package.extras]
-reauth = ["pyu2f (>=0.1.5)"]
+aiohttp = ["requests (>=2.20.0,<3.0.0dev)", "aiohttp (>=3.6.2,<4.0.0dev)"]
 pyopenssl = ["pyopenssl (>=20.0.0)"]
-aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "requests (>=2.20.0,<3.0.0dev)"]
+reauth = ["pyu2f (>=0.1.5)"]
 
 [[package]]
 name = "google-auth-oauthlib"
@@ -367,7 +369,7 @@ grpc = ["grpcio (>=1.38.0,<2.0dev)"]
 
 [[package]]
 name = "google-cloud-secret-manager"
-version = "2.12.0"
+version = "2.12.4"
 description = "Secret Manager API API client library"
 category = "main"
 optional = false
@@ -376,8 +378,8 @@ python-versions = ">=3.7"
 [package.dependencies]
 google-api-core = {version = ">=1.32.0,<2.0.0 || >=2.8.0,<3.0.0dev", extras = ["grpc"]}
 grpc-google-iam-v1 = ">=0.12.4,<1.0.0dev"
-proto-plus = ">=1.15.0,<2.0.0dev"
-protobuf = ">=3.19.0,<4.0.0dev"
+proto-plus = ">=1.22.0,<2.0.0dev"
+protobuf = ">=3.19.0,<5.0.0dev"
 
 [package.extras]
 libcst = ["libcst (>=0.2.5)"]
@@ -423,8 +425,8 @@ python-versions = ">= 3.6"
 google-crc32c = ">=1.0,<2.0dev"
 
 [package.extras]
-requests = ["requests (>=2.18.0,<3.0.0dev)"]
 aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)"]
+requests = ["requests (>=2.18.0,<3.0.0dev)"]
 
 [[package]]
 name = "googleapis-common-protos"
@@ -580,9 +582,9 @@ tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
-reports = ["lxml"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
 dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
@@ -712,7 +714,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "prometheus-client"
@@ -727,7 +729,7 @@ twisted = ["twisted"]
 
 [[package]]
 name = "proto-plus"
-version = "1.20.6"
+version = "1.22.1"
 description = "Beautiful, Pythonic protocol buffers."
 category = "main"
 optional = false
@@ -797,8 +799,8 @@ python-versions = ">=3.6.1"
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
-email = ["email-validator (>=1.0.3)"]
 dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydata-google-auth"
@@ -821,7 +823,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
@@ -842,8 +844,8 @@ py = ">=1.5.0"
 wcwidth = "*"
 
 [package.extras]
-testing = ["xmlschema", "requests", "nose", "mock", "hypothesis (>=3.56)", "argcomplete"]
 checkqa-mypy = ["mypy (==v0.761)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -920,8 +922,8 @@ idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-oauthlib"
@@ -1058,9 +1060,9 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-tests = ["simplejson", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "pretend", "freezegun (>=0.2.8)", "coverage"]
-docs = ["twisted", "sphinxcontrib-mermaid", "sphinx-notfound-page", "sphinx", "myst-parser", "furo"]
-dev = ["twisted", "sphinxcontrib-mermaid", "sphinx-notfound-page", "sphinx", "myst-parser", "furo", "simplejson", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "pretend", "freezegun (>=0.2.8)", "coverage", "tomli", "cogapp", "rich", "pre-commit"]
+dev = ["pre-commit", "rich", "cogapp", "tomli", "coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio (>=0.17)", "pytest (>=6.0)", "simplejson", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
+tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio (>=0.17)", "pytest (>=6.0)", "simplejson"]
 
 [[package]]
 name = "tomli"
@@ -1129,9 +1131,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-secure = ["ipaddress", "certifi", "idna (>=2.0.0)", "cryptography (>=1.3.4)", "pyOpenSSL (>=0.14)"]
-brotli = ["brotlipy (>=0.6.0)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 
 [[package]]
 name = "wcwidth"
@@ -1164,7 +1166,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "9cce61418fb5ea4e1b0a0d31f90a052a2ce68359b0c432d72fdbdc2e27193b68"
+content-hash = "95ab9053286cb743bc1b94c06afcc14a16d7804bc73db90e0469839174f89fe5"
 
 [metadata.files]
 aiohttp = []

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -21,7 +21,7 @@ cachetools = ">=2.0.0,<5.0"
 google-cloud-secret-manager = "^2.11.1"
 structlog = "^22.1.0"
 python-json-logger = "^2.0.4"
-calitp = "2022.8.12a2"
+calitp = "2022.9.1a3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.1.7"
+version = "3.1.8"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/1736

Switches GTFS request building to use the new pipeline-specific Airtable fields with clear query param or header auth. Also loads everything from secrets manager rather than a mix of env vars and secrets manager. The underlying calitp PR is https://github.com/cal-itp/calitp-py/pull/80.

I am also making some improvements to the [Grafana dashboard](https://monitoring.k8s.calitp.jarv.us/d/N1XVLOe7z/gtfs-rt-archiver-v3?orgId=1&var-namespace=gtfs-rt-v3-dev&from=now-15m&to=now&refresh=10s) as part of this work.

Splitting off the Airtable auth change in another PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally in Airflow and deployed to dev archiver.

## Screenshots (optional)
Schedule
```
[2022-09-02 01:09:37,667] {storage.py:305} INFO - saving 197.2 kB to gs://test-calitp-gtfs-schedule-raw/schedule/dt=2022-09-02/base64_url=aHR0cHM6Ly9naXRodWIuY29tL0xBQ01UQS9sb3MtYW5nZWxlcy1yZWdpb25hbC1ndGZzL3Jhdy9tYWluL2JlbGxmbG93ZXItY2EtdXMvYmVsbGZsb3dlci1jYS11cy56aXA=/ts=2022-09-02T00:56:38.130087+00:00/bellflower-ca-us.zip
took 13 minutes ago to process 210 records
[2022-09-02 01:09:38,403] {storage.py:305} INFO - saving 802.9 kB to gs://test-calitp-gtfs-schedule-raw/download_schedule_feed_results/dt=2022-09-02/ts=2022-09-02T00:56:38.130087+00:00/results.jsonl
successfully fetched 206 of 210
Failures:
```
RT
```
gtfs-rt-archiver-v3-consumer_1  | saving 685 Bytes from https://redondobeachbct.com/gtfs-rt/alerts to gs://test-calitp-gtfs-rt-raw/service_alerts/dt=2022-09-02/hour=2022-09-02T01:00:00+00:00/ts=2022-09-02T01:10:40+00:00/base64_url=aHR0cHM6Ly9yZWRvbmRvYmVhY2hiY3QuY29tL2d0ZnMtcnQvYWxlcnRz/feed
gtfs-rt-archiver-v3-consumer_1  | [2022-09-02 01:10:47,157] INFO:huey:Worker-2:gtfs_rt_archiver_v3.tasks.fetch: f36de1eb-25c8-43c5-980e-49500e621a88 exp=5 (2022-09-02 01:10:45.761352) executed in 1.452s
gtfs-rt-archiver-v3-consumer_1  | INFO:huey:gtfs_rt_archiver_v3.tasks.fetch: f36de1eb-25c8-43c5-980e-49500e621a88 exp=5 (2022-09-02 01:10:45.761352) executed in 1.452s
```