### PR TITLE
Added data_quality_pipeline column to int_gtfs_rt__daily_url_index

### DIFF
--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -400,7 +400,7 @@ models:
           RT data type: "GTFS Alerts", "GTFS VehiclePositions", "GTFS TripUpdates".
         tests:
           - not_null
-      - name: data_quality_pipeline
+      - name: use_in_data_quality_pipeline
   - name: int_gtfs_schedule__all_scheduled_service
     description: |
       **Use with caution: This table lists service for all feeds, regardless of whether the given feed

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -400,7 +400,7 @@ models:
           RT data type: "GTFS Alerts", "GTFS VehiclePositions", "GTFS TripUpdates".
         tests:
           - not_null
-      - name: use_in_data_quality_pipeline
+      - name: data_quality_pipeline
   - name: int_gtfs_schedule__all_scheduled_service
     description: |
       **Use with caution: This table lists service for all feeds, regardless of whether the given feed

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -400,6 +400,7 @@ models:
           RT data type: "GTFS Alerts", "GTFS VehiclePositions", "GTFS TripUpdates".
         tests:
           - not_null
+      - name: data_quality_pipeline
   - name: int_gtfs_schedule__all_scheduled_service
     description: |
       **Use with caution: This table lists service for all feeds, regardless of whether the given feed

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
@@ -17,7 +17,7 @@ int_gtfs_rt__daily_url_index AS (
         url_to_encode AS string_url,
         base64_url,
         type,
-        datasets.data_quality_pipeline
+        datasets.data_quality_pipeline AS use_in_data_quality_pipeline
 
     FROM int_gtfs_rt__distinct_download_configs AS configs
     LEFT JOIN stg_transit_database__gtfs_datasets AS datasets

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
@@ -12,10 +12,13 @@ stg_transit_database__gtfs_datasets AS (
 
 int_gtfs_rt__daily_url_index AS (
     SELECT
+
         configs.dt,
         url_to_encode AS string_url,
         base64_url,
-        type
+        type,
+        datasets.data_quality_pipeline
+
     FROM int_gtfs_rt__distinct_download_configs AS configs
     LEFT JOIN stg_transit_database__gtfs_datasets AS datasets
         ON configs._config_extract_ts = datasets.ts

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__daily_url_index.sql
@@ -17,7 +17,7 @@ int_gtfs_rt__daily_url_index AS (
         url_to_encode AS string_url,
         base64_url,
         type,
-        datasets.data_quality_pipeline AS use_in_data_quality_pipeline
+        datasets.data_quality_pipeline
 
     FROM int_gtfs_rt__distinct_download_configs AS configs
     LEFT JOIN stg_transit_database__gtfs_datasets AS datasets

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
@@ -12,7 +12,7 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
-    WHERE use_in_data_quality_pipeline
+    WHERE data_quality_pipeline
 
 ),
 

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
@@ -12,6 +12,8 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
+    WHERE data_quality_pipeline IS TRUE
+
 ),
 
 int_gtfs_rt__unioned_parse_outcomes AS (

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
@@ -12,7 +12,7 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
-    WHERE data_quality_pipeline IS TRUE
+    WHERE use_in_data_quality_pipeline
 
 ),
 

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
@@ -12,12 +12,11 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
+    WHERE data_quality_pipeline
     {% if is_incremental() %}
-    WHERE dt >= DATE '{{ max_date }}'
-        AND data_quality_pipeline
+    AND dt >= DATE '{{ max_date }}'
     {% else %}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
-        AND data_quality_pipeline
+    AND dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
     {% endif %}
 ),
 

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
@@ -12,7 +12,7 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
-    WHERE use_in_data_quality_pipeline
+    WHERE data_quality_pipeline
 
 ),
 

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
@@ -12,6 +12,8 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
+    WHERE data_quality_pipeline IS TRUE
+
 ),
 
 int_gtfs_rt__unioned_parse_outcomes AS (

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
@@ -12,12 +12,11 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
+    WHERE data_quality_pipeline
     {% if is_incremental() %}
-    WHERE dt >= DATE '{{ max_date }}'
-        AND data_quality_pipeline
+    AND dt >= DATE '{{ max_date }}'
     {% else %}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
-        AND data_quality_pipeline
+    AND dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
     {% endif %}
 ),
 
@@ -32,7 +31,7 @@ parse_outcomes AS (
     {% if is_incremental() %}
     WHERE dt >= DATE '{{ max_date }}'
     {% else %}
-        WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('INCREMENTAL_PARTITIONS_LOOKBACK_DAYS') }} DAY)
     {% endif %}
 ),
 

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
@@ -12,7 +12,7 @@ WITH
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
-    WHERE data_quality_pipeline IS TRUE
+    WHERE use_in_data_quality_pipeline
 
 ),
 

--- a/warehouse/models/staging/transit_database/_stg_transit_database.yml
+++ b/warehouse/models/staging/transit_database/_stg_transit_database.yml
@@ -104,6 +104,7 @@ models:
       - *key
       - *name
       - name: data
+      - name: data_quality_pipeline
       - name: type
         description: |
           "data" labels mapped to "service_alerts", "vehicle_positions", "trip_updates",


### PR DESCRIPTION
# Description
In the new RT archiver dashboard tables we were pulling in feeds that are marked as "false" for the data quality pipeline, resulting in empty rows upon join. To resolve this, we added the `data_quality_pipeline` column to `int_gtfs_rt__daily_url_index`, and then filtered the two `fct_hourly_rt_feed_files*` tables where that column is TRUE, also updated yml files

Files changed:
* `int_gtfs_rt__daily_url_index.sql`
  * Added the column `use_in_data_quality_pipeline` from `stg_transit_database__gtfs_datasets`
* `fct_hourly_rt_feed_files.sql`
  * Filtered for the new column `use_in_data_quality_pipeline` on import of `int_gtfs_rt__daily_url_index.sql` where it is `TRUE`
* `fct_hourly_rt_feed_files_success.sql`
  * Filtered for the new column `use_in_data_quality_pipeline` on import of `int_gtfs_rt__daily_url_index.sql` where it is `TRUE`

yml docs updates:
* `_stg_transit_database.yml`
* `_int_gtfs.yaml`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
locally with `dbt run` and `dbt test`, and in a test Metabase dashboard
