### PR TITLE
Airtable schema updates

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
@@ -142,6 +142,9 @@ schema_fields:
   - name: organizations_copy
     type: STRING
     mode: REPEATED
+  - name: regional_feed_type
+    type: STRING
+    mode: NULLABLE
   - name: id
     type: STRING
     mode: NULLABLE

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
@@ -107,6 +107,9 @@ schema_fields:
   - name: currently_operating__from_services_
     type: BOOLEAN
     mode: REPEATED
+  - name: customer_facing
+    type: BOOLEAN
+    mode: NULLABLE
   - name: id
     type: STRING
     mode: NULLABLE

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -160,6 +160,15 @@ models:
         description: |
           If "true", indicates that this dataset should be ingested by the
           Cal-ITP data pipeline. Nulls indicate dataset should not be ingested.
+      - name: regional_feed_type
+        description: |
+          Describes whether this feed is a combined regional feed or has a relation
+          to a combined regional feed in some manner.
+          For example for MTC 511, the combined regional feed has type "Combined
+          Regional Feed", and the MTC-published subfeeds have type "Regional Subfeed".
+          If you are performing an analysis where using a regional combined feed is
+          inappropriate (even though that is the customer-facing data), this field can
+          help you assess other alternative feeds for the same services and organizations.
       - name: base64_url
       - name: deprecated_date
         description: |

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -169,6 +169,7 @@ models:
           If you are performing an analysis where using a regional combined feed is
           inappropriate (even though that is the customer-facing data), this field can
           help you assess other alternative feeds for the same services and organizations.
+          Not specified (null) for feeds with no relationship to regional feeds.
       - name: base64_url
       - name: deprecated_date
         description: |
@@ -248,6 +249,7 @@ models:
           should be receiving GTFS data in trip planning applications. Every service/dataset
           type combo with a record in this table should have exactly one of those records
           marked as customer-facing.
+          This field is "true" for customer-facing feeds and otherwise null.
           This field is intended to replace the `category` field over time.
       - name: category
         description: |

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -352,6 +352,57 @@ models:
         description: |
           Service/dataset relationship type; "primary" indicates that we believe that this
           set of datasets is ingested by trip planners (and therefore is rider-facing) for this service.
+  - name: dim_ntd_agency_info
+    description: |
+      2018 NTD Agency Info Table
+      Imported 10/6/2021 from
+      https://www7.fta.dot.gov/ntd/data-product/2018-annual-database-agency-information
+    columns:
+      - *key
+      - name: ntd_id
+      - name: legacy_ntd_id
+      - name: ntd_agency_name
+      - name: reporter_acronym
+      - name: doing_business_as
+      - name: reporter_status
+      - name: reporter_type
+      - name: reporting_module
+      - name: organization_type
+      - name: reported_by_ntd_id
+      - name: reported_by_name
+      - name: subrecipient_type
+      - name: fy_end_date
+      - name: original_due_date
+      - name: address_line_1
+      - name: address_line_2
+      - name: p_o__box
+      - name: city
+      - name: state
+      - name: zip_code
+      - name: zip_code_ext
+      - name: region
+      - name: url
+      - name: fta_recipient_id
+      - name: duns_number
+      - name: service_area_sq_miles
+      - name: service_area_pop
+      - name: primary_uza
+      - name: uza_name
+      - name: tribal_area_name
+      - name: population
+      - name: density
+      - name: sq_miles
+      - name: voms_do
+      - name: voms_pt
+      - name: total_voms
+      - name: volunteer_drivers
+      - name: personal_vehicles
+      - name: organization_key
+        tests:
+          - relationships:
+             to: ref('dim_organizations')
+             field: key
+      - name: calitp_extracted_at
   - name: bridge_components_x_properties_and_features
     description: |
       Mapping table between components and properties_and_features.

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -233,6 +233,13 @@ models:
           - relationships:
              to: ref('dim_gtfs_datasets')
              field: key
+      - name: customer_facing
+        description: |
+          Indicates that this gtfs service data relationship represents the primary way that customers
+          should be receiving GTFS data in trip planning applications. Every service/dataset
+          type combo with a record in this table should have exactly one of those records
+          marked as customer-facing.
+          This field is intended to replace the `category` field over time.
       - name: category
         description: |
           "Primary" (indicating that this is the canonical dataset for this service) or

