### PR TITLE
Add new columns to fct_vehicle_positions_messages key generation & fix column name in staging test

### DIFF
--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -20,7 +20,9 @@ keying AS (
 
 fct_vehicle_positions_messages AS (
     SELECT
-        {{ dbt_utils.surrogate_key(['base64_url', '_extract_ts', 'id']) }} as key,
+        -- ideally this would not include vehicle_id / trip_id, but using it for now because
+        -- MTC 511 regional feed does not have feed-unique entity ids
+        {{ dbt_utils.surrogate_key(['base64_url', '_extract_ts', 'id', 'vehicle_id', 'trip_id']) }} as key,
         gtfs_dataset_key,
         dt,
         hour,

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -49,7 +49,7 @@ models:
             - _extract_ts
             - id
           # test hour = 0 UTC because that's 5pm Pacific = PM peak, good sample of data
-          where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM ts)) = 0
+          where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM _extract_ts)) = 0
     columns:
       - name: dt
       - name: hour


### PR DESCRIPTION
# Description

One more follow up for #1836 / #1870:

> It seems that the reason that our tests are failing in the new `fct_vehicle_positions_messages` table is the MTC regional (combined / RG) feed doesn't give each message entity a unique id.
> So, for example, if 3 different agencies have a message with id = 5, MTC doesn't seem to do anything to make those IDs unique and in the RG feed we just get three messages with that same ID.

To work around this, adding additional fields to synthetic key generation.

Also fixes column name in staging table test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Verified that this new key should be *actually* unique:

<details> <summary>test SQL</summary>

```
with dbt_test__target as (

  select key as unique_field, base64_url, vehicle_id, trip_id
  from (select * from `cal-itp-data-infra`.`mart_gtfs`.`fct_vehicle_positions_messages` where dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AND (EXTRACT(HOUR FROM hour)) = 0) dbt_subquery
  where key is not null

),

dups AS (

    select
        base64_url,
        unique_field,
        vehicle_id,
        trip_id,
        count(*) as n_records

    from dbt_test__target
    group by base64_url, unique_field, vehicle_id, trip_id
    having count(*) > 1
)

SELECT * FROM dups
ORDER BY base64_url
```

^ returns no results:

![image](https://user-images.githubusercontent.com/55149902/193684077-67f39f26-41d6-4085-b4dd-c1e182918941.png)

</details>
