### PR TITLE
Fct daily scheduled trips

### DIFF
--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -108,7 +108,7 @@ models:
         description: '{{ doc("gtfs_calendar_dates__date") }}'
       - name: day_name
         description: String name of day of the week like "monday"
-      - name: service_indicator
+      - name: has_service
         description: |
           Boolean indicating whether there is service for this `service_id` / `day_name` pair
           between `start_date` and `end_date`.

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -139,7 +139,13 @@ models:
     columns:
       - name: feed_key
         description: Foreign key for `dim_schedule_feeds`.
+        tests:
+          - not_null
       - name: service_date
         description: Date on which service was scheduled.
+        tests:
+          - not_null
       - name: service_id
         description: Service identifier from calendar and/or calendar_dates.
+        tests:
+          - not_null

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -85,3 +85,30 @@ models:
         description: |
           Timestamp for when the given row was inserted into the table.
           Primarily useful for debugging, not meaningful for general use.
+  - name: int_gtfs_schedule__long_calendar
+    description: |
+      This table transforms the raw GTFS calendar.txt format (where each row corresponds to a `service_id` and
+      each day of the week is a column and service indicators are entered in a "wide" fashion) into a long format,
+      where a row is identified by `feed_key`, `service_id`, and `day_name`.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - feed_key
+            - service_id
+            - day_name
+    columns:
+      - name: base64_url
+      - name: feed_key
+        description: Foreign key for `dim_schedule_feeds`.
+      - name: service_id
+        description: '{{ doc("gtfs_calendar__service_id") }}'
+      - name: start_date
+        description: '{{ doc("gtfs_calendar__start_date") }}'
+      - name: end_date
+        description: '{{ doc("gtfs_calendar_dates__date") }}'
+      - name: day_name
+        description: String name of day of the week like "monday"
+      - name: service_indicator
+        description: |
+          Boolean indicating whether there is service for this `service_id` / `day_name` pair
+          between `start_date` and `end_date`.

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -112,3 +112,34 @@ models:
         description: |
           Boolean indicating whether there is service for this `service_id` / `day_name` pair
           between `start_date` and `end_date`.
