### PR TITLE
handle missing metadata more flexibly in RT parse/validate jobs

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp==2022.10.27.3
+calitp==2022.12.1
 intake==0.6.1
 ipdb==0.13.4
 gusty==0.6.0

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -636,6 +636,8 @@ def main(
     total = len(files) + len(files_missing_metadata) + len(files_invalid_metadata)
     percentage_valid = len(files) / total
     if percentage_valid < 0.99:
+        typer.secho(f"missing: {files_missing_metadata}")
+        typer.secho(f"invalid: {files_invalid_metadata}")
         raise RuntimeError(
             f"too many files have missing/invalid metadata; {total - len(files)} of {total}"
         )

--- a/jobs/gtfs-rt-parser-v2/poetry.lock
+++ b/jobs/gtfs-rt-parser-v2/poetry.lock
@@ -99,7 +99,7 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "calitp"
-version = "2022.12.1a0"
+version = "2022.12.1"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
@@ -1215,7 +1215,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "5ed46f25d246a1b712e2b3d490423e74e4df78e7d44b3f3c424d02c3962c4f6b"
+content-hash = "d73ca6eb1b6d97d27091a4129950558fd3cfea905c42a9bba4a682fb9821c17d"
 
 [metadata.files]
 aiohttp = []

--- a/jobs/gtfs-rt-parser-v2/poetry.lock
+++ b/jobs/gtfs-rt-parser-v2/poetry.lock
@@ -61,11 +61,11 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "backoff"
-version = "1.11.1"
+version = "2.2.1"
 description = "Function decoration for backoff and retry"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7,<4.0"
 
 [[package]]
 name = "black"
@@ -99,29 +99,32 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "calitp"
-version = "2022.9.15"
+version = "2022.12.1a0"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
 python-versions = ">=3.8,<3.11"
 
 [package.dependencies]
-fsspec = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
-gcsfs = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
+backoff = ">=2.1.2,<3.0.0"
+fsspec = "2022.5.0"
+gcsfs = "2022.5.0"
 google-api-core = ">=1.32.0,<2.0.0dev"
 google-cloud-bigquery = ">=1.15.0,<3.0.0dev"
 google-cloud-bigquery-storage = "2.14.1"
+google-cloud-secret-manager = "1.0.0"
 gtfs-realtime-bindings = ">=0.0.7,<0.0.8"
 humanize = ">=4.2.3,<5.0.0"
 Jinja2 = "<3.1.0"
-pandas = ">=1.3.3,<2.0.0"
-pandas-gbq = "<0.15.0"
+pandas = "1.3.3"
+pandas-gbq = "0.14.1"
 pendulum = ">=2.1.2,<3.0.0"
 protobuf = ">=3.19.0,<4.0.0dev"
 pydantic = ">=1.9.1,<2.0.0"
-siuba = ">=0.3.0,<0.4.0"
+siuba = ">=0.4.0,<0.5.0"
 sqlalchemy-bigquery = ">=1.4.4,<2.0.0"
 tqdm = ">=4.64.0,<5.0.0"
+typing-extensions = "3.10.0.2"
 
 [[package]]
 name = "certifi"
@@ -209,7 +212,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "fsspec"
-version = "2022.8.2"
+version = "2022.5.0"
 description = "File-system specification"
 category = "main"
 optional = false
@@ -229,7 +232,7 @@ github = ["requests"]
 gs = ["gcsfs"]
 gui = ["panel"]
 hdfs = ["pyarrow (>=1)"]
-http = ["requests", "aiohttp (!=4.0.0a0,!=4.0.0a1)"]
+http = ["requests", "aiohttp"]
 libarchive = ["libarchive-c"]
 oci = ["ocifs"]
 s3 = ["s3fs"]
@@ -248,16 +251,16 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "gcsfs"
-version = "2022.8.2"
+version = "2022.5.0"
 description = "Convenient Filesystem interface over GCS"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-aiohttp = "<4.0.0a0 || >4.0.0a0,<4.0.0a1 || >4.0.0a1"
+aiohttp = "<4"
 decorator = ">4.1.2"
-fsspec = "2022.8.2"
+fsspec = "2022.5.0"
 google-auth = ">=1.2"
 google-auth-oauthlib = "*"
 google-cloud-storage = "*"
@@ -391,6 +394,18 @@ google-auth = ">=1.25.0,<3.0dev"
 grpc = ["grpcio (>=1.38.0,<2.0dev)"]
 
 [[package]]
+name = "google-cloud-secret-manager"
+version = "1.0.0"
+description = "Secret Manager API API client library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[package.dependencies]
+google-api-core = {version = ">=1.14.0,<2.0.0dev", extras = ["grpc"]}
+grpc-google-iam-v1 = ">=0.12.3,<0.13dev"
+
+[[package]]
 name = "google-cloud-storage"
 version = "1.44.0"
 description = "Google Cloud Storage API client library"
@@ -442,6 +457,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
+grpcio = {version = ">=1.0.0,<2.0.0dev", optional = true, markers = "extra == \"grpc\""}
 protobuf = ">=3.15.0,<5.0.0dev"
 
 [package.extras]
@@ -457,6 +473,18 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
 docs = ["sphinx"]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.12.4"
+description = "IAM API client library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+googleapis-common-protos = {version = ">=1.56.0,<2.0.0dev", extras = ["grpc"]}
+grpcio = ">=1.0.0,<2.0.0dev"
 
 [[package]]
 name = "grpcio"
@@ -652,23 +680,19 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.4.4"
+version = "1.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7.1"
 
 [package.dependencies]
-numpy = [
-    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
-    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
-    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
-]
-python-dateutil = ">=2.8.1"
-pytz = ">=2020.1"
+numpy = ">=1.17.3"
+python-dateutil = ">=2.7.3"
+pytz = ">=2017.3"
 
 [package.extras]
-test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
 name = "pandas-gbq"
@@ -760,8 +784,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "proto-plus"
@@ -836,14 +860,14 @@ pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
 name = "pydantic"
-version = "1.10.1"
+version = "1.9.2"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6.1"
 
 [package.dependencies]
-typing-extensions = ">=4.1.0"
+typing-extensions = ">=3.7.4.3"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -990,7 +1014,7 @@ toml = ["setuptools (>=42)"]
 
 [[package]]
 name = "siuba"
-version = "0.3.0"
+version = "0.4.2"
 description = "A package for quick, scrappy analyses with pandas and SQL"
 category = "main"
 optional = false
@@ -1146,11 +1170,11 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "3.10.0.2"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = "*"
 
 [[package]]
 name = "urllib3"
@@ -1191,7 +1215,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "012df2cdc2a918fc5415591ed3533fbc5b745c12caf1e30ba81aeaba7622223d"
+content-hash = "5ed46f25d246a1b712e2b3d490423e74e4df78e7d44b3f3c424d02c3962c4f6b"
 
 [metadata.files]
 aiohttp = []
@@ -1220,11 +1244,13 @@ google-auth-oauthlib = []
 google-cloud-bigquery = []
 google-cloud-bigquery-storage = []
 google-cloud-core = []
+google-cloud-secret-manager = []
 google-cloud-storage = []
 google-crc32c = []
 google-resumable-media = []
 googleapis-common-protos = []
 greenlet = []
+grpc-google-iam-v1 = []
 grpcio = []
 gtfs-realtime-bindings = []
 humanize = []

--- a/jobs/gtfs-rt-parser-v2/pyproject.toml
+++ b/jobs/gtfs-rt-parser-v2/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.10"
-calitp = "2022.12.1a0"
+calitp = "2022.12.1"
 gtfs-realtime-bindings = "0.0.7"
 google-auth = "1.32.1"
 pathy = {extras = ["gcs"], version = "^0.6.1"}

--- a/jobs/gtfs-rt-parser-v2/pyproject.toml
+++ b/jobs/gtfs-rt-parser-v2/pyproject.toml
@@ -6,8 +6,7 @@ authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.10"
-calitp = "2022.9.15"
-backoff = "1.11.1"
+calitp = "2022.12.1a0"
 gtfs-realtime-bindings = "0.0.7"
 google-auth = "1.32.1"
 pathy = {extras = ["gcs"], version = "^0.6.1"}
@@ -16,6 +15,7 @@ memory-profiler = "^0.60.0"
 matplotlib = "^3.5.1"
 typer = "^0.6.1"
 protobuf = "^3.20.2"
+backoff = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/jobs/gtfs-schedule-validator/poetry.lock
+++ b/jobs/gtfs-schedule-validator/poetry.lock
@@ -77,29 +77,32 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "calitp"
-version = "2022.9.15"
+version = "2022.12.1a0"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
 python-versions = ">=3.8,<3.11"
 
 [package.dependencies]
-fsspec = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
-gcsfs = ">=2022.5.0,<2022.7.1 || >2022.7.1,<2023.0.0"
+backoff = ">=2.1.2,<3.0.0"
+fsspec = "2022.5.0"
+gcsfs = "2022.5.0"
 google-api-core = ">=1.32.0,<2.0.0dev"
 google-cloud-bigquery = ">=1.15.0,<3.0.0dev"
 google-cloud-bigquery-storage = "2.14.1"
+google-cloud-secret-manager = "1.0.0"
 gtfs-realtime-bindings = ">=0.0.7,<0.0.8"
 humanize = ">=4.2.3,<5.0.0"
 Jinja2 = "<3.1.0"
-pandas = ">=1.3.3,<2.0.0"
-pandas-gbq = "<0.15.0"
+pandas = "1.3.3"
+pandas-gbq = "0.14.1"
 pendulum = ">=2.1.2,<3.0.0"
 protobuf = ">=3.19.0,<4.0.0dev"
 pydantic = ">=1.9.1,<2.0.0"
-siuba = ">=0.3.0,<0.4.0"
+siuba = ">=0.4.0,<0.5.0"
 sqlalchemy-bigquery = ">=1.4.4,<2.0.0"
 tqdm = ">=4.64.0,<5.0.0"
+typing-extensions = "3.10.0.2"
 
 [[package]]
 name = "certifi"
@@ -157,7 +160,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "fsspec"
-version = "2022.11.0"
+version = "2022.5.0"
 description = "File-system specification"
 category = "main"
 optional = false
@@ -177,7 +180,7 @@ github = ["requests"]
 gs = ["gcsfs"]
 gui = ["panel"]
 hdfs = ["pyarrow (>=1)"]
-http = ["requests", "aiohttp (!=4.0.0a0,!=4.0.0a1)"]
+http = ["requests", "aiohttp"]
 libarchive = ["libarchive-c"]
 oci = ["ocifs"]
 s3 = ["s3fs"]
@@ -196,16 +199,16 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "gcsfs"
-version = "2022.11.0"
+version = "2022.5.0"
 description = "Convenient Filesystem interface over GCS"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-aiohttp = "<4.0.0a0 || >4.0.0a0,<4.0.0a1 || >4.0.0a1"
+aiohttp = "<4"
 decorator = ">4.1.2"
-fsspec = "2022.11.0"
+fsspec = "2022.5.0"
 google-auth = ">=1.2"
 google-auth-oauthlib = "*"
 google-cloud-storage = "*"
@@ -338,6 +341,18 @@ google-auth = ">=1.25.0,<3.0dev"
 grpc = ["grpcio (>=1.38.0,<2.0dev)"]
 
 [[package]]
+name = "google-cloud-secret-manager"
+version = "1.0.0"
+description = "Secret Manager API API client library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[package.dependencies]
+google-api-core = {version = ">=1.14.0,<2.0.0dev", extras = ["grpc"]}
+grpc-google-iam-v1 = ">=0.12.3,<0.13dev"
+
+[[package]]
 name = "google-cloud-storage"
 version = "2.6.0"
 description = "Google Cloud Storage API client library"
@@ -390,6 +405,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
+grpcio = {version = ">=1.0.0,<2.0.0dev", optional = true, markers = "extra == \"grpc\""}
 protobuf = ">=3.15.0,<5.0.0dev"
 
 [package.extras]
@@ -406,6 +422,18 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 [package.extras]
 docs = ["sphinx", "docutils (<0.18)"]
 test = ["objgraph", "psutil", "faulthandler"]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.12.4"
+description = "IAM API client library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+googleapis-common-protos = {version = ">=1.56.0,<2.0.0dev", extras = ["grpc"]}
+grpcio = ">=1.0.0,<2.0.0dev"
 
 [[package]]
 name = "grpcio"
@@ -536,22 +564,19 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.5.1"
+version = "1.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7.1"
 
 [package.dependencies]
-numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
-    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-]
-python-dateutil = ">=2.8.1"
-pytz = ">=2020.1"
+numpy = ">=1.17.3"
+python-dateutil = ">=2.7.3"
+pytz = ">=2017.3"
 
 [package.extras]
