### PR TITLE
fix gtfs validator version external table schema column name

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/validation_notices.yml
@@ -29,7 +29,7 @@ schema_fields:
             type: JSON
           - name: auth_headers
             type: JSON
-      - name: gtfs_validator_versions
+      - name: gtfs_validator_version
         type: STRING
   - name: code
     type: STRING


### PR DESCRIPTION
# Description

I am working on v2 validation models and found this typo in the external table. I need it deployed since dbt sources (correctly) point at the production version of external tables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
```
Deleting external table if exists: cal-itp-data-infra-staging.external_gtfs_schedule.validation_notices
Creating external table: cal-itp-data-infra-staging.external_gtfs_schedule.validation_notices Table(TableReference(DatasetReference('cal-itp-data-infra-staging', 'external_gtfs_schedule'), 'validation_notices')) ['gs://test-calitp-gtfs-schedule-validation/validation_notices/*.jsonl.gz'] {'mode': 'CUSTOM', 'source_uri_prefix': 'validation_notices/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/'}
[2022-11-01 15:20:08,694] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=create_external_tables, task_id=validation_notices, execution_date=20221012T000000, start_date=20221101T151718, end_date=20221101T152008
```

## Screenshots (optional)
