### PR TITLE
Assessed organization & service indices

### DIFF
--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -40,7 +40,86 @@ models:
           combination_of_columns:
             - code
             - severity
+  - name: int_gtfs_quality__daily_assessment_candidate_entities
+    description: |
+      A row here is a combination of an organization, service, service / GTFS dataset relationship,
+      GTFS dataset, and schedule feed that existed as of the given date. This combined entity
+      represents a candidate for GTFS guideline adherence assessment. The `assessed` column
+      indicates whether the candidate was actually in scope for assessment on the given date, based on whether:
+      * The organization had `reporting_category` = 'Core' or 'Other Public Transit'
+      * The service was `currently_operating`
+      * The service had `service_type` 'fixed-route'
+      * The service/GTFS dataset relationship was `customer_facing` or had `category` = 'primary'
+      (i.e., according to our data, was this dataset ingested by trip planners on this date
+      to represent this service)
 
+      Entities that fail any of the criteria will *not* be included as `assessed` for the given date.
+
+      The data in this table comes directly from historical extracts from the Transit Database. This means
+      that it is subject to historical data quality issues. On days when an extract failed, entities
+      may not resolve correctly.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - key
+            - date
+    columns:
+      - name: key
+        description: |
+          Synthetic key from `organization_key`, `service_key`, `gtfs_service_data_key`, `gtfs_dataset_key`,
+          and `schedule_feed_key`.
+        tests:
+          - not_null
+      - name: date
+        description: |
+          Date on which this combination of records is present in our data.
+      - name: organization_name
+      - name: service_name
+      - name: gtfs_dataset_name
+      - name: gtfs_dataset_type
+      - name: assessed
+        description: |
+          Boolean indicator for whether this combined entity met the criteria to be "assessed"
+          on the given date. Applies "and" logic to `organization_assessed`, `service_assessed`,
+          and `gtfs_service_data_assessed`.
+      - name: organization_assessed
+        description: |
+          Boolean indicator for whether the given organization record met the criteria to be "assessed"
+          on the given date, i.e., had `reporting_category` = 'Core' or 'Other Public Transit'.
+      - name: service_assessed
+        description: |
+          Boolean indicator for whether the given organization record met the criteria to be "assessed"
+          on the given date, i.e., was `currently_operating` and had `service_type` 'fixed-route'.
+      - name: gtfs_service_data_assessed
+        description: |
+          Boolean indicator for whether the given service/GTFS dataset (`gtfs_service_data`) record met
+          the criteria to be "assessed" on the given date, i.e., was `customer_facing` or had `category` = 'primary'.
+      - name: base64_url
+      - name: organization_key
+        description: |
+          Foreign key to `dim_organizations`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: service_key
+        description: |
+          Foreign key to `dim_services`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: gtfs_service_data_key
+        description: |
+          Foreign key to `dim_gtfs_service_data`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: gtfs_dataset_key
+        description: |
+          Foreign key to `dim_gtfs_datasets`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: schedule_feed_key
+        description: |
+          Foreign key to `dim_schedule_feeds`. Because `dim_schedule_feeds` is slowly-
+          changing dimension, joins using this key are not subject to the historical
+          limitations noted for the other foreign keys in this table.
   - name: int_gtfs_quality__no_schedule_validation_errors
     tests: &stg_gtfs_guideline_tests_schedule
       - dbt_utils.unique_combination_of_columns:

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__daily_assessed_entities.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__daily_assessed_entities.sql
@@ -1,0 +1,52 @@
+{{ config(materialized='table') }}
+
+WITH assessed_orgs AS (
+    SELECT *
+
+    FROM {{ ref('int_transit_database__organizations_history') }}
+),
+
+services AS (
+    SELECT *
+    FROM {{ ref('int_transit_database__services_history') }}
+),
+
+service_data AS (
+    SELECT *
+    FROM {{ ref('int_transit_database__gtfs_service_data_history') }}
+),
+
+datasets AS (
+    SELECT *
+    FROM {{ ref('int_transit_database__gtfs_datasets_history') }}
+),
+
+
+full_join AS (
+    SELECT
+        COALESCE(orgs.date, services.date,) AS date
+        orgs.key AS organization_key,
+        orgs.name AS organization_name,
+        orgs.assessment_status AS organization_raw_assessment_status,
+        orgs.reporting_category AS orgs.reporting_category,
+        services.key AS service_key,
+        services.name AS service_name,
+        services.assessment_status AS services_raw_assessment_status,
+        services.currently_operating AS service_currently_operating,
+        service_type,
+        gtfs_service_data_key,
+        gtfs_service_data.customer_facing AS gtfs_service_data_customer_facing,
+        gtfs_service_data.category AS gtfs_service_data_category,
+
+    FROM orgs
+    FULL OUTER JOIN services
+        ON orgs.date = services.date
+        AND orgs.mobility_services_managed = services.key
+        AND orgs.key = services.provider
+    FULL OUTER JOIN gtfs_service_data
+        ON services.date = gtfs_service_data.date
+        AND services.key = gtfs_service_data.service_key
+
+
+
+)

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__daily_assessed_entities.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__daily_assessed_entities.sql
@@ -1,8 +1,7 @@
 {{ config(materialized='table') }}
 
