### PR TITLE
temporarily add services.gtfs schedule quality column

### DIFF
--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -90,6 +90,33 @@ models:
         description: |
           Boolean for whether service is currently active
       - name: gtfs_schedule_status
+        description: |
+          Options are: `needed`, `research`,  `ok`, `need long-term solution`,
+          or `not public`.
+          This field may also be empty (null).
+          **Note: This field is manually entered in the Transit Database,
+          so it may be subject to some gaps in coverage and it is not updated automatically.
+          Data in this field may not align with data from the GTFS pipeline,
+          for example in `views.gtfs_schedule_dim_feeds`.**
+      - name: gtfs_schedule_quality
+        description: |
+          Status of overall GTFS quality for a given transit service. Options are:
+          `0 - Does not have GTFS Schedule`;
+          `1 - Has URL for GTFS downloading`;
+          `2 - GTFS data has active service`;
+          `3 - GTFS data has zero validation errors`;
+          `4 - GTFS data has zero validation warnings`;
+          `5 - GTFS data satisfies first tier of GTFS Guidelines`;
+          `6 - GTFS data satisfies all GTFS Guidelines`.
+          This field can also be empty (null). Sometimes this field is null (missing) even
+          for services that **do** have GTFS schedule data.
+          **Note: This field is manually entered in the Transit Database,
+          so it may be subject to some gaps in coverage and it is not updated automatically.
+          Data in this field may not align with validations data from the
+          GTFS pipeline, for example in `views.validation_fact_daily_feed_notices`,
+          or GTFS guidelines checks implemented in `mart_gtfs_guidelines.fact_daily_guideline_checks`.
+          Use those tables directly for the most up-to-date information on individual GTFS feeds'
+          validation and guideline statuses.**
   - name: dim_products
     description: '{{ doc("products_table") }}'
     columns:

--- a/warehouse/models/mart/transit_database/dim_services.sql
+++ b/warehouse/models/mart/transit_database/dim_services.sql
@@ -15,7 +15,10 @@ dim_services AS (
         mode,
         currently_operating,
         operating_counties,
+        -- TODO: remove this field when v2, automatic determinations are available
         gtfs_schedule_status,
+        -- TODO: remove this field when v2, automatic determinations are available
+        gtfs_schedule_quality,
         calitp_extracted_at
     FROM latest_services
 )

--- a/warehouse/models/staging/transit_database/stg_transit_database__services.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__services.sql
@@ -20,7 +20,10 @@ stg_transit_database__services AS (
         provider,
         operator,
         funding_sources,
+        -- TODO: remove this field when v2, automatic determinations are available
         gtfs_schedule_status,
+        -- TODO: remove this field when v2, automatic determinations are available
+        gtfs_schedule_quality,
         operating_counties,
         dt AS calitp_extracted_at
     FROM once_daily_services


### PR DESCRIPTION
# Description

Resolves #1782 by making the `services.gtfs schedule quality` field available in the warehouse in the `mart_transit_database.dim_services` table. Per Slack ([thread](https://cal-itp.slack.com/archives/C040XD9UB33/p1663115063896459)), this is intended to be a temporary solution until more automated data is easily available. See [this comment](https://github.com/cal-itp/data-infra/issues/1782#issuecomment-1256345628) for limitations of this data. 

Resolves #1782

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Ran in staging dbt, confirmed that column is available. See `cal-itp-data-infra-staging.laurie_mart_transit_database.dim_services` table.
