### PR TITLE
new check for Fares v2 validation

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -83,6 +83,10 @@
 "Feed will be valid for more than 30 days"
 {% endmacro %}
 
+{% macro passes_fares_validator() %}
+"Passes Fares v2 portion of MobilityData GTFS Schedule Validator"
+{% endmacro %}
+
 -- declare features
 {% macro compliance() %}
 "Compliance"
@@ -110,6 +114,10 @@
 
 {% macro best_practices_alignment() %}
 "Best Practices Alignment"
+{% endmacro %}
+
+{% macro fare_completeness() %}
+"Fare Completeness"
 {% endmacro %}
 
 -- columns

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -72,3 +72,7 @@ models:
   - name: int_gtfs_quality__no_30_day_feed_expiration
     tests: *stg_gtfs_guideline_tests
     columns: *stg_gtfs_guideline_columns
+
+  - name: int_gtfs_quality__passes_fares_validator
+    tests: *stg_gtfs_guideline_tests
+    columns: *stg_gtfs_guideline_columns

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__passes_fares_validator.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__passes_fares_validator.sql
@@ -1,0 +1,65 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__schedule_feed_guideline_index') }}
+),
+
+keyed_parse_outcomes AS (
+    SELECT * FROM {{ ref('int_gtfs_schedule__keyed_parse_outcomes')}}
+),
+
+daily_feed_fare_files AS (
+    SELECT feed_key,
+           COUNT(*) AS ct_files
+      FROM keyed_parse_outcomes
+     WHERE parse_success
+       AND gtfs_filename IN ('fare_leg_rules',
+                             'rider_categories',
+                             'fare_containers',
+                             'fare_products',
+                             'fare_rules',
+                             'fare_transfer_rules',
+                             'fare_attributes'
+                             )
+       AND feed_key IS NOT null
+     GROUP BY 1
+),
+
+validation_fact_daily_feed_codes_fares_related AS (
+    SELECT * FROM {{ ref('fct_daily_schedule_feed_validation_notices') }}
+     WHERE code IN ('fare_transfer_rule_duration_limit_type_without_duration_limit',
+                    'fare_transfer_rule_duration_limit_without_type',
+                    'fare_transfer_rule_invalid_transfer_count',
+                    'fare_transfer_rule_missing_transfer_count',
+                    'fare_transfer_rule_with_forbidden_transfer_count',
+                    'invalid_currency_amount'
+                    )
+),
+
+validation_notices_by_day AS (
+    SELECT
+        feed_key,
+        date,
+        SUM(total_notices) as validation_notices
+    FROM validation_fact_daily_feed_codes_fares_related
+    GROUP BY feed_key, date
+),
+
+int_gtfs_quality__passes_fares_validator AS (
+    SELECT
+        idx.date,
+        idx.feed_key,
+        {{ passes_fares_validator() }} AS check,
+        {{ fare_completeness() }} AS feature,
+        CASE
+            WHEN files.feed_key IS null THEN "N/A"
+            WHEN notices.validation_notices = 0 THEN "PASS"
+            WHEN notices.validation_notices > 0 THEN "FAIL"
+        END AS status
+    FROM feed_guideline_index idx
+    LEFT JOIN validation_notices_by_day notices
+        ON idx.feed_key = notices.feed_key
+            AND idx.date = notices.date
+    LEFT JOIN daily_feed_fare_files files
+        ON idx.feed_key = files.feed_key
+)
+
+SELECT * FROM int_gtfs_quality__passes_fares_validator

--- a/warehouse/models/mart/gtfs_quality/fct_daily_feed_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_feed_guideline_checks.md
@@ -10,7 +10,7 @@ Here is a list of currently-implemented checks:
 
 | Check | Feature | Description |
 | ------------------------------------ |---------|------------ |
