### PR TITLE
use newest calitp to let it handle metadata retries, and deploy to test

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.9.15
+calitp==2022.9.21
 fsspec==2022.5.0
 gcsfs==2022.5.0
 intake==0.6.1
@@ -11,7 +11,6 @@ geopandas==0.9.0
 pyairtable==1.0.0
 structlog==21.5.0
 typer==0.4.0
-backoff==1.11.1
 tabulate==0.8.9
 typing-extensions==3.10.0.2
 jinja2<3.1.0

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.3'
+  newTag: '3.2.4'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.4'
+  newTag: '3.2.5'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.3'
+  newTag: '3.2.4'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.2.4'
+  newTag: '3.2.5'

--- a/services/gtfs-rt-archiver-v3/poetry.lock
+++ b/services/gtfs-rt-archiver-v3/poetry.lock
@@ -99,13 +99,14 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "calitp"
-version = "2022.9.15"
+version = "2022.9.20a0"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
 python-versions = ">=3.8,<3.11"
 
 [package.dependencies]
+backoff = ">=2.1.2,<3.0.0"
 fsspec = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
 gcsfs = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
 google-api-core = ">=1.32.0,<2.0.0dev"
@@ -1173,7 +1174,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "5b83ec3fa28cebf4f97eea988e1f2979a89a8478a5c73f25c5f9a1e854d8b9d8"
+content-hash = "b5fafb139fd7a9b940cc0738710dd36a42a187c897fe6b17da629cd737dab31a"
 
 [metadata.files]
 aiohttp = []

--- a/services/gtfs-rt-archiver-v3/poetry.lock
+++ b/services/gtfs-rt-archiver-v3/poetry.lock
@@ -99,7 +99,7 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "calitp"
-version = "2022.9.20a0"
+version = "2022.9.21"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
@@ -1174,7 +1174,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "b5fafb139fd7a9b940cc0738710dd36a42a187c897fe6b17da629cd737dab31a"
+content-hash = "b1142c627ee127863901e91a0260d80f7555762de8012a353b2037123b5d5d7c"
 
 [metadata.files]
 aiohttp = []

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.2.4"
+version = "3.2.5"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.2.3"
+version = "3.2.4"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
@@ -21,7 +21,7 @@ cachetools = ">=2.0.0,<5.0"
 google-cloud-secret-manager = "^2.11.1"
 structlog = "^22.1.0"
 python-json-logger = "^2.0.4"
-calitp = "2022.9.15"
+calitp = "2022.9.20a0"
 backoff = "^2.1.2"
 
 [tool.poetry.dev-dependencies]

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -21,7 +21,7 @@ cachetools = ">=2.0.0,<5.0"
 google-cloud-secret-manager = "^2.11.1"
 structlog = "^22.1.0"
 python-json-logger = "^2.0.4"
-calitp = "2022.9.20a0"
+calitp = "2022.9.21"
 backoff = "^2.1.2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/1817

Retries were also attempting a write, which fails because of the retention policy. I made a change in calitp to just retry on the metadata and provide a flag (does not retry by default).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
This is deployed to test RT and I have tested with schedule. Will deploy to prod on merge.

## Screenshots (optional)
```
[2022-09-21 15:54:15,892] {storage.py:259} INFO - saving 276.2 kB to gs://test-calitp-gtfs-schedule-raw-v2/download_schedule_feed_results/dt=2022-09-21/ts=2022-09-21T15:45:30.045952+00:00/results.jsonl
successfully fetched 210 of 211
Failures:
 404 Client Error: Not Found for url: http://data.trilliumtransit.com/gtfs/taft-co-us/taft-ca-us.zip
Skipping since in development mode! Would have emailed 1 failures.
[2022-09-21 15:54:17,414] {python.py:151} INFO - Done. Returned value was: None
[2022-09-21 15:54:17,421] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=download_gtfs_schedule_v2, task_id=download_schedule_feeds, execution_date=20220401T000000, start_date=20220901T193927, end_date=20220921T155417
```