--- a/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
+++ b/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
@@ -13,6 +13,7 @@ dim_gtfs_datasets AS (
         airtable_record_id,
         name,
         data,
+        regional_feed_type,
         uri,
         future_uri,
         aggregated_to_gtfs_dataset_key,

--- a/warehouse/models/mart/transit_database/dim_gtfs_service_data.sql
+++ b/warehouse/models/mart/transit_database/dim_gtfs_service_data.sql
@@ -13,6 +13,7 @@ dim_gtfs_service_data AS (
         name,
         service_key,
         gtfs_dataset_key,
+        customer_facing,
         category,
         agency_id,
         network_id,

--- a/warehouse/models/mart/transit_database/dim_ntd_agency_info.sql
+++ b/warehouse/models/mart/transit_database/dim_ntd_agency_info.sql
@@ -1,0 +1,56 @@
+{{ config(materialized='table') }}
+
+WITH latest_ntd_agency_info AS (
+    {{ get_latest_dense_rank(
+        external_table = ref('stg_transit_database__ntd_agency_info'),
+        order_by = 'calitp_extracted_at DESC'
+        ) }}
+),
+
+dim_ntd_agency_info AS (
+    SELECT
+        key,
+        ntd_id,
+        legacy_ntd_id,
+        agency_name AS ntd_agency_name,
+        reporter_acronym,
+        doing_business_as,
+        reporter_status,
+        reporter_type,
+        reporting_module,
+        organization_type,
+        reported_by_ntd_id,
+        reported_by_name,
+        subrecipient_type,
+        fy_end_date,
+        original_due_date,
+        address_line_1,
+        address_line_2,
+        p_o__box,
+        city,
+        state,
+        zip_code,
+        zip_code_ext,
+        region,
+        url,
+        fta_recipient_id,
+        duns_number,
+        service_area_sq_miles,
+        service_area_pop,
+        primary_uza,
+        uza_name,
+        tribal_area_name,
+        population,
+        density,
+        sq_miles,
+        voms_do,
+        voms_pt,
+        total_voms,
+        volunteer_drivers,
+        personal_vehicles,
+        organization_key,
+        calitp_extracted_at
+    FROM latest_ntd_agency_info
+)
+
+SELECT * FROM dim_ntd_agency_info

--- a/warehouse/models/staging/transit_database/_stg_transit_database.yml
+++ b/warehouse/models/staging/transit_database/_stg_transit_database.yml
@@ -105,6 +105,7 @@ models:
         tests: *primary_key_tests
       - *name
       - name: data
+      - name: regional_feed_type
       - name: fares_v2_status
       - name: fares_notes
       - name: pathways_status

--- a/warehouse/models/staging/transit_database/_stg_transit_database.yml
+++ b/warehouse/models/staging/transit_database/_stg_transit_database.yml
@@ -144,6 +144,7 @@ models:
       - name: service_key
       - name: gtfs_dataset_key
       - name: dataset_type
+      - name: customer_facing
       - name: category
       - name: agency_id
       - name: network_id

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -64,6 +64,7 @@ stg_transit_database__gtfs_datasets AS (
         {{ trim_make_empty_string_null(column_name = "name") }} AS name,
         data,
         data_quality_pipeline,
+        regional_feed_type,
         fares_v2_status,
         fares_notes,
         pathways_status,

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
@@ -13,6 +13,7 @@ stg_transit_database__gtfs_service_data AS (
         unnested_services AS service_key,
         unnested_gtfs_dataset AS gtfs_dataset_key,
         dataset_type,
+        customer_facing,
         category,
         agency_id,
         network_id,


### PR DESCRIPTION
# Description

This PR:
* Creates a `mart_transit_database.dim_ntd_agency_info` table, to address a request from @juliama0780 on Slack. 
* Ingests the new `gtfs_service_data.customer_facing` field and adds it to the relevant staging and mart tables
* Ingests the new `gtfs_datasets.regional_feed_type` field and adds it to the relevant staging and mart tables

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Ran `create_external_tables` in local Airflow and then `dbt run` and `dbt test` for the affected tables. (Changed my Airtable source to point at the staging project locally to pick up the new columns.)
