### PR TITLE
add missing backoff for publishing

### DIFF
--- a/warehouse/poetry.lock
+++ b/warehouse/poetry.lock
@@ -114,6 +114,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "black"
 version = "22.3.0"
 description = "The uncompromising code formatter."
@@ -257,13 +265,14 @@ test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
 
 [[package]]
 name = "dask"
-version = "2022.9.1"
+version = "2022.11.1"
 description = "Parallel PyData with Task Scheduling"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 
 [package.dependencies]
+click = ">=7.0"
 cloudpickle = ">=1.1.1"
 fsspec = ">=0.6.0"
 numpy = {version = ">=1.18", optional = true, markers = "extra == \"dataframe\""}
@@ -275,10 +284,10 @@ toolz = ">=0.8.2"
 
 [package.extras]
 array = ["numpy (>=1.18)"]
-complete = ["bokeh (>=2.4.2)", "distributed (==2022.9.1)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+complete = ["bokeh (>=2.4.2,<3)", "distributed (==2022.11.1)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
 dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
-diagnostics = ["bokeh (>=2.4.2)", "jinja2"]
-distributed = ["distributed (==2022.9.1)"]
+diagnostics = ["bokeh (>=2.4.2,<3)", "jinja2"]
+distributed = ["distributed (==2022.11.1)"]
 test = ["pandas", "pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
 
 [[package]]
@@ -1866,7 +1875,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "0613034428c6d8749a5be70d211470b8f7a19381e506762a380d513ac634b5e1"
+content-hash = "dacd8047c38677f15d37d67bb4992bc951cd8216f8568b31d341b10fc54eb2f8"
 
 [metadata.files]
 agate = []
@@ -1878,6 +1887,7 @@ async-timeout = []
 attrs = []
 babel = []
 backcall = []
+backoff = []
 black = []
 bleach = []
 cachetools = []

--- a/warehouse/pyproject.toml
+++ b/warehouse/pyproject.toml
@@ -30,6 +30,7 @@ python-slugify = "^6.1.2"
 swifter = "^1.1.3"
 dbt-metabase = {git = "https://github.com/JarvusInnovations/dbt-metabase.git"}
 sentry-sdk = "^1.9.8"
+backoff = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/warehouse/requirements.txt
+++ b/warehouse/requirements.txt
@@ -7,6 +7,7 @@ async-timeout==4.0.2; python_version >= "3.7"
 attrs==22.1.0; python_version >= "3.7" and python_full_version >= "3.7.2"
 babel==2.10.3; python_version >= "3.6" and python_full_version >= "3.7.2"
 backcall==0.2.0; python_version >= "3.8"
+backoff==2.2.1; python_version >= "3.7" and python_version < "4.0"
 black==22.3.0; python_full_version >= "3.6.2"
 bleach==5.0.1; python_version >= "3.7"
 cachetools==5.2.0; python_version >= "3.7" and python_version < "4.0" and (python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "3.11" or python_full_version >= "3.6.0" and python_version >= "3.7" and python_version < "3.11")
@@ -19,7 +20,7 @@ cligj==0.7.2; python_version >= "3.7" and python_full_version < "3.0.0" or pytho
 cloudpickle==2.2.0; python_version >= "3.8"
 colorama==0.4.5; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 commonmark==0.9.1; python_full_version >= "3.6.3" and python_full_version < "4.0.0"
-dask==2022.9.1; python_version >= "3.8"
+dask==2022.11.1; python_version >= "3.8"
 db-dtypes==1.0.4; python_version >= "3.7" and python_version < "3.11"
 dbt-bigquery==1.2.0; python_version >= "3.7"
 dbt-core==1.2.1; python_full_version >= "3.7.2"


### PR DESCRIPTION
# Description

Quick follow-up to https://github.com/cal-itp/data-infra/pull/1971, I thought backoff was already in the warehouse project but it was not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Verified that the `publish_california_open_data` task starts successfully.
```
[2022-11-21 19:12:01,735] {pod_launcher.py:149} INFO - reading manifest from gs://test-calitp-dbt-artifacts/latest/manifest.json
[2022-11-21 19:12:02,165] {pod_launcher.py:149} INFO - writing 17 rows to gs://test-calitp-publish/california_open_data__metadata/dt=2022-11-21/ts=2022-11-21T19:12:02.200905Z/metadata.csv
[2022-11-21 19:12:02,547] {pod_launcher.py:149} INFO - writing 172 rows to gs://test-calitp-publish/california_open_data__dictionary/dt=2022-11-21/ts=2022-11-21T19:12:02.200905Z/dictionary.csv
[2022-11-21 19:12:02,885] {pod_launcher.py:149} INFO - handling agency e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2
Downloading: 100%|██████████| 360/360 [00:00<00:00, 2809.07rows/s]
[2022-11-21 19:12:04,403] {pod_launcher.py:149} INFO - writing 360 rows (45.2 kB) from gtfs_schedule.agency to gs://test-calitp-publish/california_open_data__agency/dt=2022-11-21/ts=2022-11-21T19:12:02.200905Z/agency.csv
[2022-11-21 19:12:04,455] {pod_launcher.py:149} INFO - would be uploading to https://data.ca.gov e8f9d49e-2bb6-400b-b01f-28bc2e0e7df2 if --publish
```

## Screenshots (optional)
