### PR TITLE
Sentry email changes

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -3,7 +3,7 @@
 sentry:
   user:
     create: true
-    email: admin@sentry.local
+    email: general+cal-itp@jarv.us
     existingSecret: sentry-secrets
     existingSecretKey: admin-password
   nginx:

--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -23,7 +23,7 @@ sentry:
   mail:
     backend: smtp
     useTls: true
-    username: "apikey"
+    username: "PM-T-outbound-FUA5Xw3iImqk9PVLER6dkt"
     port: 587
-    host: "smtp.sendgrid.net"
+    host: "smtp.postmarkapp.com"
     from: "bot@calitp.org"


### PR DESCRIPTION
# Description

This has already been deployed, but we're switching to a new Postmark email instead of Sendgrid. I've also updated Airflow to use `bot@calitp.org` via Postmark.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
