### PR TITLE
pin proper versions of protobuf

### DIFF
--- a/jobs/gtfs-rt-parser-v2/poetry.lock
+++ b/jobs/gtfs-rt-parser-v2/poetry.lock
@@ -1191,7 +1191,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "f3267609534ff58c95cb73f638b3bfc8a66ca9c537a5868842b367581512e224"
+content-hash = "012df2cdc2a918fc5415591ed3533fbc5b745c12caf1e30ba81aeaba7622223d"
 
 [metadata.files]
 aiohttp = []

--- a/jobs/gtfs-rt-parser-v2/pyproject.toml
+++ b/jobs/gtfs-rt-parser-v2/pyproject.toml
@@ -15,6 +15,7 @@ yappi = "^1.3.3"
 memory-profiler = "^0.60.0"
 matplotlib = "^3.5.1"
 typer = "^0.6.1"
+protobuf = "^3.20.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/jobs/gtfs-rt-parser/poetry.lock
+++ b/jobs/gtfs-rt-parser/poetry.lock
@@ -778,8 +778,8 @@ testing = ["google-api-core[grpc] (>=1.22.2)"]
 
 [[package]]
 name = "protobuf"
-version = "4.21.9"
-description = ""
+version = "3.20.3"
+description = "Protocol Buffers"
 category = "main"
 optional = false
 python-versions = ">=3.7"
@@ -1194,7 +1194,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "95db46ef48bfbf836f38621ad5d45018417683f000daa618ec5d0a1290cd73e6"
+content-hash = "01398c15435804faea937dad160f4f0f38f0ac584a9b341601ebafb03cd765f7"
 
 [metadata.files]
 aiohttp = []

--- a/jobs/gtfs-rt-parser/pyproject.toml
+++ b/jobs/gtfs-rt-parser/pyproject.toml
@@ -25,6 +25,7 @@ black = "22.3.0"
 yappi = "^1.3.3"
 memory-profiler = "^0.60.0"
 matplotlib = "^3.5.1"
+protobuf = "^3.20.2"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
# Description

poetry updated us to protobuf version 4+ which breaks the realtime bindings; this PR pins protobuf where necessary. v2 is actually running fine right now, as it happens to lock a good version of protobuf.

There's an open PR in the realtime bindings repo to fix this by pinning the deps required by the realtime bindings library https://github.com/MobilityData/gtfs-realtime-bindings/pull/91

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
```
[2022-11-22 18:30:11,818] {pod_launcher.py:149} INFO - saving 6962 outcomes to gs://test-calitp-gtfs-rt-parsed/service_alerts_outcomes/dt=2022-11-15/hour=2022-11-15T18:00:00+00:00/service_alerts.jsonl
[2022-11-22 18:30:13,807] {pod_launcher.py:149} INFO - fin.
[2022-11-22 18:30:20,056] {pod_launcher.py:198} INFO - Event: parse-rt-service-alerts.881310a1c5fc498f84e45a7f0256e01f had an event of type Succeeded
[2022-11-22 18:30:20,056] {pod_launcher.py:311} INFO - Event with job id parse-rt-service-alerts.881310a1c5fc498f84e45a7f0256e01f Succeeded
[2022-11-22 18:30:20,273] {pod_launcher.py:198} INFO - Event: parse-rt-service-alerts.881310a1c5fc498f84e45a7f0256e01f had an event of type Succeeded
[2022-11-22 18:30:20,273] {pod_launcher.py:311} INFO - Event with job id parse-rt-service-alerts.881310a1c5fc498f84e45a7f0256e01f Succeeded
[2022-11-22 18:30:20,551] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=parse_and_validate_rt_v2, task_id=parse_rt_service_alerts, execution_date=20221115T181500, start_date=20221122T182911, end_date=20221122T183020
```
```
[2022-11-22 18:44:10,675] {pod_launcher.py:149} INFO - writing 180 lines to gs://test-rt-parsed/service_alerts_outcomes/dt=2022-11-15/itp_id=98/url_number=0/hour=18/gtfs_rt_service_alerts_url.jsonl.gz
[2022-11-22 18:44:11,501] {pod_launcher.py:149} INFO - fin.
[2022-11-22 18:44:13,685] {pod_launcher.py:198} INFO - Event: parse-rt-service-alerts.81e3ead37fb84cf09c1866db5ab53a01 had an event of type Succeeded
[2022-11-22 18:44:13,685] {pod_launcher.py:311} INFO - Event with job id parse-rt-service-alerts.81e3ead37fb84cf09c1866db5ab53a01 Succeeded
[2022-11-22 18:44:13,778] {pod_launcher.py:198} INFO - Event: parse-rt-service-alerts.81e3ead37fb84cf09c1866db5ab53a01 had an event of type Succeeded
[2022-11-22 18:44:13,778] {pod_launcher.py:311} INFO - Event with job id parse-rt-service-alerts.81e3ead37fb84cf09c1866db5ab53a01 Succeeded
[2022-11-22 18:44:13,930] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=parse_and_validate_rt, task_id=parse_rt_service_alerts, execution_date=20221115T181500, start_date=20221122T184015, end_date=20221122T184413
```

## Screenshots (optional)
