### PR TITLE
save extract not extract path on rt processing outcomes

### DIFF
--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -197,7 +197,7 @@ class RTHourlyAggregation(PartitionedGCSArtifact):
 
 
 class RTFileProcessingOutcome(ProcessingOutcome):
-    extract_path: str
+    extract: GTFSRTFeedExtract
     aggregation: Optional[RTHourlyAggregation]
 
 
@@ -372,7 +372,7 @@ def validate_and_upload(
                     step=hour.step,
                     success=False,
                     exception=e,
-                    extract_path=extract.path,
+                    extract=extract,
                 )
             )
             continue
@@ -396,7 +396,7 @@ def validate_and_upload(
             RTFileProcessingOutcome(
                 step=hour.step,
                 success=True,
-                extract_path=extract.path,
+                extract=extract,
             )
         )
 
@@ -448,7 +448,7 @@ def parse_and_upload(
                         step="parse",
                         success=False,
                         exception=e,
-                        extract_path=extract.path,
+                        extract=extract,
                     )
                 )
                 continue
@@ -466,7 +466,7 @@ def parse_and_upload(
                         step="parse",
                         success=False,
                         exception=ValueError(msg),
-                        extract_path=extract.path,
+                        extract=extract,
                     )
                 )
                 continue
@@ -494,7 +494,7 @@ def parse_and_upload(
                 RTFileProcessingOutcome(
                     step="parse",
                     success=True,
-                    extract_path=extract.path,
+                    extract=extract,
                 )
             )
             del parsed
@@ -541,7 +541,7 @@ def parse_and_validate(
                 RTFileProcessingOutcome(
                     step=hour.step,
                     success=False,
-                    extract_path=extract.path,
+                    extract=extract,
                     exception=NoScheduleDataSpecified(),
                 )
                 for extract in hour.extracts
@@ -575,7 +575,7 @@ def parse_and_validate(
                 RTFileProcessingOutcome(
                     step=hour.step,
                     success=False,
-                    extract_path=extract.path,
+                    extract=extract,
                     exception=e,
                 )
                 for extract in hour.extracts

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -200,6 +200,13 @@ class RTFileProcessingOutcome(ProcessingOutcome):
     extract: GTFSRTFeedExtract
     aggregation: Optional[RTHourlyAggregation]
 
+    @validator("aggregation", allow_reuse=True, always=True)
+    def aggregation_exists_if_success(cls, v, values):
+        assert (v is not None) == values[
+            "success"
+        ], "aggregation can exist if and only if the outcome is successful"
+        return v
+
 
 class GTFSRTJobResult(PartitionedGCSArtifact):
     step: RTProcessingStep
@@ -397,6 +404,7 @@ def validate_and_upload(
                 step=hour.step,
                 success=True,
                 extract=extract,
+                aggregation=hour,
             )
         )
 
@@ -495,6 +503,7 @@ def parse_and_upload(
                     step="parse",
                     success=True,
                     extract=extract,
+                    aggregation=hour,
                 )
             )
             del parsed


### PR DESCRIPTION
# Description

Quick fix, mistake found during external table creation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally.

## Screenshots (optional)
```
[2022-09-20 16:24:19,188] {pod_launcher.py:149} INFO - writing 1021739 lines to gs://test-calitp-gtfs-rt-parsed/trip_updates/dt=2022-09-15/hour=2022-09-15T18:00:00+00:00/base64_url=aHR0cHM6Ly9hcGkuZ29zd2lmdC5seS9yZWFsLXRpbWUvbGFtZXRyby9ndGZzLXJ0LXRyaXAtdXBkYXRlcw==/trip_updates.jsonl.gz
[2022-09-20 16:24:21,515] {pod_launcher.py:149} INFO - saving 14675 outcomes to gs://test-calitp-gtfs-rt-parsed/trip_updates_outcomes/dt=2022-09-15/hour=2022-09-15T18:00:00+00:00/trip_updates.jsonl
[2022-09-20 16:24:24,146] {pod_launcher.py:149} INFO - fin.
[2022-09-20 16:24:26,387] {pod_launcher.py:198} INFO - Event: parse-rt-trip-updates.6b2039a27a28420094b6b07e7c3132cf had an event of type Succeeded
[2022-09-20 16:24:26,387] {pod_launcher.py:311} INFO - Event with job id parse-rt-trip-updates.6b2039a27a28420094b6b07e7c3132cf Succeeded
[2022-09-20 16:24:26,482] {pod_launcher.py:198} INFO - Event: parse-rt-trip-updates.6b2039a27a28420094b6b07e7c3132cf had an event of type Succeeded
[2022-09-20 16:24:26,482] {pod_launcher.py:311} INFO - Event with job id parse-rt-trip-updates.6b2039a27a28420094b6b07e7c3132cf Succeeded
[2022-09-20 16:24:26,639] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=parse_and_validate_rt_v2, task_id=parse_rt_trip_updates, execution_date=20220915T181500, start_date=20220915T193506, end_date=20220920T162426
```