### PR TITLE
V2 dim shapes geo

### DIFF
--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -187,6 +187,7 @@ models:
             - shape_pt_sequence
     columns:
       - name: base64_url
+      - name: ts
       - name: shape_id
         description: '{{ doc("gtfs_shapes__shape_id") }}'
         tests:

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -175,3 +175,43 @@ models:
       - name: step
       - name: base64_url
       - name: ts
+  - name: int_gtfs_schedule__incremental_shapes
+    description: |
+      This table is an incremental, sparse history of GTFS schedule shapes data.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - base64_url
+            - ts
+            - shape_id
+            - shape_pt_sequence
+    columns:
+      - name: base64_url
+      - name: shape_id
+        description: '{{ doc("gtfs_shapes__shape_id") }}'
+        tests:
+        - not_null
+      - name: shape_pt_lat
+        description: '{{ doc("gtfs_shapes__shape_pt_lat") }}'
+        tests:
+        - not_null
+        meta:
+          metabase.semantic_type: type/Latitude
+          ckan.type: FLOAT
+          ckan.length: 6
+          ckan.precision: 3
+      - name: shape_pt_lon
+        description: '{{ doc("gtfs_shapes__shape_pt_lon") }}'
+        tests:
+        - not_null
+        meta:
+          metabase.semantic_type: type/Longitude
+          ckan.type: FLOAT
+          ckan.length: 7
+          ckan.precision: 3
+      - name: shape_pt_sequence
+        description: '{{ doc("gtfs_shapes__shape_pt_sequence") }}'
+        tests:
+        - not_null
+      - name: shape_dist_traveled
+        description: '{{ doc("gtfs_shapes__shape_dist_traveled") }}'

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__incremental_shapes.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__incremental_shapes.sql
@@ -31,6 +31,7 @@ int_gtfs_schedule__incremental_shapes AS (
         t1.shape_pt_sequence,
         t1.shape_dist_traveled,
         t1.base64_url,
+        t1.ts,
         CURRENT_TIMESTAMP() AS _inserted_at
     FROM stg_gtfs_schedule__shapes t1
     INNER JOIN dim_schedule_feeds t2

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__incremental_shapes.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__incremental_shapes.sql
@@ -1,0 +1,42 @@
+{{ config(materialized='incremental') }}
+
+-- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost
+-- save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination
+{% if is_incremental() %}
+    {% set timestamps = dbt_utils.get_column_values(table=this, column='ts', order_by = 'ts DESC', max_records = 1) %}
+    {% set max_ts = timestamps[0] %}
+{% endif %}
+
+WITH dim_schedule_feeds AS (
+    SELECT *
+    FROM {{ ref('dim_schedule_feeds') }}
+    {% if is_incremental() %}
+    WHERE _valid_from > '{{ max_ts }}'
+    {% endif %}
+),
+
+stg_gtfs_schedule__shapes AS (
+    SELECT *
+    FROM {{ ref('stg_gtfs_schedule__shapes') }}
+    {% if is_incremental() %}
+    WHERE _dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% endif %}
+),
+
+int_gtfs_schedule__incremental_shapes AS (
+    SELECT
+        t1.shape_id,
+        t1.shape_pt_lat,
+        t1.shape_pt_lon,
+        t1.shape_pt_sequence,
+        t1.shape_dist_traveled,
+        t1.base64_url,
+        CURRENT_TIMESTAMP() AS _inserted_at
+    FROM stg_gtfs_schedule__shapes t1
+    INNER JOIN dim_schedule_feeds t2
+        ON t1.base64_url = t2.base64_url
+        AND t1.ts = t2._valid_from
+)
+
+SELECT *
+FROM int_gtfs_schedule__incremental_shapes

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -1240,3 +1240,33 @@ models:
           - relationships:
               to: ref('dim_schedule_feeds')
               field: key
+  - name: dim_shapes_geo
+    description: |
+      Each row is a shape, constructed from the points listed in
+      `dim_shapes`, with the shape geometry described as an ordered
+      array of points in the `pt_array` column.
+      We cannot construct a LineString because of BigQuery limitations;
+      see: https://gis.stackexchange.com/questions/426188/can-i-represent-a-route-that-doubles-back-on-itself-in-bigquery-with-a-linestrin.
+    tests:
+      - dbt_utils.mutually_exclusive_ranges:
+          lower_bound_column: _valid_from
+          upper_bound_column: _valid_to
+          partition_by: base64_url, shape_id
+          gaps: required
+    columns:
+      - name: key
+        description: |
+          Synthetic primary key constructed from `feed_key` and `shape_id`.
+        tests: *primary_key_tests
+      - *feed_key
+      - *base64_url
+      - name: shape_id
+        description: '{{ doc("gtfs_shapes__shape_id") }}'
+        tests:
+        - not_null
+      - name: pt_array
+        description: Ordered array of WKT points that describe this shape.
+        tests:
+        - not_null
+      - *_valid_from
+      - *_valid_to

