### PR TITLE
make rt v2 validation artifacts have consistent names (and make lint pass)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,9 +32,12 @@ repos:
         additional_dependencies: ['dbt-bigquery', 'sqlfluff-templater-dbt']
         # skip: L003 indentation stuff -- TODO
         # skip: L010 uppercase keywords -- TODO
+        # skip: L011 implicit/explicit aliasing of tables? -- TODO
         # skip: L022 spacing between CTEs -- TODO
+        # skip: L036 select targets should be on new line unless only 1 target
         # skip: L038 trailing comma in SELECT, bigquery is OK with this
         # skip: L039 unnecessary whitespace, this is tricky with templating
+        # skip: L059 unnecessary quoted identifier, we need this for `extract` among others
         # skip: parsing, templating that are unfixable by linter
         # skip: line too long, keywords should not be used as identifier (at least for now...)
         # skip: unqualified reference from multiple tables
@@ -43,5 +46,5 @@ repos:
         # skip: joins should not include subqueries -- TODO
         # skip: use left join instead of right join -- TODO
         # skip: use single quotes instead of double -- TODO
-        args: [--dialect, "bigquery", --ignore, "parsing,templating",--exclude-rules, "L003,L010,L022,L038,L039,L016,L029,L027,L032,L034,L014,L042,L055,L064"]
+        args: [--dialect, "bigquery", --ignore, "parsing,templating",--exclude-rules, "L003,L010,L011,L022,L036,L038,L039,L059,L016,L029,L027,L032,L034,L014,L042,L055,L064"]
         files: "warehouse/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: 1.7.4
     hooks:
       - id: bandit
-        args: ["-ll", "--skip=B108,B608,B310,B303"]
+        args: ["-ll", "--skip=B108,B608,B310,B303,B324"]
         files: .py$
   - repo: https://github.com/sqlfluff/sqlfluff
     rev: 1.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
     hooks:
       - id: sqlfluff-lint
         additional_dependencies: ['dbt-bigquery', 'sqlfluff-templater-dbt']
+        # skip: L003 indentation stuff -- TODO
+        # skip: L010 uppercase keywords -- TODO
+        # skip: L022 spacing between CTEs -- TODO
+        # skip: L038 trailing comma in SELECT, bigquery is OK with this
+        # skip: L039 unnecessary whitespace, this is tricky with templating
         # skip: parsing, templating that are unfixable by linter
         # skip: line too long, keywords should not be used as identifier (at least for now...)
         # skip: unqualified reference from multiple tables
@@ -38,5 +43,5 @@ repos:
         # skip: joins should not include subqueries -- TODO
         # skip: use left join instead of right join -- TODO
         # skip: use single quotes instead of double -- TODO
-        args: [--dialect, "bigquery", --ignore, "parsing,templating",--exclude-rules, "L016,L029,L027,L032,L034,L014,L042,L055,L064"]
+        args: [--dialect, "bigquery", --ignore, "parsing,templating",--exclude-rules, "L003,L010,L022,L038,L039,L016,L029,L027,L032,L034,L014,L042,L055,L064"]
         files: "warehouse/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,32 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.3.0
     hooks:
-      - id: flake8
-        args: ["--ignore=E501,W503"] # line too long and line before binary operator (black is ok with these)
-        types:
-          - python
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
         args: ["--unsafe"]
         exclude: 'kubernetes/apps/charts/.*'
       - id: check-added-large-files
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+        args: ["--ignore=E501,W503"] # line too long and line before binary operator (black is ok with these)
+        types:
+          - python
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/bandit
-    rev: 1.7.0
+    rev: 1.7.4
     hooks:
       - id: bandit
         args: ["-ll", "--skip=B108,B608,B310,B303"]
         files: .py$
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 1.2.1
+    rev: 1.4.1
     hooks:
       - id: sqlfluff-lint
         additional_dependencies: ['dbt-bigquery', 'sqlfluff-templater-dbt']

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_notices.yml
@@ -1,14 +1,14 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__GTFS_RT_VALIDATION') }}"
 source_objects:
