### PR TITLE
fix ucla bruin bus alerts url

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1729,6 +1729,6 @@ ucla-bruin-bus:
   feeds:
     - gtfs_schedule_url: https://uclabruinbus.tripshot.com/v1/gtfs.zip?regionId=CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
       gtfs_rt_vehicle_positions_url: https://uclabruinbus.tripshot.com/v1/gtfs/realtime/vehiclePosition/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
-      gtfs_rt_service_alerts_url: ttps://uclabruinbus.tripshot.com/v1/gtfs/realtime/serviceAlert/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
+      gtfs_rt_service_alerts_url: https://uclabruinbus.tripshot.com/v1/gtfs/realtime/serviceAlert/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
       gtfs_rt_trip_updates_url: https://uclabruinbus.tripshot.com/v1/gtfs/realtime/tripUpdate/CA558DDC-D7F2-4B48-9CAC-DEEA1134F820
   itp_id: 486


### PR DESCRIPTION
# Description

Add missing `h` to Bruin Bus URL in `agencies.yml`.

Resolves: issue caught by @aly-medina on Slack 🙏 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?
Confirmed fixed URL downloads data 
