### PR TITLE
make keyed parse outcomes intermediate table

### DIFF
--- a/warehouse/models/docs/_docs_gtfs_outcomes.md
+++ b/warehouse/models/docs/_docs_gtfs_outcomes.md
@@ -12,3 +12,36 @@ List (array) of filenames found inside the zipfile being unzipped.
 List (array) of directories found inside the zipfile being unzipped.
 If more than one directory is present, the zipfile is not valid for our pipeline.
 {% enddocs %}
+
+{% docs column_schedule_parse_success %}
+Whether this file was parsed (from .txt to .json) successfully. False indicates file was not ingested and data will not be available.
+{% enddocs %}
+
+{% docs column_schedule_parse_exception %}
+If parse_success is false, what exception was encountered in parsing.
+{% enddocs %}
+
+{% docs column_schedule_parse_filename %}
+Filename within the original zipfile. Mostly for debugging. Use `gtfs_filename` column for most analysis.
+{% enddocs %}
+
+{% docs column_schedule_parse_feed_name %}
+Feed name from GTFS download config.
+Should not be used for joins.
+{% enddocs %}
+
+{% docs column_schedule_parse_feed_url %} Feed URL from GTFS download config.
+Should not be used for joins.
+{% enddocs %}
+
+{% docs column_schedule_parse_original_filename %}
+Full original filename from within zipfile; may contain a parent
+directory name. Mostly for debugging. Use `gtfs_filename` for most analysis purposes.
+{% enddocs %}
+
+{% docs column_schedule_parse_gtfs_filename %}
+The name of the GTFS file to which this data has been mapped.
+This is guaranteed to be a file that is listed in the GTFS
+spec at gtfs.org, for example "shapes".
+This should be used for analysis and filtering.
+{% enddocs %}

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -216,3 +216,36 @@ models:
         - not_null
       - name: shape_dist_traveled
         description: '{{ doc("gtfs_shapes__shape_dist_traveled") }}'
+  - name: int_gtfs_schedule__keyed_parse_outcomes
+    description: |
+      All GTFS schedule file parse outcomes, with `feed_key` identifier joined
+      on to facilitate downstream use.
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('stg_gtfs_schedule__file_parse_outcomes')
+    columns:
+      - name: feed_key
+        description: |
+          Foreign key to `dim_schedule_feeds`.
+        tests:
+          - relationships:
+              to: ref('dim_schedule_feeds')
+              field: key
+      - name: parse_success
+        description: '{{ doc("column_schedule_parse_success") }}'
+      - name: parse_exception
+        description: '{{ doc("column_schedule_parse_exception") }}'
+      - name: filename
+        description: '{{ doc("column_schedule_parse_filename") }}'
+      - name: _config_extract_ts
+      - name: feed_name
+        description: '{{ doc("column_schedule_parse_feed_name") }}'
+      - name: feed_url
+        description: '{{ doc("column_schedule_parse_feed_url") }}'
+      - name: original_filename
+        description: '{{ doc("column_schedule_parse_original_filename") }}'
+      - name: gtfs_filename
+        description: '{{ doc("column_schedule_parse_gtfs_filename") }}'
+      - name: dt
+      - name: ts
+      - name: base64_url

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -227,6 +227,9 @@ models:
       - name: feed_key
         description: |
           Foreign key to `dim_schedule_feeds`.
+          Because `dim_schedule_feeds` only includes unique feed versions where all files
+          were parsed successfully, this will not be populated for downloads where no data
+          changed relative to what had already been ingested or for cases where parsing failed.
         tests:
           - relationships:
               to: ref('dim_schedule_feeds')

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -227,9 +227,8 @@ models:
       - name: feed_key
         description: |
           Foreign key to `dim_schedule_feeds`.
-          Because `dim_schedule_feeds` only includes unique feed versions where all files
-          were parsed successfully, this will not be populated for downloads where no data
-          changed relative to what had already been ingested or for cases where parsing failed.
+          Because `dim_schedule_feeds` only includes unique feed versions, this will not be populated
+          for downloads where no data changed relative to what had already been ingested.
         tests:
           - relationships:
               to: ref('dim_schedule_feeds')

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__keyed_parse_outcomes.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__keyed_parse_outcomes.sql
@@ -1,0 +1,30 @@
+WITH stg_gtfs_schedule__parse_outcomes AS (
+    SELECT * FROM {{ ref('stg_gtfs_schedule__file_parse_outcomes') }}
+),
+
+dim_schedule_feeds AS (
+    SELECT * FROM {{ ref('dim_schedule_feeds') }}
+),
+
+int_gtfs_schedule__keyed_parse_outcomes AS (
+    SELECT
+        feeds.key AS feed_key,
+        parse.parse_success,
+        parse.parse_exception,
+        parse.filename,
+        parse._config_extract_ts,
+        parse.feed_name,
+        parse.feed_url,
+        parse.original_filename,
+        parse.fields,
+        parse.gtfs_filename,
+        parse.dt,
+        parse.ts,
+        parse.base64_url
+    FROM stg_gtfs_schedule__parse_outcomes AS parse
+    LEFT JOIN dim_schedule_feeds AS feeds
+        ON parse.ts = feeds._valid_from
+        AND parse.base64_url = feeds.base64_url
+)
+
+SELECT * FROM int_gtfs_schedule__keyed_parse_outcomes

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -50,6 +50,25 @@ models:
             - base64_url
             - ts
             - filename
+    columns:
+      - name: parse_success
+        description: '{{ doc("column_schedule_parse_success") }}'
+      - name: parse_exception
+        description: '{{ doc("column_schedule_parse_exception") }}'
+      - name: filename
+        description: '{{ doc("column_schedule_parse_filename") }}'
+      - name: _config_extract_ts
+      - name: feed_name
+        description: '{{ doc("column_schedule_parse_feed_name") }}'
+      - name: feed_url
+        description: '{{ doc("column_schedule_parse_feed_url") }}'
+      - name: original_filename
+        description: '{{ doc("column_schedule_parse_original_filename") }}'
+      - name: gtfs_filename
+        description: '{{ doc("column_schedule_parse_gtfs_filename") }}'
+      - name: dt
+      - name: ts
+      - name: base64_url
   - name: stg_gtfs_rt__vehicle_positions
     description: |
       Vehicle positions realtime data.


### PR DESCRIPTION
# Description

@owades asked how to join `stg_gtfs_schedule__file_parse_outcomes` to implement my proposal in #1968 and I realized that there isn't really a great way to do this. This PR creates a new intermediate table with individual parse outcomes joined with feed_key. PR also adds documentation for the existing table because it wasn't documented.

Questions for @atvaccaro:
- `dim_schedule_feeds` depends on parse outcomes via `joined_feed_outcomes` already, so this is creating a weird dependency graph.... How worried are we about that? I think at some point we will want to push a feed versioning table into the intermediate and have stuff inherit from that, because if we want to add any actual attributes to `dim_schedule_feeds` (like calendar date ranges etc.) that would require a circular dependency with what we have now, I think.
- Should this be in the mart? Maybe only the rows where `feed_key` is populated?
- This also made me realize that if we have a genuine flake where a file isn't parsed it's possible we won't do anything about that? I just checked and so far we don't have any rows where parsing failed. LMK if we should write an issue for this.

Resolves # [issue]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`poetry run dbt run -s int_gtfs_schedule__keyed_parse_outcomes` and `poetry run dbt test -s int_gtfs_schedule__keyed_parse_outcomes`
