### PR TITLE
Json depend on unzip

### DIFF
--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/agency_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/agency_txt.yml
@@ -1,3 +1,4 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 input_table_name: agency.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/areas_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/areas_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: areas.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/attributions_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/attributions_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: attributions.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/calendar_dates_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/calendar_dates_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: calendar_dates.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/calendar_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/calendar_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: calendar.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_attributes_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_attributes_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: fare_attributes.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_leg_rules_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_leg_rules_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: fare_leg_rules.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_products_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_products_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: fare_products.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_rules_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_rules_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: fare_rules.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/feed_info_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/feed_info_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: feed_info.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/frequencies_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/frequencies_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: frequencies.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/levels_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/levels_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: levels.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/pathways_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/pathways_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: pathways.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/routes_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/routes_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: routes.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/shapes_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/shapes_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: shapes.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/stop_areas_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/stop_areas_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: stop_areas.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/stop_times_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/stop_times_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: stop_times.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/stops_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/stops_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: stops.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/transfers_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/transfers_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: transfers.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/translations_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/translations_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: translations.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/trips_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/trips_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperator
-
+dependencies:
+  - unzip_gtfs_schedule
 
 input_table_name: trips.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
@@ -39,11 +39,11 @@ def log(*args, err=False, fg=None, pbar=None, **kwargs):
 
 
 class GTFSScheduleFeedExtractUnzipOutcome(ProcessingOutcome):
-    zipfile_extract_path: str
+    extract: GTFSScheduleFeedExtract
     zipfile_extract_md5hash: Optional[str]
     zipfile_files: Optional[List[str]]
     zipfile_dirs: Optional[List[str]]
-    extracted_files: Optional[List[str]]
+    extracted_files: Optional[List[GTFSScheduleFeedFile]]
 
 
 class ScheduleUnzipResult(PartitionedGCSArtifact):
@@ -114,7 +114,6 @@ def process_feed_files(
         file_extract = GTFSScheduleFeedFile(
             ts=extract.ts,
             extract_config=extract.config,
-            zipfile_path=extract.path,
             original_filename=file,
             # only replace slashes so that this is a mostly GCS-filepath-safe string
             # if we encounter something else, we will address: https://cloud.google.com/storage/docs/naming-objects
@@ -153,19 +152,19 @@ def unzip_individual_feed(
         log(f"Can't process {extract.path}: {e}", pbar=pbar)
         return GTFSScheduleFeedExtractUnzipOutcome(
             success=False,
+            extract=extract,
             zipfile_extract_md5hash=zipfile_md5_hash,
-            zipfile_extract_path=extract.path,
             exception=e,
             zipfile_files=files,
             zipfile_dirs=directories,
         )
     return GTFSScheduleFeedExtractUnzipOutcome(
         success=True,
+        extract=extract,
         zipfile_extract_md5hash=zipfile_md5_hash,
-        zipfile_extract_path=extract.path,
         zipfile_files=files,
         zipfile_dirs=directories,
-        extracted_files=[file.path for file in zipfile_files],
+        extracted_files=zipfile_files,
     )
 
 

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -110,7 +110,6 @@ class GTFSScheduleFeedFile(PartitionedGCSArtifact):
     partition_names: ClassVar[List[str]] = GTFSScheduleFeedExtract.partition_names
     ts: pendulum.DateTime
     extract_config: GTFSDownloadConfig
-    zipfile_path: str
     original_filename: str
 
     # if you try to set table directly, you get an error because it "shadows a BaseModel attribute"


### PR DESCRIPTION
# Description

Cleanups post #1754 before turning schedule parse & unzip in prod.

* Add dependency between unzip & parse DAG tasks
* Stop saving filepaths, instead save whole extract objects
* Stop putting metadata header in JSONL files (undoes change from #1754 that we no longer want)
* Give each parsing task its own results file
* Handle case where no files are found to convert to JSON

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran locally in Airflow with @atvaccaro as my witness
