### PR TITLE
image pull policy is confusing!!!

### DIFF
--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.1'
+  newTag: '3.2.2'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.1'
+  newTag: '3.2.2'

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.2.1"
+version = "3.2.2"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
I'm not 100% sure what happened, I assume the cluster didn't re-pull the latest for prod? But I'm not sure what happens if the nodes were pulling the latest for the test deployment? I need to learn some more.