### PR TITLE
bugfix: omit null values from rt_feed_guideline_index

### DIFF
--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feed_guideline_index.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feed_guideline_index.sql
@@ -12,6 +12,8 @@ int_gtfs_quality__rt_feed_guideline_index AS (
         feed_type,
     FROM fct_daily_rt_feed_files
     WHERE date < CURRENT_DATE
+      AND base64_url IS NOT null
+      AND feed_type IS NOT null
 )
 
 SELECT * FROM int_gtfs_quality__rt_feed_guideline_index


### PR DESCRIPTION
# Description

Two new sentry issues have appeared, related to null values in rt_feed_guideline_index ("RT-FGI").
[1](https://sentry.calitp.org/organizations/sentry/issues/17583/?environment=cal-itp-data-infra&project=2&query=is%3Aunresolved+assigned%3Ascott.owades%40dot.ca.gov&statsPeriod=14d) & [2](https://sentry.calitp.org/organizations/sentry/issues/17582/?environment=cal-itp-data-infra&project=2&query=is%3Aunresolved+assigned%3Ascott.owades%40dot.ca.gov&statsPeriod=14d).

By my count, RT-FGI has 5 null rows for base64_url, and 5 null rows for feed_type. I can resolve by making this change to FGI. I have not explored going further upstream into `fct_daily_rt_feed_files`, but will accept that as a recommendation instead.

Resolves # [issue]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I successfully ran `dbt build [int table]+` on one of the RT int tables, with no errors downstream.

## Screenshots (optional)
The "before":
![Screen Shot 2022-12-08 at 10 40 12 AM](https://user-images.githubusercontent.com/3301353/206540137-381ca03e-60f2-4baf-9976-e38d2ed6c670.png)
