### PR TITLE
fix publish_open_data dag's start date so it will actually run

### DIFF
--- a/airflow/dags/publish_open_data/METADATA.yml
+++ b/airflow/dags/publish_open_data/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2022-09-12"
     email:
       - "andrew.v@jarv.us"
       - "eric.dasmalchi@dot.ca.gov"


### PR DESCRIPTION
# Description

We noticed that the `publish_open_data` DAG has not actually ever had a scheduled run since it got merged in August. It looks like the `start_date` setting was tripping it up. Hard-coding the start date should resolve. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? 
N/A, having a hard coded start date is standard