+  - name: int_gtfs_schedule__daily_scheduled_service_index
+    description: |
+      An index listing date, feed, and `service_id` combinations for which service was scheduled (i.e.,
+      the `service_id` is "in effect" and says that service occurred).
+      Essentially, it takes `calendar` and `calendar_dates` for a given feed, takes the dates for which that
+      feed was "in effect", and combines those into a long list of all service_ids that were in effect for a given
+      date, then filters down to only those where service was actually scheduled on that date.
+      For example, a row in this table with `feed_key = A`, `service_date = 2022-10-01`, `service_id = 1` indicates
+      that:
+      * Feed A was online on 2022-10-01
+      * Service ID 1 covers the date 2022-10-01, i.e., if service ID 1 is defined in `calendar.txt`,
+         `start_date <= 2022-10-01 <= end_date` and if service ID ` is defined in `calendar_dates.txt`,
+         `2022-10-01` is listed as a `date` within that file.
+      * The service indicator is `true` for 2022-10-01 (a Saturday). So, if this service was defined in `calendar.txt`,
+         `saturday = 1` for `service_id = 1`, and there is no `exception_type = 2` in `calendar_dates.txt` for this service and date.
+         If this service is defined exclusively in `calendar_dates.txt`, then `exception_type = 1` is listed for `2022-10-01` in that file.
+      This table therefore excludes `service_id` values which were in effect (i.e., feed was online and date range of service
+      overlaps with service date) but where service was not scheduled.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - feed_key
+            - service_date
+            - service_id
+    columns:
+      - name: feed_key
+        description: Foreign key for `dim_schedule_feeds`.
+      - name: service_date
+        description: Date on which service was scheduled.
+      - name: service_id
+        description: Service identifier from calendar and/or calendar_dates.

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__daily_scheduled_service_index.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__daily_scheduled_service_index.sql
@@ -69,7 +69,7 @@ daily_services AS (
             AND (t2.service_id = t3.service_id OR t2.service_id IS NULL)
 ),
 
-fct_daily_scheduled_service AS (
+int_gtfs_schedule__daily_scheduled_service_index AS (
     SELECT
         service_date,
         cd_date,
@@ -80,4 +80,4 @@ fct_daily_scheduled_service AS (
         AND service_indicator
 )
 
-SELECT * FROM fct_daily_scheduled_service
+SELECT * FROM int_gtfs_schedule__daily_scheduled_service_index

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__daily_scheduled_service_index.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__daily_scheduled_service_index.sql
@@ -30,6 +30,9 @@ boolean_calendar_dates AS (
 ),
 
 -- decide that exception type 2 trumps exception type 1
+-- i.e., if same date appears twice with two exception types
+-- the cancelation wins and we say no service on that date
+-- (this generally shouldn't happen)
 summarize_calendar_dates AS (
     SELECT
         date,
@@ -40,34 +43,41 @@ summarize_calendar_dates AS (
     GROUP BY date, feed_key, service_id
 ),
 
-
---   * is_in_service for service_date(s) past today are not stable. They reflect
---     what the most recent feed thinks will be in service in e.g. 2050-01-01.
--- preprocess calendar dates
-
 daily_services AS (
 
     SELECT
         t1.date AS service_date,
+        t3.date AS cd_date,
         t1.feed_key,
         t2.service_id AS calendar_service_id,
         t2.service_indicator AS calendar_service_indicator,
         t3.service_id AS calendar_dates_service_id,
         t3.service_indicator AS calendar_dates_service_indicator,
         COALESCE(t2.service_id, t3.service_id) AS service_id,
-        COALESCE(t2.service_indicator, TRUE)
-        AND COALESCE(t3.service_indicator, TRUE)
-        AND ((t2.service_id IS NOT NULL) OR (t3.service_id IS NOT NULL)) AS service_indicator
+        -- calendar_dates takes precedence if present: it can modify calendar
+        -- if no calendar_dates, use calendar
+        -- if neither, no service
+        COALESCE(t3.service_indicator, t2.service_indicator, FALSE) AS service_indicator
     FROM fct_daily_schedule_feeds AS t1
     LEFT JOIN int_gtfs_schedule__long_calendar AS t2
         ON t1.feed_key = t2.feed_key
             AND t1.day_num = t2.day_num
             AND t1.date BETWEEN t2.start_date AND t2.end_date
-    FULL OUTER JOIN summarize_calendar_dates AS t3
+    LEFT JOIN summarize_calendar_dates AS t3
         ON t1.feed_key = t3.feed_key
             AND t1.date = t3.date
-            AND t2.service_id = t3.service_id
+            AND (t2.service_id = t3.service_id OR t2.service_id IS NULL)
+),
+
+fct_daily_scheduled_service AS (
+    SELECT
+        service_date,
+        cd_date,
+        feed_key,
+        service_id
+    FROM daily_services
+    WHERE service_id IS NOT NULL
+        AND service_indicator
 )
 
-
-SELECT * FROM daily_services
+SELECT * FROM fct_daily_scheduled_service

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__daily_scheduled_service_index.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__daily_scheduled_service_index.sql
@@ -46,27 +46,27 @@ summarize_calendar_dates AS (
 daily_services AS (
 
     SELECT
-        t1.date AS service_date,
-        t3.date AS cd_date,
-        t1.feed_key,
-        t2.service_id AS calendar_service_id,
-        t2.service_indicator AS calendar_service_indicator,
-        t3.service_id AS calendar_dates_service_id,
-        t3.service_indicator AS calendar_dates_service_indicator,
-        COALESCE(t2.service_id, t3.service_id) AS service_id,
+        daily_feeds.date AS service_date,
+        cal_dates.date AS cd_date,
+        daily_feeds.feed_key,
+        long_cal.service_id AS calendar_service_id,
+        long_cal.service_indicator AS calendar_service_indicator,
+        cal_dates.service_id AS calendar_dates_service_id,
+        cal_dates.service_indicator AS calendar_dates_service_indicator,
+        COALESCE(long_cal.service_id, cal_dates.service_id) AS service_id,
         -- calendar_dates takes precedence if present: it can modify calendar
         -- if no calendar_dates, use calendar
         -- if neither, no service
-        COALESCE(t3.service_indicator, t2.service_indicator, FALSE) AS service_indicator
-    FROM fct_daily_schedule_feeds AS t1
-    LEFT JOIN int_gtfs_schedule__long_calendar AS t2
-        ON t1.feed_key = t2.feed_key
-            AND t1.day_num = t2.day_num
-            AND t1.date BETWEEN t2.start_date AND t2.end_date
-    LEFT JOIN summarize_calendar_dates AS t3
-        ON t1.feed_key = t3.feed_key
-            AND t1.date = t3.date
-            AND (t2.service_id = t3.service_id OR t2.service_id IS NULL)
+        COALESCE(cal_dates.service_indicator, long_cal.service_indicator, FALSE) AS service_indicator
+    FROM fct_daily_schedule_feeds AS daily_feeds
+    LEFT JOIN int_gtfs_schedule__long_calendar AS long_cal
+        ON daily_feeds.feed_key = long_cal.feed_key
+            AND daily_feeds.day_num = long_cal.day_num
+            AND daily_feeds.date BETWEEN long_cal.start_date AND long_cal.end_date
+    LEFT JOIN summarize_calendar_dates AS cal_dates
+        ON daily_feeds.feed_key = cal_dates.feed_key
+            AND daily_feeds.date = cal_dates.date
+            AND (long_cal.service_id = cal_dates.service_id OR long_cal.service_id IS NULL)
 ),
 
 int_gtfs_schedule__daily_scheduled_service_index AS (

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
@@ -20,7 +20,7 @@ int_gtfs_schedule__long_calendar AS (
             start_date,
             end_date,
             "{{ dow[0] }}" AS day_name,
-            "{{ dow[1] }}" AS day_num,
+            {{ dow[1] }} AS day_num,
             CAST({{ dow[0] }} AS boolean) AS service_indicator
         FROM dim_calendar
     {% endfor %}

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
@@ -22,7 +22,7 @@ int_gtfs_schedule__long_calendar AS (
             end_date,
             "{{ dow[0] }}" AS day_name,
             {{ dow[1] }} AS day_num,
-            CAST({{ dow[0] }} AS boolean) AS service_indicator
+            CAST({{ dow[0] }} AS boolean) AS has_service
         FROM dim_calendar
     {% endfor %}
 )

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
@@ -1,0 +1,31 @@
+{{ config(materialized='table') }}
+
+-- TODO: make an intermediate calendar and use that instead of the dimension
+WITH dim_calendar AS (
+    SELECT *
+    FROM {{ ref('dim_calendar') }}
+),
+
+int_gtfs_schedule__long_calendar AS (
+    -- Note that you can unnest values easily in SQL, but getting the column names
+    -- is weirdly hard. To work around this, we just UNION ALL.
+    {% for dow in ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"] %}
+
+        {% if not loop.first %}
+            UNION ALL
+        {% endif %}
+
+        SELECT
+            base64_url,
+            feed_key,
+            service_id,
+            start_date,
+            end_date,
+            "{{ dow | title }}" AS day_name,
+            CAST({{ dow }} AS boolean) AS service_indicator
+        FROM dim_calendar
+    {% endfor %}
+)
+
+SELECT *
+FROM int_gtfs_schedule__long_calendar

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 -- TODO: make an intermediate calendar and use that instead of the dimension
 WITH dim_calendar AS (
     SELECT *
@@ -9,7 +7,7 @@ WITH dim_calendar AS (
 int_gtfs_schedule__long_calendar AS (
     -- Note that you can unnest values easily in SQL, but getting the column names
     -- is weirdly hard. To work around this, we just UNION ALL.
-    {% for dow in ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"] %}
+    {% for dow in [("monday", 2), ("tuesday", 3), ("wednesday", 4), ("thursday", 5), ("friday", 6), ("saturday", 7), ("sunday", 0)] %}
 
         {% if not loop.first %}
             UNION ALL
@@ -21,8 +19,9 @@ int_gtfs_schedule__long_calendar AS (
             service_id,
             start_date,
             end_date,
-            "{{ dow | title }}" AS day_name,
-            CAST({{ dow }} AS boolean) AS service_indicator
+            "{{ dow[0] }}" AS day_name,
+            "{{ dow[1] }}" AS day_num,
+            CAST({{ dow[0] }} AS boolean) AS service_indicator
         FROM dim_calendar
     {% endfor %}
 )

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
@@ -4,6 +4,7 @@ WITH dim_calendar AS (
     FROM {{ ref('dim_calendar') }}
 ),
 
+-- TODO: see if this can be refactored using UNPIVOT (logic inherited from v1 warehouse, wondering if it should be revisited)
 int_gtfs_schedule__long_calendar AS (
     -- Note that you can unnest values easily in SQL, but getting the column names
     -- is weirdly hard. To work around this, we just UNION ALL.

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -1117,3 +1117,34 @@ models:
         description: '{{ doc("gtfs_stop_times__timepoint") }}'
     meta:
       publish.gis_coordinate_system_epsg: WGS84
+  - name: fct_daily_scheduled_trips
+    description: |
+      A daily table showing all trips that were scheduled on a given date.
+      If a `service_date`, `trip_key` pair is present in this table,
+      it means that that `trip_key` was scheduled to occur on that `service_date`.
+      Specifically, it means that the associated `service_id` was active and had service
+      scheduled. Dates where a `service_id` was active but not scheduled (for example,
+      weekend dates within a weekday service's effective dates) are not listed in this table.
+    columns:
+      - name: key
+        tests:
+          - unique:
+              where: "not warning_duplicate_trip_primary_key"
+          - not_null
+      - name: feed_key
+        description: Foreign key to dim_schedule_feeds.
+      - name: service_date
+        description: Date on which this trip was active.
+      - name: service_id
+        description: |
+          Service ID from calendar or calendar_dates that determines that this trip
+          has service on this date.
+      - name: trip_key
+        description: Foreign key to dim_trips.
+      - name: route_key
+        description: Foreign key to dim_routes.
+      - name: warning_duplicate_trip_primary_key
+        description: |
+          Rows with `true` in this column have a duplicate primary key in dim_trips;
+          i.e., `trip_id` is duplicated within an individual feed instance.
+          Treat these rows with caution.

--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_service.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_service.sql
@@ -1,0 +1,73 @@
+{{ config(materialized='table') }}
+
+WITH dim_calendar_dates AS (
+    SELECT *
+    FROM {{ ref('dim_calendar_dates') }}
+),
+
+int_gtfs_schedule__long_calendar AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_schedule__long_calendar') }}
+),
+
+fct_daily_schedule_feeds AS (
+    SELECT
+        *,
+        EXTRACT(DAYOFWEEK FROM date) AS day_num
+    FROM {{ ref('fct_daily_schedule_feeds') }}
+),
+
+boolean_calendar_dates AS (
+    SELECT
+        date,
+        feed_key,
+        service_id,
+        CASE
+            WHEN exception_type = 1 THEN TRUE
+            WHEN exception_type = 2 THEN FALSE
+        END AS service_indicator
+    FROM dim_calendar_dates
+),
+
+-- decide that exception type 2 trumps exception type 1
+summarize_calendar_dates AS (
+    SELECT
+        date,
+        feed_key,
+        service_id,
+        LOGICAL_AND(service_indicator) AS service_indicator
+    FROM boolean_calendar_dates
+    GROUP BY date, feed_key, service_id
+),
+
+
+--   * is_in_service for service_date(s) past today are not stable. They reflect
+--     what the most recent feed thinks will be in service in e.g. 2050-01-01.
+-- preprocess calendar dates
+
+daily_services AS (
+
+    SELECT
+        t1.date AS service_date,
+        t1.feed_key,
+        t2.service_id AS calendar_service_id,
+        t2.service_indicator AS calendar_service_indicator,
+        t3.service_id AS calendar_dates_service_id,
+        t3.service_indicator AS calendar_dates_service_indicator,
+        COALESCE(t2.service_id, t3.service_id) AS service_id,
+        COALESCE(t2.service_indicator, TRUE)
+        AND COALESCE(t3.service_indicator, TRUE)
+        AND ((t2.service_id IS NOT NULL) OR (t3.service_id IS NOT NULL)) AS service_indicator
+    FROM fct_daily_schedule_feeds AS t1
+    LEFT JOIN int_gtfs_schedule__long_calendar AS t2
+        ON t1.feed_key = t2.feed_key
+            AND t1.day_num = t2.day_num
+            AND t1.date BETWEEN t2.start_date AND t2.end_date
+    FULL OUTER JOIN summarize_calendar_dates AS t3
+        ON t1.feed_key = t3.feed_key
+            AND t1.date = t3.date
+            AND t2.service_id = t3.service_id
+)
+
+
+SELECT * FROM daily_services

--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_trips.sql
@@ -1,0 +1,36 @@
+{{ config(materialized='table') }}
+
+WITH int_gtfs_schedule__daily_scheduled_service_index AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index') }}
+),
+
+dim_trips AS (
+    SELECT *
+    FROM {{ ref('dim_trips') }}
+),
+
+dim_routes AS (
+    SELECT *
+    FROM {{ ref('dim_routes') }}
+),
+
+fct_daily_scheduled_trips AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['t1.service_date', 't2.key']) }} as key,
+        t1.service_date,
+        t1.feed_key,
+        t1.service_id,
+        t2.key AS trip_key,
+        t3.key AS route_key,
+        t2.warning_duplicate_primary_key AS warning_duplicate_trip_primary_key
+    FROM int_gtfs_schedule__daily_scheduled_service_index AS t1
+    LEFT JOIN dim_trips AS t2
+        ON t1.feed_key = t2.feed_key
+        AND t1.service_id = t2.service_id
+    LEFT JOIN dim_routes AS t3
+        ON t1.feed_key = t3.feed_key
+        AND t2.route_id = t3.route_id
+)
+
+SELECT * FROM fct_daily_scheduled_trips

--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_trips.sql
@@ -17,20 +17,20 @@ dim_routes AS (
 
 fct_daily_scheduled_trips AS (
     SELECT
-        {{ dbt_utils.surrogate_key(['t1.service_date', 't2.key']) }} as key,
-        t1.service_date,
-        t1.feed_key,
-        t1.service_id,
-        t2.key AS trip_key,
-        t3.key AS route_key,
-        t2.warning_duplicate_primary_key AS warning_duplicate_trip_primary_key
-    FROM int_gtfs_schedule__daily_scheduled_service_index AS t1
-    LEFT JOIN dim_trips AS t2
-        ON t1.feed_key = t2.feed_key
-        AND t1.service_id = t2.service_id
-    LEFT JOIN dim_routes AS t3
-        ON t1.feed_key = t3.feed_key
-        AND t2.route_id = t3.route_id
+        {{ dbt_utils.surrogate_key(['service_index.service_date', 'trips.key']) }} as key,
+        service_index.service_date,
+        service_index.feed_key,
+        service_index.service_id,
+        trips.key AS trip_key,
+        routes.key AS route_key,
+        trips.warning_duplicate_primary_key AS warning_duplicate_trip_primary_key
+    FROM int_gtfs_schedule__daily_scheduled_service_index AS service_index
+    LEFT JOIN dim_trips AS trips
+        ON service_index.feed_key = trips.feed_key
+        AND service_index.service_id = trips.service_id
+    LEFT JOIN dim_routes AS routes
+        ON service_index.feed_key = routes.feed_key
+        AND trips.route_id = routes.route_id
 )
 
 SELECT * FROM fct_daily_scheduled_trips


### PR DESCRIPTION
# Description

Progress towards #1761. Creates a `fct_daily_scheduled_trips` table. Also creates `int_gtfs_schedule__daily_scheduled_service_index` (and, in the process, `int_gtfs_schedule__long_calendar.sql`) to support further service and trip summary work. For example the current (v1) `fact_daily_service` table contains information about first stop, last stop on that service. I think that would be part of a `fct_daily_scheduled_service` table in the mart based on `fct_daily_scheduled_trips`. We can add further summary information in follow-up PRs, but this creates the skeleton. 

I think we will need to clean up/iterate the interplay between mart and intermediate tables here, but I think that can come with time and isn't prohibitive.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

dbt run & dbt test on the two new tables succeeds. 
