### PR TITLE
Dim schedule feeds better handle unzip

### DIFF
--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -175,7 +175,7 @@ models:
       - name: step
       - name: base64_url
       - name: ts
-  - name: int_gtfs_schedule__stop_times
+  - name: int_gtfs_schedule__incremental_stop_times
     description: |
       This table is an incremental, sparse history of GTFS schedule stop times data.
       It is a precursor to `dim_stop_times` with the goal of facilitating duplicate detection and missing key issues.
@@ -199,7 +199,8 @@ models:
       - name: stop_id
         description: '{{ doc("gtfs_stop_times__stop_id") }}'
         tests:
-        - not_null
+        - not_null:
+            severity: warn
       - name: stop_sequence
         description: '{{ doc("gtfs_stop_times__stop_sequence") }}'
         tests:

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -3,8 +3,16 @@ version: 2
 models:
   - name: dim_schedule_feeds
     description: |
-      Each row is a "feed", representing a unique combination of a specific zipfile and associated
-      `gtfs_dataset` record (i.e., a specific consistent "version" of a GTFS dataset.)
+      Each row is a "feed", representing a unique zipfile version that was successfully downloaded and
+      has data in the warehouse.
+      When data fails to download, we do not interpolate it unless an identical zipfile is subsequently
+      downloaded. So for example, say we download zipfile A from URL X on January 1, then the download
+      or unzip operation fails for any reason on January 2, and then we download zipfile A from URL X
+      again on January 3. If you check this table on January 3 before the new data has appeared in the
+      warehouse, it will show zipfile A has expired on January 2. But once the same zipfile is ingested
+      again, if you check on January 4, we will show that zipfile A was continuously in effect
+      January 1-3. The reason for this is that if a new zipfile version B were to be uploaded on January 3,
+      we would want to correctly say that we don't know what was in effect on January 2.
       This table should be used to understand "versions" of constituent data like routes, trips, etc.
     tests:
       - dbt_utils.mutually_exclusive_ranges:

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -3,8 +3,8 @@ version: 2
 models:
   - name: dim_schedule_feeds
     description: |
-      Each row is a "feed", representing a unique zipfile version that was successfully downloaded and
-      has data in the warehouse.
+      Each row is a "feed", representing a unique zipfile version associated with the same GTFS dataset record
+      that was successfully downloaded and has data in the warehouse.
       When data fails to download, we do not interpolate it unless an identical zipfile is subsequently
       downloaded. So for example, say we download zipfile A from URL X on January 1, then the download
       or unzip operation fails for any reason on January 2, and then we download zipfile A from URL X

--- a/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
+++ b/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
@@ -1,12 +1,20 @@
 {{ config(materialized='table') }}
 
-{% set timestamps = dbt_utils.get_column_values(table=ref('int_gtfs_schedule__joined_feed_outcomes'), column='ts', order_by = 'ts DESC', max_records = 1) %}
-{% set latest_processed_timestamp = timestamps[0] %}
+-- TODO: when we have dbt-utils version 0.8.5 or higher, could just use get_column_values with a where clause
+-- we can have a lag where download success is populated but unzip success is not
+{% set get_max_ts_sql %}
+    SELECT MAX(ts) AS max_ts
+    FROM {{ ref('int_gtfs_schedule__joined_feed_outcomes') }}
+    WHERE unzip_success IS NOT NULL
+{% endset %}
+
+{%- set timestamps = dbt_utils.get_query_results_as_dict(get_max_ts_sql) -%}
+{%- set latest_processed_timestamp = timestamps['max_ts'][0] -%}
 
 WITH int_gtfs_schedule__joined_feed_outcomes AS (
     SELECT *
     FROM {{ ref('int_gtfs_schedule__joined_feed_outcomes') }}
-    WHERE EXTRACT(DATE FROM ts) < EXTRACT(DATE FROM TIMESTAMP '{{ latest_processed_timestamp }}')
+    WHERE EXTRACT(DATE FROM ts) <= EXTRACT(DATE FROM TIMESTAMP '{{ latest_processed_timestamp }}')
         AND download_success AND unzip_success
 ),
 

--- a/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
+++ b/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
@@ -18,22 +18,14 @@ hashed AS (
     FROM int_gtfs_schedule__joined_feed_outcomes
 ),
 
