### PR TITLE
create trip update mart table(s)

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -125,14 +125,24 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`, `vehicle_id`, and `trip_id`.
-        tests:
-          - unique:
-              where: '__rt_sampled__'
+        tests: &rt_key_tests
           - not_null:
               where: '__rt_sampled__'
-      - <<: *gtfs_dataset_key
-        config:
-          where: '__rt_sampled__'
+      - &gtfs_rt_dataset_key
+        name: gtfs_dataset_key
+        tests:
+          - not_null:
+              config:
+                where: '__rt_sampled__'
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
+              config:
+                # there are a dozen rows of SMART transit which was deleted from Airtable
+                # this will work without exception once the Airtable dim is historical;
+                # this threshold may need to increase if the backfill occurs prior to that
+                error_if: ">20"
+                where: '__rt_sampled__'
       - name: dt
       - name: hour
       - name: base64_url
@@ -190,20 +200,8 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`, `vehicle_id`, and `trip_id`.
-        tests:
-          - unique:
-              # TODO: make an RT test macro that does this date subtraction
-              # test hour = 0 UTC because that's 5pm Pacific = PM peak, good sample of data
-              where: '__rt_sampled__'
-          - not_null:
-              where: '__rt_sampled__'
-      - name: gtfs_dataset_key
-        description: |
-          The primary key for the record in `dim_gtfs_datasets` associated with this message.
-        columns:
-          - <<: *gtfs_dataset_key
-            config:
-              where: '__rt_sampled__'
+        tests: *rt_key_tests
+      - *gtfs_rt_dataset_key
       - name: dt
         description: |
           Date on which we scraped this message.

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -113,6 +113,17 @@ models:
       - name: zipfile_dirs
         description: '{{ doc("column_zipfile_dirs") }}'
 
+  - name: fct_stop_time_updates
+    description: |
+      Unnested and de-duped stop time updates.
+    columns:
+      - name: key
+        tests: &rt_key_tests
+          - unique:
+              where: '__rt_sampled__'
+          - not_null:
+              where: '__rt_sampled__'
+
   - name: fct_trip_updates_messages
     description: |
       Each row is a message received from a trip updates GTFS RT feed.
