### PR TITLE
Disable legacy dbt models and migrate tile publishing

### DIFF
--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -11,7 +11,6 @@ arguments:
   - '--save-artifacts'
   - '--deploy-docs'
   - '--sync-metabase'
-  - '--exclude="gtfs_schedule_latest_only gtfs_views gtfs_views_staging rt_views staging.gtfs_guidelines mart.gtfs_guidelines"'
 
 is_delete_operator_pod: true
 startup_timeout_seconds: 300

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -12,7 +12,6 @@ arguments:
   - '--save-artifacts'
   - '--deploy-docs'
   - '--sync-metabase'
-  - '--exclude="gtfs_schedule_latest_only gtfs_views gtfs_views_staging rt_views staging.gtfs_guidelines mart.gtfs_guidelines"'
 
 is_delete_operator_pod: true
 startup_timeout_seconds: 300

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -35,18 +35,22 @@ models:
       columns: true
 
     gtfs_schedule_latest_only:
+      +enabled: false
       +materialized: table
       schema: gtfs_schedule
 
     gtfs_views:
+      +enabled: false
       +materialized: table
       schema: views
 
     gtfs_views_staging:
+      +enabled: false
       +materialized: view
       schema: gtfs_views_staging
 
     rt_views:
+      +enabled: false
       +materialized: table
       schema: views
 
@@ -64,9 +68,19 @@ models:
       +materialized: view
       schema: staging
 
+      # legacy guidelines
+      gtfs_guidelines:
+        +enabled: false
+
     mart:
       transit_database:
         schema: mart_transit_database
+
+      # legacy guidelines
+      gtfs_guidelines:
+        +enabled: false
+        schema: mart_gtfs_guidelines
+
       gtfs_quality:
         schema: mart_gtfs_quality
       gtfs:

--- a/warehouse/models/gtfs_views/_gtfs_views.yml
+++ b/warehouse/models/gtfs_views/_gtfs_views.yml
@@ -927,23 +927,3 @@ models:
         description: |
          Total number of routes present in active feed
          (not necessarily operating on date)
-
-exposures:
-  - name: calitp_map_tile_server
-    type: application
-    maturity: low
-    url: ""
-    description: Just the shapes as map tiles
-    depends_on:
-      - ref("gtfs_schedule_dim_shapes_geo_latest")
-    owner:
-      email: andrew.v@jarv.us
-    meta:
-      destinations:
-        - type: tiles
-          bucket: gs://calitp-publish
-          format: geojsonl # note that this is the intermediary format
-          tile_format: mbtiles
-          geo_column: pt_array
-          layer_names:
-            - GTFS Schedule Shapes (Latest)

--- a/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
+++ b/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
@@ -941,3 +941,23 @@ exposures:
                 Each row is a cleaned row from a trips.txt file.
                 Definitions for the original GTFS fields are available at:
                 https://gtfs.org/reference/static#tripstxt.
+
+
+  - name: calitp_map_tile_server
+    type: application
+    maturity: low
+    url: ""
+    description: Just the shapes as map tiles
+    depends_on:
+      - ref("dim_shapes_arrays_latest")
+    owner:
+      email: andrew.v@jarv.us
+    meta:
+      destinations:
+        - type: tiles
+          bucket: gs://calitp-publish
+          format: geojsonl # note that this is the intermediary format
+          tile_format: mbtiles
+          geo_column: pt_array
+          layer_names:
+            - GTFS Schedule Shapes (Latest)

--- a/warehouse/models/mart/gtfs_schedule_latest/dim_shapes_arrays_latest.sql
+++ b/warehouse/models/mart/gtfs_schedule_latest/dim_shapes_arrays_latest.sql
@@ -1,0 +1,9 @@
+WITH
+dim_shapes_arrays_latest AS (
+    {{ get_latest_schedule_data(
+    table_name = ref('dim_shapes_arrays'),
+    clean_table_name = 'dim_shapes_arrays'
+    ) }}
+)
+
+SELECT * FROM dim_shapes_arrays_latest

--- a/warehouse/models/payments_views/_payments_views.yml
+++ b/warehouse/models/payments_views/_payments_views.yml
@@ -3,8 +3,8 @@ version: 2
 models:
   - name: payments_feeds
     columns:
-      - name: calitp_itp_id
-      - name: calitp_url_number
+      - name: gtfs_dataset_source_record_id
+        description: Unversioned key to dim_gtfs_datasets natural key from Airtable.
       - name: participant_id
         description: Littlepay-assigned Participant ID.
 

