### PR TITLE
RT performance tweaks

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/archiver-app-vars.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/archiver-app-vars.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: archiver-app-vars
 data:
+  CALITP_HUEY_BACKOFF: "1"
+  CALITP_HUEY_MAX_DELAY: "1"
+  CALITP_HUEY_READ_TIMEOUT: "20"
   CALITP_HUEY_REDIS_HOST: redis
   CALITP_USER: pipeline
   GOOGLE_APPLICATION_CREDENTIALS: /secrets/gtfs-feed-secrets/google_application_credentials.json

--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: gtfs-rt-archiver-consumer
 spec:
-  replicas: 5
+  replicas: 6
   strategy:
     type: Recreate
   selector:

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/archiver-channel-vars.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/archiver-channel-vars.yaml
@@ -6,6 +6,5 @@ data:
   AIRFLOW_ENV: cal-itp-data-infra
   CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG: "gs://calitp-gtfs-download-config"
   CALITP_BUCKET__GTFS_RT_RAW: "gs://calitp-gtfs-rt-raw-v2"
-  HUEY_CONSUMER_WORKERS: "16"
   SENTRY_DSN: "https://0fc56e5e8a96482da63b8d9dd3955ee7@sentry.calitp.org/2"
   SENTRY_ENVIRONMENT: cal-itp-data-infra

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.5.0'
+  newTag: '3.5.1'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.4.0'
+  newTag: '3.5.0'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
@@ -6,6 +6,7 @@ data:
   AIRFLOW_ENV: development
   CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG: "gs://test-calitp-gtfs-download-config"
   CALITP_BUCKET__GTFS_RT_RAW: "gs://test-calitp-gtfs-rt-raw-v2"
+  CALITP_HUEY_BLOCKING: "false"
   CALITP_HUEY_CONSUMER_WORKERS: "16"
   SENTRY_DSN: "https://e498431022154366b0ff8b71cf2d93e0@sentry.calitp.org/2"
   SENTRY_ENVIRONMENT: test

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
@@ -6,7 +6,5 @@ data:
   AIRFLOW_ENV: development
   CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG: "gs://test-calitp-gtfs-download-config"
   CALITP_BUCKET__GTFS_RT_RAW: "gs://test-calitp-gtfs-rt-raw-v2"
-  CALITP_HUEY_BLOCKING: "false"
-  CALITP_HUEY_CONSUMER_WORKERS: "16"
   SENTRY_DSN: "https://e498431022154366b0ff8b71cf2d93e0@sentry.calitp.org/2"
   SENTRY_ENVIRONMENT: test

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
@@ -6,6 +6,6 @@ data:
   AIRFLOW_ENV: development
   CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG: "gs://test-calitp-gtfs-download-config"
   CALITP_BUCKET__GTFS_RT_RAW: "gs://test-calitp-gtfs-rt-raw-v2"
-  CALITP_HUEY_CONSUMER_WORKERS: "8"
+  CALITP_HUEY_CONSUMER_WORKERS: "16"
   SENTRY_DSN: "https://e498431022154366b0ff8b71cf2d93e0@sentry.calitp.org/2"
   SENTRY_ENVIRONMENT: test

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/archiver-channel-vars.yaml
@@ -6,6 +6,6 @@ data:
   AIRFLOW_ENV: development
   CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG: "gs://test-calitp-gtfs-download-config"
   CALITP_BUCKET__GTFS_RT_RAW: "gs://test-calitp-gtfs-rt-raw-v2"
-  HUEY_CONSUMER_WORKERS: "8"
+  CALITP_HUEY_CONSUMER_WORKERS: "8"
   SENTRY_DSN: "https://e498431022154366b0ff8b71cf2d93e0@sentry.calitp.org/2"
   SENTRY_ENVIRONMENT: test

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/consumer.patch.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/consumer.patch.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: gtfs-rt-archiver-consumer
 spec:
-  replicas: 2
+  replicas: 3
   template:
     spec:
       containers:

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/consumer.patch.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/consumer.patch.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: gtfs-rt-archiver-consumer
 spec:
-#  replicas: 6
+  replicas: 3
   template:
     spec:
       containers:

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/consumer.patch.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/consumer.patch.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: gtfs-rt-archiver-consumer
 spec:
-  replicas: 3
+#  replicas: 6
   template:
     spec:
       containers:

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.5.0'
+  newTag: '3.5.1'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '3.4.0'
+  newTag: '3.5.0'

--- a/services/gtfs-rt-archiver-v3/docker-compose.yml
+++ b/services/gtfs-rt-archiver-v3/docker-compose.yml
@@ -9,7 +9,7 @@ x-gtfs-rt-archiver-v3-common:
     CALITP_BUCKET__GTFS_RT_RAW: "gs://dev-calitp-gtfs-rt-raw"
     CALITP_HUEY_REDIS_HOST: redis
     GOOGLE_APPLICATION_CREDENTIALS: /tmp/secret.json
-    HUEY_CONSUMER_WORKERS: 4
+    CALITP_HUEY_CONSUMER_WORKERS: 4
     SENTRY_DSN: $SENTRY_DSN
     SENTRY_ENVIRONMENT: "development"
 services:

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -46,9 +46,11 @@ def main(
             os.environ[key] = value
 
     config = ConsumerConfig(
-        workers=int(os.getenv("HUEY_CONSUMER_WORKERS", 32)),
-        periodic=False,
+        workers=int(os.getenv("CALITP_HUEY_CONSUMER_WORKERS", 16)),
         worker_type=WORKER_THREAD,
+        backoff=float(os.getenv("CALITP_HUEY_BACKOFF", 1.15)),  # default from huey
+        max_delay=float(os.getenv("CALITP_HUEY_MAX_DELAY", 10.0)),  # default from huey
+        periodic=False,
     )
     logger = logging.getLogger("huey")
     config.setup_logger(logger)

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -37,15 +37,21 @@ class PydanticSerializer(Serializer):
         return Message(*d.values())
 
 
-huey = RedisHuey(
+class RedisHueyWithMetrics(RedisHuey):
+    pass
+
+
+huey = RedisHueyWithMetrics(
     name=f"gtfs-rt-archiver-v3-{os.environ['AIRFLOW_ENV']}",
-    blocking=False,
+    blocking=os.getenv("CALITP_HUEY_BLOCKING", "true").lower()
+    in ("true", "t", "yes", "y", "1"),
     results=False,
     # serializer=PydanticSerializer(),
     url=os.getenv("CALITP_HUEY_REDIS_URL"),
     host=os.getenv("CALITP_HUEY_REDIS_HOST"),
     port=os.getenv("CALITP_HUEY_REDIS_PORT"),
     password=os.getenv("CALITP_HUEY_REDIS_PASSWORD"),
+    read_timeout=int(os.getenv("CALITP_HUEY_READ_TIMEOUT", 1)),  # default from huey
 )
 
 

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.4.0"
+version = "3.5.0"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "3.5.0"
+version = "3.5.1"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description

1. Disables backoff and sets max_delay to 1, i.e. huey clients will always wait 1 second between task checks rather than scaling backoff
2. Switches from non-blocking workers to blocking; this means workers will block for up to 20 seconds (i.e. at minimum through the next tick) while reading from an empty queue; this should reduce the delay metric.

Also various clean-up such as making environment variable prefixes consistent and moving some hard-coded configs to env vars.

See https://github.com/cal-itp/data-infra/issues/1948#issuecomment-1334018195 for why I chose not to add a read-from-redis metric.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Deploying tweaks to test as I make them.

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/4305366/205113640-21c07cbf-2b3c-4460-a362-c6c664484462.png)
