### PR TITLE
Allow historical feeds to map to current gtfs_dataset records

### DIFF
--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -21,3 +21,25 @@ models:
             - product_key
             - component_key
             - calitp_extracted_at
+
+  - name: int_transit_database__urls_to_gtfs_datasets
+    description: |
+      Creates a 1:N relationship so any given extract/URL in the
+      GTFS models can identify its source gtfs_datasets record.
+      Currently this is unversioned; any historical URLs point
+      to the latest version of their gtfs_datasets record.
+    columns:
+      - name: base64_url
+        tests:
+          - not_null
+          - unique
+      - name: gtfs_dataset_key
+        tests:
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
+              config:
+                # four SMART urls and two test URLs that have been removed
+                # will work once the dim is historical
+                error_if: ">10"
+                warn_if: ">0"

--- a/warehouse/models/intermediate/transit_database/int_transit_database__urls_to_gtfs_datasets.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__urls_to_gtfs_datasets.sql
@@ -1,0 +1,21 @@
+WITH
+
+gtfs_datasets AS (
+    SELECT * FROM {{ ref('stg_transit_database__gtfs_datasets') }}
+),
+
+int_transit_database__urls_to_gtfs_datasets AS (
+    SELECT
+        base64_url,
+        airtable_record_id AS gtfs_dataset_key -- this is defined in {{ ref('dim_gtfs_datasets') }}
+    FROM gtfs_datasets
+    WHERE base64_url IS NOT NULL
+    -- NOTE: there could be more than 1 record per URL per ts if a given
+    -- URL is set in more than one gtfs_dataset row; our general assertion
+    -- is that we really should think of the underlying Airtable data
+    -- as unique at the URL level and merge records if necessary to
+    -- enforce that uniqueness constraint
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY base64_url ORDER BY ts DESC) = 1
+)
+
+SELECT * FROM int_transit_database__urls_to_gtfs_datasets

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -23,6 +23,18 @@ models:
         name: base64_url
         description: |
           Base 64 encoded URL from which this data was scraped.
+      - &gtfs_dataset_key
+        name: gtfs_dataset_key
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
+              config:
+                # there are a dozen rows of SMART transit which was deleted from Airtable
+                # this will work without exception once the Airtable dim is historical;
+                # this threshold may need to increase if the backfill occurs prior to that
+                error_if: ">20"
       - &_valid_from
         name: _valid_from
         description: '{{ doc("column_valid_from") }}'
@@ -45,10 +57,7 @@ models:
       - name: feed_key
         description: |
           Foreign key to the `dim_schedule_feeds` table.
-      - &gtfs_dataset_key
-        name: gtfs_dataset_key
-        description: |
-          Foreign key to the `dim_gtfs_datasets` table.
+      - *gtfs_dataset_key
       - name: is_future
         description: |
           Boolean indicating whether this date is in the future relative to the last time that the table
@@ -132,16 +141,18 @@ models:
           entity `id`, `vehicle_id`, and `trip_id`.
         tests:
           - unique:
-              config:
-                # TODO: make an RT test macro that does this date subtraction
-                # test hour = 0 UTC because that's 5pm Pacific = PM peak, good sample of data
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM hour)) = 0
+              # TODO: make an RT test macro that does this date subtraction
+              # test hour = 0 UTC because that's 5pm Pacific = PM peak, good sample of data
+              where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM hour)) = 0
           - not_null:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM hour)) = 0
+              where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM hour)) = 0
       - name: gtfs_dataset_key
         description: |
           The primary key for the record in `dim_gtfs_datasets` associated with this message.
+        columns:
+          - <<: *gtfs_dataset_key
+            config:
+              where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM hour)) = 0
       - name: dt
         description: |
           Date on which we scraped this message.
@@ -156,7 +167,7 @@ models:
       - name: _extract_ts
         description: |
           Time at which this message was scraped.
-      - name: _gtfs_dataset_name
+      - name: _name
         description: |
           String name of the GTFS dataset of which this message is a part.
           This field is provided for human readability and should not be used as a join key.
@@ -973,8 +984,7 @@ models:
           Synthetic primary key constructed from `feed_key` and `trip_id`.
         tests:
           - unique:
