### PR TITLE
cleanly return if no rt files to process

### DIFF
--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -621,6 +621,13 @@ def main(
         progress=progress,
     )
 
+    if not files:
+        typer.secho(
+            f"WARNING: found no files to process for {feed_type} {pendulum_hour.isoformat()}, exiting",
+            fg=typer.colors.YELLOW,
+        )
+        return
+
     rt_aggs: Dict[Tuple[pendulum.DateTime, str], List[GTFSRTFeedExtract]] = defaultdict(
         list
     )


### PR DESCRIPTION
```
➜  gtfs-rt-parser-v2 git:(handle-no-rt-files) poetry run python gtfs_rt_parser.py validate service_alerts 2021-09-15T17:00:00 --progress --verbose
listing all files in gs://test-calitp-gtfs-rt-raw/service_alerts/dt=2021-09-15/hour=2021-09-15T17:00:00+00:00/
WARNING: found no files to process for service_alerts 2021-09-15T17:00:00+00:00, exiting
```