### PR TITLE
only print the type and status code if applicable

### DIFF
--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -49,7 +49,7 @@ def main():
             result = requests.get(url, headers=h, timeout=10)
             result.raise_for_status()
         except Exception as e:
-            print(f"Failed to download {url}")
+            print(f"Failed to download {key}")
             reason = f"Reason: {type(e)}"
             if isinstance(e, HTTPError):
                 reason = f"{reason}({e.response.status_code})"

--- a/script/agencies_verify.py
+++ b/script/agencies_verify.py
@@ -2,6 +2,7 @@ import logging
 import requests
 import sys
 import yaml
+from requests import HTTPError
 
 sys.path.append("services/gtfs-rt-archive/src/gtfs_rt_archive/")
 
@@ -49,7 +50,10 @@ def main():
             result.raise_for_status()
         except Exception as e:
             print(f"Failed to download {url}")
-            print(f"Reason: {e}")
+            reason = f"Reason: {type(e)}"
+            if isinstance(e, HTTPError):
+                reason = f"{reason}({e.response.status_code})"
+            print(reason)
             fails.append(url)
             continue
         successes.append(url)


### PR DESCRIPTION
# Description

Quick fix for what @lauriemerrell observed in that failed requests in `agencies_verify.py` that use query auth params end up logging those keys under certain exception types. We need to start the process of rotating keys anyways.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
n/a

## Screenshots (optional)
