### PR TITLE
switch keying for vp messages

### DIFF
--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -22,7 +22,7 @@ fct_vehicle_positions_messages AS (
     SELECT
         -- ideally this would not include vehicle_id / trip_id, but using it for now because
         -- MTC 511 regional feed does not have feed-unique entity ids
-        {{ dbt_utils.surrogate_key(['base64_url', '_extract_ts', 'id', 'vehicle_id', 'trip_id']) }} as key,
+        {{ dbt_utils.surrogate_key(['base64_url', '_extract_ts', 'id', 'position_latitude', 'position_longitude']) }} as key,
         gtfs_dataset_key,
         dt,
         hour,

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -43,11 +43,15 @@ models:
       Vehicle positions realtime data.
       See https://gtfs.org/realtime/reference/ for specification.
     tests:
+      # ideally base64_url, _extract_ts, id would be sufficient
+      # but this is not the case in the MTC 511 feed, so adding position
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - base64_url
             - _extract_ts
             - id
+            - position_latitude
+            - position_longitude
           # test hour = 0 UTC because that's 5pm Pacific = PM peak, good sample of data
           where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM _extract_ts)) = 0
     columns:


### PR DESCRIPTION
# Description

Alas, the attempt in #1872 to make the keying unique failed in prod (realized this morning that when I tested on 10/3, I was getting weekend data in the date filter -- presumably it failed overnight because of more plentiful weekday data coming in for Monday which introduced dups.) 

Switching to use lat/long as part of the key, confirmed no dups for this set of attributes in yesterday's data for 0 hour UTC. Also bringing staging into alignment. 

Resolves dbt test failures / Sentry issues: 
![image](https://user-images.githubusercontent.com/55149902/193835993-0e13d24c-25eb-4137-8e1c-2ef08fc8d2b1.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran `dbt run -s +fct_vehicle_positions_messages` / `dbt test -s +fct_vehicle_positions_messages`, both complete with 100% success


SQL also pasted below that was used to determine that this set of attributes was in fact unique; confirmed no dups

<details><summary>SQL details</summary>

```
with dbt_test__target as (

  select base64_url, _extract_ts, id, position_latitude, position_longitude
  from (select * from `cal-itp-data-infra`.`mart_gtfs`.`fct_vehicle_positions_messages` where dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AND (EXTRACT(HOUR FROM hour)) = 0) dbt_subquery

),

dups AS (

    select
        base64_url, _extract_ts, id, position_latitude, position_longitude,
        count(*) as n_records

    from dbt_test__target
    group by base64_url, _extract_ts, id, position_latitude, position_longitude
    having count(*) > 1
)

SELECT * FROM dups
ORDER BY base64_url
```

</details>