-valid_global_extracts AS (
-    SELECT
-        ts,
-        COUNT(*) AS ct,
-        SUM(int_download_success) AS ct_successful
-    FROM hashed
-    GROUP BY ts
-    -- TODO: these are made up constants
-    HAVING (ct / ct_successful > .9) AND (ct >= 40)
-),
-
 next_valid_extract AS (
     SELECT
         ts,
         LEAD(ts) OVER (ORDER BY ts) AS next_ts
-    FROM valid_global_extracts
+    FROM hashed
+    GROUP BY ts
+    -- TODO: these are made up constants indicating "enough success to say that the downloader ran"
+    HAVING ( (SUM(int_download_success) / COUNT(*)) > .9) AND (COUNT(*) >= 40)
 ),
 
 latest_attempt_by_feed AS (


### PR DESCRIPTION
# Description

This PR addresses #1985 by changing the way that `dim_schedule_feeds` (v2 warehouse) handles download and unzip failures. Previously, we used `where download_success and unzip_success is not null` as a way to skip the most recent rows where data has been downloaded but not unzipped yet, but this led to the issue described in #1985.

This PR changes the logic to the following: 
```
 When data fails to download, we do not interpolate it unless an identical zipfile is subsequently
      downloaded. So for example, say we download zipfile A from URL X on January 1, then the download
      or unzip operation fails for any reason on January 2, and then we download zipfile A from URL X
      again on January 3. If you check this table on January 3 before the new data has appeared in the
      warehouse, it will show zipfile A has expired on January 2. But once the same zipfile is ingested
      again, if you check on January 4, we will show that zipfile A was continuously in effect
      January 1-3. The reason for this is that if a new zipfile version B were to be uploaded on January 3,
      we would want to correctly say that we don't know what was in effect on January 2.
```

Previously, if the most recent download attempt was a failure, we would just interpolate that to still be in effect. This is a more conservative interpretation.

In our current production tables, it results in only two changes:

* `Metrolink` (#1989) -- previously the feed downloaded on 11/4 was listed as still "in effect" into the future, now it ends on 11/5 (first day it failed to download). **If we get a successful download again and the zipfile is identical, we will link those up and the end date for this specific feed_key will be extended.**
* `Tulare` (issue identified in #1985) -- now, the two days that the file failed to parse are skipped over and we interpolate the same zipfile remaining in effect 11/5-11/8.

PR also consolidates some CTEs to make the `dim_schedule_feeds` construction more efficient. 

Resolves #1985

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`dbt run -s dim_schedule_feeds` and `dbt test -s dim_schedule_feeds`, which does uncover some failing tests in the `dim_shapes` tables where the feed key relationship is failing. I refreshed those tables in my namespace and the tests pass, indicating that we don't need to run a full refresh after this merges; everything should work out on its own.

Also, I tested the `dim_schedule_feeds` table with an artificial time limit of November 7 and verified that the `Tulare` feed showed as `_valid_to` November 6 (the last successful parse) and then that extended to our placeholder end date when removing the time cap and running again. 

<details>
<summary> SQL used for testing </summary>
SQL to compare current prod with namespaced changes:
```
SELECT DISTINCT 
  changed.key,
  changed.base64_url,
  changed._valid_from,
  changed._valid_to,
  old.key,
  old.base64_url,
  old._valid_from,
  old._valid_to
FROM `cal-itp-data-infra-staging.laurie_mart_gtfs.dim_schedule_feeds` changed
FULL OUTER JOIN `cal-itp-data-infra.mart_gtfs.dim_schedule_feeds` old
USING(key, base64_url, _valid_from, _valid_to)
WHERE old.key IS NULL or changed.key IS NULL
ORDER BY changed._valid_from DESC
```

SQL used to inspect Tulare in particular:
```
SELECT *
FROM `cal-itp-data-infra-staging.laurie_mart_gtfs.dim_schedule_feeds`
WHERE base64_url = 'aHR0cHM6Ly90dWxhcmVjb2cub3JnL3RjYWcvZGF0YS1naXMtbW9kZWxpbmcvZ3Rmcy1kYXRhL3R1bGFyZS1jb3VudHktcmVnaW9uYWwtdHJhbnNpdC1hZ2VuY3ktdGNydGEtZ3Rmcw=='
ORDER BY _valid_from DESC
```

</details>
