### PR TITLE
Add Unitrans Feeds and Header

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1744,3 +1744,10 @@ oregon-point:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 487
+  agency_name: Unitrans
+  feeds:
+    - gtfs_schedule_url: https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip
+      gtfs_rt_vehicle_positions_url: https://webservices.umoiq.com/api/gtfs-rt/v1/vehicle-positions/unitrans
+      gtfs_rt_service_alerts_url: https://webservices.umoiq.com/api/gtfs-rt/v1/service-alerts/unitrans
+      gtfs_rt_trip_updates_url: https://webservices.umoiq.com/api/gtfs-rt/v1/trip-updates/unitrans
+  itp_id: 351

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1460,9 +1460,9 @@ unitrans:
   agency_name: Unitrans
   feeds:
     - gtfs_schedule_url: https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://webservices.umoiq.com/api/gtfs-rt/v1/vehicle-positions/unitrans
+      gtfs_rt_service_alerts_url: https://webservices.umoiq.com/api/gtfs-rt/v1/service-alerts/unitrans
+      gtfs_rt_trip_updates_url: https://webservices.umoiq.com/api/gtfs-rt/v1/trip-updates/unitrans
   itp_id: 351
 vacaville-city-coach:
   agency_name: Vacaville City Coach
@@ -1744,10 +1744,3 @@ oregon-point:
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null
   itp_id: 487
-  agency_name: Unitrans
-  feeds:
-    - gtfs_schedule_url: https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip
-      gtfs_rt_vehicle_positions_url: https://webservices.umoiq.com/api/gtfs-rt/v1/vehicle-positions/unitrans
-      gtfs_rt_service_alerts_url: https://webservices.umoiq.com/api/gtfs-rt/v1/service-alerts/unitrans
-      gtfs_rt_trip_updates_url: https://webservices.umoiq.com/api/gtfs-rt/v1/trip-updates/unitrans
-  itp_id: 351

--- a/airflow/data/headers.yml
+++ b/airflow/data/headers.yml
@@ -118,3 +118,12 @@
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
+- header-data:
+    x-umo-iq-api-key: {{ UNITRANS_KEY }}
+  URLs:
+    - itp_id: 351 # Unitrans
+      url_number: 0
+      rt_urls:
+        - gtfs_rt_vehicle_positions_url
+        - gtfs_rt_service_alerts_url
+        - gtfs_rt_trip_updates_url


### PR DESCRIPTION
# Description

Adding Unitrans Feed and Header authorization key.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

GTFS Schedule downloaded locally; authorizations to be tested due to API keys.
