### PR TITLE
Add GMV URLs for Vine Transit

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1511,6 +1511,10 @@ vine-transit:
       gtfs_rt_vehicle_positions_url: https://api.511.org/transit/vehiclepositions?api_key={{ MTC_511_API_KEY}}&agency=VN
       gtfs_rt_service_alerts_url: https://api.511.org/transit/servicealerts?api_key={{ MTC_511_API_KEY}}
       gtfs_rt_trip_updates_url: https://api.511.org/transit/tripupdates?api_key={{ MTC_511_API_KEY}}&agency=VN
+    - gtfs_schedule_url: https://napa.syncromatics.com/gtfs
+      gtfs_rt_vehicle_positions_url: https://napa.syncromatics.com/gtfs-rt/vehiclepositions
+      gtfs_rt_service_alerts_url: https://napa.syncromatics.com/gtfs-rt/alerts
+      gtfs_rt_trip_updates_url: https://napa.syncromatics.com/gtfs-rt/tripupdates
   itp_id: 218
 visalia-transit:
   agency_name: Visalia Transit


### PR DESCRIPTION
# Description

Adds some GMV URLs for Vine Transit

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Downloaded locally.
