### PR TITLE
fix two-row feed info issue

### DIFF
--- a/warehouse/models/gtfs_views/gtfs_schedule_dim_feeds.sql
+++ b/warehouse/models/gtfs_views/gtfs_schedule_dim_feeds.sql
@@ -19,7 +19,7 @@ feed_info_clean AS (
                 feed_version,
                 calitp_extracted_at
             ORDER BY feed_end_date DESC
-        ) AS row_num
+        ) AS rank
     FROM {{ ref('feed_info_clean') }}
 ),
 
@@ -44,7 +44,7 @@ feed_feed_info AS (
             AND T1.calitp_extracted_at < T2.calitp_deleted_at
             AND T2.calitp_extracted_at < T1.calitp_deleted_at
             AND T2.calitp_itp_id != 200
-            AND T2.row_num = 1
+            AND T2.rank = 1
 ),
 
 gtfs_schedule_dim_feeds AS (


### PR DESCRIPTION
# Description

This is a slightly hacky fix for #1471. This has been an issue for a while but now that we have RT data for Foothill Transit (#1794) it is causing the `gtfs_rt_fact_daily_validations_errors` incremental table to fail to build. This is a more significant effect than anything else so far so I think it's worth fixing this ASAP to get that table working. 

Resolves #1471

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

I ran the updated version in my local dbt to create `cal-itp-data-infra-staging.laurie_views.gtfs_schedule_dim_feeds` and then compared that with the prod table:

```
SELECT  
  t1.feed_key,
  t1.calitp_itp_id,
  t1.calitp_url_number,
  t1.calitp_extracted_at,
  t2.feed_key,
  t2.calitp_itp_id,
  t2.calitp_url_number,
  t2.calitp_extracted_at
FROM `cal-itp-data-infra.views.gtfs_schedule_dim_feeds` AS t1
FULL OUTER JOIN `cal-itp-data-infra-staging.laurie_views.gtfs_schedule_dim_feeds` AS t2
  USING(feed_key)
WHERE t1.feed_key IS NULL or t2.feed_key IS NULL
ORDER BY t1.calitp_extracted_at DESC
```

Confirmed that the only rows affected by this change are the 4 faulty Foothill Transit feeds:
![image](https://user-images.githubusercontent.com/55149902/191076823-6bd8f90c-8319-45c5-b016-a2b660cdc722.png)
