### PR TITLE
Add assessments column

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -232,3 +232,6 @@ schema_fields:
   - name: hubspot_company_record_id
     type: STRING
     mode: NULLABLE
+  - name: assessment_status
+    type: STRING
+    mode: NULLABLE

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -80,6 +80,10 @@ models:
       - name: hubspot_company_record_id
         description: |
           Organization's ID in Hubspot CRM.
+      - name: assessment_status
+        description: |
+          Is either "Yes" or "No" and indicates whether this Organization
+          manages qualifying assessed services
   - name: dim_services
     description: '{{ doc("services_table") }}'
     columns:
@@ -125,6 +129,10 @@ models:
           or GTFS guidelines checks implemented in `mart_gtfs_guidelines.fact_daily_guideline_checks`.
           Use those tables directly for the most up-to-date information on individual GTFS feeds'
           validation and guideline statuses.**
+      - name: assessment_status
+        description: |
+          Is either "Yes" or "No" and indicates whether this Service qualifies as
+          being an assessed service
   - name: dim_products
     description: '{{ doc("products_table") }}'
     columns:
@@ -362,6 +370,11 @@ models:
             relationships:
               to: ref('dim_gtfs_datasets')
               field: key
+      - name: service_assessment_status
+        description: |
+          If "Yes", this service should be considered "assessed" by Cal-ITP
+          for quality and reporting purposes.
+          If "No", this service is not "asssessed".
       - name: service_alerts_gtfs_dataset_key
         tests:
           - *ref_gtfs_datasets_key

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -22,6 +22,7 @@ dim_organizations AS (
         hubspot_company_record_id,
         gtfs_static_status,
         gtfs_realtime_status,
+        assessment_status,
         alias,
         calitp_extracted_at
     FROM latest_organizations

--- a/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
+++ b/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
@@ -34,6 +34,7 @@ dim_provider_service_gtfs AS (
             'gtfs_dataset_key_trip_updates']) }} AS key,
         quartet_pivoted.service_key,
         services.name AS service_name,
+        services.assessment_status AS service_assessment_status,
         organizations.key AS organization_key,
         organizations.name AS organization_name,
         organizations.itp_id AS itp_id,

--- a/warehouse/models/mart/transit_database/dim_services.sql
+++ b/warehouse/models/mart/transit_database/dim_services.sql
@@ -19,6 +19,7 @@ dim_services AS (
         gtfs_schedule_status,
         -- TODO: remove this field when v2, automatic determinations are available
         gtfs_schedule_quality,
+        assessment_status,
         calitp_extracted_at
     FROM latest_services
 )

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -27,6 +27,7 @@ stg_transit_database__organizations AS (
         gtfs_datasets_produced,
         gtfs_static_status,
         gtfs_realtime_status,
+        assessment_status,
         dt AS calitp_extracted_at
     FROM once_daily_organizations
     LEFT JOIN UNNEST(once_daily_organizations.ntd_id) as unnested_ntd_records

--- a/warehouse/models/staging/transit_database/stg_transit_database__services.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__services.sql
@@ -24,6 +24,7 @@ stg_transit_database__services AS (
         -- TODO: remove this field when v2, automatic determinations are available
         gtfs_schedule_quality,
         operating_counties,
+        assessment_status,
         dt AS calitp_extracted_at
     FROM once_daily_services
 )


### PR DESCRIPTION
# Description

Add new assessment status columns to `services`, `organizations`, and `dim_provider_gtfs_data` tables. 

Resolves #2034 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`dbt run` and `dbt test` for organizations and services; `dbt build` for `dim_provider_gtfs_data`. I temporarily pointed `_src_airtable` at the staging external tables for testing `organizations` with the new column.

## Screenshots (optional)
