### PR TITLE
add pool for airtable

### DIFF
--- a/airflow/dags/airtable_loader_v2/METADATA.yml
+++ b/airflow/dags/airtable_loader_v2/METADATA.yml
@@ -14,6 +14,7 @@ default_args:
     email_on_retry: False
     retries: 1
     retry_delay: !timedelta 'minutes: 2'
+    pool: airtable_pool
     concurrency: 50
     #sla: !timedelta 'hours: 2'
 wait_for_defaults:


### PR DESCRIPTION
# Description

@lauriemerrell has been noticing instability in the nightly AIrtable downloads. We've paused the old v1 DAGs now but I want to also limit the new DAG since it's composed of ~20 tasks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/4305366/188658353-0b5dc713-dc46-4d13-abdc-5b49b158f0c2.png)
