### PR TITLE
add an external table creation pool

### DIFF
--- a/airflow/dags/create_external_tables/METADATA.yml
+++ b/airflow/dags/create_external_tables/METADATA.yml
@@ -16,5 +16,6 @@ default_args:
     retries: 0
     retry_delay: !timedelta 'minutes: 2'
     concurrency: 50
+    pool: external_table_pool
     #sla: !timedelta 'hours: 2'
 latest_only: True


### PR DESCRIPTION
I think firing off the 40+ tasks at once overloads our celery workers. I've created `external_table_pool` so we can limit but adjust vs a hard-coded concurrency limit.

![image](https://user-images.githubusercontent.com/4305366/191383848-4cb41627-b929-4621-b296-95558ed1bee6.png)
