### PR TITLE
Add v2 check v2 trip alignment

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -32,7 +32,7 @@
 {% endmacro %}
 
 {% macro trip_id_alignment() %}
-"All trip_ids provided in the GTFS-rt feed exist in the GTFS data"
+"All trip_ids provided in the GTFS-rt feed exist in the GTFS Schedule feed"
 {% endmacro %}
 
 {% macro vehicle_positions_feed_present() %}

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -63,7 +63,6 @@ models:
     tests: *stg_gtfs_guideline_tests
     columns: *stg_gtfs_guideline_columns
 
-
   - name: int_gtfs_quality__shapes_file_present
     tests: *stg_gtfs_guideline_tests
     columns: *stg_gtfs_guideline_columns
@@ -103,3 +102,5 @@ models:
   - name: int_gtfs_quality__no_expired_services
     tests: *stg_gtfs_guideline_tests
     columns: *stg_gtfs_guideline_columns
+
+# todo: add tests for this PR

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -11,20 +11,6 @@ models:
             - feed_key
             - date
 
-  - name: int_gtfs_quality__no_rt_critical_validation_errors
-    description: |
-      Checks for any critical validation notices in RT feeds.
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - date
-            - base64_url
-    columns:
-      - name: status
-        tests:
-          - dbt_utils.not_null_proportion:
-              at_least: 0.99
-
   - name: int_gtfs_quality__rt_validation_outcomes
     description: |
       Unioned, incremental table of RT validation outcomes.
@@ -46,7 +32,7 @@ models:
             - severity
 
   - name: int_gtfs_quality__no_schedule_validation_errors
-    tests: &stg_gtfs_guideline_tests
+    tests: &stg_gtfs_guideline_tests_schedule
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - date
@@ -60,47 +46,60 @@ models:
               at_least: 0.99
 
   - name: int_gtfs_quality__shapes_valid
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__shapes_file_present
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__technical_contact_listed
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__shapes_for_all_trips
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__include_tts
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__pathways_valid
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__complete_wheelchair_accessibility_data
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__no_7_day_feed_expiration
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__no_30_day_feed_expiration
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__passes_fares_validator
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__no_expired_services
-    tests: *stg_gtfs_guideline_tests
+    tests: *stg_gtfs_guideline_tests_schedule
     columns: *stg_gtfs_guideline_columns
 
