### PR TITLE
Hotfixes for missing refs (fct_schedule_feed_downloads & dim_schedule_feeds)

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -23,18 +23,6 @@ models:
         name: base64_url
         description: |
           Base 64 encoded URL from which this data was scraped.
-      - &gtfs_dataset_key
-        name: gtfs_dataset_key
-        tests:
-          - not_null
-          - relationships:
-              to: ref('dim_gtfs_datasets')
-              field: key
-              config:
-                # there are a dozen rows of SMART transit which was deleted from Airtable
-                # this will work without exception once the Airtable dim is historical;
-                # this threshold may need to increase if the backfill occurs prior to that
-                error_if: ">20"
       - &_valid_from
         name: _valid_from
         description: '{{ doc("column_valid_from") }}'
@@ -57,7 +45,18 @@ models:
       - name: feed_key
         description: |
           Foreign key to the `dim_schedule_feeds` table.
-      - *gtfs_dataset_key
+      - &gtfs_dataset_key
+        name: gtfs_dataset_key
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
+              config:
+                # there are a dozen rows of SMART transit which was deleted from Airtable
+                # this will work without exception once the Airtable dim is historical;
+                # this threshold may need to increase if the backfill occurs prior to that
+                error_if: ">20"
       - name: is_future
         description: |
           Boolean indicating whether this date is in the future relative to the last time that the table
@@ -77,7 +76,9 @@ models:
         description: |
           Foreign key to the `dim_schedule_feeds` table.
         tests:
-          - not_null
+          - not_null:
+              config:
+                where: download_success
           - relationships:
               to: ref('dim_schedule_feeds')
               field: key

--- a/warehouse/models/mart/gtfs/fct_schedule_feed_downloads.sql
+++ b/warehouse/models/mart/gtfs/fct_schedule_feed_downloads.sql
@@ -5,6 +5,11 @@ WITH joined_feed_outcomes AS (
     FROM {{ ref('int_gtfs_schedule__joined_feed_outcomes') }}
 ),
 
+dim_schedule_feeds AS (
+    SELECT *
+    FROM {{ ref('dim_schedule_feeds') }}
+),
+
 urls_to_gtfs_datasets AS (
     SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
 ),
@@ -13,7 +18,7 @@ fct_schedule_feeds AS (
     SELECT
         {{ dbt_utils.surrogate_key(['j.base64_url', 'j.ts']) }} as key,
         f.key AS feed_key,
-        j.gtfs_dataset_key,
+        u.gtfs_dataset_key,
         j.ts,
         j.base64_url,
         j.download_success,
@@ -25,6 +30,8 @@ fct_schedule_feeds AS (
         j.zipfile_dirs,
         j.pct_files_successfully_parsed
     FROM joined_feed_outcomes AS j
+    LEFT JOIN urls_to_gtfs_datasets AS u
+        ON j.base64_url = u.base64_url
     LEFT JOIN dim_schedule_feeds AS f
         ON j.base64_url = f.base64_url
         AND j.ts BETWEEN f._valid_from AND f._valid_to


### PR DESCRIPTION
# Description

PR #1937 introduced two issues:
* Merged with tests referencing `gtfs_dataset_key` column in `dim_schedule_feeds` table, but that column is no longer actually present in that table 
* Deleted reference to `dim_schedule_feeds` in `fct_schedule_feed_downloads` but that reference was still needed; did not actually substitute in the reference to the new URL mapping table correctly

This PR fixes both of these issues. This PR also adds a `where` qualifier in the `not_null` test on `fct_schedule_feed_downloads` clarifying that `feed_key` is only present if the feed download actually succeeded.

Fixes the following Sentry alerts:
https://sentry.calitp.org/organizations/sentry/issues/8305/?project=2
```
DbtTestError
test.calitp_warehouse.not_null_dim_schedule_feeds_gtfs_dataset_key.8507969a6a - Database Error in test not_null_dim_schedule_feeds_gtfs_dataset_key (models/mart/gtfs/_mart_gtfs.yml)
  Unrecognized name: gtfs_dataset_key at [15:7]
  compiled SQL at target/run/calitp_warehouse/models/mart/gtfs/_mart_gtfs.yml/not_null_dim_schedule_feeds_gtfs_dataset_key.sql
```
https://sentry.calitp.org/organizations/sentry/issues/8306/?project=2
```
DbtTestFail

test.calitp_warehouse.not_null_fct_schedule_feed_downloads_gtfs_dataset_key.680edfcdfa - Got 5818 results, configured to fail if != 0
```
https://sentry.calitp.org/organizations/sentry/issues/8309/?project=2
```
DbtTestError

test.calitp_warehouse.relationships_dim_schedule_feeds_gtfs_dataset_key__key__ref_dim_gtfs_datasets_.ef0dd5229e - Database Error in test relationships_dim_schedule_feeds_gtfs_dataset_key__key__ref_dim_gtfs_datasets_ (models/mart/gtfs/_mart_gtfs.yml)
  Unrecognized name: gtfs_dataset_key at [14:11]
  compiled SQL at target/run/calitp_warehouse/models/mart/gtfs/_mart_gtfs.yml/relationships_dim_schedule_fee_31e87560d51bfc14361a26beb4f30f07.sql
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`poetry run dbt run -s fct_schedule_feed_downloads dim_schedule_feeds` & 
`poetry run dbt test -s fct_schedule_feed_downloads dim_schedule_feeds`
