### PR TITLE
fix to_url_safe_base64

### DIFF
--- a/warehouse/macros/url_safe_base64.sql
+++ b/warehouse/macros/url_safe_base64.sql
@@ -2,7 +2,7 @@
 -- based on the docs here: https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#to_base64
 
 {% macro to_url_safe_base64(column) %}
-REPLACE(REPLACE(TO_BASE64(CAST({{ column }} AS BYTES)),'-','+'),'_','/')
+REPLACE(REPLACE(TO_BASE64(CAST({{ column }} AS BYTES)),'+','-'),'/','_')
 {% endmacro %}
 
 {% macro from_url_safe_base64(column) %}


### PR DESCRIPTION
# Description

Fixes a bug in base64 encoding macro that caused some joins to fail between Airtable and GTFS data

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
