### PR TITLE
Add check for pathway/location related validation notices

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -43,6 +43,10 @@
 "Service alerts RT feed is present"
 {% endmacro %}
 
+{% macro pathways_valid() %}
+"No pathways-related errors appear in the MobilityData GTFS Schedule Validator"
+{% endmacro %}
+
 -- declare features
 {% macro compliance() %}
 "Compliance"

--- a/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_guidelines/fact_daily_guideline_checks.sql
@@ -21,6 +21,10 @@ stg_gtfs_guidelines__shapes_valid AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__shapes_valid') }}
 ),
 
+stg_gtfs_guidelines__pathways_valid AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__pathways_valid') }}
+),
+
 stg_gtfs_guidelines__technical_contact_listed AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__technical_contact_listed') }}
 ),
@@ -65,6 +69,10 @@ fact_daily_guideline_checks AS (
     SELECT
         {{ gtfs_guidelines_columns() }}
     FROM stg_gtfs_guidelines__shapes_valid
+    UNION ALL
+    SELECT
+        {{ gtfs_guidelines_columns() }}
+    FROM stg_gtfs_guidelines__pathways_valid
     UNION ALL
     SELECT
         {{ gtfs_guidelines_columns() }}

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -20,6 +20,8 @@ checks_implemented AS (
     UNION ALL
     SELECT {{ shapes_valid() }}, {{ accurate_service_data() }}
     UNION ALL
+    SELECT {{ pathways_valid() }}, {{ accurate_accessibility_data() }}
+    UNION ALL
     SELECT {{ technical_contact_listed() }}, {{ technical_contact_availability() }}
     UNION ALL
     SELECT {{ no_rt_critical_validation_errors() }}, {{ compliance() }}

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -24,7 +24,6 @@ checks_implemented AS (
 ),
 
 -- create an index: all feed/date/check combinations
--- we never want results from the current date, as data will be incomplete
 stg_gtfs_guidelines__feed_check_index AS (
     SELECT
         t2.calitp_itp_id,
@@ -38,7 +37,6 @@ stg_gtfs_guidelines__feed_check_index AS (
     LEFT JOIN gtfs_schedule_dim_feeds AS t2
         USING (feed_key)
     CROSS JOIN checks_implemented AS t3
-    WHERE t1.date < CURRENT_DATE
 )
 
 SELECT * FROM stg_gtfs_guidelines__feed_check_index

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -24,6 +24,7 @@ checks_implemented AS (
 ),
 
 -- create an index: all feed/date/check combinations
+-- we never want results from the current date, as data will be incomplete
 stg_gtfs_guidelines__feed_check_index AS (
     SELECT
         t2.calitp_itp_id,
@@ -37,6 +38,7 @@ stg_gtfs_guidelines__feed_check_index AS (
     LEFT JOIN gtfs_schedule_dim_feeds AS t2
         USING (feed_key)
     CROSS JOIN checks_implemented AS t3
+    WHERE t1.date < CURRENT_DATE
 )
 
 SELECT * FROM stg_gtfs_guidelines__feed_check_index

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__pathways_valid.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__pathways_valid.sql
@@ -1,0 +1,50 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
+    WHERE check = {{ pathways_valid() }}
+),
+
+-- For this check we are only looking for errors and warnings related to pathways
+validation_fact_daily_feed_codes_pathway_related AS (
+    SELECT * FROM {{ ref('validation_fact_daily_feed_codes') }}
+     WHERE code IN (
+                    'pathway_to_platform_with_boarding_areas',
+                    'pathway_to_wrong_location_type',
+                    'pathway_unreachable_location',
+                    'pathway_dangling_generic_node',
+                    'pathway_loop',
+                    'missing_level_id',
+                    'platform_without_parent_station',
+                    'station_with_parent_station',
+                    'wrong_parent_location_type'
+            )
+),
+
+pathway_validation_notices_by_day AS (
+    SELECT
+        feed_key,
+        date,
+        SUM(n_notices) as validation_notices
+    FROM validation_fact_daily_feed_codes_pathway_related
+    GROUP BY feed_key, date
+),
+
+pathway_validation_check AS (
+    SELECT
+        t1.date,
+        t1.calitp_itp_id,
+        t1.calitp_url_number,
+        t1.calitp_agency_name,
+        t1.feed_key,
+        t1.check,
+        t1.feature,
+        CASE
+            WHEN t2.validation_notices = 0 THEN "PASS"
+            WHEN t2.validation_notices > 0 THEN "FAIL"
+        END AS status
+      FROM feed_guideline_index t1
+      LEFT JOIN pathway_validation_notices_by_day t2
+             ON t1.date = t2.date
+            AND t1.feed_key = t2.feed_key
+)
+
+SELECT * FROM pathway_validation_check


### PR DESCRIPTION
# Description

New GTFS check:
If any of the following pathway/location related validation notices are present in the GTFS schedule validator, then FAIL the check. If not, then PASS.

Notices:
- pathway_to_platform_with_boarding_areas
- pathway_to_wrong_location_type
- pathway_unreachable_location
- pathway_dangling_generic_node
- pathway_loop
- missing_level_id
- platform_without_parent_station
- station_with_parent_station
- wrong_parent_location_type

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I confirmed that 2 of these notices exist in the schedule validator table, and that the output of each subquery looks as expected. Aside from the list of eligible notices, this is exactly the same as the `shapes_valid` check.
