### PR TITLE
sync gtfs quality to metabase

### DIFF
--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -18,12 +18,16 @@ models:
         tests: &primary_key_tests
           - unique
           - not_null
+        meta: &pk_meta
+          metabase.semantic_type: type/PK
       - name: date
         tests:
           - not_null
       - name: feed_key
         tests:
           - not_null
+        meta: &fk_meta
+          metabase.semantic_type: type/FK
       - name: status
         tests:
           - dbt_utils.not_null_proportion:

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -6,7 +6,6 @@ models:
   #   appropriate grain
   - name: fct_daily_feed_guideline_checks
     description: '{{ doc("fct_daily_feed_guideline_checks") }}'
-
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -44,12 +43,14 @@ models:
         description: |
           Synthetic primary key constructed from date, feed_key, and code.
         tests: *primary_key_tests
+        meta: *pk_meta
       - name: date
         tests:
           - not_null
       - name: feed_key
         tests:
           - not_null
+        meta: *fk_meta
       - name: code
         tests:
           - not_null

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -224,6 +224,7 @@ def run(
             ("mart_transit_database", "Data Marts (formerly Warehouse Views)"),
             ("mart_gtfs_guidelines", "Data Marts (formerly Warehouse Views)"),
             ("mart_gtfs", "Data Marts (formerly Warehouse Views)"),
+            ("mart_gtfs_quality", "Data Marts (formerly Warehouse Views)"),
         ]:
             args = [
                 "dbt-metabase",


### PR DESCRIPTION
# Description

Sync the `mart_gtfs_quality` dataset to Metabase and set a few data types to facilitate use in Metabase. 

@owades: This would let you start working on a v2 dashboard if you want?

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Don't think there's a great way to test this locally; changes should be low-risk. 
