### PR TITLE
Remove Humboldt service alert URL from headers.yml

### DIFF
--- a/airflow/data/headers.yml
+++ b/airflow/data/headers.yml
@@ -17,7 +17,6 @@
       url_number: 0
       rt_urls:
         - gtfs_rt_vehicle_positions_url
-        - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
     - itp_id: 159 # Lake Transit
       url_number: 0


### PR DESCRIPTION
# Description

Removing service alerts feed in headers.yml for Humbolt Transit Authority.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Confirmed feed does not require header authorization.
