### PR TITLE
add a 4th prod archiver consumer

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: gtfs-rt-archiver-consumer
 spec:
-  replicas: 3
+  replicas: 4
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
already deployed; grafana told us tasks were expiring, so I bumped consumers to 4; that 4th consumer was unschedulable because we were maxing out the node pool and I had neglected to turn on auto-scaling; that node pool will auto-scale now so we will be good until we hit 6 nodes worth of requirements (3 previously)