### PR TITLE
5 new draft checks for rt feed

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -4,7 +4,7 @@
 {% endmacro %}
 
 {% macro no_validation_errors() %}
-"Static feed produces no errors in MobilityData GTFS Schedule Validator"
+"No errors in MobilityData GTFS Schedule Validator"
 {% endmacro %}
 
 {% macro complete_wheelchair_accessibility_data() %}

--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -4,7 +4,7 @@
 {% endmacro %}
 
 {% macro no_validation_errors() %}
-"Static feed produces no validation errors in GTFS Validator"
+"Static feed produces no errors in MobilityData GTFS Schedule Validator"
 {% endmacro %}
 
 {% macro complete_wheelchair_accessibility_data() %}
@@ -16,11 +16,31 @@
 {% endmacro %}
 
 {% macro shapes_valid() %}
-"No shapes-related errors appear in the MobilityData GTFS Validator"
+"No shapes-related errors appear in the MobilityData GTFS Schedule Validator"
 {% endmacro %}
 
 {% macro technical_contact_listed() %}
 "Technical contact is listed in feed_contact_email field within the feed_info.txt file"
+{% endmacro %}
+
+{% macro no_rt_critical_validation_errors() %}
+"No critical errors in the MobilityData GTFS Realtime Validator"
+{% endmacro %}
+
+{% macro trip_id_alignment() %}
+"All trip_ids provided in the GTFS-rt feed exist in the GTFS data"
+{% endmacro %}
+
+{% macro vehicle_positions_feed_present() %}
+"Vehicle positions RT feed is present"
+{% endmacro %}
+
+{% macro trip_updates_feed_present() %}
+"Trip updates RT feed is present"
+{% endmacro %}
+
+{% macro service_alerts_feed_present() %}
+"Service alerts RT feed is present"
 {% endmacro %}
 
 -- declare features
@@ -38,6 +58,10 @@
 
 {% macro technical_contact_availability() %}
 "Technical Contact Availability"
+{% endmacro %}
+
+{% macro fixed_route_completeness() %}
+"Fixed-Route Completeness"
 {% endmacro %}
 
 -- columns

--- a/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
@@ -25,6 +25,26 @@ stg_gtfs_guidelines__technical_contact_listed AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__technical_contact_listed') }}
 ),
 
+stg_gtfs_guidelines__no_rt_critical_validation_errors AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__no_rt_critical_validation_errors') }}
+),
+
+stg_gtfs_guidelines__trip_id_alignment AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__trip_id_alignment') }}
+),
+
+stg_gtfs_guidelines__vehicle_positions_feed_present AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__vehicle_positions_feed_present') }}
+),
+
+stg_gtfs_guidelines__trip_updates_feed_present AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__trip_updates_feed_present') }}
+),
+
+stg_gtfs_guidelines__service_alerts_feed_present AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__service_alerts_feed_present') }}
+),
+
 fact_daily_guideline_checks AS (
     SELECT
         {{ gtfs_guidelines_columns() }}
@@ -49,6 +69,26 @@ fact_daily_guideline_checks AS (
     SELECT
         {{ gtfs_guidelines_columns() }}
     FROM stg_gtfs_guidelines__technical_contact_listed
+    UNION ALL
+    SELECT
+        {{ gtfs_guidelines_columns() }}
+    FROM no_rt_critical_validation_errors
+    UNION ALL
+    SELECT
+        {{ gtfs_guidelines_columns() }}
+    FROM stg_gtfs_guidelines__trip_id_alignment
+    UNION ALL
+    SELECT
+        {{ gtfs_guidelines_columns() }}
+    FROM stg_gtfs_guidelines__vehicle_positions_feed_present
+    UNION ALL
+    SELECT
+        {{ gtfs_guidelines_columns() }}
+    FROM stg_gtfs_guidelines__trip_updates_feed_present
+    UNION ALL
+    SELECT
+        {{ gtfs_guidelines_columns() }}
+    FROM stg_gtfs_guidelines__service_alerts_feed_present
 )
 
 SELECT * FROM fact_daily_guideline_checks

--- a/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
@@ -72,7 +72,7 @@ fact_daily_guideline_checks AS (
     UNION ALL
     SELECT
         {{ gtfs_guidelines_columns() }}
-    FROM no_rt_critical_validation_errors
+    FROM stg_gtfs_guidelines__no_rt_critical_validation_errors
     UNION ALL
     SELECT
         {{ gtfs_guidelines_columns() }}

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -21,6 +21,16 @@ checks_implemented AS (
     SELECT {{ shapes_valid() }}, {{ accurate_service_data() }}
     UNION ALL
     SELECT {{ technical_contact_listed() }}, {{ technical_contact_availability() }}
+    UNION ALL
+    SELECT {{ no_rt_critical_validation_errors() }}, {{ compliance() }}
+    UNION ALL
+    SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}
+    UNION ALL
+    SELECT {{ vehicle_positions_feed_present() }}, {{ compliance() }}
+    UNION ALL
+    SELECT {{ trip_updates_feed_present() }}, {{ compliance() }}
+    UNION ALL
+    SELECT {{ service_alerts_feed_present() }}, {{ compliance() }}
 ),
 
 -- create an index: all feed/date/check combinations

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ no_rt_critical_validation_errors() }}
 ),
 
