### PR TITLE
add v2 mart_gtfs to metabase sync

### DIFF
--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -220,6 +220,7 @@ def run(
             ("gtfs_schedule", "GTFS Schedule Feeds Latest"),
             ("mart_transit_database", "Data Marts (formerly Warehouse Views)"),
             ("mart_gtfs_guidelines", "Data Marts (formerly Warehouse Views)"),
+            ("mart_gtfs", "Data Marts (formerly Warehouse Views)"),
         ]:
             args = [
                 "dbt-metabase",


### PR DESCRIPTION
# Description

Want to sync v2 GTFS data to Metabase systematically (rather than just add manually via Metabase admin UI).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Not sure if/how to test, @atvaccaro open to suggestions