-  - "service_alerts_validations/*.jsonl.gz"
-destination_project_dataset_table: "external_gtfs_rt_v2.service_alerts_validations"
+  - "service_alerts_validation_notices/*.jsonl.gz"
+destination_project_dataset_table: "external_gtfs_rt_v2.service_alerts_validation_notices"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: true
-  source_uri_prefix: "service_alerts_validations/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
+  source_uri_prefix: "service_alerts_validation_notices/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata
     type: RECORD

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_outcomes.yml
@@ -1,14 +1,14 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__GTFS_RT_VALIDATION') }}"
 source_objects:
-  - "vehicle_positions_validations_outcomes/*.jsonl"
-destination_project_dataset_table: "external_gtfs_rt_v2.vehicle_positions_validations_outcomes"
+  - "service_alerts_validation_outcomes/*.jsonl"
+destination_project_dataset_table: "external_gtfs_rt_v2.service_alerts_validation_outcomes"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: true
-  source_uri_prefix: "vehicle_positions_validations_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
+  source_uri_prefix: "service_alerts_validation_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_notices.yml
@@ -1,14 +1,14 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__GTFS_RT_VALIDATION') }}"
 source_objects:
-  - "trip_updates_validations/*.jsonl.gz"
-destination_project_dataset_table: "external_gtfs_rt_v2.trip_updates_validations"
+  - "trip_updates_validation_notices/*.jsonl.gz"
+destination_project_dataset_table: "external_gtfs_rt_v2.trip_updates_validation_notices"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: true
-  source_uri_prefix: "trip_updates_validations/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
+  source_uri_prefix: "trip_updates_validation_notices/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata
     type: RECORD

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_outcomes.yml
@@ -1,14 +1,14 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__GTFS_RT_VALIDATION') }}"
 source_objects:
-  - "service_alerts_validations_outcomes/*.jsonl"
-destination_project_dataset_table: "external_gtfs_rt_v2.service_alerts_validations_outcomes"
+  - "trip_updates_validation_outcomes/*.jsonl"
+destination_project_dataset_table: "external_gtfs_rt_v2.trip_updates_validation_outcomes"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: true
-  source_uri_prefix: "service_alerts_validations_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
+  source_uri_prefix: "trip_updates_validation_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_notices.yml
@@ -1,14 +1,14 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__GTFS_RT_VALIDATION') }}"
 source_objects:
-  - "vehicle_positions_validations/*.jsonl.gz"
-destination_project_dataset_table: "external_gtfs_rt_v2.vehicle_positions_validations"
+  - "vehicle_positions_validation_notices/*.jsonl.gz"
+destination_project_dataset_table: "external_gtfs_rt_v2.vehicle_positions_validation_notices"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: true
-  source_uri_prefix: "vehicle_positions_validations/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
+  source_uri_prefix: "vehicle_positions_validation_notices/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata
     type: RECORD

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_outcomes.yml
@@ -1,14 +1,14 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__GTFS_RT_VALIDATION') }}"
 source_objects:
-  - "trip_updates_validations_outcomes/*.jsonl"
-destination_project_dataset_table: "external_gtfs_rt_v2.trip_updates_validations_outcomes"
+  - "vehicle_positions_validation_outcomes/*.jsonl"
+destination_project_dataset_table: "external_gtfs_rt_v2.vehicle_positions_validation_outcomes"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: true
-  source_uri_prefix: "trip_updates_validations_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
+  source_uri_prefix: "vehicle_positions_validation_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/warehouse/models/gtfs_schedule_latest_only/frequencies.sql
+++ b/warehouse/models/gtfs_schedule_latest_only/frequencies.sql
@@ -1,7 +1,7 @@
 {{ config(materialized='table') }}
 
 WITH