--- It's called "hourly" but if you use the "file_count_day" it's a daily table
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
@@ -1,0 +1,66 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ no_rt_critical_validation_errors() }}
+),
+
+-- It's called "hourly" but if you use the "file_count_day" it's a daily table
+gtfs_rt_fact_files_wide_daily AS (
+SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
+),
+
+gtfs_rt_fact_daily_validation_errors AS (
+    SELECT * FROM {{ ref('gtfs_rt_fact_daily_validation_errors') }}
+),
+
+gtfs_rt_validation_code_descriptions AS (
+    SELECT * FROM {{ ref('gtfs_rt_validation_code_descriptions') }}
+),
+
+rt_files_by_day AS (
+    SELECT
+        calitp_itp_id,
+        calitp_url_number,
+        date_extracted AS date,
+        COUNT(*) AS rt_files
+    FROM gtfs_rt_fact_files_wide_daily
+    GROUP BY 1,2,3
+),
+
+errors_by_day AS (
+    SELECT
+        t1.feed_key,
+        t1.date,
+        SUM(t1.occurrences) AS errors
+    FROM gtfs_rt_fact_daily_validation_errors AS t1
+    LEFT JOIN gtfs_rt_validation_code_descriptions AS t2
+         ON t1.error_id = t2.code
+    WHERE t2.is_critical = "y"
+    GROUP BY t1.feed_key, t1.date
+),
+
+errors_daily_check AS (
+    SELECT
+        t1.date,
+        t1.calitp_itp_id,
+        t1.calitp_url_number,
+        t1.calitp_agency_name,
+        t1.check,
+        t1.feature,
+        t2.rt_files,
+        t3.errors,
+        CASE
+            WHEN rt_files > 0 AND errors IS null THEN "PASS"
+            WHEN rt_files IS null THEN "FAIL"
+            WHEN errors > 0 THEN "FAIL"
+        END AS status,
+    FROM feed_guideline_index AS t1
+    LEFT JOIN rt_files_by_day AS t2
+         ON t1.calitp_itp_id = t2.calitp_itp_id
+         AND t1.calitp_url_number = t2.calitp_url_number
+         AND t1.date = t2.date
+    LEFT JOIN errors_by_day AS t3
+         ON t1.feed_key = t3.feed_key
+         AND t1.date = t3.date
+)
+
+SELECT * FROM errors_daily_check

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
@@ -48,6 +48,7 @@ errors_daily_check AS (
         t1.feature,
         t2.rt_files,
         t3.errors,
+        t1.feed_key,
         CASE
             WHEN rt_files > 0 AND errors IS null THEN "PASS"
             WHEN rt_files IS null THEN "FAIL"

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ no_rt_critical_validation_errors() }}
 ),
 
--- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL+feed type
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
@@ -1,0 +1,40 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ vehicle_positions_feed_present() }}
+),
+
+-- It's called "hourly" but if you use the "file_count_day" it's a daily table
+gtfs_rt_fact_files_wide_daily AS (
+SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
+),
+
+rt_files_by_day AS (
+    SELECT
+        calitp_itp_id,
+        calitp_url_number,
+        date_extracted AS date,
+        name
+    FROM gtfs_rt_fact_files_wide_daily
+    WHERE name = "service_alerts"
+),
+
+feed_daily_check AS (
+    SELECT
+        t1.date,
+        t1.calitp_itp_id,
+        t1.calitp_url_number,
+        t1.calitp_agency_name,
+        t1.check,
+        t1.feature,
+        CASE
+            WHEN t2.name IS NOT null THEN "PASS"
+        ELSE "FAIL"
+        END AS status,
+    FROM feed_guideline_index AS t1
+    LEFT JOIN rt_files_by_day AS t2
+         ON t1.calitp_itp_id = t2.calitp_itp_id
+         AND t1.calitp_url_number = t2.calitp_url_number
+         AND t1.date = t2.date
+)
+
+SELECT * FROM feed_daily_check

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ service_alerts_feed_present() }}
 ),
 
--- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL+feed type
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
@@ -1,6 +1,6 @@
 WITH feed_guideline_index AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
-    WHERE check = {{ vehicle_positions_feed_present() }}
+    WHERE check = {{ service_alerts_feed_present() }}
 ),
 
 -- It's called "hourly" but if you use the "file_count_day" it's a daily table

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_present.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ service_alerts_feed_present() }}
 ),
 
--- It's called "hourly" but if you use the "file_count_day" it's a daily table
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
@@ -1,9 +1,9 @@
 WITH feed_guideline_index AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
-    WHERE check = {{ no_rt_critical_validation_errors() }}
+    WHERE check = {{ trip_id_alignment() }}
 ),
 
--- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL+feed type
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ no_rt_critical_validation_errors() }}
 ),
 
--- It's called "hourly" but if you use the "file_count_day" it's a daily table
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
@@ -44,6 +44,7 @@ errors_daily_check AS (
         t1.feature,
         t2.rt_files,
         t3.errors,
+        t1.feed_key,
         CASE
             WHEN rt_files > 0 AND errors IS null THEN "PASS"
             WHEN rt_files IS null THEN "FAIL"

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
@@ -1,0 +1,62 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ no_rt_critical_validation_errors() }}
+),
+
+-- It's called "hourly" but if you use the "file_count_day" it's a daily table
+gtfs_rt_fact_files_wide_daily AS (
+SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
+),
+
+gtfs_rt_fact_daily_validation_errors AS (
+    SELECT * FROM {{ ref('gtfs_rt_fact_daily_validation_errors') }}
+),
+
+rt_files_by_day AS (
+    SELECT
+        calitp_itp_id,
+        calitp_url_number,
+        date_extracted AS date,
+        COUNT(*) AS rt_files
+    FROM gtfs_rt_fact_files_wide_daily
+    GROUP BY 1,2,3
+),
+
+errors_by_day AS (
+    SELECT
+        feed_key,
+        date,
+        SUM(occurrences) AS errors
+    FROM gtfs_rt_fact_daily_validation_errors AS t1
+    -- Description for error E003:
+    ---- "All trip_ids provided in the GTFS-rt feed must exist in the GTFS data, unless the schedule_relationship is ADDED"
+    WHERE error_id = "E003"
+    GROUP BY feed_key, date
+),
+
+errors_daily_check AS (
+    SELECT
+        t1.date,
+        t1.calitp_itp_id,
+        t1.calitp_url_number,
+        t1.calitp_agency_name,
+        t1.check,
+        t1.feature,
+        t2.rt_files,
+        t3.errors,
+        CASE
+            WHEN rt_files > 0 AND errors IS null THEN "PASS"
+            WHEN rt_files IS null THEN "FAIL"
+            WHEN errors > 0 THEN "FAIL"
+        END AS status,
+    FROM feed_guideline_index AS t1
+    LEFT JOIN rt_files_by_day AS t2
+         ON t1.calitp_itp_id = t2.calitp_itp_id
+         AND t1.calitp_url_number = t2.calitp_url_number
+         AND t1.date = t2.date
+    LEFT JOIN errors_by_day AS t3
+         ON t1.feed_key = t3.feed_key
+         AND t1.date = t3.date
+)
+
+SELECT * FROM errors_daily_check

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ trip_updates_feed_present() }}
 ),
 
--- It's called "hourly" but if you use the "file_count_day" it's a daily table
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ trip_updates_feed_present() }}
 ),
 
--- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL+feed type
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
@@ -1,0 +1,40 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ vehicle_positions_feed_present() }}
+),
+
+-- It's called "hourly" but if you use the "file_count_day" it's a daily table
+gtfs_rt_fact_files_wide_daily AS (
+SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
+),
+
+rt_files_by_day AS (
+    SELECT
+        calitp_itp_id,
+        calitp_url_number,
+        date_extracted AS date,
+        name
+    FROM gtfs_rt_fact_files_wide_daily
+    WHERE name = "trip_updates"
+),
+
+feed_daily_check AS (
+    SELECT
+        t1.date,
+        t1.calitp_itp_id,
+        t1.calitp_url_number,
+        t1.calitp_agency_name,
+        t1.check,
+        t1.feature,
+        CASE
+            WHEN t2.name IS NOT null THEN "PASS"
+        ELSE "FAIL"
+        END AS status,
+    FROM feed_guideline_index AS t1
+    LEFT JOIN rt_files_by_day AS t2
+         ON t1.calitp_itp_id = t2.calitp_itp_id
+         AND t1.calitp_url_number = t2.calitp_url_number
+         AND t1.date = t2.date
+)
+
+SELECT * FROM feed_daily_check

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_present.sql
@@ -1,6 +1,6 @@
 WITH feed_guideline_index AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
-    WHERE check = {{ vehicle_positions_feed_present() }}
+    WHERE check = {{ trip_updates_feed_present() }}
 ),
 
 -- It's called "hourly" but if you use the "file_count_day" it's a daily table

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_present.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ vehicle_positions_feed_present() }}
 ),
 
--- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL+feed type
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_present.sql
@@ -1,0 +1,40 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ vehicle_positions_feed_present() }}
+),
+
+-- It's called "hourly" but if you use the "file_count_day" it's a daily table
+gtfs_rt_fact_files_wide_daily AS (
+SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
+),
+
+rt_files_by_day AS (
+    SELECT
+        calitp_itp_id,
+        calitp_url_number,
+        date_extracted AS date,
+        name
+    FROM gtfs_rt_fact_files_wide_daily
+    WHERE name = "vehicle_positions"
+),
+
+feed_daily_check AS (
+    SELECT
+        t1.date,
+        t1.calitp_itp_id,
+        t1.calitp_url_number,
+        t1.calitp_agency_name,
+        t1.check,
+        t1.feature,
+        CASE
+            WHEN t2.name IS NOT null THEN "PASS"
+        ELSE "FAIL"
+        END AS status,
+    FROM feed_guideline_index AS t1
+    LEFT JOIN rt_files_by_day AS t2
+         ON t1.calitp_itp_id = t2.calitp_itp_id
+         AND t1.calitp_url_number = t2.calitp_url_number
+         AND t1.date = t2.date
+)
+
+SELECT * FROM feed_daily_check

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_present.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_present.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
     WHERE check = {{ vehicle_positions_feed_present() }}
 ),
 
--- It's called "hourly" but if you use the "file_count_day" it's a daily table
+-- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL
 gtfs_rt_fact_files_wide_daily AS (
 SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),


### PR DESCRIPTION
# Description

5 new checks:
**no_rt_critical_validation_errors**: If the feed has >0 RT files on the given day AND no critical errors in the RT validator, then PASS. If either condition isn't met, FAIL 
**trip_id_alignment**: If the feed has >0 RT files on the given day AND didn't not have an error in the validator related to mismatched trip_id's, then PASS. If either condition isn't met, FAIL. The specific conditions for the validator check are: "All trip_ids provided in the GTFS-rt feed must exist in the GTFS data, unless the schedule_relationship is ADDED"
**vehicle_positions_feed_present**, **trip_updates_feed_present**, & **service_alerts_feed_present**: If the given feed is present at least once on the day, PASS. else, FAIL


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
no_rt_critical_validation_errors:
manually cross-check output with values from gtfs_rt_fact_daily_validation_errors and gtfs_rt_fact_files_wide_hourly, for 5 rows of results.

trip_id_alignment:
manually cross-check output with values from gtfs_rt_fact_daily_validation_errors and gtfs_rt_fact_files_wide_hourly, for 5 rows of results.

vehicle_positions_feed_present:
manually cross-check with gtfs_rt_fact_files_wide_hourly for 5 rows

trip_updates_feed_present:
manually cross-check with gtfs_rt_fact_files_wide_hourly for 5 rows

service_alerts_feed_present:
manually cross-check with gtfs_rt_fact_files_wide_hourly for 5 rows

## Screenshots (optional)