-test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
+test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
 name = "pandas-gbq"
@@ -656,14 +681,14 @@ pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
 name = "pydantic"
-version = "1.10.2"
+version = "1.9.2"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6.1"
 
 [package.dependencies]
-typing-extensions = ">=4.1.0"
+typing-extensions = ">=3.7.4.3"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -795,7 +820,7 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "siuba"
-version = "0.3.0"
+version = "0.4.2"
 description = "A package for quick, scrappy analyses with pandas and SQL"
 category = "main"
 optional = false
@@ -918,11 +943,11 @@ test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "3.10.0.2"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = "*"
 
 [[package]]
 name = "urllib3"
@@ -959,8 +984,8 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.8,<3.11"
-content-hash = "600232339139c2117a4978d03c0b612256c18fb6116001605de645867d7972ee"
+python-versions = ">=3.8,<3.10"
+content-hash = "9a6ff8e9c13793b80bbca4030914e25141742a78816f96ec4d180aafbc241a71"
 
 [metadata.files]
 aiohttp = []
@@ -986,11 +1011,13 @@ google-auth-oauthlib = []
 google-cloud-bigquery = []
 google-cloud-bigquery-storage = []
 google-cloud-core = []
+google-cloud-secret-manager = []
 google-cloud-storage = []
 google-crc32c = []
 google-resumable-media = []
 googleapis-common-protos = []
 greenlet = []