@@ -125,9 +136,7 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`, `vehicle_id`, and `trip_id`.
-        tests: &rt_key_tests
-          - not_null:
-              where: '__rt_sampled__'
+        tests: *rt_key_tests
       - &gtfs_rt_dataset_key
         name: gtfs_dataset_key
         tests:

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -112,6 +112,50 @@ models:
         description: '{{ doc("column_zipfile_files") }}'
       - name: zipfile_dirs
         description: '{{ doc("column_zipfile_dirs") }}'
+
+  - name: fct_trip_updates_messages
+    description: |
+      Each row is a message received from a trip updates GTFS RT feed.
+      See https://gtfs.org/realtime/reference/#message-tripupdate for information
+      about message structure.
+      Due to data size, this table **must** be queried with a date filter (like `WHERE dt = 'YYYY-MM-DD'`).
+      Hour filters will also further improve performance.
+    columns:
+      - name: key
+        description: |
+          Synthetic primary key constructed from `base64_url`, `extract_ts`,
+          entity `id`, `vehicle_id`, and `trip_id`.
+        tests:
+          - unique:
+              where: '__rt_sampled__'
+          - not_null:
+              where: '__rt_sampled__'
+      - <<: *gtfs_dataset_key
+        config:
+          where: '__rt_sampled__'
+      - name: dt
+      - name: hour
+      - name: base64_url
+      - name: _extract_ts
+      - name: _config_extracted_at
+      - name: _name
+      - name: header_timestamp
+      - name: header_incrementality
+      - name: header_version
+      - name: id
+      - name: trip_update_timestamp
+      - name: trip_update_delay
+      - name: vehicle_id
+      - name: vehicle_label
+      - name: vehicle_license_plate
+      - name: trip_id
+      - name: trip_route_id
+      - name: trip_direction_id
+      - name: trip_start_time
+      - name: trip_start_date
+      - name: trip_schedule_relationship
+      - name: stop_time_updates
+
   - name: fct_vehicle_locations
     description: |
       De-duped vehicle positions, removing redundant/duplicated positions

--- a/warehouse/models/mart/gtfs/fct_stop_time_updates.sql
+++ b/warehouse/models/mart/gtfs/fct_stop_time_updates.sql
@@ -1,0 +1,28 @@
+WITH
+
+fct_trip_updates_messages AS (
+    SELECT * FROM {{ ref('fct_trip_updates_messages') }}
+),
+
+fct_stop_time_updates AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['base64_url',
+                                    '_extract_ts',
+                                    'trip_id',
+                                    'stop_time_update.stopSequence',
+        ]) }} as key,
+        fct_trip_updates_messages.* EXCEPT (key),
+        stop_time_update.stopSequence AS stop_sequence,
+        stop_time_update.stopId AS stop_id,
+        stop_time_update.arrival.delay AS arrival_delay,
+        stop_time_update.arrival.time AS arrival_time,
+        stop_time_update.arrival.uncertainty AS arrival_uncertainty,
+        stop_time_update.departure.delay AS departure_delay,
+        stop_time_update.departure.time AS departure_time,
+        stop_time_update.departure.uncertainty AS departure_uncertainty,
+        stop_time_update.scheduleRelationship AS schedule_relationship,
+    FROM fct_trip_updates_messages
+    LEFT JOIN UNNEST(stop_time_updates) AS stop_time_update
+)
+
+SELECT * FROM fct_stop_time_updates

--- a/warehouse/models/mart/gtfs/fct_stop_time_updates.sql
+++ b/warehouse/models/mart/gtfs/fct_stop_time_updates.sql
@@ -2,6 +2,13 @@ WITH
 
 fct_trip_updates_messages AS (
     SELECT * FROM {{ ref('fct_trip_updates_messages') }}
+    -- TODO: these have duplicate rows down to the stop level, maybe should exclude
+--     WHERE _gtfs_dataset_name NOT IN (
+--         'Bay Area 511 Regional TripUpdates',
+--         'BART TripUpdates',
+--         'Bay Area 511 Muni TripUpdates',
+--         'Unitrans Trip Updates'
+--     )
 ),
 
 fct_stop_time_updates AS (
@@ -9,9 +16,12 @@ fct_stop_time_updates AS (
         {{ dbt_utils.surrogate_key(['base64_url',
                                     '_extract_ts',
                                     'trip_id',
+                                    'trip_update_timestamp',
                                     'stop_time_update.stopSequence',
+                                    'stop_time_update.stopId',
         ]) }} as key,
-        fct_trip_updates_messages.* EXCEPT (key),
+        fct_trip_updates_messages.* EXCEPT (key, stop_time_updates),
+        fct_trip_updates_messages.key AS _trip_updates_message_key,
         stop_time_update.stopSequence AS stop_sequence,
         stop_time_update.stopId AS stop_id,
         stop_time_update.arrival.delay AS arrival_delay,

--- a/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
@@ -26,7 +26,8 @@ keying AS (
 
 fct_trip_updates_messages AS (
     SELECT
-        {{ dbt_utils.surrogate_key(['base64_url', '_extract_ts', 'id']) }} as key,
+        -- TODO: this is not unique yet
+        {{ dbt_utils.surrogate_key(['base64_url', '_extract_ts', 'id', 'vehicle_id', 'trip_id']) }} as key,
         gtfs_dataset_key,
         dt,
         hour,

--- a/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
@@ -1,0 +1,63 @@
+WITH stg_gtfs_rt__trip_updates AS (
+    SELECT *
+    FROM {{ ref('stg_gtfs_rt__trip_updates') }}
+),
+
+urls_to_gtfs_datasets AS (
+    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
+),
+
+dim_gtfs_datasets AS (
+    SELECT *
+    FROM {{ ref('dim_gtfs_datasets') }}
+),
+
+keying AS (
+    SELECT
+        urls_to_gtfs_datasets.gtfs_dataset_key,
+        gd.name as _gtfs_dataset_name,
+        tu.*
+    FROM stg_gtfs_rt__trip_updates AS tu
+    LEFT JOIN urls_to_gtfs_datasets
+        ON tu.base64_url = urls_to_gtfs_datasets.base64_url
+    LEFT JOIN dim_gtfs_datasets AS gd
+        ON urls_to_gtfs_datasets.gtfs_dataset_key = gd.key
+),
+
+fct_trip_updates_messages AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['base64_url', '_extract_ts', 'id']) }} as key,
+        gtfs_dataset_key,
+        dt,
+        hour,
+        base64_url,
+        _extract_ts,
+        _config_extract_ts,
+        _gtfs_dataset_name,
+
+        header_timestamp,
+        header_version,
+        header_incrementality,
+
+        id,
+
+        trip_update_timestamp,
+        trip_update_delay,
+
+        vehicle_id,
+        vehicle_label,
+        vehicle_license_plate,
+
+        trip_id,
+        trip_route_id,
+        trip_direction_id,
+        trip_start_time,
+        trip_start_date,
+        trip_schedule_relationship,
+
+        stop_time_updates,
+    FROM keying
+)
+
+
+SELECT * FROM fct_trip_updates_messages

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -69,22 +69,39 @@ models:
       - name: dt
       - name: ts
       - name: base64_url
+
+  - name: stg_gtfs_rt__trip_updates
+    description: |
+      Trip updates realtime data.
+      See https://gtfs.org/realtime/reference/ for specification.
+    columns:
+      - name: dt
+      - name: hour
+      - name: base64_url
+      - name: _extract_ts
+      - name: _config_extracted_at
+      - name: _name
+      - name: header_timestamp
+      - name: header_incrementality
+      - name: header_version
+      - name: id
+      - name: trip_update_timestamp
+      - name: trip_update_delay
+      - name: vehicle_id
+      - name: vehicle_label
+      - name: vehicle_license_plate
+      - name: trip_id
+      - name: trip_route_id
+      - name: trip_direction_id
+      - name: trip_start_time
+      - name: trip_start_date
+      - name: trip_schedule_relationship
+      - name: stop_time_updates
+
   - name: stg_gtfs_rt__vehicle_positions
     description: |
       Vehicle positions realtime data.
       See https://gtfs.org/realtime/reference/ for specification.
-    tests:
-      # ideally base64_url, _extract_ts, id would be sufficient
-      # but this is not the case in the MTC 511 feed, so adding position
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - base64_url
-            - _extract_ts
-            - id
-            - position_latitude
-            - position_longitude
-          # test hour = 0 UTC because that's 5pm Pacific = PM peak, good sample of data
-          where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM _extract_ts)) = 0
     columns:
       - name: dt
       - name: hour
@@ -117,6 +134,7 @@ models:
       - name: bearing
       - name: odometer
       - name: speed
+
   - name: stg_gtfs_schedule__agency
     description: |
       Cleaned GTFS schedule agency data.

--- a/warehouse/models/staging/gtfs/gtfs_quality/_stg_gtfs_quality.yml
+++ b/warehouse/models/staging/gtfs/gtfs_quality/_stg_gtfs_quality.yml
@@ -35,9 +35,9 @@ models:
         name: key
         tests:
           - not_null:
-              where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM hour)) = 0
+              where: '__rt_sampled__'
           - unique:
-              where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY) AND (EXTRACT(HOUR FROM hour)) = 0
+              where: '__rt_sampled__'
 
   - name: stg_gtfs_rt__service_alerts_validation_outcomes
     description: |

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
@@ -1,0 +1,41 @@
+WITH external_trip_updates AS (
+    SELECT *
+    FROM {{ source('external_gtfs_rt', 'trip_updates') }}
+),
+
+stg_gtfs_rt__trip_updates AS (
+    SELECT
+        dt,
+        hour,
+        base64_url,
+
+        metadata.extract_ts AS _extract_ts,
+        metadata.extract_config.extracted_at AS _config_extract_ts,
+        metadata.extract_config.name AS _name,
+
+        TIMESTAMP_SECONDS(header.timestamp) AS header_timestamp,
+        header.incrementality AS header_incrementality,
+        header.gtfsRealtimeVersion AS header_version,
+
+        id,
+
+        TIMESTAMP_SECONDS(tripUpdate.timestamp) AS trip_update_timestamp,
+        tripUpdate.delay as trip_update_delay,
+
+        tripUpdate.vehicle.id AS vehicle_id,
+        tripUpdate.vehicle.label AS vehicle_label,
+        tripUpdate.vehicle.licensePlate AS vehicle_license_plate,
+
+        tripUpdate.trip.tripId AS trip_id,
+        tripUpdate.trip.routeId AS trip_route_id,
+        tripUpdate.trip.directionId AS trip_direction_id,
+        tripUpdate.trip.startTime AS trip_start_time,
+        tripUpdate.trip.startDate AS trip_start_date,
+        tripUpdate.trip.scheduleRelationship AS trip_schedule_relationship,
+
+        tripUpdate.stopTimeUpdate AS stop_time_updates,
+
+    FROM external_trip_updates
+)
+
+SELECT * FROM stg_gtfs_rt__trip_updates


### PR DESCRIPTION
# Description

Expose trip updates in two mart models: `fct_trip_updates_messages` and `fct_stop_time_updates`

These are view-materialized and require partition filtering, but perform column renaming (🐫 to 🐍 ), record flattening, and array unnesting.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tests do fail currently due to what I think is bad input data; I've chosen not to filter it out quite yet; changing the test may be better.

## Screenshots (optional)