-| No errors in MobilityData GTFS Schedule Validator |Compliance |GTFS Schedule Validator produced no errors for the transit provider’s static feed. |
+| No errors in MobilityData GTFS Schedule Validator | Compliance |GTFS Schedule Validator produced no errors for the transit provider’s static feed. |
 |No shapes-related errors appear in the MobilityData GTFS Validator | Accurate Service Data | None of the following shapes-related errors appear in the GTFS Schedule Validator: decreasing_shape_distance, equal_shape_distance_diff_coordinates, decreasing_or_equal_shape_distance, decreasing_or_equal_shape_distance |
 | Feed will be valid for more than 7 days | Best Practices Alignment | The dataset expiration date defined in feed_info.txt is in 8 days or more |
 | Feed will be valid for more than 30 days | Best Practices Alignment | The dataset expiration date defined in feed_info.txt is in 31 days or more |
@@ -20,4 +20,5 @@ Here is a list of currently-implemented checks:
 | Include tts_stop_name entries in stops.txt for stop names that are pronounced incorrectly in most mobile applications. | Accurate Accessibility Data | For every stop_name in stops.txt containing text that is commonly mispronounced in trip planning applications, there is a non-null tts_stop_name field which is not identical to the stop_name field. The commonly mispronounced text includes directional abbreviations ("n","s","e","w","ne","se","sw","nw","nb","sb","eb","wb"), right-of-way names ("st","rd","blvd","hwy"), two or more adjacent numerals, and the symbols "/", "(" and ")".|
 |Includes complete wheelchair accessibility data in both stops.txt and trips.txt | Accurate Accessibility Data | Trips.txt contains non-empty values for each trip in the wheelchair_accessible column, and stops.txt contains non-empty values for each stop in the wheelchair_boarding column.|
 | No pathways-related errors appear in the MobilityData GTFS Validator | Accurate Accessibility Data| A transit provider is eligible for this check if they have at least one stop listed in stops.txt that: 1) Has "station" or "transit center" in the name, 2) Serves rail, or 3) Has a parent_station listed. For transit providers eligible for this check, they will pass if none of the following pathways-related notices appear in the GTFS Schedule Validator: pathway_to_platform_with_boarding_areas, pathway_to_wrong_location_type, pathway_unreachable_location, missing_level_id, station_with_parent_station, wrong_parent_location_type. |
+|Passes Fares v2 portion of MobilityData GTFS Schedule Validator | Fare Completeness | None of the following errors appear in the MobilityData GTFS Schedule Validator: |
 {% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_feed_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_feed_guideline_checks.sql
@@ -13,6 +13,9 @@ unioned AS (
             ref('int_gtfs_quality__include_tts'),
             ref('int_gtfs_quality__pathways_valid'),
             ref('int_gtfs_quality__complete_wheelchair_accessibility_data'),
+            ref('int_gtfs_quality__passes_fares_validator'),
+            ref('int_gtfs_quality__no_7_day_feed_expiration'),
+            ref('int_gtfs_quality__no_30_day_feed_expiration'),
         ],
     ) }}
 ),

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -39,6 +39,8 @@ WITH stg_gtfs_quality__intended_checks AS (
     SELECT {{ no_7_day_feed_expiration() }}, {{ best_practices_alignment() }}
     UNION ALL
     SELECT {{ no_30_day_feed_expiration() }}, {{ best_practices_alignment() }}
+    UNION ALL
+    SELECT {{ passes_fares_validator() }}, {{ fare_completeness() }}
 )
 
 SELECT * FROM stg_gtfs_quality__intended_checks


### PR DESCRIPTION
# Description

New check:

If feed has any of the following files:
- fare_leg_rules
- rider_categories
- fare_containers
- fare_products
- fare_transfer_rules

...then check whether any of the following errors show up from GTFS validator:

- fare_transfer_rule_duration_limit_type_without_duration_limit
- fare_transfer_rule_duration_limit_without_type
- fare_transfer_rule_invalid_transfer_count
- fare_transfer_rule_missing_transfer_count
- fare_transfer_rule_with_forbidden_transfer_count
- invalid_currency_amount

If there are any errors, then FAIL. If there are no errors, PASS. If none of the files are present, then give a status of "N/A"

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
`./dbt.sh test --select int_gtfs_quality__passes_fares_validator+`
Ran an aggregate check to see that results pass smell-test - see image below.

<img width="729" alt="Screen Shot 2022-11-17 at 4 53 07 PM" src="https://user-images.githubusercontent.com/3301353/202591408-baa7dff9-24e8-461f-9017-433c99cc8f65.png">
