### PR TITLE
Create RT validations index and daily facts, and implement a single check on top of notices

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -21,9 +21,8 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
-
-# Configuring models
-# Full documentation: https://docs.getdbt.com/docs/configuring-models
+vars:
+  INCREMENTAL_PARTITIONS_LOOKBACK_DAYS: 30
 
 models:
   calitp_warehouse:

--- a/warehouse/macros/gtfs_rt_stg_outcomes.sql
+++ b/warehouse/macros/gtfs_rt_stg_outcomes.sql
@@ -9,6 +9,7 @@ WITH raw_aggregation_outcomes AS (
 
 stg_gtfs_rt__agg_outcomes AS (
     SELECT
+        {{ dbt_utils.surrogate_key(['`extract`.ts', 'base64_url']) }} AS key,
         dt,
         hour,
         `extract`.config.name AS name,
@@ -22,7 +23,7 @@ stg_gtfs_rt__agg_outcomes AS (
         `extract`.response_headers AS download_response_headers,
         aggregation.step AS step,
         base64_url,
-        `extract`.ts
+        `extract`.ts AS extract_ts
     FROM raw_aggregation_outcomes
 )
 

--- a/warehouse/macros/gtfs_rt_stg_validation_notices.sql
+++ b/warehouse/macros/gtfs_rt_stg_validation_notices.sql
@@ -6,7 +6,7 @@ WITH raw_validation_notices AS (
 stg_gtfs_rt__validation_notices AS (
     SELECT
         -- this mainly exists so we can use WHERE in tests
-        {{ dbt_utils.surrogate_key(['metadata.extract_ts', 'base64_url', 'errorMessage.messageId']) }} AS key,
+        {{ dbt_utils.surrogate_key(['metadata.extract_ts', 'base64_url', 'errorMessage.validationRule.errorId']) }} AS key,
         dt,
         hour,
         base64_url,

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -11,6 +11,29 @@ models:
             - feed_key
             - date
 
+  - name: int_gtfs_quality__no_rt_critical_validation_errors
+    description: |
+      Checks for any critical validation notices in RT feeds.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date
+            - base64_url
+    columns:
+      - name: status
+        tests:
+          - dbt_utils.not_null_proportion:
+              at_least: 0.99
+
+  - name: int_gtfs_quality__rt_validation_outcomes
+    description: |
+      Unioned, incremental table of RT validation outcomes.
+    columns:
+      - name: key
+        tests:
+          - not_null
+          - unique
+
   - name: int_gtfs_quality__schedule_validation_severities
     description: |
       List of codes and their severity in the GTFS validator.

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
@@ -33,6 +33,7 @@ int_gtfs_quality__no_rt_critical_validation_errors AS (
     SELECT
         idx.date,
         idx.base64_url,
+        idx.feed_type,
         {{ no_rt_critical_validation_errors() }} AS check,
         {{ compliance() }} AS feature,
         rt_files,

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
@@ -40,8 +40,7 @@ int_gtfs_quality__no_rt_critical_validation_errors AS (
         errors,
         CASE
             WHEN COALESCE(errors, 0) = 0 THEN "PASS"
-            WHEN rt_files IS null THEN "FAIL"
-            WHEN errors > 0 THEN "FAIL"
+            WHEN rt_files IS NOT NULL THEN "FAIL" -- we had no errors, but did have files
         END AS status,
     FROM feed_guideline_index AS idx
     LEFT JOIN count_files AS files

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
@@ -1,0 +1,54 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index') }}
+),
+
+fct_daily_rt_feed_files AS (
+    SELECT * FROM {{ ref('fct_daily_rt_feed_files') }}
+),
+
+fct_daily_rt_feed_validation_notices AS (
+    SELECT * FROM {{ ref('fct_daily_rt_feed_validation_notices') }}
+),
+
+count_files AS (
+    SELECT
+        base64_url,
+        date,
+        SUM(parse_success_file_count) AS rt_files
+    FROM fct_daily_rt_feed_files
+    GROUP BY 1, 2
+),
+
+critical_notices AS (
+    SELECT
+        date,
+        base64_url,
+        SUM(total_notices) AS errors,
+    FROM fct_daily_rt_feed_validation_notices
+    WHERE is_critical
+    GROUP BY 1, 2
+),
+
+int_gtfs_quality__no_rt_critical_validation_errors AS (
+    SELECT
+        idx.date,
+        idx.base64_url,
+        {{ no_rt_critical_validation_errors() }} AS check,
+        {{ compliance() }} AS feature,
+        rt_files,
+        errors,
+        CASE
+            WHEN COALESCE(errors, 0) = 0 THEN "PASS"
+            WHEN rt_files IS null THEN "FAIL"
+            WHEN errors > 0 THEN "FAIL"
+        END AS status,
+    FROM feed_guideline_index AS idx
+    LEFT JOIN count_files AS files
+    ON idx.date = files.date
+        AND idx.base64_url = files.base64_url
+    LEFT JOIN critical_notices AS notices
+    ON idx.date = notices.date
+        AND idx.base64_url = notices.base64_url
+)
+
+SELECT * FROM int_gtfs_quality__no_rt_critical_validation_errors

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feed_guideline_index.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feed_guideline_index.sql
@@ -9,6 +9,7 @@ int_gtfs_quality__rt_feed_guideline_index AS (
     SELECT
         date,
         base64_url,
+        feed_type,
     FROM fct_daily_rt_feed_files
     WHERE date < CURRENT_DATE
 )

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feed_guideline_index.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feed_guideline_index.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='ephemeral') }}
+
+WITH fct_daily_rt_feed_files AS (
+    SELECT * FROM {{ ref('fct_daily_rt_feed_files') }}
+),
+
+-- we never want results from the current date, as data will be incomplete
+int_gtfs_quality__rt_feed_guideline_index AS (
+    SELECT
+        date,
+        base64_url,
+    FROM fct_daily_rt_feed_files
+    WHERE date < CURRENT_DATE
+)
+
+SELECT * FROM int_gtfs_quality__rt_feed_guideline_index

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
@@ -1,0 +1,42 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by = {'field': 'dt', 'data_type': 'date'},
+) }}
+
+{% if is_incremental() %}
+    {% set timestamps = dbt_utils.get_column_values(table=this, column='ts', order_by = 'ts DESC', max_records = 1) %}
+    {% set max_ts = timestamps[0] %}
+{% endif %}
+
+WITH
+
+int_gtfs_quality__rt_validation_notices AS (
+    -- predicate pushdown does not seem to work through UNIONs so list these all out
+    SELECT * FROM {{ ref('stg_gtfs_rt__service_alerts_validation_notices') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
+    {% endif %}
+
+    UNION ALL
+
+    SELECT * FROM {{ ref('stg_gtfs_rt__trip_updates_validation_notices') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
+    {% endif %}
+
+    UNION ALL
+
+    SELECT * FROM {{ ref('stg_gtfs_rt__vehicle_positions_validation_notices') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
+    {% endif %}
+)
+
+SELECT * FROM int_gtfs_quality__rt_validation_notices

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized='incremental',
     incremental_strategy='insert_overwrite',
-    partition_by = {'field': 'dt', 'data_type': 'date'},
-    granularity = 'day',
+    partition_by = {
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
 ) }}
 
 {% if is_incremental() %}

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     incremental_strategy='insert_overwrite',
     partition_by = {'field': 'dt', 'data_type': 'date'},
+    granularity = 'day',
 ) }}
 
 {% if is_incremental() %}

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_outcomes.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_outcomes.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='incremental',
     incremental_strategy='insert_overwrite',
-    partition_by={
+    partition_by = {
         'field': 'dt',
         'data_type': 'date',
         'granularity': 'day',

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_outcomes.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_outcomes.sql
@@ -1,0 +1,46 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by={
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
+
+{% if is_incremental() %}
+    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set max_dt = timestamps[0] %}
+{% endif %}
+
+WITH
+
+int_gtfs_quality__rt_validation_outcomes AS (
+    -- predicate pushdown does not seem to work through UNIONs so list these all out
+    SELECT * FROM {{ ref('stg_gtfs_rt__service_alerts_validation_outcomes') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
+    {% else %}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
+    {% endif %}
+
+    UNION ALL
+
+    SELECT * FROM {{ ref('stg_gtfs_rt__trip_updates_validation_outcomes') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
+    {% else %}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
+    {% endif %}
+
+    UNION ALL
+
+    SELECT * FROM {{ ref('stg_gtfs_rt__vehicle_positions_validation_outcomes') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
+    {% else %}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
+    {% endif %}
+)
+
+SELECT * FROM int_gtfs_quality__rt_validation_outcomes

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_severities.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_validation_severities.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+WITH validation_notices AS (
+    SELECT * FROM {{ ref('gtfs_rt_validation_code_descriptions') }}
+),
+
+int_gtfs_quality__rt_validation_severities AS (
+    -- TODO: if a future version of the validator changes a codes severity
+    -- we will end up with multiple entries for code (our primary key)
+    -- we either need to change track this table, or use only the most recent
+    -- levels of code x severity
+    -- TODO: another option is to make this a seed built from later versions
+    -- of the validator with the -n flag https://github.com/MobilityData/gtfs-validator/blob/master/docs/USAGE.md#via-cli-app
+    SELECT DISTINCT
+        code,
+        severity
+    FROM validation_notices
+)
+
+SELECT * FROM int_gtfs_quality__rt_validation_severities

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -1252,8 +1252,12 @@ models:
       description: One of `service_alerts`, `vehicle_positions`, and `trip_updates`.
     - name: parse_success_file_count
       description: Count of files successfully parsed. Target is 4,320 (one file every 20 seconds.)
+      tests:
+        - not_null
     - name: parse_failure_file_count
       description: Count of files where parsing failed, but a file was present.
+      tests:
+        - not_null
     - *gtfs_dataset_key
     - name: schedule_to_use_for_rt_validation_gtfs_dataset_key
       description: |

--- a/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
@@ -55,8 +55,8 @@ pivoted_parse_outcomes AS (
         dt,
         base64_url,
         feed_type,
-        parse_success_file_count,
-        parse_failure_file_count
+        COALESCE(parse_success_file_count, 0) AS parse_success_file_count,
+        COALESCE(parse_failure_file_count, 0) AS parse_failure_file_count,
     FROM grouped_parse_outcomes
     PIVOT(SUM(file_count) FOR aggregation_outcome IN ("parse_success_file_count", "parse_failure_file_count"))
 ),

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -7,13 +7,15 @@ models:
   - name: fct_daily_schedule_feed_guideline_checks
     description: '{{ doc("fct_daily_schedule_feed_guideline_checks") }}'
     columns:
-      - name: key
+      - &key
+        name: key
         tests: &primary_key_tests
-          - not_null
           - unique
+          - not_null
         meta: &pk_meta
           metabase.semantic_type: type/PK
-      - name: date
+      - &date
+        name: date
         tests:
           - not_null
       - name: feed_key
@@ -22,6 +24,15 @@ models:
         meta: &fk_meta
           metabase.semantic_type: type/FK
       - name: status
+      - &check
+        name: check
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_gtfs_quality__intended_checks')
+              field: check
+      - &status
+        name: status
         tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.99
@@ -31,19 +42,14 @@ models:
     description: '{{ doc("fct_daily_rt_feed_guideline_checks") }}'
     tests:
     columns:
-      - name: key
-        tests: *primary_key_tests
-        meta: *pk_meta
-      - name: date
-        tests:
-          - not_null
+      - *key
+      - *date
       - name: base64_url
+      - name: feed_key
         tests:
           - not_null
-      - name: status
-        tests:
-          - dbt_utils.not_null_proportion:
-              at_least: 0.99
+      - *check
+      - *status
 
 
   - name: fct_daily_rt_feed_validation_notices
@@ -56,13 +62,8 @@ models:
       - dbt_utils.expression_is_true:
           expression: 'validated_extracts = validation_successes + validation_exceptions'
     columns:
-      - name: key
-        description: |
-          Synthetic primary key constructed from date, feed_key, and code.
-        tests: *primary_key_tests
-      - name: date
-        tests:
-          - not_null
+      - *key
+      - *date
       - name: code
         tests:
           - not_null
@@ -107,9 +108,7 @@ models:
           Synthetic primary key constructed from date, feed_key, and code.
         tests: *primary_key_tests
         meta: *pk_meta
-      - name: date
-        tests:
-          - not_null
+      - *date
       - name: feed_key
         tests:
           - not_null

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -48,6 +48,9 @@ models:
       - name: feed_key
         tests:
           - not_null
+          - relationships:
+              to: ref('dim_schedule_feeds')
+              field: key
       - *check
       - *status
 

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -4,19 +4,13 @@ models:
   # TODO: once we have checks that occur above the feed level (e.g. organization)
   #   we will need to create additional daily check fact tables at the
   #   appropriate grain
-  - name: fct_daily_feed_guideline_checks
-    description: '{{ doc("fct_daily_feed_guideline_checks") }}'
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - date
-            - feed_key
-            - check
+  - name: fct_daily_schedule_feed_guideline_checks
+    description: '{{ doc("fct_daily_schedule_feed_guideline_checks") }}'
     columns:
       - name: key
         tests: &primary_key_tests
-          - unique
           - not_null
+          - unique
         meta: &pk_meta
           metabase.semantic_type: type/PK
       - name: date
@@ -31,6 +25,75 @@ models:
         tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.99
+
+
+  - name: fct_daily_rt_feed_guideline_checks
+    description: '{{ doc("fct_daily_rt_feed_guideline_checks") }}'
+    tests:
+    columns:
+      - name: key
+        tests: *primary_key_tests
+        meta: *pk_meta
+      - name: date
+        tests:
+          - not_null
+      - name: base64_url
+        tests:
+          - not_null
+      - name: status
+        tests:
+          - dbt_utils.not_null_proportion:
+              at_least: 0.99
+
+
+  - name: fct_daily_rt_feed_validation_notices
+    description: |
+      A daily model of validation notices found per feed. Data
+      is filled in so there is always a count of notices per day
+      per feed, even if that count is zero; null counts indicate
+      a lack of validation for that feed on that day.
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: 'validated_extracts = validation_successes + validation_exceptions'
+    columns:
+      - name: key
+        description: |
+          Synthetic primary key constructed from date, feed_key, and code.
+        tests: *primary_key_tests
+      - name: date
+        tests:
+          - not_null
+      - name: code
+        tests:
+          - not_null
+      - name: is_critical
+        tests:
+          - not_null
+      - name: parsed_files
+        tests:
+          - dbt_utils.not_null_proportion:
+              at_least: 0.99
+          - dbt_utils.expression_is_true:
+              expression: '<= 4320'
+      - name: validated_extracts
+        tests:
+          - dbt_utils.not_null_proportion:
+              at_least: 0.99
+          - dbt_utils.expression_is_true:
+              expression: '<= 4320'
+      - name: validation_successes
+        tests:
+          - dbt_utils.not_null_proportion:
+              at_least: 0.99
+          - dbt_utils.expression_is_true:
+              expression: '<= 4320'
+      - name: validation_exceptions
+        tests:
+          - dbt_utils.not_null_proportion:
+              at_least: 0.99
+          - dbt_utils.expression_is_true:
+              expression: '<= 4320'
+      - name: total_notices
 
   - name: fct_daily_schedule_feed_validation_notices
     description: |

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -18,11 +18,13 @@ models:
         name: date
         tests:
           - not_null
-      - name: feed_key
+      - &schedule_feed_key
+        name: feed_key
         tests:
           - not_null
-        meta: &fk_meta
-          metabase.semantic_type: type/FK
+          - relationships:
+              to: ref('dim_schedule_feeds')
+              field: key
       - name: status
       - &check
         name: check
@@ -45,12 +47,8 @@ models:
       - *key
       - *date
       - name: base64_url
-      - name: feed_key
         tests:
           - not_null
-          - relationships:
-              to: ref('dim_schedule_feeds')
-              field: key
       - *check
       - *status
 
@@ -106,16 +104,9 @@ models:
       per feed, even if that count is zero; null counts indicate
       a lack of validation for that feed on that day.
     columns:
-      - name: key
-        description: |
-          Synthetic primary key constructed from date, feed_key, and code.
-        tests: *primary_key_tests
-        meta: *pk_meta
+      - *key
       - *date
-      - name: feed_key
-        tests:
-          - not_null
-        meta: *fk_meta
+      - *schedule_feed_key
       - name: code
         tests:
           - not_null

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
@@ -10,5 +10,5 @@ Here is a list of currently-implemented checks:
 
 | Check | Feature | Description |
 | ------------------------------------ |---------|------------ |
-|No critical errors in the MobilityData GTFS Realtime Validator | Compliance | The feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no critical errors for any RT feed on that day.|
+|No critical errors in the MobilityData GTFS Realtime Validator | Compliance | The feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no critical errors for any RT feed extract on that day.|
 {% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
@@ -1,0 +1,14 @@
+{% docs fct_daily_rt_feed_guideline_checks %}
+
+Each row represents a date/guideline check/feed combination, with pass/fail
+information indicating whether that feed complied with that check on that date.
+A row will exist for every check, for every row from the index which is driven
+by fct_daily_rt_feeds. Only contains checks that are performed at the feed
+level.
+
+Here is a list of currently-implemented checks:
+
+| Check | Feature | Description |
+| ------------------------------------ |---------|------------ |
+|No critical errors in the MobilityData GTFS Realtime Validator | Compliance | The feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no critical errors for any RT feed on that day.|
+{% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+WITH
+
+unioned AS (
+    {{ dbt_utils.union_relations(
+        relations=[
+            ref('int_gtfs_quality__no_rt_critical_validation_errors'),
+        ],
+    ) }}
+),
+
+fct_daily_rt_feed_guideline_checks AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['date', 'base64_url', 'check']) }} AS key,
+        *
+    FROM unioned
+)
+
+SELECT * FROM fct_daily_rt_feed_guideline_checks

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
@@ -1,0 +1,48 @@
+{{ config(materialized='table') }}
+
+WITH fct_daily_rt_feed_files AS (
+    SELECT * FROM {{ ref('fct_daily_rt_feed_files') }}
+),
+
+codes AS (
+    SELECT * FROM {{ ref('stg_gtfs_quality__rt_validation_code_descriptions') }}
+),
+
+outcomes AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__rt_validation_outcomes') }}
+),
+
+notices AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__rt_validation_notices') }}
+),
+
+fct_daily_rt_feed_validation_notices AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['daily_feeds.date', 'daily_feeds.base64_url', 'codes.code', 'codes.is_critical']) }} AS key,
+        daily_feeds.date,
+        daily_feeds.base64_url,
+        codes.code,
+        codes.is_critical,
+        -- TODO: at some point, these codes will be versioned by validator version
+        ARRAY_AGG(DISTINCT notices.gtfs_validator_version IGNORE NULLS) AS gtfs_validator_versions,
+        SUM(daily_feeds.parse_success_file_count) / COUNT(daily_feeds.key) AS parsed_files,
+        COUNT(DISTINCT outcomes.extract_ts) AS validated_extracts,
+        COUNTIF(outcomes.validation_success) AS validation_successes,
+        COUNT(outcomes.validation_exception) AS validation_exceptions,
+        COALESCE(
+            SUM(ARRAY_LENGTH(occurrence_list)),
+            CASE WHEN COUNTIF(outcomes.validation_success) > 0 THEN 0 END
+        ) AS total_notices,
+    FROM fct_daily_rt_feed_files AS daily_feeds
+    LEFT JOIN outcomes
+        ON daily_feeds.base64_url = outcomes.base64_url
+        AND daily_feeds.date = EXTRACT(DATE FROM outcomes.extract_ts)
+    CROSS JOIN codes
+    LEFT JOIN notices
+        ON outcomes.extract_ts = notices.ts
+        AND outcomes.base64_url = notices.base64_url
+        AND codes.code = notices.error_message_validation_rule_error_id
+    GROUP BY 1, 2, 3, 4, 5
+)
+
+SELECT * FROM fct_daily_rt_feed_validation_notices

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
@@ -16,6 +16,14 @@ notices AS (
     SELECT * FROM {{ ref('int_gtfs_quality__rt_validation_notices') }}
 ),
 
+-- This CTE starts with daily RT feeds, then pulls in validation outcomes
+-- to give us a row per actual validation execution (outcome) that we have;
+-- then cross-join codes to give us "buckets" per outcome since the
+-- underlying notices will not contain a code that did not trigger a notice;
+-- finally, we aggregate everything back up to the date/URL/code level
+-- and count how many parsed and validated files we have, and sum the
+-- notice occurrences; if we have successful validations but no occurrences,
+-- we assume the feeds passed the code 100% of the time
 fct_daily_rt_feed_validation_notices AS (
     SELECT
         {{ dbt_utils.surrogate_key(['daily_feeds.date', 'daily_feeds.base64_url', 'codes.code', 'codes.is_critical']) }} AS key,

--- a/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_guideline_checks.md
@@ -1,4 +1,4 @@
-{% docs fct_daily_feed_guideline_checks %}
+{% docs fct_daily_schedule_feed_guideline_checks %}
 
 Each row represents a date/guideline check/feed combination, with pass/fail
 information indicating whether that feed complied with that check on that date.

--- a/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_guideline_checks.sql
@@ -20,11 +20,11 @@ unioned AS (
     ) }}
 ),
 
