### PR TITLE
update tech contact check to get rid of nulls and dedupe

### DIFF
--- a/warehouse/models/staging/gtfs_guidelines/_stg_gtfs_guidelines.yml
+++ b/warehouse/models/staging/gtfs_guidelines/_stg_gtfs_guidelines.yml
@@ -156,3 +156,20 @@ models:
       - name: status
         tests:
           - not_null
+  - name: stg_gtfs_guidelines__technical_contact_listed
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date
+            - calitp_itp_id
+            - calitp_url_number
+    columns:
+      - name: date
+      - name: calitp_itp_id
+      - name: calitp_url_number
+      - name: calitp_agency_name
+      - name: check
+      - name: feature
+      - name: status
+        tests:
+          - not_null

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__technical_contact_listed.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__technical_contact_listed.sql
@@ -17,29 +17,16 @@ daily_technical_contact_check AS (
         t1.check,
         t1.feature,
         CASE
-            WHEN t2.feed_contact_email IS NOT null THEN "PASS"
+            WHEN LOGICAL_AND(t2.feed_contact_email IS NOT NULL) THEN "PASS"
             ELSE "FAIL"
-        END AS status,
-        COUNT(*)
+        END AS status
     FROM feed_guideline_index AS t1
     LEFT JOIN feed_info_clean AS t2
        ON t1.calitp_itp_id = t2.calitp_itp_id
       AND t1.calitp_url_number = t2.calitp_url_number
       AND t1.date >= t2.calitp_extracted_at
       AND t1.date < t2.calitp_deleted_at
-    GROUP BY 1,2,3,4,5,6,7
-),
-
-daily_technical_contact_check_dedupe AS (
-    SELECT
-        date,
-        calitp_itp_id,
-        calitp_url_number,
-        calitp_agency_name,
-        check,
-        feature,
-        status
-    FROM daily_technical_contact_check
+    GROUP BY 1,2,3,4,5,6
 )
 
-SELECT * FROM daily_technical_contact_check_dedupe
+SELECT * FROM daily_technical_contact_check

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__technical_contact_listed.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__technical_contact_listed.sql
@@ -7,21 +7,8 @@ feed_info_clean AS (
     SELECT * FROM {{ ref('feed_info_clean') }}
 ),
 
-feed_info_clean_check AS (
-    SELECT
-        calitp_itp_id,
-        calitp_url_number,
-        calitp_extracted_at,
-        calitp_deleted_at,
-        CASE
-            WHEN feed_contact_email IS NOT null THEN "PASS"
-        ELSE "FAIL"
-        END AS status
-    FROM feed_info_clean
-),
-
 -- Joins our feed-level check with feed_guideline_index, where each feed will have a row for every day it is active
-daily_feed_info_clean_check AS (
+daily_technical_contact_check AS (
     SELECT
         t1.date,
         t1.calitp_itp_id,
@@ -29,13 +16,30 @@ daily_feed_info_clean_check AS (
         t1.calitp_agency_name,
         t1.check,
         t1.feature,
-        t2.status
+        CASE
+            WHEN t2.feed_contact_email IS NOT null THEN "PASS"
+            ELSE "FAIL"
+        END AS status,
+        COUNT(*)
     FROM feed_guideline_index AS t1
-    LEFT JOIN feed_info_clean_check AS t2
+    LEFT JOIN feed_info_clean AS t2
        ON t1.calitp_itp_id = t2.calitp_itp_id
       AND t1.calitp_url_number = t2.calitp_url_number
       AND t1.date >= t2.calitp_extracted_at
       AND t1.date < t2.calitp_deleted_at
+    GROUP BY 1,2,3,4,5,6,7
+),
+
+daily_technical_contact_check_dedupe AS (
+    SELECT
+        date,
+        calitp_itp_id,
+        calitp_url_number,
+        calitp_agency_name,
+        check,
+        feature,
+        status
+    FROM daily_technical_contact_check
 )
 
-SELECT * FROM daily_feed_info_clean_check
+SELECT * FROM daily_technical_contact_check_dedupe


### PR DESCRIPTION
# Description

I found two issues in `stg_gtfs_guidelines__technical_contact_listed.sql` that were impacting the downstream fact table:
- Because a dedupe wasn't performed, a fanout situation was created
- Because the check was defined prior to the join with `feed_guideline_index`, there existed unintentional nulll values in the status column

Note that this is one of the checks I built before I started including tests for each check.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I spot checked several passing and failing values, and queried to make sure there are no longer null values being created.
I added a dbt test for this table, confirmed that it failed prior to the fix, and passed after the fix.
I wrote a query to compare the features statuses between the staging table on my schema and the main staging table, and found that the they were always equal.

## Screenshots (optional)
