### PR TITLE
Added prod service account to payments_rides row access policy

### DIFF
--- a/warehouse/models/payments_views/payments_rides.sql
+++ b/warehouse/models/payments_views/payments_rides.sql
@@ -33,7 +33,7 @@
 ]
 
 ) }}
--- TODO: In the last policy of the macro call above, see if we can get the prod service account out of context
+-- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context
 
 WITH
 

--- a/warehouse/models/payments_views/payments_rides.sql
+++ b/warehouse/models/payments_views/payments_rides.sql
@@ -22,6 +22,7 @@
 ) }}",
 " {{ create_row_access_policy(
     principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+                  'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',
                   'domain:calitp.org',
                   'user:angela@compiler.la',

--- a/warehouse/models/payments_views/payments_rides.sql
+++ b/warehouse/models/payments_views/payments_rides.sql
@@ -33,6 +33,7 @@
 ]
 
 ) }}
+-- TODO: In the last policy of the macro call above, see if we can get the prod service account out of context
 
 WITH
 


### PR DESCRIPTION
# Description

In #2042 we added three dbt custom tests in to `payments_rides` to monitor daily, weekly, and monthly transaction deltas - but the row access policy on the table prevented the tests from being run correctly.

To resolve this, we added the prod service account to the row access policy so that it can query the table and run the tests appropriately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
ran with prod service account
