### PR TITLE
fix issue introduced in #2044; use correct cte in final select

### DIFF
--- a/warehouse/macros/gtfs_rt_stg_outcomes.sql
+++ b/warehouse/macros/gtfs_rt_stg_outcomes.sql
@@ -28,6 +28,6 @@ stg_gtfs_rt__agg_outcomes AS (
     FROM raw_outcomes
 )
 
-SELECT * FROM raw_outcomes
+SELECT * FROM stg_gtfs_rt__agg_outcomes
 
 {% endmacro %}


### PR DESCRIPTION
# Description

Bug introduced in #2044, final select pulls raw data instead of the renamed stuff. Caused dbt failures overnight, will need to rerun the affected table's lineage once this merges.

![image](https://user-images.githubusercontent.com/55149902/206210566-f2a4df00-1b25-4c0b-b012-7ae6eb44e68d.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`dbt run / dbt test` there are failing downstream tests but I do not think they are caused by this, talking to @atvaccaro offline

## Screenshots (optional)