-fct_daily_feed_guideline_checks AS (
+fct_daily_schedule_feed_guideline_checks AS (
     SELECT
         {{ dbt_utils.surrogate_key(['date', 'feed_key', 'check']) }} AS key,
         *
     FROM unioned
 )
 
-SELECT * FROM fct_daily_feed_guideline_checks
+SELECT * FROM fct_daily_schedule_feed_guideline_checks

--- a/warehouse/models/mart/gtfs_quality/fct_implemented_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_implemented_checks.sql
@@ -10,7 +10,14 @@ existing_checks AS (
     SELECT DISTINCT
         check,
         feature
-    FROM {{ ref('fct_daily_feed_guideline_checks') }}
+    FROM {{ ref('fct_daily_schedule_feed_guideline_checks') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        check,
+        feature
+    FROM {{ ref('fct_daily_rt_feed_guideline_checks') }}
 ),
 
 fct_implemented_checks AS (

--- a/warehouse/models/rt_views/_rt_views.yml
+++ b/warehouse/models/rt_views/_rt_views.yml
@@ -208,7 +208,7 @@ models:
           - not_null
       - name: type
         description: GTFS realtime type (service_alerts, trip_updates, or vehicle_positions)
-  - name: gtfs_rt_validation_code_descriptions
+  - name: gtfs_rt_validation_code_descriptions_legacy
     description: |
       Cal-ITP critical validation codes. Primary key is code.
     columns:

--- a/warehouse/models/rt_views/gtfs_rt_validation_code_descriptions_legacy.sql
+++ b/warehouse/models/rt_views/gtfs_rt_validation_code_descriptions_legacy.sql
@@ -1,8 +1,8 @@
 {{ config(materialized='table') }}
 
-WITH gtfs_rt_validation_code_descriptions AS (
+WITH gtfs_rt_validation_code_descriptions_legacy AS (
     SELECT *
     FROM {{ source('gtfs_rt_raw', 'validation_code_descriptions') }}
 )
 
-SELECT * FROM gtfs_rt_validation_code_descriptions
+SELECT * FROM gtfs_rt_validation_code_descriptions_legacy

--- a/warehouse/models/staging/gtfs/gtfs_quality/_stg_gtfs_quality.yml
+++ b/warehouse/models/staging/gtfs/gtfs_quality/_stg_gtfs_quality.yml
@@ -11,6 +11,21 @@ models:
             - check
             - feature
 
+  - name: stg_gtfs_quality__rt_validation_code_descriptions
+    description: |
+      Metadata for codes that come from the GTFS RT validator.
+    columns:
+      - name: code
+        tests:
+          - not_null
+          - unique
+      - name: description
+        tests:
+          - not_null
+      - name: is_critical
+        tests:
+          - not_null
+
   - name: stg_gtfs_rt__service_alerts_validation_notices
     description: |
       Validation notices resulting from executing the RT

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -17,8 +17,8 @@ WITH stg_gtfs_quality__intended_checks AS (
     SELECT {{ pathways_valid() }}, {{ accurate_accessibility_data() }}
     UNION ALL
     SELECT {{ technical_contact_listed() }}, {{ technical_contact_availability() }}
-    {# UNION ALL #}
-    {# SELECT {{ no_rt_critical_validation_errors() }}, {{ compliance() }} #}
+    UNION ALL
+    SELECT {{ no_rt_critical_validation_errors() }}, {{ compliance() }}
     {# UNION ALL #}
     {# SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }} #}
     {# UNION ALL #}

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__rt_validation_code_descriptions.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__rt_validation_code_descriptions.sql
@@ -1,0 +1,15 @@
+WITH
+
+source AS (
+    SELECT * FROM {{ ref('gtfs_rt_validation_code_descriptions') }}
+),
+
+stg_gtfs_quality__rt_validation_code_descriptions AS (
+    SELECT
+        code,
+        description,
+        COALESCE(is_critical = 'y', false) AS is_critical,
+   FROM source
+)
+
+SELECT * FROM stg_gtfs_quality__rt_validation_code_descriptions

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
@@ -13,7 +13,7 @@ gtfs_rt_fact_daily_validation_errors AS (
 ),
 
 gtfs_rt_validation_code_descriptions AS (
-    SELECT * FROM {{ ref('gtfs_rt_validation_code_descriptions') }}
+    SELECT * FROM {{ ref('gtfs_rt_validation_code_descriptions_legacy') }}
 ),
 
 rt_files_by_day AS (

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -96,6 +96,7 @@ def run(
     project_dir: Path = os.environ.get("DBT_PROJECT_DIR", os.getcwd()),
     profiles_dir: Path = os.environ.get("DBT_PROFILES_DIR", os.getcwd()),
     target: str = os.environ.get("DBT_TARGET"),
+    dbt_seed: bool = True,
     dbt_run: bool = True,
     full_refresh: bool = False,
     dbt_test: bool = False,
@@ -135,6 +136,16 @@ def run(
     subprocess.run(get_command("compile")).check_returncode()
 
     results_to_check = []
+
+    if dbt_seed:
+        results_to_check.append(subprocess.run(get_command("seed")))
+
+        with open("./target/run_results.json") as f:
+            run_results = RunResults(**json.load(f))
+        with open("./target/manifest.json") as f:
+            manifest = Manifest(**json.load(f))
+
+        report_failures_to_sentry(run_results, manifest)
 
     if dbt_run:
         args = ["run"]

--- a/warehouse/seeds/_seeds.yml
+++ b/warehouse/seeds/_seeds.yml
@@ -1,0 +1,22 @@
+version: 2
+
+seeds:
+  - name: gtfs_rt_validation_code_descriptions
+    description: |
+      A list of validation codes output by the GTFS RT validator, and their severities.
+      Originally sourced from https://docs.google.com/spreadsheets/d/1GDDaDlsBPCYn3dtYPSABnce9ns3ekJ8Jzfgyy56lZz4/edit#gid=617612870.
+    columns:
+      - name: code
+        tests:
+          - not_null
+          - unique
+
+  - name: gtfs_schedule_validation_code_descriptions
+    description: |
+      A list of validation codes output by the GTFS Schedule validator, and their severities.
+      Originally sourced from https://docs.google.com/spreadsheets/d/1GDDaDlsBPCYn3dtYPSABnce9ns3ekJ8Jzfgyy56lZz4/edit#gid=0.
+    columns:
+      - name: name
+        tests:
+          - not_null
+          - unique

--- a/warehouse/seeds/gtfs_rt_validation_code_descriptions.csv
+++ b/warehouse/seeds/gtfs_rt_validation_code_descriptions.csv
@@ -1,0 +1,58 @@
+Code,Description,Is_Critical
+E001,Not in POSIX time,y
+E002,stop_time_updates not strictly sorted,y
+E003,GTFS-rt trip_id does not exist in GTFS data,y
+E004,GTFS-rt route_id does not exist in GTFS data,
+E006,Missing required trip field for frequency-based exact_times = 0,
+E009,GTFS-rt stop_sequence isn't provided for trip that visits same stop_id more than once,y
+E010,location_type not 0 in stops.txt (Note that this is implemented but not executed because it's specific to GTFS - see issue #126),
+E011,GTFS-rt stop_id does not exist in GTFS data,y
+E012,Header timestamp should be greater than or equal to all other timestamps,
+E013,Frequency type 0 trip schedule_relationship should be UNSCHEDULED or empty,
+E015,All stop_ids referenced in GTFS-rt TripUpdates and VehiclePositions feeds must have the location_type = 0,
+E016,trip_ids with schedule_relationship ADDED must not be in GTFS data,
+E017,GTFS-rt content changed but has the same header timestamp,
+E018,GTFS-rt header timestamp decreased between two sequential iterations,
+E019,GTFS-rt frequency type 1 trip start_time must be a multiple of GTFS headway_secs later than GTFS start_time,
+E020,Invalid start_time format,y
+E021,Invalid start_date format,y
+E022,Sequential stop_time_update times are not increasing,y
+E023,trip start_time does not match first GTFS arrival_time,
+E024,trip direction_id does not match GTFS data,
+E025,stop_time_update departure time is before arrival time,
+E026,Invalid vehicle position,y
+E027,Invalid vehicle bearing,
+E028,Vehicle position outside agency coverage area,
+E029,Vehicle position far from trip shape,y
+E030,GTFS-rt alert trip_id does not belong to GTFS-rt alert route_id in GTFS trips.txt,
+E031,Alert informed_entity.route_id does not match informed_entity.trip.route_id,
+E032,Alert does not have an informed_entity,
+E033,Alert informed_entity does not have any specifiers,
+E034,GTFS-rt agency_id does not exist in GTFS data,
+E035,GTFS-rt trip.trip_id does not belong to GTFS-rt trip.route_id in GTFS trips.txt,
+E036,Sequential stop_time_updates have the same stop_sequence,
+E037,Sequential stop_time_updates have the same stop_id,
+E038,Invalid header.gtfs_realtime_version,
+E039,FULL_DATASET feeds should not include entity.is_deleted,
+E040,stop_time_update doesn't contain stop_id or stop_sequence,y
+E041,trip doesn't have any stop_time_updates,
+E042,arrival or departure provided for NO_DATA stop_time_update,
+E043,stop_time_update doesn't have arrival or departure,y
+E044,stop_time_update arrival/departure doesn't have delay or time,y
+E045,GTFS-rt stop_time_update stop_sequence and stop_id do not match GTFS,
+E046,GTFS-rt stop_time_update without time doesn't have arrival/departure time in GTFS,
+E047,VehiclePosition and TripUpdate ID pairing mismatch,
+E048,header timestamp not populated (GTFS-rt v2.0 and higher),
+E049,header incrementality not populated (GTFS-rt v2.0 and higher),
+E050,timestamp is in the future,
+E051,GTFS-rt stop_sequence not found in GTFS data,
+E052,vehicle.id is not unique,
+W001,timestamps not populated,
+W002,vehicle_id not populated,
+W003,ID in one feed missing from the other,
+W004,vehicle speed is unrealistic,
+W005,Missing vehicle_id in trip_update for frequency-based exact_times = 0,
+W006,trip_update missing trip_id,
+W007,Refresh interval is more than 35 seconds,y
+W008,Header timestamp is older than 65 seconds,y
+W009,schedule_relationship not populated,

--- a/warehouse/seeds/gtfs_schedule_validation_code_descriptions.csv
+++ b/warehouse/seeds/gtfs_schedule_validation_code_descriptions.csv
@@ -1,0 +1,53 @@
+Type,Name,Human_Readable_Description,"Critical_for_reporting",What_to_Report
+Error,BlockTripsWithOverlappingStopTimesNotice,"Trips within the same block have overlapping stop times, which is not allowed.",,Count
+Error,CsvParsingFailedNotice,The validator was unable to parse a field. This is typically caused by a cell containing more than 4096 characters.,,File Name
+Error,DecreasingOrEqualShapeDistanceNotice,"Two consecutive points in shapes.txt should have increasing values for shape_dist_traveled. If the values are equal, this is considered as an error.",,Count
+Error,DecreasingOrEqualStopTimeDistanceNotice,"Two consecutive stop times in a trip should have increasing distance. If the values are equal, this is considered as an error.",,Count
+Error,DuplicatedColumnNotice,The input file CSV header has the same column name repeated.,,File Name
+Error,DuplicateFareRuleZoneIdFieldsNotice,"Each of the following fields should be unique in fare_rules.txt: fare_rules.route_id, fare_rules.origin_id, fare_rules.contains_id and fare_rules.destination_id",,Rows by fare_id
+Error,DuplicateKeyNotice,The values of the given key and rows are duplicates.,,File Name
+Error,EmptyFileNotice,"Empty csv file found in the archive: file does not have any headers, or is a required file and does not have any data. The GTFS specification requires the first line of each file to contain field names and required files must have data.",,File Name
+Error,ForeignKeyViolationNotice,The values of the given key and rows of one table cannot be found with values of the given key in another table.,,File Names
+Error,InconsistentAgencyTimezoneNotice,Agencies from GTFS agency.txt have been found to have different timezones.,,Rows by agency_id
+Error,InvalidColorNotice,"A color is coded incorrectly. A color must be encoded as a six-digit hexadecimal number. The leading ""#"" should not be included.",,Row by route_id: field contents
+Error,InvalidCurrencyNotice,Value of field with type currency is not valid. Currency code must follow ISO 4217.,,Row by fare_id: field contents
+Error,InvalidDateNotice,A date is coded incorrectly. Dates must have the YYYYMMDD format.,,"If calendar or calendar_dates. File name, row by service_id, and field contents. If feed_info: File name and field contents."
+Error,InvalidEmailNotice,A field contains a malformed email address.,,File name and field contents
+Error,InvalidFloatNotice,A field cannot be parsed as a floating point number.,,File name and field name
+Error,InvalidIntegerNotice,A field cannot be parsed as an integer.,,File name and field name
+Error,InvalidLanguageCodeNotice,A field contains a wrong language code. Language codes must follow IETF BCP 47.,,File name and field contents
+Error,InvalidRowLengthNotice,A row in the input file has a different number of values than specified by the CSV header.,,File name and field name
+Error,InvalidTimeNotice,"Value of field with type time is not valid. Time must be in the H:MM:SS, HH:MM:SS or HHH:MM:SS format.",,File name and field contents
+Error,InvalidTimezoneNotice,Value of field with type timezone is not valid.Timezones are defined at www.iana.org. Timezone names never contain the space character but may contain an underscore.,,File name and field contents
+Error,InvalidUrlNotice,A field contains a malformed URL.,,File name and field contents
+Error,LocationWithoutParentStationNotice,"The following location types must have a parent station: entrance, generic node, boarding_area.",,Row by stop_id if under 10; otherwise a count of affected rows
+Error,MissingCalendarAndCalendarDateFilesNotice,Both files calendar_dates.txt and calendar.txt are missing from the GTFS dataset. At least one of the files must be provided.,,Binary
+Error,MissingRequiredColumnNotice,A required column is missing.,,File name and field name
+Error,MissingRequiredFieldNotice,A required field is blank.,,File name and field name
+Error,MissingRequiredFileNotice,A required file is missing.,,File name
+Error,MissingTripEdgeNotice,First and last stop of a trip must define both arrival_time and departure_time fields.,,Row by trip_id if under 10; otherwise a count of affected trips.
+Error,NewLineInValueNotice,A value in CSV file has a new line or carriage return.,,File name
+Error,NumberOutOfRangeNotice,The values in the given column of the input rows are out of range.,,File name and field name
+Error,OverlappingFrequencyNotice,Trip frequencies must not overlap in time.,,Row by trip_id if under 10; otherwise a count of affected trips.
+Error,RouteBothShortAndLongNameMissingNotice,Both short_name and long_name are missing for a route. At least one is required.,,Row by route_id
+Error,SameNameAndDescriptionForRouteNotice,The GTFS spec requires that a route_description is distinct from both the route short and long names.,,Row by route_id
+Error,StartAndEndRangeEqualNotice,Date or time fields have been found equal.,,Count of affected rows
+Error,StartAndEndRangeOutOfOrderNotice,Date or time fields have been found out of order.,,Count of affected rows
+Error,StationWithParentStationNotice,Field parent_station must be empty when location_type is 2 (entrance/exit).,,"Rows by stop ID if fewer than 10, otherwise a count of affected rows"
+Error,StopTimeWithArrivalBeforePreviousDepartureTimeNotice,The departure_time must not precede the arrival_time in stop_times.txt if both are given.,,Count of affected rows
+Error,WrongParentLocationTypeNotice,"Value of field location_type of parent found in field parent_station is invalid. Stops, Platforms, Entrance/exit, and generic nodes can only have a Station as a parent. Boarding Area can only have Platform as a parent. Stations cannot have a parent. All other combinations are prohibited.",,Count of affected rows
+Warning,DuplicateRouteNameNotice,All routes of the same route_type with the same agency_id should have unique combinations of route_short_name and route_long_name.,,Row by route_id
+Warning,EmptyColumnNameNotice,A column name has not been provided. Such columns are skipped by the validator.,,File name
+Warning,EmptyRowNotice,A row in the input file has only spaces.,,File name
+Warning,FeedExpirationDateNotice,"At any time, the published GTFS dataset should be valid for at least the next 7 days, and ideally for as long as the operator is confident that the schedule will continue to be operated. If possible, the GTFS dataset should cover at least the next 30 days of service.",,Binary
+Warning,MoreThanOneEntityNotice,A file that is expected to have only one row has more than one row.,,File name
+Warning,NonAsciiOrNonPrintableCharNotice,A value of filed with type id contains non ASCII or non printable characters. This is not recommended.,,File name and field contents
+Warning,PlatformWithoutParentStationNotice,A platform has no parent_station field set.,,"Row by stop_id if fewer than 10, otherwise count affected rows"
+Warning,RouteShortAndLongNameEqualNotice,Short and long name should not be identical.,,Row by route_id
+Warning,RouteShortNameTooLongNotice,Short name of a route is too long (more than 12 characters). Note that major trip planning applications start truncating short names after seven characters.,,Field contents
+Warning,StartAndEndTimeEqualNotice,"The start_time and end_time in frequencies.txt should not match, or block IDs will not be able to represent linked trips.",,count of affected rows
+Warning,StopTimeTimepointWithoutTimesNotice,Any record with stop_times.timepoint set to 1 should define a value for stop_times.arrival_time and stop_times.departure_time fields.,,count of affected rows
+Warning,StopTooFarFromTripShapeNotice,"Per GTFS Best Practices, route alignments (in shapes.txt) should be within 100 meters of stop locations which a trip serves.",,count of affected rows
+Warning,TooFastTravelNotice,"As implemented in the original Google Python GTFS validator, the calculated speed between stops should not be greater than 150 km/h (42 m/s SI or 93 mph).",,count of affected rows
+Warning,UnexpectedEnumValueNotice,An enum has an unexpected value.,,file name and field name
+Warning,UnusableTripNotice,A trip must visit more than one stop in stop_times.txt to be usable by passengers for boarding and alighting.,,"rows by trip_id if fewer than 10, otherwise a count of affected rows"


### PR DESCRIPTION
# Description

Follow-up to https://github.com/cal-itp/data-infra/pull/1945, progress towards https://github.com/cal-itp/data-infra/issues/1904. Creates the infrastructure necessary to develop feed-level checks for RT up through `fct_daily_rt_feed_guideline_checks` with one example check implemented.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Still working on it locally, tests pass but unsure if the models are good yet.

```
➜  warehouse git:(v2-rt-validations-framework) poetry run dbt build -s +fct_daily_rt_feed_guideline_checks+
20:12:18  Running with dbt=1.2.1
...
20:15:05  Finished running 19 view models, 103 tests, 1 seed, 6 table models, 3 incremental models in 0 hours 2 minutes and 38.91 seconds (158.91s).
20:15:05
20:15:05  Completed with 3 warnings:
20:15:05
20:15:05  Warning in test relationships_int_transit_database__urls_to_gtfs_datasets_gtfs_dataset_key__key__ref_dim_gtfs_datasets_ (models/intermediate/transit_database/_int_transit_database.yml)
20:15:05    Got 6 results, configured to warn if >0
20:15:05
20:15:05    compiled SQL at target/compiled/calitp_warehouse/models/intermediate/transit_database/_int_transit_database.yml/relationships_int_transit_data_15961df448f73cc529e2d786b56cd25f.sql
20:15:05
20:15:05  Warning in test relationships_fct_schedule_feed_downloads_gtfs_dataset_key__key__ref_dim_gtfs_datasets_ (models/mart/gtfs/_mart_gtfs.yml)
20:15:05    Got 20 results, configured to warn if != 0
20:15:05
20:15:05    compiled SQL at target/compiled/calitp_warehouse/models/mart/gtfs/_mart_gtfs.yml/relationships_fct_schedule_fee_f70034b868db33c646d494e151175683.sql
20:15:05
20:15:05  Warning in test relationships_fct_daily_schedule_feeds_gtfs_dataset_key__key__ref_dim_gtfs_datasets_ (models/mart/gtfs/_mart_gtfs.yml)
20:15:05    Got 15 results, configured to warn if != 0
20:15:05
20:15:05    compiled SQL at target/compiled/calitp_warehouse/models/mart/gtfs/_mart_gtfs.yml/relationships_fct_daily_schedu_039cc2c075c6cdbc7b9cf0c141dbf9c8.sql
20:15:05
20:15:05  Done. PASS=129 WARN=3 ERROR=0 SKIP=0 TOTAL=132
```

## Screenshots (optional)