-# todo: add tests for this PR
+  - name: int_gtfs_quality__no_rt_critical_validation_errors
+    tests: &stg_gtfs_guideline_tests_rt
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date
+            - base64_url
+            - feed_type
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('int_gtfs_quality__rt_feed_guideline_index')
+    columns: *stg_gtfs_guideline_columns
+
+  - name: int_gtfs_quality__trip_id_alignment
+    tests: *stg_gtfs_guideline_tests_rt
+    columns: *stg_gtfs_guideline_columns

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
@@ -39,8 +39,8 @@ int_gtfs_quality__no_rt_critical_validation_errors AS (
         rt_files,
         errors,
         CASE
-            WHEN COALESCE(errors, 0) = 0 THEN "PASS"
-            WHEN rt_files IS NOT NULL THEN "FAIL" -- we had no errors, but did have files
+            WHEN rt_files IS NOT NULL AND COALESCE(errors, 0) = 0 THEN "PASS"
+            WHEN rt_files IS NOT NULL AND errors > 0 THEN "FAIL" -- we had no errors, but did have files
         END AS status,
     FROM feed_guideline_index AS idx
     LEFT JOIN count_files AS files

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_critical_validation_errors.sql
@@ -39,8 +39,8 @@ int_gtfs_quality__no_rt_critical_validation_errors AS (
         rt_files,
         errors,
         CASE
-            WHEN rt_files IS NOT NULL AND COALESCE(errors, 0) = 0 THEN "PASS"
-            WHEN rt_files IS NOT NULL AND errors > 0 THEN "FAIL" -- we had no errors, but did have files
+            WHEN rt_files IS NOT NULL AND COALESCE(errors, 0) = 0 THEN "PASS" -- files present and no errors
+            WHEN rt_files IS NOT NULL AND errors > 0 THEN "FAIL" -- files present and there are errors
         END AS status,
     FROM feed_guideline_index AS idx
     LEFT JOIN count_files AS files

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__trip_id_alignment.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__trip_id_alignment.sql
@@ -41,8 +41,8 @@ int_gtfs_quality__trip_id_alignment AS (
         rt_files,
         errors,
         CASE
-            WHEN COALESCE(errors, 0) = 0 THEN "PASS"
-            WHEN rt_files IS NOT NULL THEN "FAIL" -- we had no errors, but did have files
+            WHEN rt_files IS NOT NULL AND COALESCE(errors, 0) = 0 THEN "PASS"
+            WHEN rt_files IS NOT NULL AND errors > 0 THEN "FAIL" -- we had no errors, but did have files
         END AS status,
     FROM feed_guideline_index AS idx
     LEFT JOIN count_files AS files

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__trip_id_alignment.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__trip_id_alignment.sql
@@ -1,0 +1,56 @@
+WITH feed_guideline_index AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index') }}
+),
+
+fct_daily_rt_feed_files AS (
+    SELECT * FROM {{ ref('fct_daily_rt_feed_files') }}
+),
+
+fct_daily_rt_feed_validation_notices AS (
+    SELECT * FROM {{ ref('fct_daily_rt_feed_validation_notices') }}
+),
+
+count_files AS (
+    SELECT
+        base64_url,
+        date,
+        SUM(parse_success_file_count) AS rt_files
+    FROM fct_daily_rt_feed_files
+    GROUP BY 1, 2
+),
+
+critical_notices AS (
+    SELECT
+        date,
+        base64_url,
+        SUM(total_notices) AS errors,
+    FROM fct_daily_rt_feed_validation_notices
+    -- Description for code E003:
+    ---- "All trip_ids provided in the GTFS-rt feed must exist in the GTFS data, unless the schedule_relationship is ADDED"
+    WHERE code = "E003"
+    GROUP BY 1, 2
+),
+
+int_gtfs_quality__trip_id_alignment AS (
+    SELECT
+        idx.date,
+        idx.base64_url,
+        idx.feed_type,
+        {{ trip_id_alignment() }} AS check,
+        {{ fixed_route_completeness() }} AS feature,
+        rt_files,
+        errors,
+        CASE
+            WHEN COALESCE(errors, 0) = 0 THEN "PASS"
+            WHEN rt_files IS NOT NULL THEN "FAIL" -- we had no errors, but did have files
+        END AS status,
+    FROM feed_guideline_index AS idx
+    LEFT JOIN count_files AS files
+    ON idx.date = files.date
+        AND idx.base64_url = files.base64_url
+    LEFT JOIN critical_notices AS notices
+    ON idx.date = notices.date
+        AND idx.base64_url = notices.base64_url
+)
+
+SELECT * FROM int_gtfs_quality__trip_id_alignment

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__trip_id_alignment.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__trip_id_alignment.sql
@@ -41,8 +41,8 @@ int_gtfs_quality__trip_id_alignment AS (
         rt_files,
         errors,
         CASE
-            WHEN rt_files IS NOT NULL AND COALESCE(errors, 0) = 0 THEN "PASS"
-            WHEN rt_files IS NOT NULL AND errors > 0 THEN "FAIL" -- we had no errors, but did have files
+            WHEN rt_files IS NOT NULL AND COALESCE(errors, 0) = 0 THEN "PASS" -- files present and no errors
+            WHEN rt_files IS NOT NULL AND errors > 0 THEN "FAIL" -- files present and there are errors
         END AS status,
     FROM feed_guideline_index AS idx
     LEFT JOIN count_files AS files

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
@@ -11,4 +11,5 @@ Here is a list of currently-implemented checks:
 | Check | Feature | Description |
 | ------------------------------------ |---------|------------ |
 |No critical errors in the MobilityData GTFS Realtime Validator | Compliance | The feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no critical errors for any RT feed extract on that day.|
+|All trip_ids provided in the GTFS-rt feed exist in the GTFS Schedule feed| Fixed-Route Completeness | Error code E003 does not appear in the MobilityData GTFS Realtime Validator on that day.|
 {% enddocs %}

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -21,8 +21,8 @@ WITH stg_gtfs_quality__intended_checks AS (
     SELECT {{ no_expired_services() }}, {{ best_practices_alignment() }}
     UNION ALL
     SELECT {{ no_rt_critical_validation_errors() }}, {{ compliance() }}
-    {# UNION ALL #}
-    {# SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }} #}
+    UNION ALL
+    SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}
     {# UNION ALL #}
     {# SELECT {{ vehicle_positions_feed_present() }}, {{ compliance() }} #}
     {# UNION ALL #}


### PR DESCRIPTION
# Description

Migrate trip-id-alignment check to v2
This checks that no trip_ids appear in RT that aren't in the associated schedule. Note that we also need to do a more in depth check that sees whether all trips in schedule appear in RT.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
./dbt test
Looked at aggregate data to confirm that most feeds pass and a subset fails
