### PR TITLE
send sigint to huey for graceful exists and give 5 seconds grace period

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
@@ -41,6 +41,11 @@ spec:
               cpu: 1
             limits:
               memory: 1Gi
+          lifecycle:
+            preStop:
+              exec:
+                command: ["kill", "-2", "1"]
+      terminationGracePeriodSeconds: 5
       volumes:
         - name: gtfs-feed-secrets
           secret:


### PR DESCRIPTION
in addition to those retries, I realized deploys were causing issues because huey forcefully stops workers on a SIGTERM; this can mean a worker is stopped in between writing a file and updating the metadata

this is applied to test and I will apply to prod on merge

```
INFO:huey:gtfs_rt_archiver_v3.tasks.fetch: 4bd3550a-0aea-4d66-98c1-26277d0f5f6d exp=5 (2022-09-19 17:44:25.085849) executed in 3.607s
[2022-09-19 17:44:25,627] INFO:huey.consumer:MainThread:Received SIGINT
INFO:huey.consumer:Received SIGINT
[2022-09-19 17:44:25,627] INFO:huey.consumer:MainThread:Shutting down gracefully...
INFO:huey.consumer:Shutting down gracefully...
[2022-09-19 17:44:25,639] INFO:huey.consumer:MainThread:Received SIGTERM
INFO:huey.consumer:Received SIGTERM
saving 245.3 kB from https://ladotbus.com/gtfs-rt/tripupdates to gs://test-calitp-gtfs-rt-raw-v2/trip_updates/dt=2022-09-19/hour=2022-09-19T17:00:00+00:00/ts=2022-09-19T17:44:20+00:00/base64_url=aHR0cHM6Ly9sYWRvdGJ1cy5jb20vZ3Rmcy1ydC90cmlwdXBkYXRlcw==/feed
[2022-09-19 17:44:25,956] INFO:huey:Worker-7:gtfs_rt_archiver_v3.tasks.fetch: f9cfc549-d0ba-49a9-9a98-164b871e58af exp=5 (2022-09-19 17:44:25.094158) executed in 3.749s
INFO:huey:gtfs_rt_archiver_v3.tasks.fetch: f9cfc549-d0ba-49a9-9a98-164b871e58af exp=5 (2022-09-19 17:44:25.094158) executed in 3.749s
```