### PR TITLE
Add Foothill's RT URLs

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -490,9 +490,9 @@ foothill-transit:
   agency_name: Foothill Transit
   feeds:
     - gtfs_schedule_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Zip.ashx
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=VehiclePosition
+      gtfs_rt_service_alerts_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=Alert
+      gtfs_rt_trip_updates_url: https://foothilltransit.rideralerts.com/myStop/GTFS-Realtime.ashx?Type=TripUpdate
   itp_id: 112
 fresno-area-express:
   agency_name: Fresno Area Express


### PR DESCRIPTION
# Description

These URLs appear to work without a static IP address now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Sent requests in Postman and received a successful response for each.