### PR TITLE
docs: remove references to deprecated airtable dags

### DIFF
--- a/docs/airflow/production-maintenance.md
+++ b/docs/airflow/production-maintenance.md
@@ -80,8 +80,11 @@ In addition to the tabular view above, here is a diagram representing DAG depend
       sandbox;
       create_external_tables;
       check_feed_aggregators;
+      rt_loader_files;
       parse_and_validate_rt;
+      parse_and_validate_rt_v2;
       transform_warehouse;
+      unzip_and_validate_gtfs_schedule;
 ```
 
 ## Task-level considerations

--- a/docs/airflow/production-maintenance.md
+++ b/docs/airflow/production-maintenance.md
@@ -26,9 +26,7 @@ DAGs are listed in alphabetical order, as they appear in the Airflow UI.
 
 | DAG | Safe after 24h | `depends_ on_past` | All of history | Depends on | Notes |
 | --- | --- | --- | --- | --- | --- |
-`airtable_loader` | **⛔ No*** | No | **🔂 No** | N/A | All tasks are unsafe after 24 hours |
 `airtable_loader_v2` | Yes | No | No* | N/A | Don't need to rerun more than once if multiple failures; scrapes data that is correctly timestamped |
-`airtable_views` | Yes | No | Yes* | `airtable_ loader` | Latest-only data |
 `amplitude_benefits` | Yes | No | **🔂 No** | N/A | |
 `check_feed_aggregators` | **⛔ No** | No | **🔂 No** | N/A | |
 `create_external_tables` | N/A | N/A | N/A | N/A | Once-only (defines external tables); does not generally need to be re-run  |
@@ -52,6 +50,8 @@ DAGs are listed in alphabetical order, as they appear in the Airflow UI.
 
 The following DAGs are still listed in the Airflow UI even though they are **deprecated or indefinitely paused**. They never need to be re-run.
 
+* `airtable_loader`
+* `airtable_views`
 * `check_data_freshness`
 * `gtfs_schedule`
 * `gtfs_views_staging`
@@ -69,7 +69,6 @@ In addition to the tabular view above, here is a diagram representing DAG depend
 ```{mermaid}
   graph TD;
       airtable_loader_v2;
-      airtable_loader-->airtable_views;
       amplitude_benefits;
       download_gtfs_schedule_v2;
       gtfs_downloader-->gtfs_loader;

--- a/docs/airflow/production-maintenance.md
+++ b/docs/airflow/production-maintenance.md
@@ -44,7 +44,7 @@ DAGs are listed in alphabetical order, as they appear in the Airflow UI.
 `rt_loader_files` | Yes | No | **🔂 No** | N/A | |
 `sandbox` | N/A | N/A | N/A | N/A | Testing only; does not need to be re-run |
 `transform_warehouse` | Yes | No | Yes | N/A | Runs dbt warehouse |
-`unzip_and_validate_gtfs_schedule_` | Yes | No | **🔂 No** | N/A | |
+`unzip_and_validate_gtfs_schedule` | Yes | No | **🔂 No** | N/A | |
 
 ### Deprecated DAGs
 
@@ -57,6 +57,7 @@ The following DAGs are still listed in the Airflow UI even though they are **dep
 * `gtfs_views_staging`
 * `gtfs_views`
 * `parse_rt`
+* `payments_views`
 * `rt_timestamp_fix`
 * `rt_views`
 * `transitstacks_loader`


### PR DESCRIPTION
# Description

Docs updates that should have been made in #1699, my bad. Removes references to now-deprecated Airtable Airflow DAGs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested? N/A
