### PR TITLE
Remove nulls from referenced tables unnested audit table

### DIFF
--- a/warehouse/models/mart/audit/_mart_audit.yml
+++ b/warehouse/models/mart/audit/_mart_audit.yml
@@ -71,7 +71,8 @@ models:
       for more details.
       Note that because this table possesses one row for each array entry in the original
       table's referenced_tables column, sums and other statistics on its columns won't work
-      without additional filtering/grouping.
+      without additional filtering/grouping. There are no corresponding rows in this table for
+      entries in the original table that have an empty referenced_tables array.
     columns:
       - name: timestamp
         tests:

--- a/warehouse/models/mart/audit/fct_bigquery_data_access_referenced_tables.sql
+++ b/warehouse/models/mart/audit/fct_bigquery_data_access_referenced_tables.sql
@@ -1,8 +1,9 @@
 {{ config(materialized='table') }}
 
 WITH fct_bigquery_data_access_unnested AS (
-    SELECT * FROM {{ ref('fct_bigquery_data_access') }}
-    LEFT JOIN UNNEST(fct_bigquery_data_access.referenced_tables) AS referenced_table
+    SELECT *
+      FROM {{ ref('fct_bigquery_data_access') }},
+      UNNEST(fct_bigquery_data_access.referenced_tables) AS referenced_table
 ),
 
 fct_bigquery_data_access_referenced_tables AS (


### PR DESCRIPTION
# Description

The version of `fct_bigquery_data_access` with an unnested referenced_tables column, `fct_bigquery_data_access_referenced_tables`, failed tests because of the presence of unnested null arrays in the original table that were expanded into null column values via a left join. Since this unnested table is already not going to be relied upon for a canonical cost accounting (due to row duplication), and is instead oriented toward model-specific accounting, we can simply leave those null values behind in the original table when we unnest.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

All dbt tests have been run locally for `fct_bigquery_data_access` and `fct_bigquery_data_access_referenced_tables`, and the tables have been recreated in a staging environment using the updated code and manually inspected for the test condition that broke overnight.