-WITH assessed_orgs AS (
+WITH orgs AS (
     SELECT *
-
     FROM {{ ref('int_transit_database__organizations_history') }}
 ),
 
@@ -21,32 +20,74 @@ datasets AS (
     FROM {{ ref('int_transit_database__gtfs_datasets_history') }}
 ),
 
+feeds AS (
+    SELECT *
+    FROM {{ ref('fct_daily_schedule_feeds') }}
+    -- this table goes into the future
+    WHERE date <= CURRENT_DATE()
+),
 
 full_join AS (
     SELECT
-        COALESCE(orgs.date, services.date,) AS date
-        orgs.key AS organization_key,
+        COALESCE(orgs.date,
+            services.date,
+            service_data.date,
+            datasets.date,
+            feeds.date) AS date,
+        COALESCE(orgs.organization_key, services.provider_organization_key) AS organization_key,
+        COALESCE(orgs.mobility_services_managed_service_key,
+            services.service_key,
+            service_data.service_key)
+            AS service_key,
+        COALESCE(service_data.gtfs_dataset_key,
+            datasets.key) AS gtfs_dataset_key,
+
         orgs.name AS organization_name,
         orgs.assessment_status AS organization_raw_assessment_status,
-        orgs.reporting_category AS orgs.reporting_category,
-        services.key AS service_key,
+        orgs.reporting_category AS reporting_category,
+        COALESCE(
+            orgs.assessment_status,
+            (orgs.reporting_category = "Core") OR (orgs.reporting_category = "Other Public Transit")
+        ) AS organization_assessed,
+
         services.name AS service_name,
         services.assessment_status AS services_raw_assessment_status,
         services.currently_operating AS service_currently_operating,
-        service_type,
-        gtfs_service_data_key,
-        gtfs_service_data.customer_facing AS gtfs_service_data_customer_facing,
-        gtfs_service_data.category AS gtfs_service_data_category,
+        service_type_str,
+        COALESCE(
+            services.assessment_status,
+            services.currently_operating
+                AND CONTAINS_SUBSTR(services.service_type_str, "fixed-route")
+        ) AS service_assessed,
 
+        gtfs_service_data_key,
+        service_data.customer_facing AS gtfs_service_data_customer_facing,
+        service_data.category AS gtfs_service_data_category,
+        COALESCE(
+            service_data.customer_facing,
+            service_data.category = "primary"
+        ) AS gtfs_service_data_assessed,
+
+        datasets.name AS gtfs_dataset_name,
+        datasets.data AS gtfs_dataset_data,
+        datasets.regional_feed_type,
+        datasets.base64_url,
+
+        feeds.feed_key
     FROM orgs
     FULL OUTER JOIN services
         ON orgs.date = services.date
-        AND orgs.mobility_services_managed = services.key
-        AND orgs.key = services.provider
-    FULL OUTER JOIN gtfs_service_data
-        ON services.date = gtfs_service_data.date
-        AND services.key = gtfs_service_data.service_key
-
-
-
+        AND orgs.mobility_services_managed_service_key = services.service_key
+        AND orgs.organization_key = services.provider_organization_key
+    FULL OUTER JOIN service_data
+        ON services.date = service_data.date
+        AND services.key = service_data.service_key
+    FULL OUTER JOIN datasets
+        ON service_data.date = datasets.date
+        AND service_data.gtfs_dataset_key = datasets.key
+    FULL OUTER JOIN feeds
+        ON datasets.date = feeds.date
+        AND datasets.base64_url = feeds.base64_url
 )
+
+SELECT * FROM full_join

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
@@ -96,7 +96,6 @@ full_join AS (
 int_gtfs_quality__daily_assessment_candidate_entities AS (
     SELECT
         {{ dbt_utils.surrogate_key([
-            'date',
             'organization_key',
             'service_key',
             'gtfs_service_data_key',

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
@@ -15,15 +15,11 @@ int_gtfs_rt__daily_url_index AS (
         configs.dt,
         url_to_encode AS string_url,
         base64_url,
-        CASE
-            WHEN data = "GTFS Alerts" THEN "service_alerts"
-            WHEN data = "GTFS VehiclePositions" THEN "vehicle_positions"
-            WHEN data = "GTFS TripUpdates" THEN "trip_updates"
-        END AS type
+        type
     FROM int_gtfs_rt__distinct_download_configs AS configs
     LEFT JOIN stg_transit_database__gtfs_datasets AS datasets
         ON configs._config_extract_ts = datasets.ts
-    WHERE data IN ("GTFS Alerts", "GTFS VehiclePositions", "GTFS TripUpdates")
+    WHERE type IN ("service_alerts", "vehicle_positions", "trip_updates")
     QUALIFY RANK() OVER (PARTITION BY configs.dt, url_to_encode, base64_url ORDER BY _config_extract_ts DESC) = 1
 )
 

--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -78,8 +78,8 @@ models:
         description: Foreign key to dim_gtfs_datasets, for a record with data = "GTFS TripUpdates."
   - name: int_transit_database__services_history
     description: |
-      Daily list of services with attributes required to check whether they were
-      assessed by Cal-ITP on the given date.
+      Daily list of services, unnested to the organization/service relationship level,
+      with attributes required to check whether they were assessed by Cal-ITP on the given date.
 
       This table is different than other Transit Database data because it
       captures the historical state of various attributes. This historical
@@ -97,6 +97,9 @@ models:
           Date on which this service was in our Transit Database data.
       - name: key
         description: |
+          Synthetic key, hash of `service_key` and `provider_organization_key`.
+      - name: service_key
+        description: |
           Service record key.
       - name: name
       - name: assessment_status
@@ -113,8 +116,8 @@ models:
           Array of organization key(s) for organization(s) managing this service as of this date.
   - name: int_transit_database__organizations_history
     description: |
-      Daily list of organizations with attributes required to check whether they were
-      assessed by Cal-ITP on the given date.
+      Daily list of organizations, unnested to the organization/service relationship level,
+      with attributes required to check whether they were assessed by Cal-ITP on the given date.
 
       This table is different than other Transit Database data because it
       captures the historical state of various attributes. This historical
@@ -131,6 +134,9 @@ models:
         description: |
           Date on which this organization was in our Transit Database data.
       - name: key
+        description: |
+          Synthetic key, hash of `organization_key` and `mobility_services_managed_service_key`.
+      - name: organization_key
         description: |
           Organization record key.
       - name: name

--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -143,3 +143,62 @@ models:
       - name: mobility_services_managed
         description: |
           Array of service keys for managed services as of this date.
+  - name: int_transit_database__gtfs_service_data_history
+    description: |
+      Daily list of GTFS dataset/service relationships with attributes required to check
+      whether they were assessed by Cal-ITP on the given date.
+
+      This table is different than other Transit Database data because it
+      captures the historical state of various attributes. This historical
+      data is meant to be used for quality assessment purposes.
+
+      For the most up to date information about services, use dim_gtfs_service_data.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - key
+            - date
+    columns:
+      - name: date
+        description: |
+          Date on which this service was in our Transit Database data.
+      - name: key
+        description: |
+          Synthetic key, hash of `gtfs_service_data_key`, `service_key` and `gtfs_dataset_key`.
+      - name: gtfs_service_data_key
+        description: |
+          GTFS service data record key.
+      - name: service_key
+        description: |
+          Service record key.
+      - name: gtfs_dataset_key
+        description: |
+          GTFS dataset record key.
+      - name: name
+      - name: customer_facing
+      - name: category
+  - name: int_transit_database__gtfs_datasets_history
+    description: |
+      Daily list of GTFS datasets relationships with attributes required to check
+      whether they were assessed by Cal-ITP on the given date.
+
+      This table is different than other Transit Database data because it
+      captures the historical state of various attributes. This historical
+      data is meant to be used for quality assessment purposes.
+
+      For the most up to date information about services, use dim_gtfs_datasets.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - key
+            - date
+    columns:
+      - name: date
+        description: |
+          Date on which this service was in our Transit Database data.
+      - name: key
+        description: |
+          GTFS dataset record key.
+      - name: name
+      - name: regional_feed_type
+      - name: base64_url

--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -76,7 +76,7 @@ models:
         description: Foreign key to dim_gtfs_datasets, for a record with data = "GTFS VehiclePositions."
       - name: gtfs_dataset_key_trip_updates
         description: Foreign key to dim_gtfs_datasets, for a record with data = "GTFS TripUpdates."
-  - name: int_transit_database__service_history
+  - name: int_transit_database__services_history
     description: |
       Daily list of services with attributes required to check whether they were
       assessed by Cal-ITP on the given date.
@@ -108,3 +108,38 @@ models:
       - name: service_type
         description: |
           Service type value from raw Transit Database data as of date.
+      - name: provider
+        description: |
+          Array of organization key(s) for organization(s) managing this service as of this date.
+  - name: int_transit_database__organizations_history
+    description: |
+      Daily list of organizations with attributes required to check whether they were
+      assessed by Cal-ITP on the given date.
+
+      This table is different than other Transit Database data because it
+      captures the historical state of various attributes. This historical
+      data is meant to be used for quality assessment purposes.
+
+      For the most up to date information about organizations, use dim_organizations.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - key
+            - date
+    columns:
+      - name: date
+        description: |
+          Date on which this organization was in our Transit Database data.
+      - name: key
+        description: |
+          Organization record key.
+      - name: name
+      - name: assessment_status
+        description: |
+          Assessment status from raw Transit Database data as of date.
+      - name: reporting_category
+        description: |
+          Currently operating value from raw Transit Database data as of date.
+      - name: mobility_services_managed
+        description: |
+          Array of service keys for managed services as of this date.

--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -108,9 +108,10 @@ models:
       - name: currently_operating
         description: |
           Currently operating value from raw Transit Database data as of date.
-      - name: service_type
+      - name: service_type_str
         description: |
-          Service type value from raw Transit Database data as of date.
+          Service types from raw Transit Database data as of date, concatenated together
+          into a comma-delimited string.
       - name: provider
         description: |
           Array of organization key(s) for organization(s) managing this service as of this date.
@@ -206,5 +207,6 @@ models:
         description: |
           GTFS dataset record key.
       - name: name
+      - name: type
       - name: regional_feed_type
       - name: base64_url

--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -76,3 +76,35 @@ models:
         description: Foreign key to dim_gtfs_datasets, for a record with data = "GTFS VehiclePositions."
       - name: gtfs_dataset_key_trip_updates
         description: Foreign key to dim_gtfs_datasets, for a record with data = "GTFS TripUpdates."
+  - name: int_transit_database__service_history
+    description: |
+      Daily list of services with attributes required to check whether they were
+      assessed by Cal-ITP on the given date.
+
+      This table is different than other Transit Database data because it
+      captures the historical state of various attributes. This historical
+      data is meant to be used for quality assessment purposes.
+
+      For the most up to date information about services, use dim_services.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - key
+            - date
+    columns:
+      - name: date
+        description: |
+          Date on which this service was in our Transit Database data.
+      - name: key
+        description: |
+          Service record key.
+      - name: name
+      - name: assessment_status
+        description: |
+          Assessment status from raw Transit Database data as of date.
+      - name: currently_operating
+        description: |
+          Currently operating value from raw Transit Database data as of date.
+      - name: service_type
+        description: |
+          Service type value from raw Transit Database data as of date.

--- a/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_datasets_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_datasets_history.sql
@@ -10,6 +10,7 @@ int_gtfs_quality__gtfs_datasets_history AS (
         calitp_extracted_at AS date,
         key,
         name,
+        data,
         regional_feed_type,
         base64_url
     FROM stg_transit_database__gtfs_datasets

--- a/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_datasets_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_datasets_history.sql
@@ -10,7 +10,7 @@ int_gtfs_quality__gtfs_datasets_history AS (
         calitp_extracted_at AS date,
         key,
         name,
-        data,
+        type,
         regional_feed_type,
         base64_url
     FROM stg_transit_database__gtfs_datasets

--- a/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_datasets_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_datasets_history.sql
@@ -1,0 +1,18 @@
+{{ config(materialized='table') }}
+
+WITH stg_transit_database__gtfs_datasets AS (
+    SELECT *
+    FROM {{ ref('stg_transit_database__gtfs_datasets') }}
+),
+
+int_gtfs_quality__gtfs_datasets_history AS (
+    SELECT
+        calitp_extracted_at AS date,
+        key,
+        name,
+        regional_feed_type,
+        base64_url
+    FROM stg_transit_database__gtfs_datasets
+)
+
+SELECT * FROM int_gtfs_quality__gtfs_datasets_history

--- a/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_service_data_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_service_data_history.sql
@@ -1,0 +1,26 @@
+{{ config(materialized='table') }}
+
+WITH stg_transit_database__gtfs_service_data AS (
+    SELECT *
+    FROM {{ ref('stg_transit_database__gtfs_service_data') }}
+),
+
+int_gtfs_quality__gtfs_service_data_history AS (
+    SELECT
+        calitp_extracted_at AS date,
+        -- we used to have some records where one single gtfs_service_data record
+        -- had one service but multiple datasets, which unnest to non-unique
+        -- gtfs_service_data at the day level
+        -- we also have some duplicates -- same service/dataset but different gtfs_service_data record
+        -- decision was to just use historical data as-is, so we are handling rather than dropping
+         {{ dbt_utils.surrogate_key(['key', 'service_key', 'gtfs_dataset_key']) }} AS key,
+        key AS gtfs_service_data_key,
+        name,
+        service_key,
+        gtfs_dataset_key,
+        customer_facing,
+        category
+    FROM stg_transit_database__gtfs_service_data
+)
+
+SELECT * FROM int_gtfs_quality__gtfs_service_data_history

--- a/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_service_data_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__gtfs_service_data_history.sql
@@ -13,7 +13,7 @@ int_gtfs_quality__gtfs_service_data_history AS (
         -- gtfs_service_data at the day level
         -- we also have some duplicates -- same service/dataset but different gtfs_service_data record
         -- decision was to just use historical data as-is, so we are handling rather than dropping
-         {{ dbt_utils.surrogate_key(['key', 'service_key', 'gtfs_dataset_key']) }} AS key,
+        {{ dbt_utils.surrogate_key(['key', 'service_key', 'gtfs_dataset_key']) }} AS key,
         key AS gtfs_service_data_key,
         name,
         service_key,

--- a/warehouse/models/intermediate/transit_database/int_transit_database__organizations_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__organizations_history.sql
@@ -1,0 +1,19 @@
+{{ config(materialized='table') }}
+
+WITH stg_transit_database__organizations AS (
+    SELECT *
+    FROM {{ ref('stg_transit_database__organizations') }}
+),
+
+int_gtfs_quality__organizations_history AS (
+    SELECT
+        calitp_extracted_at AS date,
+        key,
+        name,
+        assessment_status,
+        reporting_category,
+        mobility_services_managed
+    FROM stg_transit_database__organizations
+)
+
+SELECT * FROM int_gtfs_quality__organizations_history

--- a/warehouse/models/intermediate/transit_database/int_transit_database__organizations_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__organizations_history.sql
@@ -8,12 +8,14 @@ WITH stg_transit_database__organizations AS (
 int_gtfs_quality__organizations_history AS (
     SELECT
         calitp_extracted_at AS date,
-        key,
+        {{ dbt_utils.surrogate_key(['key', 'unnested_service']) }} AS key,
+        key AS organization_key,
         name,
         assessment_status,
         reporting_category,
-        mobility_services_managed
+        unnested_service AS mobility_services_managed_service_key
     FROM stg_transit_database__organizations
+    CROSS JOIN UNNEST(stg_transit_database__organizations.mobility_services_managed) AS unnested_service
 )
 
 SELECT * FROM int_gtfs_quality__organizations_history

--- a/warehouse/models/intermediate/transit_database/int_transit_database__service_datasets_pivoted.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__service_datasets_pivoted.sql
@@ -33,16 +33,11 @@ datasets_services_joined AS (
         -- all subfeeds because the subfeeds are not listed to be used for validation of the alerts feed
         -- easiest fix (very manual) is probably just to join the alerts feed in later after the quartets are constructed
         CASE
-            WHEN data = "GTFS Schedule" THEN dim_gtfs_datasets.key
+            WHEN type = "schedule" THEN dim_gtfs_datasets.key
             ELSE dim_gtfs_datasets.schedule_to_use_for_rt_validation_gtfs_dataset_key
         END AS associated_gtfs_schedule_gtfs_dataset_key,
         customer_facing,
-        CASE
-            WHEN data = 'GTFS Schedule' THEN 'schedule'
-            WHEN data = 'GTFS Alerts' THEN 'service_alerts'
-            WHEN data = 'GTFS TripUpdates' THEN 'trip_updates'
-            WHEN data = 'GTFS VehiclePositions' THEN 'vehicle_positions'
-        END AS type
+        type
     FROM dim_gtfs_service_data
     LEFT JOIN dim_gtfs_datasets
         ON dim_gtfs_service_data.gtfs_dataset_key = dim_gtfs_datasets.key

--- a/warehouse/models/intermediate/transit_database/int_transit_database__service_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__service_history.sql
@@ -1,0 +1,19 @@
+{{ config(materialized='table') }}
+
+WITH stg_transit_database__services AS (
+    SELECT *
+    FROM {{ ref('stg_transit_database__services') }}
+),
+
+int_gtfs_quality__service_history AS (
+    SELECT
+        calitp_extracted_at AS date,
+        key,
+        name,
+        assessment_status,
+        currently_operating,
+        service_type
+    FROM stg_transit_database__services
+)
+
+SELECT * FROM int_gtfs_quality__service_history

--- a/warehouse/models/intermediate/transit_database/int_transit_database__services_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__services_history.sql
@@ -5,15 +5,16 @@ WITH stg_transit_database__services AS (
     FROM {{ ref('stg_transit_database__services') }}
 ),
 
-int_gtfs_quality__service_history AS (
+int_gtfs_quality__services_history AS (
     SELECT
         calitp_extracted_at AS date,
         key,
         name,
         assessment_status,
         currently_operating,
-        service_type
+        service_type,
+        provider
     FROM stg_transit_database__services
 )
 
-SELECT * FROM int_gtfs_quality__service_history
+SELECT * FROM int_gtfs_quality__services_history

--- a/warehouse/models/intermediate/transit_database/int_transit_database__services_history.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__services_history.sql
@@ -8,13 +8,16 @@ WITH stg_transit_database__services AS (
 int_gtfs_quality__services_history AS (
     SELECT
         calitp_extracted_at AS date,
-        key,
+        {{ dbt_utils.surrogate_key(['key', 'unnest_provider']) }} AS key,
+        key AS service_key,
         name,
         assessment_status,
         currently_operating,
-        service_type,
-        provider
+        ARRAY_TO_STRING(service_type, ",") AS service_type_str,
+        unnest_provider AS provider_organization_key,
     FROM stg_transit_database__services
+    CROSS JOIN UNNEST(stg_transit_database__services.provider) AS unnest_provider
+
 )
 
 SELECT * FROM int_gtfs_quality__services_history

--- a/warehouse/models/intermediate/transit_database/int_transit_database__urls_to_gtfs_datasets.sql
+++ b/warehouse/models/intermediate/transit_database/int_transit_database__urls_to_gtfs_datasets.sql
@@ -7,7 +7,7 @@ gtfs_datasets AS (
 int_transit_database__urls_to_gtfs_datasets AS (
     SELECT
         base64_url,
-        airtable_record_id AS gtfs_dataset_key -- this is defined in {{ ref('dim_gtfs_datasets') }}
+        key AS gtfs_dataset_key -- this is defined in {{ ref('dim_gtfs_datasets') }}
     FROM gtfs_datasets
     WHERE base64_url IS NOT NULL
     -- NOTE: there could be more than 1 record per URL per ts if a given

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -85,7 +85,7 @@ models:
         tests:
           - not_null:
               config:
-                where: download_success
+                where: download_success AND unzip_success
           - relationships:
               to: ref('dim_schedule_feeds')
               field: key

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -151,6 +151,47 @@ models:
           expression: "is_implemented"
     columns:
       - name: is_implemented
+  - name: fct_daily_guideline_checks
+    description: |
+      **Documentation coming soon**
+    columns:
+      - *key
+      - *date
+      - name: organization_name
+      - name: service_name
+      - name: gtfs_dataset_name
+      - name: gtfs_dataset_type
+      - name: base64_url
+      - name: organization_key
+        description: |
+          Foreign key to `dim_organizations`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: service_key
+        description: |
+          Foreign key to `dim_services`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: gtfs_service_data_key
+        description: |
+          Foreign key to `dim_gtfs_service_data`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: gtfs_dataset_key
+        description: |
+          Foreign key to `dim_gtfs_datasets`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: schedule_feed_key
+        description: |
+          Foreign key to `dim_schedule_feeds`. Because `dim_schedule_feeds` is slowly-
+          changing dimension, joins using this key are not subject to the historical
+          limitations noted for the other foreign keys in this table.
+      - *check
+      - name: status
+      - name: feature
+
+
 
 # TODO: This should be filled out once the reports site is actually migrated
 #exposures:

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -246,7 +246,52 @@ models:
       - *check
       - name: status
       - name: feature
-
+  - name: fct_daily_service_combined_guideline_checks
+    description: |
+      **Documentation coming soon**
+    columns:
+      - *key
+      - *date
+      - name: service_name
+        description: |
+          Service name as of date.
+      - name: organization_names_included_array
+        description: |
+          Array of organization name values (as of date) that are included in this service's assessment.
+      - name: gtfs_dataset_names_included_array
+        description: |
+          Array of GTFS dataset name values (as of date) that are included in this service's assessment.
+      - name: base64_urls_included_array
+        description: |
+          Array of base 64 URL values (as of date) that are included in this service's assessment.
+      - name: service_key
+        description: |
+          Foreign key to `dim_services`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: organization_keys_included_array
+        description: |
+          Array of organization_key values for organizations included in this service's assessment;
+          note that this is a *historical* key value and so joins may result in some unexpected behavior
+          (for example, deleted records will fail to join.)
+      - name: gtfs_service_data_keys_included_array
+        description: |
+          Array of gtfs_service_data_key values for service/GTFS dataset relationships included in this
+          service's assessment; note that this is a *historical* key value and so joins may result in
+          some unexpected behavior (for example, deleted records will fail to join.)
+      - name: gtfs_dataset_keys_included_array
+        description: |
+          Array of gtfs_dataset values for GTFS datasets included in this service's assessment;
+          note that this is a *historical* key value and so joins may result in some unexpected behavior
+          (for example, deleted records will fail to join.)
+      - name: schedule_feed_keys_included_array
+        description: |
+          Array of schedule_feed_key values for schedule feed versions included in this service's assessemnt;
+          because `dim_schedule_feeds` is a slowly-changing dimension, joins using this key are not subject
+          to the historical limitations noted for the other foreign keys in this table.
+      - *check
+      - name: status
+      - name: feature
 
 # TODO: This should be filled out once the reports site is actually migrated
 #exposures:

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -158,10 +158,20 @@ models:
       - *key
       - *date
       - name: organization_name
+        description: |
+          Organization name as of date.
       - name: service_name
+        description: |
+          Service name as of date.
       - name: gtfs_dataset_name
+        description: |
+          GTFS dataset name as of date.
       - name: gtfs_dataset_type
+        description: |
+          GTFS dataset type as of date.
       - name: base64_url
+        description: |
+          GTFS dataset base 64 URL as of date.
       - name: organization_key
         description: |
           Foreign key to `dim_organizations`; note that this is a *historical* key value and
@@ -184,13 +194,58 @@ models:
           fail to join.)
       - name: schedule_feed_key
         description: |
-          Foreign key to `dim_schedule_feeds`. Because `dim_schedule_feeds` is slowly-
+          Foreign key to `dim_schedule_feeds`. Because `dim_schedule_feeds` is a slowly-
           changing dimension, joins using this key are not subject to the historical
           limitations noted for the other foreign keys in this table.
       - *check
       - name: status
       - name: feature
-
+  - name: fct_daily_organization_combined_guideline_checks
+    description: |
+      **Documentation coming soon**
+    columns:
+      - *key
+      - *date
+      - name: organization_name
+        description: |
+          Organization name as of date.
+      - name: service_names_included_array
+        description: |
+          Array of service name values (as of date) that are included in this organization's assessment.
+      - name: gtfs_dataset_names_included_array
+        description: |
+          Array of GTFS dataset name values (as of date) that are included in this organization's assessment.
+      - name: base64_urls_included_array
+        description: |
+          Array of base 64 URL values (as of date) that are included in this organization's assessment.
+      - name: organization_key
+        description: |
+          Foreign key to `dim_organizations`; note that this is a *historical* key value and
+          so joins may result in some unexpected behavior (for example, deleted records will
+          fail to join.)
+      - name: service_keys_included_array
+        description: |
+          Array of service_key values for services included in this organization's assessment;
+          note that this is a *historical* key value and so joins may result in some unexpected behavior
+          (for example, deleted records will fail to join.)
+      - name: gtfs_service_data_keys_included_array
+        description: |
+          Array of gtfs_service_data_key values for service/GTFS dataset relationships included in this
+          organization's assessment; note that this is a *historical* key value and so joins may result in
+          some unexpected behavior (for example, deleted records will fail to join.)
+      - name: gtfs_dataset_keys_included_array
+        description: |
+          Array of gtfs_dataset values for GTFS datasets included in this organization's assessment;
+          note that this is a *historical* key value and so joins may result in some unexpected behavior
+          (for example, deleted records will fail to join.)
+      - name: schedule_feed_keys_included_array
+        description: |
+          Array of schedule_feed_key values for schedule feed versions included in this organization's assessemnt;
+          because `dim_schedule_feeds` is a slowly-changing dimension, joins using this key are not subject
+          to the historical limitations noted for the other foreign keys in this table.
+      - *check
+      - name: status
+      - name: feature
 
 
 # TODO: This should be filled out once the reports site is actually migrated

--- a/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
@@ -1,0 +1,80 @@
+{{ config(materialized='table') }}
+
+WITH implemented_checks AS (
+    SELECT *
+    FROM {{ ref('fct_implemented_checks') }}
+),
+
+assessed_entities AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_quality__daily_assessment_candidate_entities') }}
+    WHERE assessed
+),
+
+schedule_feed_checks AS (
+    SELECT *
+    FROM {{ ref('fct_daily_schedule_feed_guideline_checks') }}
+),
+
+rt_feed_checks AS (
+    SELECT *
+    FROM {{ ref('fct_daily_rt_feed_guideline_checks') }}
+),
+
+schedule_url_checks AS (
+    SELECT *
+    FROM {{ ref('fct_daily_schedule_url_guideline_checks') }}
+),
+
+idx AS (
+    SELECT
+        implemented_checks.*,
+        assessed_entities.*
+    FROM implemented_checks
+    CROSS JOIN assessed_entities
+),
+
+fct_daily_guideline_checks AS (
+    SELECT
+        {{ dbt_utils.surrogate_key([
+            'idx.date',
+            'idx.organization_key',
+            'idx.service_key',
+            'idx.gtfs_service_data_key',
+            'idx.gtfs_dataset_key',
+            'idx.schedule_feed_key',
+            'idx.check']) }} AS key,
+        idx.date,
+        idx.organization_name,
+        idx.service_name,
+        idx.gtfs_dataset_name,
+        idx.gtfs_dataset_type,
+        idx.base64_url,
+        idx.organization_key,
+        idx.service_key,
+        idx.gtfs_service_data_key,
+        idx.gtfs_dataset_key,
+        idx.schedule_feed_key,
+        idx.feature,
+        idx.check,
+        COALESCE(
+            schedule_feed_checks.status,
+            rt_feed_checks.status,
+            schedule_url_checks.status
+        ) AS status
+    FROM idx
+    LEFT JOIN schedule_feed_checks
+        ON idx.date = schedule_feed_checks.date
+        AND idx.schedule_feed_key = schedule_feed_checks.feed_key
+        AND idx.check = schedule_feed_checks.check
+    LEFT JOIN rt_feed_checks
+        ON idx.date = rt_feed_checks.date
+        AND idx.base64_url = rt_feed_checks.base64_url
+        AND idx.check = rt_feed_checks.check
+    LEFT JOIN schedule_url_checks
+        ON idx.date = schedule_url_checks.date
+        AND idx.base64_url = schedule_url_checks.base64_url
+        AND idx.check = schedule_url_checks.check
+)
+
+SELECT * FROM fct_daily_guideline_checks

--- a/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
@@ -21,13 +21,13 @@ fct_daily_organization_combined_guideline_checks AS (
             WHEN LOGICAL_AND(status = "N/A") THEN "N/A"
         END as status,
         organization_key,
-        ARRAY_AGG(DISTINCT service_name IGNORE NULLS) AS service_names_included_array,
-        ARRAY_AGG(DISTINCT gtfs_dataset_name IGNORE NULLS) AS gtfs_dataset_names_included_array,
-        ARRAY_AGG(DISTINCT base64_url IGNORE NULLS) AS base64_urls_included_array,
-        ARRAY_AGG(DISTINCT service_key IGNORE NULLS) AS service_keys_included_array,
-        ARRAY_AGG(DISTINCT gtfs_service_data_key IGNORE NULLS) AS gtfs_service_data_keys_included_array,
-        ARRAY_AGG(DISTINCT gtfs_dataset_key IGNORE NULLS) AS gtfs_dataset_keys_included_array,
-        ARRAY_AGG(DISTINCT schedule_feed_key IGNORE NULLS) AS schedule_feed_keys_included_array
+        ARRAY_AGG(DISTINCT service_name IGNORE NULLS ORDER BY service_name) AS service_names_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_name IGNORE NULLS ORDER BY gtfs_dataset_name) AS gtfs_dataset_names_included_array,
+        ARRAY_AGG(DISTINCT base64_url IGNORE NULLS ORDER BY base64_url) AS base64_urls_included_array,
+        ARRAY_AGG(DISTINCT service_key IGNORE NULLS ORDER BY service_key) AS service_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_service_data_key IGNORE NULLS ORDER BY gtfs_service_data_key) AS gtfs_service_data_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_key IGNORE NULLS ORDER BY gtfs_dataset_key) AS gtfs_dataset_keys_included_array,
+        ARRAY_AGG(DISTINCT schedule_feed_key IGNORE NULLS ORDER BY schedule_feed_key) AS schedule_feed_keys_included_array
     FROM fct_daily_guideline_checks
     GROUP BY date, organization_key, organization_name, feature, check
 )

--- a/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
@@ -1,0 +1,35 @@
+{{ config(materialized='table') }}
+
+WITH fct_daily_guideline_checks AS (
+    SELECT *
+    FROM {{ ref('fct_daily_guideline_checks') }}
+),
+
+fct_daily_organization_combined_guideline_checks AS (
+    SELECT
+        {{ dbt_utils.surrogate_key([
+            'date',
+            'organization_key',
+            'check']) }} AS key,
+        date,
+        organization_name,
+        feature,
+        check,
+        CASE
+            WHEN LOGICAL_AND(NULLIF(status, "N/A") = "PASS") THEN "PASS"
+            WHEN LOGICAL_AND(NULLIF(status, "N/A") = "FAIL") THEN "FAIL"
+            WHEN LOGICAL_AND(status = "N/A") THEN "N/A"
+        END as status,
+        organization_key,
+        ARRAY_AGG(DISTINCT service_name IGNORE NULLS) AS service_names_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_name IGNORE NULLS) AS gtfs_dataset_names_included_array,
+        ARRAY_AGG(DISTINCT base64_url IGNORE NULLS) AS base64_urls_included_array,
+        ARRAY_AGG(DISTINCT service_key IGNORE NULLS) AS service_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_service_data_key IGNORE NULLS) AS gtfs_service_data_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_key IGNORE NULLS) AS gtfs_dataset_keys_included_array,
+        ARRAY_AGG(DISTINCT schedule_feed_key IGNORE NULLS) AS schedule_feed_keys_included_array
+    FROM fct_daily_guideline_checks
+    GROUP BY date, organization_key, organization_name, feature, check
+)
+
+SELECT * FROM fct_daily_organization_combined_guideline_checks

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
@@ -21,13 +21,13 @@ fct_daily_service_combined_guideline_checks AS (
             WHEN LOGICAL_AND(status = "N/A") THEN "N/A"
         END as status,
         service_key,
-        ARRAY_AGG(DISTINCT organization_name IGNORE NULLS) AS organization_names_included_array,
-        ARRAY_AGG(DISTINCT gtfs_dataset_name IGNORE NULLS) AS gtfs_dataset_names_included_array,
-        ARRAY_AGG(DISTINCT base64_url IGNORE NULLS) AS base64_urls_included_array,
-        ARRAY_AGG(DISTINCT organization_key IGNORE NULLS) AS organization_keys_included_array,
-        ARRAY_AGG(DISTINCT gtfs_service_data_key IGNORE NULLS) AS gtfs_service_data_keys_included_array,
-        ARRAY_AGG(DISTINCT gtfs_dataset_key IGNORE NULLS) AS gtfs_dataset_keys_included_array,
-        ARRAY_AGG(DISTINCT schedule_feed_key IGNORE NULLS) AS schedule_feed_keys_included_array
+        ARRAY_AGG(DISTINCT organization_name IGNORE NULLS ORDER BY organization_name) AS organization_names_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_name IGNORE NULLS ORDER BY gtfs_dataset_name) AS gtfs_dataset_names_included_array,
+        ARRAY_AGG(DISTINCT base64_url IGNORE NULLS ORDER BY base64_url) AS base64_urls_included_array,
+        ARRAY_AGG(DISTINCT organization_key IGNORE NULLS ORDER BY organization_key) AS organization_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_service_data_key IGNORE NULLS ORDER BY gtfs_service_data_key) AS gtfs_service_data_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_key IGNORE NULLS ORDER BY gtfs_dataset_key) AS gtfs_dataset_keys_included_array,
+        ARRAY_AGG(DISTINCT schedule_feed_key IGNORE NULLS ORDER BY schedule_feed_key) AS schedule_feed_keys_included_array
     FROM fct_daily_guideline_checks
     GROUP BY date, service_key, service_name, feature, check
 )

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
@@ -1,0 +1,35 @@
+{{ config(materialized='table') }}
+
+WITH fct_daily_guideline_checks AS (
+    SELECT *
+    FROM {{ ref('fct_daily_guideline_checks') }}
+),
+
+fct_daily_service_combined_guideline_checks AS (
+    SELECT
+        {{ dbt_utils.surrogate_key([
+            'date',
+            'service_key',
+            'check']) }} AS key,
+        date,
+        service_name,
+        feature,
+        check,
+        CASE
+            WHEN LOGICAL_AND(NULLIF(status, "N/A") = "PASS") THEN "PASS"
+            WHEN LOGICAL_AND(NULLIF(status, "N/A") = "FAIL") THEN "FAIL"
+            WHEN LOGICAL_AND(status = "N/A") THEN "N/A"
+        END as status,
+        service_key,
+        ARRAY_AGG(DISTINCT organization_name IGNORE NULLS) AS organization_names_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_name IGNORE NULLS) AS gtfs_dataset_names_included_array,
+        ARRAY_AGG(DISTINCT base64_url IGNORE NULLS) AS base64_urls_included_array,
+        ARRAY_AGG(DISTINCT organization_key IGNORE NULLS) AS organization_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_service_data_key IGNORE NULLS) AS gtfs_service_data_keys_included_array,
+        ARRAY_AGG(DISTINCT gtfs_dataset_key IGNORE NULLS) AS gtfs_dataset_keys_included_array,
+        ARRAY_AGG(DISTINCT schedule_feed_key IGNORE NULLS) AS schedule_feed_keys_included_array
+    FROM fct_daily_guideline_checks
+    GROUP BY date, service_key, service_name, feature, check
+)
+
+SELECT * FROM fct_daily_service_combined_guideline_checks

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -161,10 +161,10 @@ models:
       - be *published* by an `organizations`.
     columns:
       - *key
-      - name: data
+      - name: type
         description: |
-          GTFS data type ("GTFS Schedule", "GTFS TripUpdates",
-          "GTFS VehiclePositions", or "GTFS Alerts")
+          GTFS data type ("schedule", "trip_updates",
+          "vehicle_positions", or "service_alerts")
       - name: data_quality_pipeline
         description: |
           If "true", indicates that this dataset should be ingested by the

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -159,12 +159,6 @@ models:
       - be *disaggregated into* one or more `gtfs service data` records.
       - be *produced* by one or more `organizations`
       - be *published* by an `organizations`.
-    tests:
-      - dbt_utils.mutually_exclusive_ranges:
-          lower_bound_column: _valid_from
-          upper_bound_column: _valid_to
-          partition_by: airtable_record_id
-          gaps: required
     columns:
       - *key
       - name: data
@@ -214,16 +208,6 @@ models:
         description: |
           Date extracted from Airtable. This column will be deprecated as _valid_from
           and _valid_to are more fully adopted.
-      - name: _valid_from
-        description: |
-          '{{ doc("column_valid_from") }}'
-          Currently just a constant placeholder of '1901-01-01T00:00:00+00' until
-          this table has historical data incorporated.
-      - name: _valid_to
-        description: |
-          '{{ doc("column_valid_to") }}'
-          Currently just a constant placeholder of '2099-01-01T00:00:00+00 minus one microsecond' until
-          this table has historical data incorporated.
   - name: dim_gtfs_service_data
     description: |
       Each record links together a single `gtfs dataset` and one (if possible)

--- a/warehouse/models/mart/transit_database/bridge_organizations_x_gtfs_datasets_produced.sql
+++ b/warehouse/models/mart/transit_database/bridge_organizations_x_gtfs_datasets_produced.sql
@@ -24,7 +24,7 @@ bridge_organizations_x_gtfs_datasets_managed AS (
      table_a_join_col = 'gtfs_datasets_produced',
      table_a_date_col = 'calitp_extracted_at',
      table_b = 'latest_gtfs_datasets',
-     table_b_key_col = 'airtable_record_id',
+     table_b_key_col = 'key',
      table_b_key_col_name = 'gtfs_dataset_key',
      table_b_name_col = 'name',
      table_b_name_col_name = 'gtfs_dataset_name',

--- a/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
+++ b/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
@@ -11,7 +11,7 @@ dim_gtfs_datasets AS (
     SELECT
         key,
         name,
-        data,
+        type,
         regional_feed_type,
         uri,
         future_uri,

--- a/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
+++ b/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
@@ -9,8 +9,7 @@ WITH latest_gtfs_datasets AS (
 
 dim_gtfs_datasets AS (
     SELECT
-        airtable_record_id as key,
-        airtable_record_id,
+        key,
         name,
         data,
         regional_feed_type,
@@ -21,10 +20,7 @@ dim_gtfs_datasets AS (
         data_quality_pipeline,
         schedule_to_use_for_rt_validation_gtfs_dataset_key,
         base64_url,
-        calitp_extracted_at,
-        -- TODO: make this table actually historical
-        CAST("1901-01-01" AS TIMESTAMP) AS _valid_from,
-        {{ make_end_of_valid_range('CAST("2099-01-01" AS TIMESTAMP)') }} AS _valid_to
+        calitp_extracted_at
     FROM latest_gtfs_datasets
 )
 

--- a/warehouse/models/staging/transit_database/_stg_transit_database.yml
+++ b/warehouse/models/staging/transit_database/_stg_transit_database.yml
@@ -104,6 +104,10 @@ models:
       - *key
       - *name
       - name: data
+      - name: type
+        description: |
+          "data" labels mapped to "service_alerts", "vehicle_positions", "trip_updates",
+            and "schedule" (as opposed to "GTFS Alerts" etc.)
       - name: regional_feed_type
       - name: fares_v2_status
       - name: fares_notes

--- a/warehouse/models/staging/transit_database/_stg_transit_database.yml
+++ b/warehouse/models/staging/transit_database/_stg_transit_database.yml
@@ -98,11 +98,10 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - airtable_record_id
+            - key
             - calitp_extracted_at
     columns:
-      - name: airtable_record_id
-        tests: *primary_key_tests
+      - *key
       - *name
       - name: data
       - name: regional_feed_type

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -60,7 +60,7 @@ construct_base64_url AS (
 
 stg_transit_database__gtfs_datasets AS (
     SELECT
-        id AS airtable_record_id,
+        id AS key,
         {{ trim_make_empty_string_null(column_name = "name") }} AS name,
         data,
         data_quality_pipeline,

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -97,6 +97,12 @@ stg_transit_database__gtfs_datasets AS (
         header_secret_key_name,
         url_to_encode,
         base64_url,
+        CASE
+            WHEN data = "GTFS Schedule" THEN "schedule"
+            WHEN data = "GTFS Alerts" THEN "service_alerts"
+            WHEN data = "GTFS VehiclePositions" THEN "vehicle_positions"
+            WHEN data = "GTFS TripUpdates" THEN "trip_updates"
+        END AS type,
         ts,
         dt AS calitp_extracted_at
     FROM construct_base64_url

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
@@ -13,6 +13,8 @@ stg_transit_database__gtfs_service_data AS (
         unnested_services AS service_key,
         unnested_gtfs_dataset AS gtfs_dataset_key,
         dataset_type,
+        -- only coalesce to false after the field had been created (November 23, 2022)
+        -- otherwise a null is genuinely a null
         CASE
             WHEN dt >= '2022-11-23' THEN COALESCE(customer_facing, FALSE)
         END AS customer_facing,

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_service_data.sql
@@ -13,7 +13,9 @@ stg_transit_database__gtfs_service_data AS (
         unnested_services AS service_key,
         unnested_gtfs_dataset AS gtfs_dataset_key,
         dataset_type,
-        COALESCE(customer_facing, FALSE) AS customer_facing,
+        CASE
+            WHEN dt >= '2022-11-23' THEN COALESCE(customer_facing, FALSE)
+        END AS customer_facing,
         category,
         agency_id,
         network_id,

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -27,7 +27,7 @@ stg_transit_database__organizations AS (
         gtfs_datasets_produced,
         gtfs_static_status,
         gtfs_realtime_status,
-        assessment_status,
+        assessment_status = "Yes" AS assessment_status,
         dt AS calitp_extracted_at
     FROM once_daily_organizations
     LEFT JOIN UNNEST(once_daily_organizations.ntd_id) as unnested_ntd_records


### PR DESCRIPTION
# Description

**UPDATE: Per offline discussion with @atvaccaro, some of this needs to be refactored in favor of proper historical dimensions for Airtable. I have reopened #1868 and will do that refactor there. However, per @natam1 and @juliama0780 in Slack they would like to be able to start experimenting with the new tables, understanding that they are in draft form. So I'd like to merge this as-is and do a follow-on.**

This PR creates core functionality needed for the GTFS guideline checks work:
* A `fct_daily_guideline_checks` table that creates every possible assessed entity (organization / service / GTFS service data / GTFS dataset / URL / downloaded schedule feed) for a given date and appends results of all checks performed on that entity. 
* `fct_daily_organization_combined_guideline_checks` and `fct_daily_service_combined_guideline_checks` tables that aggregate those "whole entity" checks to the organization and service levels respectively

It also semi-incidentally:
- Removes the fake historicization in `dim_gtfs_datasets` (i.e., gets rid of the `key` / `airtable_record_id` distinction, removes the placeholder `_valid_from` and `_valid_to`)
- Fixes [this issue](https://sentry.calitp.org/organizations/sentry/issues/4516/) (just because this test failed while I was testing my changes and I realized the test was misdefined)

I am slightly punting on full documentation; deferred to #2092.

Resolves #1904 

**Questions for @atvaccaro in Scott's absence:**
- On 2022-11-11 the `gtfs service data` table did not extract successfully from Airtable, so right now that data is just misaligned for that date (GTFS datasets no longer match up with services and thus organizations on that date). I think the simplest answer is just to leave it, but we could try complicated imputation if we need. (That would take us more in the direction of constructing a more SCD type table.)
- How do we feel about historical `*_name` values in `fct_daily_guideline_checks`? Should it just be historical record IDs with current names? 🤔 Currently this PR just uses name as it was on the historical date. We have exactly one organization record and two services whose names have changed while keeping record ID the same.
![image](https://user-images.githubusercontent.com/55149902/208477803-2bb999c6-8ddd-46ec-8b2b-2d86ef155df2.png) 
![image](https://user-images.githubusercontent.com/55149902/208550056-4eb5fe4a-caff-4694-a01b-93a574a0338a.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`dbt run` and `dbt test` on new tables