### PR TITLE
Update airflow production maintenance doc

### DIFF
--- a/docs/airflow/production-maintenance.md
+++ b/docs/airflow/production-maintenance.md
@@ -57,8 +57,6 @@ The following DAGs are still listed in the Airflow UI even though they are **dep
 * `gtfs_views_staging`
 * `gtfs_views`
 * `parse_rt`
-* `payments_views`
-* `payments_views_staging`
 * `rt_timestamp_fix`
 * `rt_views`
 * `transitstacks_loader`


### PR DESCRIPTION
# Description

Removed doc information for `payments_views_staging` and `payments_views` DAGs from Airflow production maintenance docs now that the DAGs have been deleted

File changed:
* docs/airflow/production-maintenance.md

## Type of change

- [x] Documentation