### PR TITLE
exclude legacy models from dbt jobs

### DIFF
--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -11,6 +11,7 @@ arguments:
   - '--save-artifacts'
   - '--deploy-docs'
   - '--sync-metabase'
+  - '--exclude="gtfs_schedule_latest_only gtfs_views gtfs_views_staging rt_views staging.gtfs_guidelines mart.gtfs_guidelines"'
 
 is_delete_operator_pod: true
 startup_timeout_seconds: 300

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -12,6 +12,7 @@ arguments:
   - '--save-artifacts'
   - '--deploy-docs'
   - '--sync-metabase'
+  - '--exclude="gtfs_schedule_latest_only gtfs_views gtfs_views_staging rt_views staging.gtfs_guidelines mart.gtfs_guidelines"'
 
 is_delete_operator_pod: true
 startup_timeout_seconds: 300

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import gcsfs
 import pendulum
@@ -105,6 +105,7 @@ def run(
     save_artifacts: bool = False,
     deploy_docs: bool = False,
     sync_metabase: bool = False,
+    exclude: Optional[str] = None,
 ) -> None:
     assert (
         dbt_docs or not save_artifacts
@@ -151,6 +152,8 @@ def run(
         args = ["run"]
         if full_refresh:
             args.append("--full-refresh")
+        if exclude:
+            args.extend(["--exclude", exclude])
         results_to_check.append(subprocess.run(get_command(*args)))
 
         with open("./target/run_results.json") as f:
@@ -162,7 +165,10 @@ def run(
         typer.echo("skipping run")
 
     if dbt_test:
-        subprocess.run(get_command("test"))
+        args = ["test"]
+        if exclude:
+            args.extend(["--exclude", exclude])
+        subprocess.run(get_command(*args))
 
         with open("./target/run_results.json") as f:
             run_results = RunResults(**json.load(f))


### PR DESCRIPTION
# Description

Pre-cursor to https://github.com/cal-itp/data-infra/pull/2112 which cannot be merged until the downstream exposures are either disabled or replaced/migrated.

This is a cost-saving measure since there is no new data upstream and we aren't changing these models.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
