### PR TITLE
GTFS Schedule optimizations: require partition filters

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_county_geography.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_county_geography.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__county_geography/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_county_geography.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_county_geography.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__county_geography/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_eligibility_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_eligibility_programs.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__eligibility_programs/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_eligibility_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_eligibility_programs.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__eligibility_programs/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
@@ -12,7 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__fare_systems/"
 schema_fields:
   - name: reservations

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
@@ -12,6 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__fare_systems/"
 schema_fields:
   - name: reservations

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__funding_programs/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__funding_programs/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
@@ -12,7 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__gtfs_datasets/"
 schema_fields:
   - name: data_quality_pipeline_disabled_notes

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
@@ -12,6 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__gtfs_datasets/"
 schema_fields:
   - name: data_quality_pipeline_disabled_notes

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
@@ -12,6 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__gtfs_service_data/"
 schema_fields:
   - name: network_id

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
@@ -12,7 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__gtfs_service_data/"
 schema_fields:
   - name: network_id

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__ntd_agency_info/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__ntd_agency_info/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -12,6 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__organizations/"
 schema_fields:
   - name: services

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -12,7 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__organizations/"
 schema_fields:
   - name: services

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_place_geography.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_place_geography.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__place_geography/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_place_geography.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_place_geography.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__place_geography/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_rider_requirements.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_rider_requirements.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__rider_requirements/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_rider_requirements.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_rider_requirements.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__rider_requirements/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -12,7 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "california_transit__services/"
 schema_fields:
   - name: eligibility_programs

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -12,6 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "california_transit__services/"
 schema_fields:
   - name: eligibility_programs

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__components/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__components/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_contracts.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_contracts.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__contracts/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_contracts.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_contracts.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__contracts/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_data_schemas.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_data_schemas.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__data_schemas/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_data_schemas.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_data_schemas.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__data_schemas/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_organizations.yml
@@ -12,6 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__organizations/"
 schema_fields:
   - name: id

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_organizations.yml
@@ -12,7 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__organizations/"
 schema_fields:
   - name: id

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_products.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_products.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__products/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_products.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_products.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__products/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_properties_features.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_properties_features.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__properties_and_features/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_properties_features.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_properties_features.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__properties_and_features/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_relationships_service_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_relationships_service_components.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__relationships_service_components/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_relationships_service_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_relationships_service_components.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__relationships_service_components/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_service_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_service_components.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__service_components/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_service_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_service_components.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__service_components/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
@@ -12,5 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
-  require_partition_filters: false
+  require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__services/"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
@@ -12,4 +12,5 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: AUTO
+  require_partition_filters: false
   source_uri_prefix: "transit_technology_stacks__services/"

--- a/airflow/dags/create_external_tables/feed_aggregator_scrape_results.yml
+++ b/airflow/dags/create_external_tables/feed_aggregator_scrape_results.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "gtfs_aggregator_scrape_results/{dt:DATE}/{ts:TIMESTAMP}/{aggregator:STRING}/"
 schema_fields:
   - name: key

--- a/airflow/dags/create_external_tables/gtfs_download_configs.yml
+++ b/airflow/dags/create_external_tables/gtfs_download_configs.yml
@@ -12,6 +12,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "gtfs_download_configs/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: extracted_at

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "service_alerts/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_outcomes.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "service_alerts_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_notices.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "service_alerts_validation_notices/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_outcomes.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "service_alerts_validation_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "trip_updates/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_outcomes.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "trip_updates_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_notices.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "trip_updates_validation_notices/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_outcomes.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "trip_updates_validation_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "vehicle_positions/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_outcomes.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "vehicle_positions_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_notices.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "vehicle_positions_validation_notices/{dt:DATE}/{hour:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_outcomes.yml
@@ -7,7 +7,6 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
-  require_partition_filter: true
   source_uri_prefix: "vehicle_positions_validation_outcomes/{dt:DATE}/{hour:TIMESTAMP}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_download_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_download_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "download_schedule_feed_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_agency_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_agency_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "agency.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_areas_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_areas_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "areas.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_attributions_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_attributions_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "attributions.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_dates_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_dates_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "calendar_dates.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "calendar.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_attributes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_attributes_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "fare_attributes.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_feed_info_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_feed_info_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "feed_info.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_leg_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_leg_rules_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "fare_leg_rules.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_products_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_products_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "fare_products.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_rules_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "fare_rules.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_transfer_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_transfer_rules_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "fare_transfer_rules.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_frequencies_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_frequencies_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "frequencies.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_levels_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_levels_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "levels.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_pathways_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_pathways_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "pathways.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_routes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_routes_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "routes.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_shapes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_shapes_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "shapes.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_areas_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_areas_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "stop_areas.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_times_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_times_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "stop_times.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stops_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stops_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "stops.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_transfers_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_transfers_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "transfers.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_translations_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_translations_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "translations.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_trips_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_trips_txt_json_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "trips.txt_parsing_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_unzip_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_unzip_outcomes.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "unzipping_results/{dt:DATE}/"
 schema_fields:
   - name: success

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/validation_notices.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/validation_notices.yml
@@ -7,6 +7,7 @@ source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
+  require_partition_filter: false
   source_uri_prefix: "validation_notices/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
 schema_fields:
   - name: metadata

--- a/airflow/plugins/operators/external_table.py
+++ b/airflow/plugins/operators/external_table.py
@@ -50,7 +50,7 @@ def _bq_client_create_external_table(
         # key schema for more than a trivial number of files
         opt.mode = hive_options.get("mode", "AUTO")
         opt.require_partition_filter = hive_options.get(
-            "require_partition_filter", False
+            "require_partition_filter", True
         )
         # TODO: this is very fragile, we should probably be calculating it from
         #       the source_objects and validating the format (prefix, trailing slashes)


### PR DESCRIPTION
# Description

~NOTE: must wait until https://github.com/cal-itp/data-infra/pull/2103 is merged~ this is merged

Closes https://github.com/cal-itp/data-infra/issues/2134

This is non-trivial to test for correctness because of a lack of true primary keys in the final dimension tables, but I've verified re-running this does not produce duplicate rows. The underlying macro first filters the _possible_ GTFS data by day, but still inner joins against feed versions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Testing as best I can, though we may still have some queries that fail. We can monitor the query access logs for failures.

`-m +mart.gtfs_schedule_latest` run/test passes as much as we would expect. `dim_translations` fails, we may just want to disable it?

## Screenshots (optional)
