### PR TITLE
specify fsspec at the top level

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,5 @@
 calitp==2023.1.3
+fsspec==2022.5.0
 intake==0.6.1
 ipdb==0.13.4
 gusty==0.6.0


### PR DESCRIPTION
# Description

This is already deployed; downgrading us back to gcsfs/fsspec 2022.5.0 but the composer requirements install isn't picking up the fsspec version without it being at the top-level `requirements.txt`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
already deployed

## Screenshots (optional)
