### PR TITLE
Remove column calitp_url_number from fact_daily_transitland_url_check

### DIFF
--- a/warehouse/models/mart/gtfs_guidelines/fact_daily_transitland_url_check.sql
+++ b/warehouse/models/mart/gtfs_guidelines/fact_daily_transitland_url_check.sql
@@ -5,7 +5,8 @@ WITH gtfs_fact_daily_transitland_url_check AS (
 
         calitp_itp_id,
 
-        calitp_url_number,
+        -- re-add calitp_url_number after the aggregator checker is migrated to use airtable and the url number value is correct
+        --calitp_url_number,
 
         url_type,
 

--- a/warehouse/models/mart/gtfs_guidelines/fact_daily_transitland_url_check.sql
+++ b/warehouse/models/mart/gtfs_guidelines/fact_daily_transitland_url_check.sql
@@ -5,7 +5,7 @@ WITH gtfs_fact_daily_transitland_url_check AS (
 
         calitp_itp_id,
 
-        -- re-add calitp_url_number after the aggregator checker is migrated to use airtable and the url number value is correct
+        -- suppressing because value is incorrect https://github.com/cal-itp/data-infra/issues/1825
         --calitp_url_number,
 
         url_type,


### PR DESCRIPTION
# Description

As noted by @owades [in this PR thread](https://github.com/cal-itp/data-infra/pull/1737#issuecomment-1253021585), the `calitp_url_number` is providing incorrect values. This PR represses the column until a fix is completed.

 A fix will come during the process of migrating the feed aggregator checker to use Airtable, as represented by this issue #1825 that @lauriemerrell created.

Once #1825 is complete we can reverse this PR.

## Type of change

- [x] (Half) Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tested locally in dbt dev environment

## Screenshots (optional)