-              config:
-                where: "not warning_duplicate_primary_key"
+              where: "not warning_duplicate_primary_key"
           - not_null
       - *base64_url
       - name: route_id
@@ -1159,6 +1169,11 @@ models:
           - not_null
       - name: feed_key
         description: Foreign key to dim_schedule_feeds.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_schedule_feeds')
+              field: key
       - name: service_date
         description: Date on which this trip was active.
       - name: service_id
@@ -1167,8 +1182,16 @@ models:
           has service on this date.
       - name: trip_key
         description: Foreign key to dim_trips.
+        tests:
+          - relationships:
+              to: ref('dim_trips')
+              field: key
       - name: route_key
         description: Foreign key to dim_routes.
+        tests:
+          - relationships:
+              to: ref('dim_routes')
+              field: key
       - name: warning_duplicate_trip_primary_key
         description: |
           Rows with `true` in this column have a duplicate primary key in dim_trips;

--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_trips.sql
@@ -15,6 +15,14 @@ dim_routes AS (
     FROM {{ ref('dim_routes') }}
 ),
 
+dim_schedule_feeds AS (
+    SELECT * FROM {{ ref('dim_schedule_feeds') }}
+),
+
+urls_to_gtfs_datasets AS (
+    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
+),
+
 fct_daily_scheduled_trips AS (
     SELECT
         {{ dbt_utils.surrogate_key(['service_index.service_date', 'trips.key']) }} as key,
@@ -23,6 +31,7 @@ fct_daily_scheduled_trips AS (
         service_index.service_id,
         trips.key AS trip_key,
         routes.key AS route_key,
+        urls_to_gtfs_datasets.gtfs_dataset_key AS gtfs_dataset_key,
         trips.warning_duplicate_primary_key AS warning_duplicate_trip_primary_key
     FROM int_gtfs_schedule__daily_scheduled_service_index AS service_index
     LEFT JOIN dim_trips AS trips
@@ -31,6 +40,10 @@ fct_daily_scheduled_trips AS (
     LEFT JOIN dim_routes AS routes
         ON service_index.feed_key = routes.feed_key
         AND trips.route_id = routes.route_id
+    LEFT JOIN dim_schedule_feeds AS feeds
+        ON service_index.feed_key = feeds.key
+    LEFT JOIN urls_to_gtfs_datasets
+        ON feeds.base64_url = urls_to_gtfs_datasets.base64_url
 )
 
 SELECT * FROM fct_daily_scheduled_trips

--- a/warehouse/models/mart/gtfs/fct_schedule_feed_downloads.sql
+++ b/warehouse/models/mart/gtfs/fct_schedule_feed_downloads.sql
@@ -5,9 +5,8 @@ WITH joined_feed_outcomes AS (
     FROM {{ ref('int_gtfs_schedule__joined_feed_outcomes') }}
 ),
 
-dim_schedule_feeds AS (
-    SELECT *
-    FROM {{ ref('dim_schedule_feeds') }}
+urls_to_gtfs_datasets AS (
+    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
 ),
 
 fct_schedule_feeds AS (

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -3,6 +3,10 @@ WITH stg_gtfs_rt__vehicle_positions AS (
     FROM {{ ref('stg_gtfs_rt__vehicle_positions') }}
 ),
 
+urls_to_gtfs_datasets AS (
+    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
+),
+
 dim_gtfs_datasets AS (
     SELECT *
     FROM {{ ref('dim_gtfs_datasets') }}
@@ -10,13 +14,14 @@ dim_gtfs_datasets AS (
 
 keying AS (
     SELECT
-        gd.key as gtfs_dataset_key,
+        urls_to_gtfs_datasets.gtfs_dataset_key,
         gd.name as _gtfs_dataset_name,
         vp.*
     FROM stg_gtfs_rt__vehicle_positions AS vp
+    LEFT JOIN urls_to_gtfs_datasets
+        ON vp.base64_url = urls_to_gtfs_datasets.base64_url
     LEFT JOIN dim_gtfs_datasets AS gd
-        ON vp.base64_url = gd.base64_url
-        AND vp._config_extract_ts BETWEEN gd._valid_from AND gd._valid_to
+        ON urls_to_gtfs_datasets.gtfs_dataset_key = gd.key
 ),
 
 fct_vehicle_positions_messages AS (

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -6,11 +6,12 @@ models:
     columns:
       - &key
         name: key
-        tests: &primary_key_tests
+        tests:
           - not_null
           - unique
         meta:
           metabase.semantic_type: type/PK
+
   - name: dim_contracts
     description: '{{ doc("contracts_table") }}'
     columns:
@@ -317,11 +318,15 @@ models:
           - relationships:
              to: ref('dim_services')
              field: key
-      - name: gtfs_dataset_key
+      - &gtfs_dataset_key
+        name: gtfs_dataset_key
         tests:
           - relationships:
-             to: ref('dim_gtfs_datasets')
-             field: key
+              to: ref('dim_gtfs_datasets')
+              field: key
+              config:
+                error_if: ">10" # four SMART urls and two test URLs that have been removed
+                warn_if: ">0"
       - name: organization_key
         tests:
           - relationships:

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -9,6 +9,15 @@ once_daily_gtfs_datasets AS (
         ) }}
 ),
 
+-- generally we should have been trimming whitespace
+-- on the Airflow/GCS side, so trim it here before encoding
+trimmed AS (
+    SELECT * EXCEPT (uri, pipeline_url),
+        TRIM(uri) AS uri,
+        TRIM(pipeline_url) AS pipeline_url
+    FROM once_daily_gtfs_datasets
+),
+
 construct_base64_url AS (
     SELECT
         *,
@@ -46,7 +55,7 @@ construct_base64_url AS (
                     END
             ELSE {{ to_url_safe_base64('pipeline_url') }}
         END AS base64_url
-    FROM once_daily_gtfs_datasets
+    FROM trimmed
 ),
 
 stg_transit_database__gtfs_datasets AS (

--- a/warehouse/poetry.lock
+++ b/warehouse/poetry.lock
@@ -257,7 +257,7 @@ test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
 
 [[package]]
 name = "dask"
-version = "2022.10.0"
+version = "2022.9.1"
 description = "Parallel PyData with Task Scheduling"
 category = "main"
 optional = false
@@ -275,10 +275,10 @@ toolz = ">=0.8.2"
 
 [package.extras]
 array = ["numpy (>=1.18)"]
-complete = ["bokeh (>=2.4.2)", "distributed (==2022.10.0)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+complete = ["bokeh (>=2.4.2)", "distributed (==2022.9.1)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
 dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
 diagnostics = ["bokeh (>=2.4.2)", "jinja2"]
-distributed = ["distributed (==2022.10.0)"]
+distributed = ["distributed (==2022.9.1)"]
 test = ["pandas", "pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
 
 [[package]]
@@ -1866,7 +1866,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "0e51f8ff3242347c10523894f91dcda84f3b8066f016424526c8cc9f77afcb9c"
+content-hash = "0613034428c6d8749a5be70d211470b8f7a19381e506762a380d513ac634b5e1"
 
 [metadata.files]
 agate = []

--- a/warehouse/pyproject.toml
+++ b/warehouse/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "~3.9"
-dbt-core = "1.2.1"
+dbt-core = "^1.0.4"
 dbt-bigquery = "^1.0.0"
 colorama = "^0.4.4"
 black = "22.3.0"


### PR DESCRIPTION
# Description

Adds an intermediate table to provide a URL-to-gtfs_dataset mapping; can provide an interface for eventual versioned/historical Airtable. The key new column is `gtfs_dataset_key` on `dim_schedule_feeds`, allowing users to look up current Airtable data via `<some gtfs data> => dim_schedule_feeds => dim_gtfs_datasets => <some airtable data>`.

One note: Since Airtable is currently latest-only; there are a handful of records `SMART` missing, as they were deleted. Therefore, the tests use a small error threshold that can be removed once Airtable is made historical.

Supports https://github.com/cal-itp/data-infra/issues/1761

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally; `poetry run dbt run -m +fct_daily_scheduled_trips && poetry run dbt test -m fct_daily_scheduled_trips dim_schedule_feeds stg_transit_database__gtfs_datasets int_transit_database__urls_to_gtfs_datasets` passes to the expected extent.

## Screenshots (optional)