--- a/warehouse/models/mart/gtfs/dim_shapes.sql
+++ b/warehouse/models/mart/gtfs/dim_shapes.sql
@@ -5,13 +5,13 @@ WITH dim_schedule_feeds AS (
     FROM {{ ref('dim_schedule_feeds') }}
 ),
 
-stg_gtfs_schedule__shapes AS (
+int_gtfs_schedule__incremental_shapes AS (
     SELECT *
-    FROM {{ ref('stg_gtfs_schedule__shapes') }}
+    FROM {{ ref('int_gtfs_schedule__incremental_shapes') }}
 ),
 
 make_dim AS (
-{{ make_schedule_file_dimension_from_dim_schedule_feeds('dim_schedule_feeds', 'stg_gtfs_schedule__shapes') }}
+{{ make_schedule_file_dimension_from_dim_schedule_feeds('dim_schedule_feeds', 'int_gtfs_schedule__incremental_shapes') }}
 ),
 
 dim_shapes AS (

--- a/warehouse/models/mart/gtfs/dim_shapes_geo.sql
+++ b/warehouse/models/mart/gtfs/dim_shapes_geo.sql
@@ -1,0 +1,58 @@
+{{ config(materialized='table') }}
+
+WITH dim_shapes AS (
+    SELECT *
+    FROM {{ ref('dim_shapes') }}
+),
+
+-- first, cast lat/long to geography
+lat_long AS (
+    SELECT
+        feed_key,
+        shape_id,
+        shape_pt_sequence,
+        ST_GEOGPOINT(
+            shape_pt_lon,
+            shape_pt_lat
+        ) AS pt_geom,
+        _valid_from,
+        _valid_to
+    FROM dim_shapes
+),
+
+-- collect points into an array
+initial_pt_array AS (
+    SELECT
+        feed_key,
+        shape_id,
+        _valid_from,
+        _valid_to,
+        -- don't try to make LINESTRING because of this issue:
+        -- https://stackoverflow.com/questions/58234223/st-makeline-discarding-duplicate-points-even-if-not-consecutive
+        -- also: https://gis.stackexchange.com/questions/426188/can-i-represent-a-route-that-doubles-back-on-itself-in-bigquery-with-a-linestrin
+        -- so instead this is just an array of WKT points
+        ARRAY_AGG(
+            -- ignore nulls so it doesn't error out if there's a null point
+            pt_geom IGNORE NULLS
+            ORDER BY shape_pt_sequence)
+        AS pt_array,
+        -- count number of rows so we can check for nulls (drops) later
+        COUNT(*) AS ct
+    FROM lat_long
+    GROUP BY feed_key, shape_id, _valid_from, _valid_to
+),
+
+dim_shapes_geo AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['feed_key', 'shape_id']) }} AS key,
+        feed_key,
+        shape_id,
+        pt_array,
+        _valid_from,
+        _valid_to
+    FROM initial_pt_array
+    -- drop shapes that had nulls
+    WHERE ARRAY_LENGTH(pt_array) = ct
+)
+
+SELECT * FROM dim_shapes_geo

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -551,6 +551,7 @@ models:
     columns:
       - name: base64_url
       - name: ts
+      - name: _dt
       - name: shape_id
         description: '{{ doc("gtfs_shapes__shape_id") }}'
         tests:

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__shapes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__shapes.sql
@@ -11,6 +11,7 @@ stg_gtfs_schedule__shapes AS (
     SELECT
         base64_url,
         ts,
+        dt AS _dt,
         {{ trim_make_empty_string_null('shape_id') }} AS shape_id,
         SAFE_CAST({{ trim_make_empty_string_null('shape_pt_lat') }} AS FLOAT64) AS shape_pt_lat,
         SAFE_CAST({{ trim_make_empty_string_null('shape_pt_lon') }} AS FLOAT64) AS shape_pt_lon,


### PR DESCRIPTION
# Description

Creates `dim_shapes_geo` in v2 warehouse, one of the key outstanding dependencies before we can migrate speedmaps.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`poetry run dbt run -s int_gtfs_schedule__incremental_shapes dim_shapes dim_shapes_geo` and 
`poetry run dbt test -s int_gtfs_schedule__incremental_shapes dim_shapes dim_shapes_geo`

Also manually examined an example shape between v1 and v2 and made sure the first few coordinates were the same 
