### PR TITLE
18 is deprecated, just use latest for everything

### DIFF
--- a/.github/workflows/build-gtfs-aggregator-checker-image.yml
+++ b/.github/workflows/build-gtfs-aggregator-checker-image.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_push:
     name: Package docker image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build-gtfs-rt-parser-image.yml
+++ b/.github/workflows/build-gtfs-rt-parser-image.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_push:
     name: Package docker image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build-gtfs-rt-parser-v2-image.yml
+++ b/.github/workflows/build-gtfs-rt-parser-v2-image.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_push:
     name: Package docker image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build-gtfs-schedule-validator-image.yml
+++ b/.github/workflows/build-gtfs-schedule-validator-image.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_push:
     name: Package docker image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry

--- a/.github/workflows/build-warehouse-image.yml
+++ b/.github/workflows/build-warehouse-image.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_push:
     name: Package docker image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
# Description

Solves the failing action in https://github.com/cal-itp/data-infra/actions/runs/3250370484

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
This is hard to do without enabling image builds on PRs, which we could discuss.

## Screenshots (optional)
