### PR TITLE
add VCTC GMV GTFS Schedule feed

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1467,10 +1467,14 @@ vacaville-city-coach:
 ventura-county-transportation-commission:
   agency_name: Ventura County Transportation Commission
   feeds:
-    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/vctc-ca-us/vctc-ca-us.zip
+    - gtfs_schedule_url: https://govcbus.com/gtfs
       gtfs_rt_vehicle_positions_url: https://govcbus.com/gtfs-rt/vehiclepositions
       gtfs_rt_service_alerts_url: https://govcbus.com/gtfs-rt/alerts
       gtfs_rt_trip_updates_url: https://govcbus.com/gtfs-rt/tripupdates
+    - gtfs_schedule_url: http://data.trilliumtransit.com/gtfs/vctc-ca-us/vctc-ca-us.zip
+      gtfs_rt_vehicle_positions_url: null
+      gtfs_rt_service_alerts_url: null
+      gtfs_rt_trip_updates_url: null
   itp_id: 380
 victor-valley-transit:
   agency_name: Victor Valley Transit


### PR DESCRIPTION
# Description

Quick agencies.yml change to add VCTC's GMV GTFS Schedule feed, needed for rt analysis to support Caltrans D5 ask. Feed already tracked in Airtable, see issue for additional context+checklist.

Resolves #1855 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
