### PR TITLE
fix: make full refresh of gtfs rt fact daily validations table work

### DIFF
--- a/warehouse/models/rt_views/gtfs_rt_fact_daily_validation_errors.sql
+++ b/warehouse/models/rt_views/gtfs_rt_fact_daily_validation_errors.sql
@@ -9,6 +9,8 @@ WITH errors AS (
     SELECT * FROM {{ ref('stg_rt__validation_errors') }}
     {% if is_incremental() or target.name == 'dev' %}
     WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+    {% else %}
+    WHERE date >= '2021-01-01'
     {% endif %}
 ),
 


### PR DESCRIPTION
# Description

The `transform_warehouse_full_refresh.dbt_run_and_upload_artifacts` DAG task is failing because you can't run a query over the RT validations data without any date partition: 

`Database Error in model gtfs_rt_fact_daily_validation_errors (models/rt_views/gtfs_rt_fact_daily_validation_errors.sql)
Cannot query over table 'cal-itp-data-infra.external_gtfs_rt.service_alerts_validations' without a filter over column(s) 'dt', 'hour', 'itp_id', 'url_number' that can be used for partition elimination`

This PR fixes this by hard-coding a start date of `2021-01-01`. In general we **do** want people to specify actual date partitions that will filter out data but for `--full-refresh` to actually re-process all the data, we need to set a fake partition date that won't actually exclude anything. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Ran it locally, using `2022-09-01` as the placeholder start date instead just to not churn through all the data. I also temporarily suppressed the `or target.name=dev` check for this just to make sure I could run it as a full refresh locally.
![image](https://user-images.githubusercontent.com/55149902/191114119-0b26d598-8fff-4336-b185-76bf1bd38752.png)

