### PR TITLE
Fix unnested referenced_table column name and add audit tables to mart

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -75,3 +75,5 @@ models:
         schema: mart_gtfs
       ad_hoc:
         schema: mart_ad_hoc
+      audit:
+        schema: mart_audit

--- a/warehouse/models/mart/audit/_mart_audit.yml
+++ b/warehouse/models/mart/audit/_mart_audit.yml
@@ -125,6 +125,6 @@ models:
       - name: job
         tests:
           - not_null
-      - name: referenced_tables
+      - name: referenced_table
         tests:
           - not_null


### PR DESCRIPTION
# Description

Due to a copy/paste oversight in YAML, the new column created for `fct_bigquery_data_access_referenced_tables` was given the same name as its unnested array form from the original `fct_bigquery_data_access` table. This has now been fixed. Additionally, `dbt_project.yml` has been modified to move these tables into their proper mart location from staging.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran dbt tests locally for the modified model

## Screenshots (optional)
