### PR TITLE
Revised tests on transitland url check tables

### DIFF
--- a/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
+++ b/warehouse/models/mart/gtfs_guidelines/_gtfs_guidelines.yml
@@ -48,9 +48,8 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - dt
-            - url_type
             - calitp_itp_id
-            - calitp_url_number
+            - url
     columns:
       - name: dt
       - name: url

--- a/warehouse/models/staging/gtfs_guidelines/_stg_gtfs_guidelines.yml
+++ b/warehouse/models/staging/gtfs_guidelines/_stg_gtfs_guidelines.yml
@@ -7,9 +7,8 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - dt
-            - url_type
             - calitp_itp_id
-            - calitp_url_number
+            - url
     columns:
       - name: dt
       - name: url


### PR DESCRIPTION
# Description
In #1827 we suppressed the `calitp_url_number` column due to bugs found (fix represented in #1825, bug identified in #1737), however we didn't revise the tests in `fact_daily_transitland_url_check` and `stg_gtfs_guidelines__fact_daily_transitland_url_check`.

This PR removes the `calitp_url_number` and `url_type` columns from the `Unique Combination of Columns` tests on both tables, and adds the `url` column.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
`dbt test` has been run locally in the dbt test environment

## Screenshots (optional)
<img width="1099" alt="Screen Shot 2022-09-21 at 4 15 01 PM" src="https://user-images.githubusercontent.com/25835059/191603137-412c1394-3d06-4aa6-a2ee-0a65704dacfc.png">