+grpc-google-iam-v1 = []
 grpcio = []
 grpcio-status = []
 gtfs-realtime-bindings = []

--- a/jobs/gtfs-schedule-validator/poetry.lock
+++ b/jobs/gtfs-schedule-validator/poetry.lock
@@ -77,7 +77,7 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "calitp"
-version = "2022.12.1a0"
+version = "2022.12.1"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
@@ -985,7 +985,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "9a6ff8e9c13793b80bbca4030914e25141742a78816f96ec4d180aafbc241a71"
+content-hash = "10bd89c27cd08b5d42f23a67e55797d22c93d9e01178a00712a63dc0d211a756"
 
 [metadata.files]
 aiohttp = []

--- a/jobs/gtfs-schedule-validator/pyproject.toml
+++ b/jobs/gtfs-schedule-validator/pyproject.toml
@@ -13,7 +13,7 @@ humanize = "^4.2.3"
 pydantic = "^1.9.1"
 pendulum = "^2.1.2"
 tqdm = "^4.64.0"
-calitp = "2022.12.1a0"
+calitp = "2022.12.1"
 backoff = "^2.2.1"
 
 [tool.poetry.dev-dependencies]

--- a/jobs/gtfs-schedule-validator/pyproject.toml
+++ b/jobs/gtfs-schedule-validator/pyproject.toml
@@ -5,16 +5,16 @@ description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8,<3.10"
 toml = "^0.10.2"
 gcsfs = "^2022.5.0"
 typer = "^0.6.1"
 humanize = "^4.2.3"
