### PR TITLE
Add Torrance api key for RT

### DIFF
--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.3.2'
+  newTag: '3.3.3'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.3.2'
+  newTag: '3.3.3'

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -94,6 +94,7 @@ AUTH_KEYS = [
     "AMTRAK_GTFS_URL",
     "CULVER_CITY_API_KEY",
     "ESCALON_RT_KEY",
+    "TORRANCE_TRANSIT_API_KEY",
     # TODO: this can be removed once we've confirmed it's no longer in Airtable
     "GRAAS_SERVER_URL",
     "MTC_511_API_KEY",

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.3.2"
+version = "3.3.3"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description

Following #1879, this PR adds the `TORRANCE_TRANSIT_API_KEY` to the v3 archiver. The key's value has been added in Secret Manager. I have deployed this change to test & confirmed it worked, can deploy to prod when PR approved.

Note that this API key is not yet referenced in Airtable; this change would be to get out ahead of that so we don't get authorization errors when the URLs **are** added.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Deployed to test. Also this is not a functional change, just adding another key. 

## Screenshots
Huey task signals in test showing recovery after restart

![image](https://user-images.githubusercontent.com/55149902/194418693-25603503-74ef-4cc5-bf33-c5b8eae7e9a6.png)

