### PR TITLE
Rt sched may 4 sample

### DIFF
--- a/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_may4_sample.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_may4_sample.sql
@@ -1,5 +1,5 @@
 WITH
--- selecting the distinct trips from GTFS Vehicle Postions for two operators (SamTrans 290 and Big Blue Bus 300) and two months
+-- selecting the distinct trips from GTFS Vehicle Postions for all operators
 vp_trips AS (
     SELECT DISTINCT
         calitp_itp_id,
@@ -11,10 +11,9 @@ vp_trips AS (
     -- https://gtfs.org/realtime/reference/#message-vehicleposition
     FROM {{ ref('stg_rt__vehicle_positions') }}
     WHERE date = '2022-05-04'
-        AND (calitp_itp_id = 182)
 ),
 
---- selecting GTFS schedule data for the same two operators and two months
+--- selecting GTFS schedule data for all operators
 sched_trips AS (
     SELECT
         trip_id,
@@ -24,7 +23,7 @@ sched_trips AS (
         calitp_url_number
     FROM {{ ref('gtfs_schedule_fact_daily_trips') }}
     WHERE service_date = '2022-05-04'
-        AND (calitp_itp_id = 182 AND is_in_service = True)
+        AND (is_in_service = True)
 ),
 
 -- joining Vehicle Position data and Scheduled data on service date, trip id and itp id and url number
@@ -48,7 +47,7 @@ rt_sched_joined AS (
 ),
 
 -- getting the percent of scheduled trips with vehicle position data and adding the common route name
-gtfs_rt_vs_schedule_trips_metro_sample AS (
+gtfs_rt_vs_schedule_trips_may4_sample AS (
     SELECT
         T1.calitp_itp_id,
         T2.agency_name,
@@ -71,4 +70,4 @@ gtfs_rt_vs_schedule_trips_metro_sample AS (
 )
 
 SELECT *
-FROM gtfs_rt_vs_schedule_trips_metro_sample
+FROM gtfs_rt_vs_schedule_trips_may4_sample

--- a/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_metro_sample.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_metro_sample.sql
@@ -1,0 +1,74 @@
+WITH
+-- selecting the distinct trips from GTFS Vehicle Postions for two operators (SamTrans 290 and Big Blue Bus 300) and two months
+vp_trips AS (
+    SELECT DISTINCT
+        calitp_itp_id,
+        calitp_url_number,
+        date AS service_date,
+        trip_id AS vp_trip_id
+    -- trip_route_id
+    -- note: to change when we want to include more operators. trip_route_id and trip_id aare optional
+    -- https://gtfs.org/realtime/reference/#message-vehicleposition
+    FROM {{ ref('stg_rt__vehicle_positions') }}
+    WHERE date = '2022-05-04'
+        AND (calitp_itp_id = 182)
+),
+
+--- selecting GTFS schedule data for the same two operators and two months
+sched_trips AS (
+    SELECT
+        trip_id,
+        route_id,
+        service_date,
+        calitp_itp_id,
+        calitp_url_number
+    FROM {{ ref('gtfs_schedule_fact_daily_trips') }}
+    WHERE service_date = '2022-05-04'
+        AND (calitp_itp_id = 182 AND is_in_service = True)
+),
+
+-- joining Vehicle Position data and Scheduled data on service date, trip id and itp id and url number
+rt_sched_joined AS (
+    SELECT
+        T1.calitp_itp_id,
+        T1.calitp_url_number,
+        T1.route_id,
+        T1.service_date,
+        COUNT(T1.trip_id) AS num_sched,
+        COUNT(T2.vp_trip_id) AS num_vp
+    -- num_vp/num_sched AS pct_w_vp
+    FROM sched_trips AS T1
+    LEFT JOIN vp_trips AS T2
+        ON
+            T1.trip_id = T2.vp_trip_id
+            AND T1.calitp_itp_id = T2.calitp_itp_id
+            AND T1.calitp_url_number = T2.calitp_url_number
+            AND T1.service_date = T2.service_date
+    GROUP BY 1, 2, 3, 4
+),
+
+-- getting the percent of scheduled trips with vehicle position data and adding the common route name
+gtfs_rt_vs_schedule_trips_metro_sample AS (
+    SELECT
+        T1.calitp_itp_id,
+        T2.agency_name,
+        T1.calitp_url_number,
+        T1.route_id,
+        T2.route_short_name,
+        T1.service_date,
+        T2.calitp_extracted_at,
+        T2.calitp_deleted_at,
+        T1.num_sched,
+        T1.num_vp,
+        num_vp / num_sched AS pct_w_vp
+    FROM rt_sched_joined AS T1
+    LEFT JOIN {{ ref('gtfs_schedule_dim_routes') }} AS T2
+        ON
+            T1.route_id = T2.route_id
+            AND T1.calitp_itp_id = T2.calitp_itp_id
+            AND T1.calitp_url_number = T2.calitp_url_number
+            AND T1.service_date BETWEEN T2.calitp_extracted_at AND T2.calitp_deleted_at
+)
+
+SELECT *
+FROM gtfs_rt_vs_schedule_trips_metro_sample

--- a/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
@@ -4,13 +4,13 @@ vp_trips AS (
     SELECT DISTINCT
         calitp_itp_id,
         calitp_url_number,
-        date AS service_date,
+        date,
         trip_id AS vp_trip_id
     -- trip_route_id
     -- note: to change when we want to include more operators. trip_route_id and trip_id are optional
     -- https://gtfs.org/realtime/reference/#message-vehicleposition
     FROM {{ ref('stg_rt__vehicle_positions') }}
-    WHERE service_date BETWEEN '2022-05-01' AND '2022-06-30'
+    WHERE date BETWEEN '2022-05-01' AND '2022-06-30'
         AND (calitp_itp_id IN (300, 290)
         )
 ),
@@ -44,7 +44,7 @@ rt_sched_joined AS (
             T1.trip_id = T2.vp_trip_id
             AND T1.calitp_itp_id = T2.calitp_itp_id
             AND T1.calitp_url_number = T2.calitp_url_number
-            AND T1.service_date = T2.service_date
+            AND T1.service_date = T2.date
     GROUP BY 1, 2, 3, 4
 ),
 

--- a/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
+++ b/warehouse/models/rt_views/gtfs_rt_vs_schedule_trips_sample.sql
@@ -4,7 +4,7 @@ vp_trips AS (
     SELECT DISTINCT
         calitp_itp_id,
         calitp_url_number,
-        date,
+        date AS service_date,
         trip_id AS vp_trip_id
     -- trip_route_id
     -- note: to change when we want to include more operators. trip_route_id and trip_id are optional
@@ -44,7 +44,7 @@ rt_sched_joined AS (
             T1.trip_id = T2.vp_trip_id
             AND T1.calitp_itp_id = T2.calitp_itp_id
             AND T1.calitp_url_number = T2.calitp_url_number
-            AND T1.service_date = T2.date
+            AND T1.service_date = T2.service_date
     GROUP BY 1, 2, 3, 4
 ),
 


### PR DESCRIPTION
# Description

Create a new table mirroring `gtfs_rt_vs_schedule_trips_sample.sql` but for all operators on a single date. 
Resolves # [1834](https://github.com/cal-itp/data-infra/issues/1834)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
<img width="961" alt="Screen Shot 2022-09-21 at 5 52 49 PM" src="https://user-images.githubusercontent.com/72096633/191635016-adb9cfd6-1f90-4926-8f5c-f8e10f3ea060.png">

## Screenshots (optional)