-backoff = "^2.1.2"
 pydantic = "^1.9.1"
 pendulum = "^2.1.2"
 tqdm = "^4.64.0"
-calitp = "2022.9.15"
+calitp = "2022.12.1a0"
+backoff = "^2.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
# Description

Related calitp PR is https://github.com/cal-itp/calitp-py/pull/91

Closes https://github.com/cal-itp/data-infra/issues/1980

Rather than raising a single exception, calitp-py will return a tuple of files, blobs missing metadata, and blobs with invalid metadata. Callers can then compare these against a threshold to decide whether to proceed. Most of the time, only a small number of files should be missing metadata (e.g. from a 500 in GCS) and we can process the rest.

Once this is merged, we will need to clear the past failed jobs and ensure they pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
RT:
```
[2022-12-01 20:23:39,196] {pod_launcher.py:149} INFO - no schedule data found for gs://test-calitp-gtfs-rt-raw-v2/service_alerts/dt=2022-12-01/hour=2022-12-01T16:00:00+00:00/ts=2022-12-01T16:00:20+00:00/base64_url=aHR0cHM6Ly9zYW50YXJvc2FpdmwuYXZhaWx0ZWMuY29tL0luZm9Qb2ludC9HVEZTLVJlYWx0aW1lLmFzaHg_VHlwZT1BbGVydA==/feed thrown for gs://test-calitp-gtfs-rt-validation/service_alerts_validation_notices/dt=2022-12-01/hour=2022-12-01T16:00:00+00:00/base64_url=aHR0cHM6Ly9zYW50YXJvc2FpdmwuYXZhaWx0ZWMuY29tL0luZm9Qb2ludC9HVEZTLVJlYWx0aW1lLmFzaHg_VHlwZT1BbGVydA==/service_alerts.jsonl.gz
[2022-12-01 20:23:39,440] {pod_launcher.py:149} INFO - saving 11390 outcomes to gs://test-calitp-gtfs-rt-validation/service_alerts_validation_outcomes/dt=2022-12-01/hour=2022-12-01T16:00:00+00:00/service_alerts.jsonl
[2022-12-01 20:23:41,978] {pod_launcher.py:149} INFO - fin.
[2022-12-01 20:23:54,200] {pod_launcher.py:198} INFO - Event: validate-rt-service-alerts.6ea91b8581e1464892c33f2b6167b753 had an event of type Succeeded
[2022-12-01 20:23:54,200] {pod_launcher.py:311} INFO - Event with job id validate-rt-service-alerts.6ea91b8581e1464892c33f2b6167b753 Succeeded
[2022-12-01 20:23:54,298] {pod_launcher.py:198} INFO - Event: validate-rt-service-alerts.6ea91b8581e1464892c33f2b6167b753 had an event of type Succeeded
[2022-12-01 20:23:54,299] {pod_launcher.py:311} INFO - Event with job id validate-rt-service-alerts.6ea91b8581e1464892c33f2b6167b753 Succeeded
[2022-12-01 20:23:54,450] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=parse_and_validate_rt_v2, task_id=validate_rt_service_alerts, execution_date=20221201T161500, start_date=20221201T201422, end_date=20221201T202354
```

