### PR TITLE
add line number to schedule jsonl files

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/agency.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/agency.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "agency/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: agency_id
     type: STRING
   - name: agency_name

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/areas.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/areas.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "areas/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: area_id
     type: STRING
   - name: area_name

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/attributions.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/attributions.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "attributions/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: attribution_id
     type: STRING
   - name: agency_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "calendar/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: service_id
     type: STRING
   - name: monday

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar_dates.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar_dates.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "calendar_dates/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: service_id
     type: STRING
   - name: date

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_attributes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_attributes.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "fare_attributes/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: fare_id
     type: STRING
   - name: price

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_leg_rules.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_leg_rules.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "fare_leg_rules/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: leg_group_id
     type: STRING
   - name: networK_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_products.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_products.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "fare_products/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: fare_product_id
     type: STRING
   - name: fare_product_name

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_rules.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_rules.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "fare_rules/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: fare_id
     type: STRING
   - name: route_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_transfer_rules.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_transfer_rules.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "fare_transfer_rules/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: from_leg_group_id
     type: STRING
   - name: to_leg_group_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/feed_info.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/feed_info.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "feed_info/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: feed_publisher_name
     type: STRING
   - name: feed_publisher_url

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/frequencies.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/frequencies.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "frequencies/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: trip_id
     type: STRING
   - name: start_time

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/levels.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/levels.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "levels/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: level_id
     type: STRING
   - name: level_index

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/pathways.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/pathways.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "pathways/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: pathway_id
     type: STRING
   - name: from_stop_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/routes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/routes.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "routes/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: agency_id
     type: STRING
   - name: route_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/shapes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/shapes.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "shapes/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: shape_id
     type: STRING
   - name: shape_pt_lat

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_areas.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_areas.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "stop_areas/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: area_id
     type: STRING
   - name: stop_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_times.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_times.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "stop_times/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: trip_id
     type: STRING
   - name: arrival_time

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/stops.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/stops.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "stops/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: stop_id
     type: STRING
   - name: stop_code

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/transfers.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/transfers.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "transfers/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: from_stop_id
     type: STRING
   - name: to_stop_id

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/translations.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/translations.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "translations/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: table_name
     type: STRING
   - name: field_name

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/trips.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/trips.yml
@@ -9,6 +9,9 @@ hive_options:
   mode: CUSTOM
   source_uri_prefix: "trips/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
   - name: route_id
     type: STRING
   - name: service_id

--- a/airflow/plugins/operators/gtfs_csv_to_jsonl.py
+++ b/airflow/plugins/operators/gtfs_csv_to_jsonl.py
@@ -89,7 +89,8 @@ def parse_individual_file(
         with fs.open(input_file.path, newline="", mode="r", encoding="utf-8-sig") as f:
             reader = csv.DictReader(f, restkey="calitp_unknown_fields")
             field_names = reader.fieldnames
-            for row in reader:
+            for line_number, row in enumerate(reader, start=1):
+                row["_line_number"] = line_number
                 lines.append(row)
 
         jsonl_content = gzip.compress(


### PR DESCRIPTION
# Description

The schedule backfill has caused many dbt tests to start failing, for example [fare rules having duplicate rows](https://sentry.calitp.org/organizations/sentry/issues/4509/?environment=cal-itp-data-infra&project=2&query=is%3Aunresolved+dbt&statsPeriod=14d). We don't really want to filter these out immediately, but we do want to ensure that we're ending up with 1 record per row in the original extract file. Adding a line number to the CSV-to-JSONL conversion task will let us check for a unique combination of ts, url, and line number.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Local Airflow.

## Screenshots (optional)
