### PR TITLE
More Sentry improvements and load a new RT key

### DIFF
--- a/airflow/dags/airtable_loader_v2/generate_gtfs_download_configs.py
+++ b/airflow/dags/airtable_loader_v2/generate_gtfs_download_configs.py
@@ -34,6 +34,9 @@ def gtfs_datasets_to_extract_configs(
         if not record.data_quality_pipeline:
             continue
         with sentry_sdk.push_scope() as scope:
+            scope.set_tag("record_id", record.id)
+            scope.set_tag("record_name", record.name)
+            scope.set_context("record", record.dict())
             try:
                 valid[record.id] = (
                     record.schedule_to_use_for_rt_validation,

--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -104,6 +104,8 @@ def download_all(task_instance, execution_date, **kwargs):
     for i, config in enumerate(configs, start=1):
         with sentry_sdk.push_scope() as scope:
             logging.info(f"attempting to fetch {i}/{len(configs)} {config.url}")
+            scope.set_tag("config_name", config.name)
+            scope.set_tag("config_url", config.url)
             scope.set_context("config", config.dict())
             try:
                 extract, content = download_feed(

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.3.1'
+  newTag: '3.3.2'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.3.1'
+  newTag: '3.3.2'

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -24,7 +24,6 @@ def set_exception_fingerprint(event, hint):
     exception = hint["exc_info"][1]
     if isinstance(exception, RTFetchException):
         event["fingerprint"] = [
-            "{{ default }}",
             str(exception),
             str(exception.url),
         ]

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -93,6 +93,7 @@ AUTH_KEYS = [
     "AC_TRANSIT_API_KEY",
     "AMTRAK_GTFS_URL",
     "CULVER_CITY_API_KEY",
+    "ESCALON_RT_KEY",
     # TODO: this can be removed once we've confirmed it's no longer in Airtable
     "GRAAS_SERVER_URL",
     "MTC_511_API_KEY",

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -131,10 +131,12 @@ def load_auth_dict():
 def scoped(f):
     @wraps(f)
     def inner(*args, **kwargs):
-        config = kwargs.get("config")
+        config: GTFSDownloadConfig = kwargs.get("config")
         with sentry_sdk.push_scope() as scope:
             scope.clear_breadcrumbs()
             if config:
+                scope.set_tag("config_name", config.name)
+                scope.set_tag("config_url", config.url)
                 scope.set_context("config", config.dict())
             return f(*args, **kwargs)
 

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -132,7 +132,8 @@ def scoped(f):
     @wraps(f)
     def inner(*args, **kwargs):
         config: GTFSDownloadConfig = kwargs.get("config")
-        with sentry_sdk.push_scope() as scope:
+        # to be honest I don't really know why push_scope() does not work here
+        with sentry_sdk.configure_scope() as scope:
             scope.clear_breadcrumbs()
             if config:
                 scope.set_tag("config_name", config.name)
@@ -186,7 +187,7 @@ def fetch(tick: datetime, config: GTFSDownloadConfig):
             else:
                 msg = "other non-request exception occurred during download_feed"
             logger.exception(msg, **kwargs)
-            raise RTFetchException(config.url, cause=e, status_code=status_code)
+            raise RTFetchException(config.url, cause=e, status_code=status_code) from e
 
         typer.secho(
             f"saving {humanize.naturalsize(len(content))} from {config.url} to {extract.path}"

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.3.1"
+version = "3.3.2"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description

This lumps together a couple changes to deploy at once.

1. Adds a new RT key to read from secrets manager
2. Removes default fingerprinting from RT fetch failures so stacktrace changes do not affect grouping
3. Adds more tags and context to various Sentry scopes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
see https://sentry.calitp.org/organizations/sentry/issues/427/events/9ae9974a6c664c7d83cab348e854fffd/?environment=test&project=2 for the new sentry context

## Screenshots (optional)