Schedule:
```
[2022-12-01 21:30:53,623] {pod_launcher.py:149} INFO - got 220 successes and 0 failures
[2022-12-01 21:30:53,623] {pod_launcher.py:149} INFO - saving 220 to gs://test-calitp-gtfs-schedule-validation/validation_job_results/dt=2022-12-01/results.jsonl
[2022-12-01 21:30:55,891] {pod_launcher.py:198} INFO - Event: validate-gtfs-schedule.8885efdbe531483fafd37fbfeea2c355 had an event of type Succeeded
[2022-12-01 21:30:55,891] {pod_launcher.py:311} INFO - Event with job id validate-gtfs-schedule.8885efdbe531483fafd37fbfeea2c355 Succeeded
[2022-12-01 21:30:55,989] {pod_launcher.py:198} INFO - Event: validate-gtfs-schedule.8885efdbe531483fafd37fbfeea2c355 had an event of type Succeeded
[2022-12-01 21:30:55,989] {pod_launcher.py:311} INFO - Event with job id validate-gtfs-schedule.8885efdbe531483fafd37fbfeea2c355 Succeeded
[2022-12-01 21:30:56,157] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=unzip_and_validate_gtfs_schedule, task_id=validate_gtfs_schedule, execution_date=20221201T020000, start_date=20221201T211332, end_date=20221201T213056
```
I confirmed Schedule _fails_ with a file that lacks metadata.

## Screenshots (optional)
