### PR TITLE
Omit current date from fact_daily_guideline_checks

### DIFF
--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -24,7 +24,6 @@ checks_implemented AS (
 ),
 
 -- create an index: all feed/date/check combinations
--- we never want results from the current date, as data will be incomplete
 stg_gtfs_guidelines__feed_check_index AS (
     SELECT
         t2.calitp_itp_id,
@@ -38,7 +37,6 @@ stg_gtfs_guidelines__feed_check_index AS (
     LEFT JOIN gtfs_schedule_dim_feeds AS t2
         USING (feed_key)
     CROSS JOIN checks_implemented AS t3
-    WHERE t1.date < CURRENT_DATE
 )
 
 SELECT * FROM stg_gtfs_guidelines__feed_check_index

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -24,6 +24,7 @@ checks_implemented AS (
 ),
 
 -- create an index: all feed/date/check combinations
+-- we never want results from the current date, as data will be incomplete
 stg_gtfs_guidelines__feed_check_index AS (
     SELECT
         t2.calitp_itp_id,
@@ -37,6 +38,7 @@ stg_gtfs_guidelines__feed_check_index AS (
     LEFT JOIN gtfs_schedule_dim_feeds AS t2
         USING (feed_key)
     CROSS JOIN checks_implemented AS t3
+    WHERE t1.date < CURRENT_DATE
 )
 
 SELECT * FROM stg_gtfs_guidelines__feed_check_index


### PR DESCRIPTION
# Description

I observed that after 12am UTC (4pm pacific), guideline check dashboard in metabase shows skewed results, as it shows incomplete data from the current day.

This PR addresses this by preventing feed_guideline_index from ever including the current date.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

I ran this change on today's data, visible in `cal-itp-data-infra-staging.owades_mart_gtfs_guidelines.fact_daily_guideline_checks`. Verified that the most recent data is yesterday, while the main table contains data from today.

## Screenshots (optional)
