### PR TITLE
Set missing dbt bucket env var

### DIFF
--- a/airflow/dags/transform_warehouse/dbt_test.yml
+++ b/airflow/dags/transform_warehouse/dbt_test.yml
@@ -21,6 +21,7 @@ cluster_name: data-infra-apps
 namespace: airflow-jobs
 
 env_vars:
+  CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -20,11 +20,13 @@ cluster_name: data-infra-apps
 namespace: airflow-jobs
 
 env_vars:
+  CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   NETLIFY_SITE_ID: cal-itp-dbt-docs
+
 secrets:
   - deploy_type: volume
     deploy_target: /secrets/jobs-data/

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -20,10 +20,12 @@ cluster_name: data-infra-apps
 namespace: airflow-jobs
 
 env_vars:
+  CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
+
 secrets:
   - deploy_type: volume
     deploy_target: /secrets/jobs-data/


### PR DESCRIPTION
# Description

`transform_warehouse.dbt_test` has been failing for a while in prod because of a missing environment variable (and I missed it because it had been failing for a while before that due to actual test failures, so I was not checking the failure details as regularly as I should have been.)

Also setting it in the full-refresh DAG task since it was missing there

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Confirmed I can now run `test_dbt` in local Airflow:

```
[2022-09-19 14:32:06,836] {pod_launcher.py:198} INFO - Event: dbt-test.5acd7d9d7de24adf837b182829c0dc84 had an event of type Running
[2022-09-19 14:32:10,046] {pod_launcher.py:149} INFO - 14:32:10  Running with dbt=1.1.1
[2022-09-19 14:32:10,047] {pod_launcher.py:149} INFO - 14:32:10  Partial parse save file not found. Starting full parse.
[2022-09-19 14:32:12,608] {pod_launcher.py:149} INFO - 14:32:12  [[33mWARNING[0m]: Did not find matching node for patch with name 'stg_audit__cloudaudit_googleapis_com_activity' in the 'models' section of file 'models/staging/audit/_stg_audit.yml'
[2022-09-19 14:32:14,899] {pod_launcher.py:149} INFO - 14:32:15  Found 153 models, 537 tests, 0 snapshots, 0 analyses, 404 macros, 0 operations, 0 seed files, 87 sources, 5 exposures, 0 metrics
[2022-09-19 14:32:14,925] {pod_launcher.py:149} INFO - 14:32:15
[2022-09-19 14:32:15,580] {pod_launcher.py:149} INFO - 14:32:15  Concurrency: 4 threads (target='staging_service_account')
```

## Screenshots (optional)
Here's the logs from prod Airflow showing the error we are fixing here:

```
[2022-09-14 12:27:49,289] {pod_launcher.py:133} WARNING - Pod not yet started: dbt-test.e320adddd9ba478aa88bf00d269a608c
[2022-09-14 12:27:50,324] {pod_launcher.py:216} INFO - Event: dbt-test.e320adddd9ba478aa88bf00d269a608c had an event of type Failed
[2022-09-14 12:27:50,324] {pod_launcher.py:328} ERROR - Event with job id dbt-test.e320adddd9ba478aa88bf00d269a608c Failed
[2022-09-14 12:27:50,386] {pod_launcher.py:159} INFO - Traceback (most recent call last):
[2022-09-14 12:27:50,386] {pod_launcher.py:159} INFO -   File "/app/scripts/run_and_upload.py", line 12, in <module>
[2022-09-14 12:27:50,387] {pod_launcher.py:159} INFO -     CALITP_BUCKET__DBT_ARTIFACTS = os.environ["CALITP_BUCKET__DBT_ARTIFACTS"]
[2022-09-14 12:27:50,387] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.9/os.py", line 679, in __getitem__
[2022-09-14 12:27:50,388] {pod_launcher.py:159} INFO -     raise KeyError(key) from None
[2022-09-14 12:27:50,388] {pod_launcher.py:159} INFO - KeyError: 'CALITP_BUCKET__DBT_ARTIFACTS'
```
