### PR TITLE
Add a new runbook documenting AWS key rotation process

### DIFF
--- a/runbooks/rotating-littlepay-aws-keys.md
+++ b/runbooks/rotating-littlepay-aws-keys.md
@@ -1,0 +1,9 @@
+# Rotating LittlePay AWS Account Keys
+
+1.  You'll need profiles configured locally for each Littlepay `merchant_id` (the account names on LittlePay). To set up a profile, install the `aws` CLI, and follow the instructions at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html. You can find the access key id and secret for each `merchant_id` in [VaultWarden](https://vaultwarden.jarv.us/#/vault) (search for "_aws_" and you should see several entries with names that match the format "_Cal-ITP Littlepay AWS IAM Keys (<merchant_id>)_").
+
+2.  Follow the instructions provided by LittlePay for rotating the account keys. Keep track of the JSON from the key creation steps, as you'll be storing these in VaultWarden later. After creating a new access key for each account and **before deleting the old credentials, test the credentials** by:
+  * Replacing the key and secret in your own local configuration and ensuring that listing keys using the `aws` CLI still works. You should see two keys listed for each account instead of one.
+  * Replacing the access key and secret in the data transfer tasks on Google Cloud. Manually re-run the tasks to ensure they complete successfully. Each one should only take a minute or so.
+
+3.  Assuming all tests succeed, overwrite the notes in VaultWarden with the new credentials (the JSON as returned in the key creation step) and run the key deletion step in from LittlePay's instructions.

--- a/runbooks/rotating-littlepay-aws-keys.md
+++ b/runbooks/rotating-littlepay-aws-keys.md
@@ -1,9 +1,17 @@
 # Rotating LittlePay AWS Account Keys
 
-1.  You'll need profiles configured locally for each Littlepay `merchant_id` (the account names on LittlePay). To set up a profile, install the `aws` CLI, and follow the instructions at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html. You can find the access key id and secret for each `merchant_id` in [VaultWarden](https://vaultwarden.jarv.us/#/vault) (search for "_aws_" and you should see several entries with names that match the format "_Cal-ITP Littlepay AWS IAM Keys (<merchant_id>)_").
+LittlePay requests that clients accessing their raw data feeds through S3 rotate the IAM keys every 90 days. They provide general instructions for doing so with the `aws` CLI tool. The following gives additional context on the Cal-ITP setup, and should be used in conjunction with those instructions.
 
-2.  Follow the instructions provided by LittlePay for rotating the account keys. Keep track of the JSON from the key creation steps, as you'll be storing these in VaultWarden later. After creating a new access key for each account and **before deleting the old credentials, test the credentials** by:
-  * Replacing the key and secret in your own local configuration and ensuring that listing keys using the `aws` CLI still works. You should see two keys listed for each account instead of one.
-  * Replacing the access key and secret in the data transfer tasks on Google Cloud. Manually re-run the tasks to ensure they complete successfully. Each one should only take a minute or so.
+0.  **Pre-requisites**
 
-3.  Assuming all tests succeed, overwrite the notes in VaultWarden with the new credentials (the JSON as returned in the key creation step) and run the key deletion step in from LittlePay's instructions.
+    You'll to install the `aws` CLI locally, and to configure profiles for each Littlepay `merchant_id` (the account names in LittlePay). To set up a profile, follow the instructions at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html. You can find the access key id and secret for each `merchant_id` in [VaultWarden](https://vaultwarden.jarv.us/#/vault) (search for "_aws_" and you should see several entries with names that match the format "_Cal-ITP Littlepay AWS IAM Keys (<merchant_id>)_").
+
+1.  **Creating new AWS credentials**
+
+    Follow the instructions provided by LittlePay for rotating the account keys. Keep track of the JSON from the key creation steps, as you'll be storing these in VaultWarden later. After creating a new access key for each account and **before deleting the old credentials, test the credentials** by:
+    * Replacing the key and secret in your own local configuration and ensuring that listing keys using the `aws` CLI still works. You should see two keys listed for each account instead of one.
+    * Replacing the access key and secret in the data transfer tasks on Google Cloud. Manually re-run the tasks to ensure they complete successfully. Each one should only take a minute or so.
+
+3.  **Updating records of AWS credentials**
+
+    Assuming all tests succeed, overwrite the notes in VaultWarden with the new credentials (the JSON as returned in the key creation step) and run the key deletion step in from LittlePay's instructions.

--- a/runbooks/rotating-littlepay-aws-keys.md
+++ b/runbooks/rotating-littlepay-aws-keys.md
@@ -4,7 +4,7 @@ LittlePay requests that clients accessing their raw data feeds through S3 rotate
 
 0.  **Pre-requisites**
 
-    You'll to install the `aws` CLI locally, and to configure profiles for each Littlepay `merchant_id` (the account names in LittlePay). To set up a profile, follow the instructions at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html. You can find the access key id and secret for each `merchant_id` in [VaultWarden](https://vaultwarden.jarv.us/#/vault) (search for "_aws_" and you should see several entries with names that match the format "_Cal-ITP Littlepay AWS IAM Keys (<merchant_id>)_").
+    You'll need to install the `aws` CLI locally, and to configure profiles for each Littlepay `merchant_id` (the account names in LittlePay). To set up a profile, follow the instructions at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html. You can find the access key id and secret for each `merchant_id` in [VaultWarden](https://vaultwarden.jarv.us/#/vault) (search for "_aws_" and you should see several entries with names that match the format "_Cal-ITP Littlepay AWS IAM Keys (<merchant_id>)_").
 
 1.  **Creating new AWS credentials**
 


### PR DESCRIPTION
# Description

This adds instructions for rotating the keys for the AWS accounts that are used to sync data from LittlePay's S3 buckets into Cal-ITP's GCS buckets. This is a task that's done regularly but infrequently, enough that it's difficult to remember the details from the last time it was done.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

These are the steps that were taken during the key rotation earlier today.