--- a/warehouse/models/payments_views/payments_feeds.sql
+++ b/warehouse/models/payments_views/payments_feeds.sql
@@ -7,16 +7,15 @@ WITH payments_feeds AS (
     FROM UNNEST(
         ARRAY<
             STRUCT<
-                calitp_itp_id INT64,
-                calitp_url_number INT64,
+                gtfs_dataset_key STRING,
                 participant_id STRING
             >
         > [
 
-            (208, 0, 'mst'),
-            (293, 0, 'sbmtd'),
-            (273, 0, 'sacrt'),
-            (473, 0, 'clean-air-express')
+            ('recysP9m9kjCJwHZe', 'mst'),
+            ('rectQfIeiKDBeJSAV', 'sbmtd'),
+            ('recbzZQUIdMmFvm1r', 'sacrt'),
+            ('recLhUJUDjFXcmOte', 'clean-air-express')
 
         ]
         )

--- a/warehouse/models/payments_views/payments_feeds.sql
+++ b/warehouse/models/payments_views/payments_feeds.sql
@@ -1,13 +1,12 @@
 WITH payments_feeds AS (
 
     SELECT
-        calitp_itp_id,
-        calitp_url_number,
+        gtfs_dataset_source_record_id,
         participant_id
     FROM UNNEST(
         ARRAY<
             STRUCT<
-                gtfs_dataset_key STRING,
+                gtfs_dataset_source_record_id STRING,
                 participant_id STRING
             >
         > [

--- a/warehouse/models/payments_views/payments_rides.sql
+++ b/warehouse/models/payments_views/payments_rides.sql
@@ -37,14 +37,16 @@
 
 WITH
 
-gtfs_schedule_dim_routes AS (
-    SELECT *
-    FROM {{ ref('gtfs_schedule_dim_routes') }}
+dim_routes AS (
+    SELECT * FROM {{ ref('dim_routes') }}
+),
+
+dim_gtfs_datasets AS (
+    SELECT * FROM {{ ref('dim_gtfs_datasets') }}
 ),
 
 payments_feeds AS (
-    SELECT *
-    FROM {{ ref('payments_feeds') }}
+    SELECT * FROM {{ ref('payments_feeds') }}
 ),
 
 stg_cleaned_micropayments AS (
@@ -98,10 +100,11 @@ gtfs_routes_with_participant AS (
         g.calitp_extracted_at,
         g.calitp_deleted_at
 
-    FROM gtfs_schedule_dim_routes AS g
+    FROM dim_routes AS g
+    LEFT JOIN dim_gtfs_datasets AS d
+        ON g.base64_url = d.base64_url
     INNER JOIN payments_feeds AS p
-        ON g.calitp_itp_id = p.calitp_itp_id
-            AND g.calitp_url_number = p.calitp_url_number
+        ON d.key = p.gtfs_dataset_key
 ),
 
 debited_micropayments AS (

--- a/warehouse/scripts/dbt_artifacts.py
+++ b/warehouse/scripts/dbt_artifacts.py
@@ -205,7 +205,11 @@ class GcsDestination(BaseModel):
         return f"{model}.{self.format.value}"
 
     def hive_path(
-        self, exposure: "Exposure", model: str, bucket: str, dt: pendulum.DateTime
+        self,
+        exposure: "Exposure",
+        model: str,
+        bucket: str,
+        dt: pendulum.DateTime,
     ):
         entity_name_parts = [
             slugify(exposure.name, separator="_"),
@@ -236,14 +240,18 @@ class TilesDestination(GcsDestination):
     def tile_filename(self, model):
         return f"{model}.{self.tile_format.value}"
 
-    def tiles_hive_path(self, exposure: "Exposure", model: str, bucket: str):
-        table_name = (
-            f'{slugify(exposure.name, separator="_")}__{self.tile_format.value}'
-        )
+    def tiles_hive_path(
+        self,
+        exposure: "Exposure",
+        model: str,
+        bucket: str,
+        dt: pendulum.DateTime,
+    ):
         return os.path.join(
             bucket,
-            table_name,
-            *self.hive_partitions,
+            f'{slugify(exposure.name, separator="_")}__{self.tile_format.value}',
+            f"dt={dt.in_tz('utc').to_date_string()}",
+            f"ts={dt.in_tz('utc').to_iso8601_string()}",
             self.tile_filename(model),
         )
 

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -487,7 +487,7 @@ def _publish_exposure(
                         tmpdir, f"{strip_modelname(node.name)}.geojsonl"
                     )
 
-                    client = bigquery.Client()
+                    client = bigquery.Client(project=node.database)
                     typer.secho(f"querying {node.schema_table}")
                     # TODO: this is not great but we have to work around how BigQuery removes overlapping line segments
                     df = client.query(
@@ -511,7 +511,10 @@ def _publish_exposure(
                         strip_modelname(node.name).title()
                     ] = geojsonl_fpath
                     hive_path = destination.hive_path(
-                        exposure, strip_modelname(node.name), bucket
+                        exposure=exposure,
+                        model=strip_modelname(node.name),
+                        bucket=bucket,
+                        dt=ts,
                     )
 
                     typer.secho(
@@ -537,7 +540,10 @@ def _publish_exposure(
                     subprocess.run(args).check_returncode()
 
                     tiles_hive_path = destination.tiles_hive_path(
-                        exposure, strip_modelname(node.name), bucket
+                        exposure=exposure,
+                        model=strip_modelname(node.name),
+                        bucket=bucket,
+                        dt=ts,
                     )
 
                     typer.secho(


### PR DESCRIPTION
# Description

Progress towards https://github.com/cal-itp/data-infra/issues/2109

TODO:

- [x] Change reports exposure when implemented (https://github.com/cal-itp/data-infra/pull/2204)
- [x] Test map tiles publishing
- [x] Change CKAN publishing when implemented (https://github.com/cal-itp/data-infra/pull/2199)
- [x] Move payments_rides over and test

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tested map tiles work. payments_rides passes to the same extent as prod.

## Screenshots (optional)
