### PR TITLE
agencies.yml: add ucla bruin bus

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1724,3 +1724,11 @@ etrans:
       gtfs_rt_service_alerts_url: https://webservices.umoiq.com/api/gtfs-rt/v1/service-alerts/escalon
       gtfs_rt_trip_updates_url: https://webservices.umoiq.com/api/gtfs-rt/v1/trip-updates/escalon
   itp_id: 107
+ucla-bruin-bus:
+  agency_name: UCLA Bruin Bus
+  feeds:
+    - gtfs_schedule_url: https://uclabruinbus.tripshot.com/v1/gtfs.zip?regionId=CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+      gtfs_rt_vehicle_positions_url: https://uclabruinbus.tripshot.com/v1/gtfs/realtime/vehiclePosition/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+      gtfs_rt_service_alerts_url: ttps://uclabruinbus.tripshot.com/v1/gtfs/realtime/serviceAlert/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+      gtfs_rt_trip_updates_url: https://uclabruinbus.tripshot.com/v1/gtfs/realtime/tripUpdate/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+  itp_id: 486


### PR DESCRIPTION
# Description

Adds UCLA Bruin Bus URLs to agencies.yml per #1896.

I also manually added ITP ID 486 to the UCLA record in the `organizations` table in Airtable. 

<img width="460" alt="image" src="https://user-images.githubusercontent.com/55149902/195880821-22bce091-ae92-4043-b615-36658f11c5f2.png">


Resolves #1896

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Confirmed all URLs work by downloading locally.
