### PR TITLE
fix: delete broken airtable import, cleanup from PR #1699

### DIFF
--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -8,5 +8,4 @@ from operators.csv_to_warehouse_operator import CsvToWarehouseOperator
 from operators.python_to_warehouse_operator import PythonToWarehouseOperator
 from operators.sql_query_operator import SqlQueryOperator
 from operators.airtable_to_gcs import AirtableToGCSOperator
-from operators.airtable_to_warehouse import AirtableToWarehouseOperator
 from operators.amplitude_to_flattened_json import AmplitudeToFlattenedJSONOperator


### PR DESCRIPTION
# Description

In #1699 I forgot to delete this import, which resulted in a DAG Import error & stopped Airflow running for the last ~day

![image](https://user-images.githubusercontent.com/55149902/188890112-24c215e4-31f2-4bfc-8997-0fdcd0045358.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? 
N/A
