### PR TITLE
add a retry and a specific log for RT archiver saving exceptions

### DIFF
--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.2'
+  newTag: '3.2.3'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.2'
+  newTag: '3.2.3'

--- a/services/gtfs-rt-archiver-v3/docker-compose.yml
+++ b/services/gtfs-rt-archiver-v3/docker-compose.yml
@@ -8,7 +8,7 @@ x-gtfs-rt-archiver-v3-common:
     CALITP_HUEY_REDIS_HOST: redis
     GOOGLE_APPLICATION_CREDENTIALS: /tmp/secret.json
     CALITP_BUCKET__AIRTABLE: "gs://test-calitp-airtable"
-    CALITP_BUCKET__GTFS_CONFIG: "gs://test-calitp-gtfs-download-config"
+    CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG: "gs://test-calitp-gtfs-download-config"
     CALITP_BUCKET__GTFS_RT_RAW: "gs://dev-calitp-gtfs-rt-raw"
 #    AC_TRANSIT_API_KEY: $AC_TRANSIT_API_KEY
 #    AMTRAK_GTFS_URL: $AMTRAK_GTFS_URL

--- a/services/gtfs-rt-archiver-v3/poetry.lock
+++ b/services/gtfs-rt-archiver-v3/poetry.lock
@@ -60,6 +60,14 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "backoff"
+version = "2.1.2"
+description = "Function decoration for backoff and retry"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "black"
 version = "22.6.0"
 description = "The uncompromising code formatter."
@@ -1165,7 +1173,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "c2d67d10b075aba6da02ea51fc8b9947d461061f08bae5cd81303e39d66baebf"
+content-hash = "5b83ec3fa28cebf4f97eea988e1f2979a89a8478a5c73f25c5f9a1e854d8b9d8"
 
 [metadata.files]
 aiohttp = []
@@ -1173,6 +1181,7 @@ aiosignal = []
 async-timeout = []
 atomicwrites = []
 attrs = []
+backoff = []
 black = []
 cachetools = []
 calitp = []

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.2.2"
+version = "3.2.3"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
@@ -22,6 +22,7 @@ google-cloud-secret-manager = "^2.11.1"
 structlog = "^22.1.0"
 python-json-logger = "^2.0.4"
 calitp = "2022.9.15"
+backoff = "^2.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
# Description

Now that we're processing new RT data in Airflow, we're seeing some missing metadata. My initial theory is that metadata is sometimes failing to be written, though I haven't been able to find errors in the logs. This PR both adds logging as well as a single retry on the save call.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
It's deployed to test.

## Screenshots (optional)
