### PR TITLE
make gtfs schedule downloads run sooner (i.e. end of the UTC day)

### DIFF
--- a/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
+++ b/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Download GTFS Schedule feeds as specified in Airtable"
-schedule_interval: "0 0 * * *"
+schedule_interval: "0 23 * * *"
 tags:
   - all_gusty_features
 default_args:


### PR DESCRIPTION
# Description

Closes https://github.com/cal-itp/data-infra/issues/1886

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally.

## Screenshots (optional)
