### PR TITLE
fix ntd id reference in organizations and dim provider gtfs data

### DIFF
--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -58,8 +58,12 @@ models:
           Core: funded by Caltrans/can control or influence somewhat
           Other Public Transit: (publicly available or managed) and publicly funded transit
           Other Transit: transit that isn't the above
-      - name: ntd_id
-        description: National Transit Database (NTD) ID
+      - name: ntd_agency_info_key
+        description: Foreign key to `dim_ntd_agency_info`.
+        tests:
+          - relationships:
+             to: ref('dim_ntd_agency_info')
+             field: key
       - name: alias
       - name: gtfs_static_status
         description: |

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -18,7 +18,7 @@ dim_organizations AS (
         caltrans_district,
         website,
         reporting_category,
-        ntd_id,
+        ntd_agency_info_key,
         hubspot_company_record_id,
         gtfs_static_status,
         gtfs_realtime_status,

--- a/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
+++ b/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
@@ -16,13 +16,17 @@ dim_gtfs_datasets AS (
     SELECT * FROM {{ ref('dim_gtfs_datasets') }}
 ),
 
+dim_ntd_agency_info AS (
+    SELECT * FROM {{ ref('dim_ntd_agency_info') }}
+),
+
 quartet_pivoted AS (
     SELECT * FROM {{ ref('int_transit_database__service_datasets_pivoted') }}
 ),
 
 dim_provider_service_gtfs AS (
     SELECT
-        {{ farm_surrogate_key(['organization_key',
+        {{ farm_surrogate_key(['organizations.key',
             'quartet_pivoted.service_key',
             'gtfs_dataset_key_schedule',
             'gtfs_dataset_key_service_alerts',
@@ -37,7 +41,7 @@ dim_provider_service_gtfs AS (
         agency_id,
         network_id,
         route_id,
-        ntd_id,
+        ntd.ntd_id,
         hubspot_company_record_id,
         gtfs_dataset_key_schedule AS schedule_gtfs_dataset_key,
         schedule.name AS schedule_name,
@@ -63,6 +67,8 @@ dim_provider_service_gtfs AS (
         ON quartet_pivoted.service_key = bridge_organizations_x_services_managed.service_key
     LEFT JOIN dim_organizations AS organizations
         ON bridge_organizations_x_services_managed.organization_key = organizations.key
+    LEFT JOIN dim_ntd_agency_info AS ntd
+        ON organizations.ntd_agency_info_key = ntd.key
 )
 
 SELECT * FROM dim_provider_service_gtfs

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -14,7 +14,7 @@ stg_transit_database__organizations AS (
         organization_type,
         roles,
         itp_id,
-        ntd_id,
+        unnested_ntd_records AS ntd_agency_info_key,
         hubspot_company_record_id,
         alias_ as alias,
         details,
@@ -29,6 +29,7 @@ stg_transit_database__organizations AS (
         gtfs_realtime_status,
         dt AS calitp_extracted_at
     FROM once_daily_organizations
+    LEFT JOIN UNNEST(once_daily_organizations.ntd_id) as unnested_ntd_records
 )
 
 SELECT * FROM stg_transit_database__organizations


### PR DESCRIPTION
# Description

Noticed that while `NTD ID` column in `organizations` in Airtable displays an NTD ID, what it pulls in is actually the NTD Agency Info record key (it displays as the NTD ID in Airtable because the NTD ID is the "record name" for the NTD Agency Info record, not because it is actually performing a lookup for the ID value.)

This PR:
* Unnests the NTD record in the `organizations` tables (staging and mart) and updates docs accordingly
* Looks up the actual NTD ID value in `dim_provider_gtfs_data`; this is of interest to analysts

Resolves -- bug noticed today

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
`dbt run` & `dbt test` for staging organizations and dim organizations (confirms no fanout from unnesting)

`dbt build` for dim_provider_gtfs_data
