### PR TITLE
remove full duplicates in calendar dates

### DIFF
--- a/warehouse/models/mart/gtfs/dim_calendar_dates.sql
+++ b/warehouse/models/mart/gtfs/dim_calendar_dates.sql
@@ -15,7 +15,8 @@ make_dim AS (
 ),
 
 dim_calendar_dates AS (
-    SELECT
+    -- some full duplicate rows
+    SELECT DISTINCT
         {{ dbt_utils.surrogate_key(['feed_key', 'service_id', 'date']) }} AS key,
         feed_key,
         service_id,

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -744,6 +744,7 @@ models:
             - ts
             - service_id
             - date
+          severity: warn
     columns:
       - name: base64_url
       - name: ts


### PR DESCRIPTION
# Description

There are some full duplicate rows in incoming `calendar_dates` files (i.e., `service_id`, `date`, and `exception_type` are identical). This PR:

* Does a `select distinct` in the mart to drop the full duplicates
* Downgrades duplicate test in staging to a warn because of these known duplicates

Resolves Sentry/dbt issues:
* `test.calitp_warehouse.dbt_utils_unique_combination_of_columns_stg_gtfs_schedule__calendar_dates_base64_url__ts__service_id__date.a81b0f78e6 - Got 77 results, configured to fail if != 0`
* `test.calitp_warehouse.dbt_utils_mutually_exclusive_ranges_dim_calendar_dates_required___valid_from__base64_url_service_id_date___valid_to.d9be22059c - Got 66 results, configured to fail if != 0`
* `test.calitp_warehouse.unique_dim_calendar_dates_key.4715b99016 - Got 66 results, configured to fail if != 0`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`poetry run dbt run -s stg_gtfs_schedule__calendar_dates dim_calendar_dates`
`poetry run dbt test -s stg_gtfs_schedule__calendar_dates dim_calendar_dates`

## Screenshots (optional)
