### PR TITLE
fix anchor yaml for feed_key column

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -267,6 +267,15 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `agency_id`.
         tests: *primary_key_tests
+      - &feed_key
+        name: feed_key
+        description: |
+          Foreign key to the `dim_schedule_feeds` table.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_schedule_feeds')
+              field: key
       - *base64_url
       - name: agency_id
         description: '{{ doc("gtfs_agency__agency_id") }}'
@@ -308,6 +317,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `area_id`.
         tests: *primary_key_tests
+      - *feed_key
       - *base64_url
       - name: area_id
         description: '{{ doc("gtfs_areas__area_id") }}'
@@ -333,7 +343,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `attribution_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: attribution_id
         description: '{{ doc("gtfs_attributions__attribution_id") }}'
@@ -377,7 +387,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `fare_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: fare_id
         description: '{{ doc("gtfs_fare_attributes__fare_id") }}'
@@ -421,7 +431,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `network_id`, `from_area_id`, `to_area_id`, and `fare_product_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: leg_group_id
         description: '{{ doc("gtfs_fare_leg_rules__leg_group_id") }}'
@@ -453,7 +463,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `fare_product_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: fare_product_id
         description: '{{ doc("gtfs_fare_products__fare_product_id") }}'
@@ -487,7 +497,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `fare_id`, `route_id`, `origin_id`, `destination_id`, and `contains_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: route_id
         description: '{{ doc("gtfs_fare_rules__route_id") }}'
@@ -515,7 +525,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, 'from_leg_group_id', 'to_leg_group_id', 'fare_product_id', 'transfer_count', and 'duration_limit'.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: from_leg_group_id
         description: '{{ doc("gtfs_fare_transfer_rules__from_leg_group_id") }}'
@@ -551,7 +561,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `feed_publisher_name`, `feed_publisher_url`, `feed_lang`, `default_lang`, `feed_version`, `feed_contact_email`, `feed_contact_url`, `feed_start_date`, and `feed_end_date`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: feed_publisher_name
         description: '{{ doc("gtfs_feed_info__feed_publisher_name") }}'
@@ -595,7 +605,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `trip_id`, and `start_time`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: trip_id
         description: '{{ doc("gtfs_frequencies__trip_id") }}'
@@ -633,7 +643,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `level_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: level_id
         description: '{{ doc("gtfs_levels__level_id") }}'
@@ -663,7 +673,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `pathway_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: pathway_id
         description: '{{ doc("gtfs_pathways__pathway_id") }}'
@@ -717,6 +727,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `route_id`.
         tests: *primary_key_tests
+      - *feed_key
       - *base64_url
       - name: route_id
         description: '{{ doc("gtfs_routes__route_id") }}'
@@ -764,7 +775,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `shape_id`, and `shape_pt_sequence`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: shape_id
         description: '{{ doc("gtfs_shapes__shape_id") }}'
@@ -812,7 +823,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `area_id` and `stop_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: area_id
         description: '{{ doc("gtfs_stop_areas__area_id") }}'
@@ -840,7 +851,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `stop_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: stop_id
         description: '{{ doc("gtfs_stops__stop_id") }}'
@@ -902,7 +913,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `from_stop_id`, `to_stop_id`, `from_trip_id`, `to_trip_id`, `from_route_id`, and `to_route_id`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: from_stop_id
         description: '{{ doc("gtfs_transfers__from_stop_id") }}'
@@ -940,7 +951,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key`, `table_name`, `field_name`, `language`, `record_id`, `record_sub_id`, and `field_value`.
         tests: *primary_key_tests
-
+      - *feed_key
       - *base64_url
       - name: table_name
         description: '{{ doc("gtfs_translations__table_name") }}'
@@ -986,6 +997,7 @@ models:
           - unique:
               where: "not warning_duplicate_primary_key"
           - not_null
+      - *feed_key
       - *base64_url
       - name: route_id
         description: '{{ doc("gtfs_trips__route_id") }}'
@@ -1035,15 +1047,7 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `service_id`.
         tests: *primary_key_tests
-      - &feed_key
-        name: feed_key
-        description: |
-          Foreign key to the `dim_schedule_feeds` table.
-        tests:
-          - not_null
-          - relationships:
-              to: ref('dim_schedule_feeds')
-              field: key
+      - *feed_key
       - *base64_url
       - name: service_id
         description: '{{ doc("gtfs_calendar__service_id") }}'
@@ -1128,7 +1132,7 @@ models:
           gaps: required
     columns:
       - name: base64_url
-      - name: ts
+      - *feed_key
       - name: trip_id
         description: '{{ doc("gtfs_stop_times__trip_id") }}'
         tests:

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -71,8 +71,7 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url` and `ts`.
         tests: *primary_key_tests
-      - &feed_key
-        name: feed_key
+      - name: feed_key
         description: |
           Foreign key to the `dim_schedule_feeds` table.
         tests:
@@ -1036,7 +1035,15 @@ models:
         description: |
           Synthetic primary key constructed from `feed_key` and `service_id`.
         tests: *primary_key_tests
-      - *feed_key
+      - &feed_key
+        name: feed_key
+        description: |
+          Foreign key to the `dim_schedule_feeds` table.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_schedule_feeds')
+              field: key
       - *base64_url
       - name: service_id
         description: '{{ doc("gtfs_calendar__service_id") }}'


### PR DESCRIPTION
# Description

In #1942, I accidentally added a `where: download_success` check in YAML that was tagged as the anchor for the `feed_key` column. This caused failures in the references to that anchor where that `download_success` column is not present. 

This PR fixes this issue & also adds use of this `feed_key` YAML anchor ref to all dimension tables (i.e., it was incorrect that only `calendar` and `calendar_dates` failed -- all the schedule dimension tables should have had this issue.) Also removes erroneous ref to `ts` column in `dim_stop_times`.

Resolves Sentry errors:
https://sentry.calitp.org/organizations/sentry/issues/8310/?project=2
```
test.calitp_warehouse.not_null_dim_calendar_feed_key.0daf07590f - Database Error in test not_null_dim_calendar_feed_key (models/mart/gtfs/_mart_gtfs.yml)
 Unrecognized name: download_success at [14:75]
 compiled SQL at target/run/calitp_warehouse/models/mart/gtfs/_mart_gtfs.yml/not_null_dim_calendar_feed_key.sql
```
https://sentry.calitp.org/organizations/sentry/issues/8311/?project=2
```
test.calitp_warehouse.not_null_dim_calendar_dates_feed_key.a9df430afe - Database Error in test not_null_dim_calendar_dates_feed_key (models/mart/gtfs/_mart_gtfs.yml)
 Unrecognized name: download_success at [14:81]
 compiled SQL at target/run/calitp_warehouse/models/mart/gtfs/_mart_gtfs.yml/not_null_dim_calendar_dates_feed_key.sql
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`poetry run dbt run -s models/mart/gtfs/` & `poetry run dbt test -s models/mart/gtfs/`
