### PR TITLE
Add password support for SFTP server

### DIFF
--- a/kubernetes/apps/manifests/sftp-server/sshd_config
+++ b/kubernetes/apps/manifests/sftp-server/sshd_config
@@ -1,6 +1,7 @@
 Port 22
-Include /etc/ssh/sshd_config.d/*.conf
+ChallengeResponseAuthentication yes
 AuthorizedKeysFile      .ssh/authorized_keys
 Subsystem       sftp    internal-sftp
 ForceCommand internal-sftp
 ChrootDirectory /sftp
+Include /etc/ssh/sshd_config.d/*.conf

--- a/kubernetes/apps/manifests/sftp-server/workload.yaml
+++ b/kubernetes/apps/manifests/sftp-server/workload.yaml
@@ -26,6 +26,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: sftp-user
+            - secretRef:
+                name: sftp-password
           ports:
             - containerPort: 22
               name: sftp
@@ -36,6 +38,8 @@ spec:
               mountPath: /config/user
             - name: server-config
               mountPath: /config/server
+            - name: server-hostkeys
+              mountPath: /config/hostkeys
           command: [ /bin/bash ]
           args:
             - -c
@@ -52,8 +56,14 @@ spec:
               else
                 echo "warn: no $SFTP_AUTHORIZED_KEYS_SRC file; user $SFTP_USER may not be able to login"
               fi
+              if [[ $SFTP_USER_PASSWORD ]]; then
+                echo "$SFTP_USER:$SFTP_USER_PASSWORD" | chpasswd
+              fi
               chown -R $SFTP_USER:$SFTP_USER "$SFTP_USER_SSH_HOME"
               cp "$SFTP_SSHD_CONFIG_SRC" /etc/ssh/sshd_config
+              for arc in /config/hostkeys/*.tar.gz; do
+                tar -C /etc/ssh -xzvf "$arc"
+              done
               ssh-keygen -A
               exec /usr/sbin/sshd -e -D
           readinessProbe:
@@ -70,6 +80,9 @@ spec:
         - name: server-config
           configMap:
             name: sftp-sshd
+        - name: server-hostkeys
+          secret:
+            secretName: sftp-hostkeys
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/kubernetes/apps/overlays/prod-sftp-ingest-elavon/internet-service.yaml
+++ b/kubernetes/apps/overlays/prod-sftp-ingest-elavon/internet-service.yaml
@@ -7,7 +7,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 22
+    - port: 2200
+      targetPort: 22
       name: sftp
   selector:
     statefulset.kubernetes.io/pod-name: sftp-server-0


### PR DESCRIPTION
The vendor was not able to effectively support troubleshooting of keyed login, so this changeset adds password support to the SFTP server, which should simplify troubleshooting if not outright resolve the problem.