-frequencies AS(
+frequencies AS (
     {{ get_latest_schedule_data(
     latest_only_source = ref('calitp_feeds'),
     table_name = 'frequencies',

--- a/warehouse/models/gtfs_views_staging/calitp_feeds.sql
+++ b/warehouse/models/gtfs_views_staging/calitp_feeds.sql
@@ -39,13 +39,13 @@ safe_urls AS (
                 AND (almost_safe_url NOT LIKE r"%api.actransit.org/transit/gtfs/download?token={\%")
                 THEN REGEXP_REPLACE(
                     almost_safe_url,
-                    "token=[a-zA-Z0-9-]+", {% raw %}"token={{ AC_TRANSIT_API_KEY }}"{% endraw %}
+                    "token=[a-zA-Z0-9-]+", {% raw %}"token={{ AC_TRANSIT_API_KEY }}"{% endraw %} -- noqa: L048
                 )
             WHEN (almost_safe_url LIKE r"%api.511.org/transit/%?api_key=%")
                 AND (almost_safe_url NOT LIKE r"%api.511.org/transit/%?api_key={\%")
                 THEN REGEXP_REPLACE(
                     almost_safe_url,
-                    "api_key=[a-zA-Z0-9-]+", {% raw %}"api_key={{ MTC_511_API_KEY }}"{% endraw %}
+                    "api_key=[a-zA-Z0-9-]+", {% raw %}"api_key={{ MTC_511_API_KEY }}"{% endraw %} -- noqa: L048
                 )
             ELSE almost_safe_url
             END) AS gtfs_schedule_url

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__incremental_trips.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__incremental_trips.sql
@@ -19,7 +19,7 @@ stg_gtfs_schedule__trips AS (
     SELECT *
     FROM {{ ref('stg_gtfs_schedule__trips') }}
     {% if is_incremental() %}
-    WHERE _dt >= EXTRACT (DATE FROM TIMESTAMP('{{ max_ts }}'))
+    WHERE _dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% endif %}
 ),
 

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -38,7 +38,7 @@ fct_vehicle_positions_messages AS (
         _gtfs_dataset_name,
 
         header_timestamp,
-        header_version
+        header_version,
         header_incrementality,
 
         id,

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -51,7 +51,7 @@ models:
         meta:
           metabase.semantic_type: type/FK
       - name: details
-        description:	Text description related to the organization
+        description: Text description related to the organization
       - name: reporting_category
         description: |
           Categories we want to hold ourselves accountable to:

--- a/warehouse/models/mart/transit_database/bridge_contracts_x_components.sql
+++ b/warehouse/models/mart/transit_database/bridge_contracts_x_components.sql
@@ -6,6 +6,7 @@ WITH latest_contracts AS (
     order_by = 'calitp_extracted_at DESC'
     ) }}
 ),
+
 latest_components AS (
     {{ get_latest_dense_rank(
     external_table = ref('stg_transit_database__components'),

--- a/warehouse/models/staging/gtfs/_src_gtfs_rt_external_tables.yml
+++ b/warehouse/models/staging/gtfs/_src_gtfs_rt_external_tables.yml
@@ -8,13 +8,13 @@ sources:
     tables:
       - name: service_alerts
       - name: service_alerts_outcomes
-      - name: service_alerts_validations
-      - name: service_alerts_validations_outcomes
+      - name: service_alerts_validation_notices
+      - name: service_alerts_validation_outcomes
       - name: vehicle_positions
       - name: vehicle_positions_outcomes
-      - name: vehicle_positions_validations
-      - name: vehicle_positions_validations_outcomes
+      - name: vehicle_positions_validation_notices
+      - name: vehicle_positions_validation_outcomes
       - name: trip_updates
       - name: trip_updates_outcomes
-      - name: trip_updates_validations
-      - name: trip_updates_validations_outcomes
+      - name: trip_updates_validation_notices
+      - name: trip_updates_validation_outcomes

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__complete_wheelchair_accessibility_data.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__complete_wheelchair_accessibility_data.sql
@@ -40,14 +40,7 @@ daily_trips AS (
        AND t1.date < t2.calitp_deleted_at
        AND t1.calitp_itp_id = t2.calitp_itp_id
        AND t1.calitp_url_number = t2.calitp_url_number
- GROUP BY
-        t1.date,
-        t1.calitp_itp_id,
-        t1.calitp_url_number,
-        t1.calitp_agency_name,
-        t1.feed_key,
-        t1.check,
-        t1.feature
+ GROUP BY 1, 2, 3, 4, 5, 6, 7
 ),
 
 summarize_stops AS (
@@ -79,14 +72,7 @@ daily_stops AS (
        AND t1.date < t2.calitp_deleted_at
        AND t1.calitp_itp_id = t2.calitp_itp_id
        AND t1.calitp_url_number = t2.calitp_url_number
- GROUP BY
-        t1.date,
-        t1.calitp_itp_id,
-        t1.calitp_url_number,
-        t1.calitp_agency_name,
-        t1.feed_key,
-        t1.check,
-        t1.feature
+  GROUP BY 1, 2, 3, 4, 5, 6, 7
 ),
 
 accessibility_check AS (

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
@@ -5,7 +5,7 @@ WITH feed_guideline_index AS (
 
 -- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL+feed type
 gtfs_rt_fact_files_wide_daily AS (
-SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
+    SELECT * FROM {{ ref('gtfs_rt_fact_files_wide_hourly') }}
 ),
 
 gtfs_rt_fact_daily_validation_errors AS (
@@ -23,7 +23,7 @@ rt_files_by_day AS (
         date_extracted AS date,
         COUNT(*) AS rt_files
     FROM gtfs_rt_fact_files_wide_daily
-    GROUP BY 1,2,3
+    GROUP BY 1, 2, 3
 ),
 
 errors_by_day AS (
@@ -35,7 +35,7 @@ errors_by_day AS (
     LEFT JOIN gtfs_rt_validation_code_descriptions AS t2
          ON t1.error_id = t2.code
     WHERE t2.is_critical = "y"
-    GROUP BY t1.feed_key, t1.date
+    GROUP BY 1, 2
 ),
 
 errors_daily_check AS (

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_validation_errors.sql
@@ -17,7 +17,7 @@ validation_errors_by_day AS (
         date,
         SUM(n_notices) as validation_errors
     FROM validation_fact_daily_feed_codes
-    LEFT JOIN validation_dim_codes USING(code)
+    LEFT JOIN validation_dim_codes USING (code)
     WHERE severity = "ERROR"
     GROUP BY feed_key, date
 ),

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__schedule_downloaded_successfully.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__schedule_downloaded_successfully.sql
@@ -14,7 +14,6 @@ static_feed_downloaded_successfully_check AS (
         CASE
             WHEN extraction_status = "success" THEN "PASS"
             WHEN extraction_status = "error" THEN "FAIL"
-        ELSE null
         END AS status,
         {{ static_feed_downloaded_successfully() }} AS check
     FROM gtfs_schedule_fact_daily_feeds

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__schedule_feed_on_transitland.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__schedule_feed_on_transitland.sql
@@ -4,13 +4,13 @@ WITH feed_guideline_index AS (
 ),
 
 fact_daily_transitland_url_check AS (
-SELECT * FROM {{ ref('stg_gtfs_guidelines__fact_daily_transitland_url_check') }}
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__fact_daily_transitland_url_check') }}
 ),
 
 -- We're using DISTINCT here as a result of bug #1825
 schedule_daily_check AS (
-    SELECT
-        DISTINCT calitp_itp_id,
+    SELECT DISTINCT
+        calitp_itp_id,
         dt AS date
    FROM fact_daily_transitland_url_check
   WHERE url_type = "gtfs_schedule_url"

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_on_transitland.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__service_alerts_feed_on_transitland.sql
@@ -4,13 +4,13 @@ WITH feed_guideline_index AS (
 ),
 
 fact_daily_transitland_url_check AS (
-SELECT * FROM {{ ref('stg_gtfs_guidelines__fact_daily_transitland_url_check') }}
+    SELECT * FROM {{ ref('stg_gtfs_guidelines__fact_daily_transitland_url_check') }}
 ),
 
 -- We're using DISTINCT here as a result of bug #1825
 service_alerts_daily_check AS (
-    SELECT
-        DISTINCT calitp_itp_id,
+    SELECT DISTINCT
+        calitp_itp_id,
         dt AS date
    FROM fact_daily_transitland_url_check
   WHERE url_type = "gtfs_rt_service_alerts_url"

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__shapes_for_all_trips.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__shapes_for_all_trips.sql
@@ -36,14 +36,7 @@ daily_trips AS (
        AND t1.date < t2.calitp_deleted_at
        AND t1.calitp_itp_id = t2.calitp_itp_id
        AND t1.calitp_url_number = t2.calitp_url_number
- GROUP BY
-        t1.date,
-        t1.calitp_itp_id,
-        t1.calitp_url_number,
-        t1.calitp_agency_name,
-        t1.feed_key,
-        t1.check,
-        t1.feature
+ GROUP BY 1, 2, 3, 4, 5, 6, 7
 ),
 
 trip_shape_check AS (

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_id_alignment.sql
@@ -19,7 +19,7 @@ rt_files_by_day AS (
         date_extracted AS date,
         COUNT(*) AS rt_files
     FROM gtfs_rt_fact_files_wide_daily
-    GROUP BY 1,2,3
+    GROUP BY 1, 2, 3
 ),
 
 errors_by_day AS (
@@ -27,11 +27,11 @@ errors_by_day AS (
         feed_key,
         date,
         SUM(occurrences) AS errors
-    FROM gtfs_rt_fact_daily_validation_errors AS t1
+    FROM gtfs_rt_fact_daily_validation_errors
     -- Description for error E003:
     ---- "All trip_ids provided in the GTFS-rt feed must exist in the GTFS data, unless the schedule_relationship is ADDED"
     WHERE error_id = "E003"
-    GROUP BY feed_key, date
+    GROUP BY 1, 2
 ),
 
 errors_daily_check AS (

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_on_transitland.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__trip_updates_feed_on_transitland.sql
@@ -9,8 +9,8 @@ SELECT * FROM {{ ref('stg_gtfs_guidelines__fact_daily_transitland_url_check') }}
 
 -- We're using DISTINCT here as a result of bug #1825
 trip_updates_daily_check AS (
-    SELECT
-        DISTINCT calitp_itp_id,
+    SELECT DISTINCT
+        calitp_itp_id,
         dt AS date
    FROM fact_daily_transitland_url_check
   WHERE url_type = "gtfs_rt_trip_updates_url"

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_on_transitland.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__vehicle_positions_feed_on_transitland.sql
@@ -9,8 +9,8 @@ SELECT * FROM {{ ref('stg_gtfs_guidelines__fact_daily_transitland_url_check') }}
 
 -- We're using DISTINCT here as a result of bug #1825
 vehicle_positions_daily_check AS (
-    SELECT
-        DISTINCT calitp_itp_id,
+    SELECT DISTINCT
+        calitp_itp_id,
         dt AS date
    FROM fact_daily_transitland_url_check
   WHERE url_type = "gtfs_rt_vehicle_positions_url"

--- a/warehouse/models/staging/rt/stg_rt__validation_errors.sql
+++ b/warehouse/models/staging/rt/stg_rt__validation_errors.sql
@@ -1,15 +1,18 @@
 WITH validation_service_alerts AS (
-    SELECT *, 'service_alerts' as rt_feed_type
+    SELECT *,
+           'service_alerts' as rt_feed_type
     FROM {{ source('gtfs_rt_external_tables', 'service_alerts_validations') }}
 ),
 
 validation_trip_updates AS (
-    SELECT *, 'trip_updates' as rt_feed_type
+    SELECT *,
+           'trip_updates' as rt_feed_type
     FROM {{ source('gtfs_rt_external_tables', 'trip_updates_validations') }}
 ),
 
 validation_vehicle_positions AS (
-    SELECT *, 'vehicle_positions' as rt_feed_type
+    SELECT *,
+           'vehicle_positions' as rt_feed_type
     FROM {{ source('gtfs_rt_external_tables', 'vehicle_positions_validations') }}
 ),
 

--- a/warehouse/models/staging/transit_database/base/base_tts_contracts_idmap.sql
+++ b/warehouse/models/staging/transit_database/base/base_tts_contracts_idmap.sql
@@ -35,7 +35,7 @@ base_tts_contracts_idmap AS (
         map.contract_vendor
     FROM latest as r
     LEFT JOIN mapped_org_ids AS map
-        USING(id, dt)
+        USING (id, dt)
 )
 
 SELECT * FROM base_tts_contracts_idmap

--- a/warehouse/models/staging/transit_database/base/base_tts_organizations_ct_organizations_map.sql
+++ b/warehouse/models/staging/transit_database/base/base_tts_organizations_ct_organizations_map.sql
@@ -1,12 +1,12 @@
 WITH
 
-ct_organizations AS (
+ct_organizations AS ( -- noqa: L045
     SELECT *
     FROM {{ source('airtable', 'california_transit__organizations') }}
     WHERE TRIM(name) != ""
 ),
 
-tts_organizations AS (
+tts_organizations AS ( -- noqa: L045
     SELECT *
     FROM {{ source('airtable', 'transit_technology_stacks__organizations') }}
     WHERE TRIM(name) != ""

--- a/warehouse/models/staging/transit_database/base/base_tts_service_components_idmap.sql
+++ b/warehouse/models/staging/transit_database/base/base_tts_service_components_idmap.sql
@@ -1,4 +1,3 @@
-
 WITH
 latest AS (
     {{ get_latest_dense_rank(
@@ -30,7 +29,7 @@ base_tts_service_components_idmap AS (
         T2.services
     FROM latest AS T1
     LEFT JOIN mapped_service_ids AS T2
-        USING(id, dt)
+        USING (id, dt)
 )
 
 SELECT * FROM base_tts_service_components_idmap

--- a/warehouse/models/staging/transit_database/base/base_tts_services_ct_services_map.sql
+++ b/warehouse/models/staging/transit_database/base/base_tts_services_ct_services_map.sql
@@ -1,12 +1,12 @@
 WITH
 
-ct_services AS (
+ct_services AS ( -- noqa: L045
     SELECT *
     FROM {{ source('airtable', 'california_transit__services') }}
     WHERE TRIM(name) != ""
 ),
 
-tts_services AS (
+tts_services AS ( -- noqa: L045
     SELECT *
     FROM {{ source('airtable', 'transit_technology_stacks__services') }}
     WHERE TRIM(name) != ""

--- a/warehouse/models/staging/transit_database/stg_transit_database__county_geography.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__county_geography.sql
@@ -1,5 +1,3 @@
-
-
 WITH
 once_daily_county_geography AS (
     {{ get_latest_dense_rank(

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -30,11 +30,11 @@ construct_base64_url AS (
                         -- if there are multiple query parameters, we leave the question mark, remove ampersand
                         -- so example.com/gtfs?auth=key&p2=v2 becomes example.com/gtfs?p2=v2
                         WHEN REGEXP_CONTAINS(uri, r"\?[\w]*\=\{\{[\w\s]*\}\}\&")
-                            THEN REGEXP_REPLACE(uri, r"[\w]*\=\{\{[\w\s]*\}\}\&","")
+                            THEN REGEXP_REPLACE(uri, r"[\w]*\=\{\{[\w\s]*\}\}\&", "")
                         -- if only one query parameter, remove the question mark
                         -- so example.com/gtfs?auth=key becomes example.com/gtfs
                         WHEN REGEXP_CONTAINS(uri, r"\?[\w]*\=\{\{[\w\s]*\}\}$")
-                            THEN REGEXP_REPLACE(uri, r"\?[\w]*\=\{\{[\w\s]*\}\}$","")
+                            THEN REGEXP_REPLACE(uri, r"\?[\w]*\=\{\{[\w\s]*\}\}$", "")
                         ELSE uri
                 END
             ELSE pipeline_url

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
@@ -1,5 +1,3 @@
-
-
 WITH
 once_daily_gtfs_service_data AS (
     {{ get_latest_dense_rank(


### PR DESCRIPTION
# Description

Precursor to https://github.com/cal-itp/data-infra/pull/1945; this PR sets the tasks, sources, and external tables of RT validation artifacts with the consistent naming scheme of `<plural rt type>_validation_<plural artifact type>` such as `vehicle_positions_validation_notices` and `vehicle_positions_validation_outcomes`. The upstream GCS paths are already correct and aligned with the Schedule naming scheme; I guess these v2 RT validation tables hadn't been used in dbt yet.

I also updated/adjusted our pre-commit versions since we were hitting failures, and made some code changes (all formatting or bugs) to pass new rules.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally with `dags test`; sqlfluff is failing with some dependency issue but we can ignore I think.

```
Deleting external table if exists: cal-itp-data-infra-staging.external_gtfs_rt_v2.vehicle_positions_validation_notices
Creating external table: cal-itp-data-infra-staging.external_gtfs_rt_v2.vehicle_positions_validation_notices Table(TableReference(DatasetReference('cal-itp-data-infra-staging', 'external_gtfs_rt_v2'), 'vehicle_positions_validation_notices')) ['gs://test-calitp-gtfs-rt-validation/vehicle_positions_validation_notices/*.jsonl.gz'] {'mode': 'CUSTOM', 'require_partition_filter': True, 'source_uri_prefix': 'vehicle_positions_validation_notices/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/'}
[2022-11-02 18:18:17,087] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=create_external_tables, task_id=rt_v2_vehicle_positions_validation_notices, execution_date=20221101T110000, start_date=20221102T181521, end_date=20221102T181817
...
Deleting external table if exists: cal-itp-data-infra-staging.external_gtfs_rt_v2.vehicle_positions_validation_outcomes
Creating external table: cal-itp-data-infra-staging.external_gtfs_rt_v2.vehicle_positions_validation_outcomes Table(TableReference(DatasetReference('cal-itp-data-infra-staging', 'external_gtfs_rt_v2'), 'vehicle_positions_validation_outcomes')) ['gs://test-calitp-gtfs-rt-validation/vehicle_positions_validation_outcomes/*.jsonl'] {'mode': 'CUSTOM', 'require_partition_filter': True, 'source_uri_prefix': 'vehicle_positions_validation_outcomes/{dt:DATE}/{hour:TIMESTAMP}/'}
[2022-11-02 18:18:20,006] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=create_external_tables, task_id=rt_v2_vehicle_positions_validation_outcomes, execution_date=20221101T110000, start_date=20221102T181521, end_date=20221102T181820
...
[2022-11-02 18:20:57,250] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=create_external_tables, task_id=gtfs_schedule_trips_txt_json_outcomes, execution_date=20221101T110000, start_date=20221102T181521, end_date=20221102T182057
[2022-11-02 18:20:57,273] {dagrun.py:477} INFO - Marking run <DagRun create_external_tables @ 2022-11-01T11:00:00+00:00: backfill__2022-11-01T11:00:00+00:00, externally triggered: False> successful
[2022-11-02 18:20:57,279] {backfill_job.py:377} INFO - [backfill progress] | finished run 1 of 1 | tasks waiting: 0 | succeeded: 97 | running: 0 | failed: 0 | skipped: 0 | deadlocked: 0 | not ready: 0
[2022-11-02 18:20:57,282] {backfill_job.py:831} INFO - Backfill done. Exiting.
```

## Screenshots (optional)
