### PR TITLE
feed aggregator checker fixes

### DIFF
--- a/jobs/gtfs-aggregator-checker/gtfs_aggregator_checker/transitfeeds.py
+++ b/jobs/gtfs-aggregator-checker/gtfs_aggregator_checker/transitfeeds.py
@@ -55,7 +55,11 @@ def get_transitfeeds_urls(progress=False):
 
         soup = BeautifulSoup(html, "html.parser")
         for a in soup.select("a"):
-            url = a["href"]
+            try:
+                url = a["href"]
+            except KeyError:
+                typer.echo(f"no href for {a}")
+                continue
             if url.startswith("/") or url.startswith(ROOT):
                 continue
             results.append((feed_url, url))

--- a/jobs/gtfs-aggregator-checker/poetry.lock
+++ b/jobs/gtfs-aggregator-checker/poetry.lock
@@ -65,6 +65,14 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.11.1"
 description = "Screen-scraping library"
@@ -616,7 +624,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "aefefba8db3342fbaab0208369119622c8f42702f097ec694f8fe0acb790dbcb"
+content-hash = "9d175f6a04b022ffe66621a0706a95bd0f1d101334805f870554f1985de202e2"
 
 [metadata.files]
 aiohttp = []
@@ -624,6 +632,7 @@ aiosignal = []
 async-timeout = []
 asynctest = []
 attrs = []
+backoff = []
 beautifulsoup4 = []
 cachetools = []
 certifi = []

--- a/jobs/gtfs-aggregator-checker/pyproject.toml
+++ b/jobs/gtfs-aggregator-checker/pyproject.toml
@@ -16,6 +16,7 @@ jsonlines = "^3.0.0"
 gcsfs = "^2022.3.0"
 mypy = "^0.942"
 types-PyYAML = "^6.0.5"
+backoff = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
# Description

use requests and backoff to work around incomplete reads, and catch a keyerror when a tag is missing href

Handles failure seen in https://cal-itp.slack.com/archives/C0332307HKM/p1669905414238899

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
local airflow
```
[2022-12-01 17:50:46,485] {pod_launcher.py:149} INFO - saving results to gs://gtfs-data-test/feed_aggregator_checks/dt=2022-09-21/checks.jsonl
[2022-12-01 17:50:46,606] {pod_launcher.py:149} INFO - Results saved to gs://gtfs-data-test/feed_aggregator_checks/dt=2022-09-21/checks.jsonl
Fetching individual feed URLs: 100%|██████████| 177/177 [00:37<00:00,  4.70it/s]
[2022-12-01 17:50:48,850] {pod_launcher.py:198} INFO - Event: check-aggregators.98ea5ed01d234792ae2b3b9c3eedca48 had an event of type Succeeded
[2022-12-01 17:50:48,851] {pod_launcher.py:311} INFO - Event with job id check-aggregators.98ea5ed01d234792ae2b3b9c3eedca48 Succeeded
[2022-12-01 17:50:48,955] {pod_launcher.py:198} INFO - Event: check-aggregators.98ea5ed01d234792ae2b3b9c3eedca48 had an event of type Succeeded
[2022-12-01 17:50:48,955] {pod_launcher.py:311} INFO - Event with job id check-aggregators.98ea5ed01d234792ae2b3b9c3eedca48 Succeeded
[2022-12-01 17:50:49,202] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=check_feed_aggregators, task_id=check_aggregators, execution_date=20220921T000000, start_date=20221201T174010, end_date=20221201T175049
```

## Screenshots (optional)
