### PR TITLE
fix macro ref

### DIFF
--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql
@@ -26,7 +26,7 @@ checks_implemented AS (
     UNION ALL
     SELECT {{ technical_contact_listed() }}, {{ technical_contact_availability() }}
     UNION ALL
-    SELECT {{ no_rt_critical_validation_errors() }}, {{ compliance_rt() }}
+    SELECT {{ no_rt_validation_errors() }}, {{ compliance_rt() }}
     UNION ALL
     SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
+++ b/warehouse/models/staging/gtfs_guidelines/stg_gtfs_guidelines__no_rt_critical_validation_errors.sql
@@ -1,6 +1,6 @@
 WITH feed_guideline_index AS (
     SELECT * FROM {{ ref('stg_gtfs_guidelines__feed_guideline_index') }}
-    WHERE check = {{ no_rt_critical_validation_errors() }}
+    WHERE check = {{ no_rt_validation_errors() }}
 ),
 
 -- gtfs_rt_fact_files_wide_hourly has one row per day per ID+URL+feed type


### PR DESCRIPTION
# Description

dbt job failed today: 

`Compilation Error in model stg_gtfs_guidelines__feed_guideline_index (models/staging/gtfs_guidelines/stg_gtfs_guidelines__feed_guideline_index.sql) - 'no_rt_critical_validation_errors' is undefined. This can happen when calling a macro that does not exist.`

The `no_rt_critical_validation_errors` macro was renamed in #2153 but the references to the macro in the v1 models were not updated.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested? 
hasn't, running affected tables locally seems wasteful because they have a ton of upstream dependencies that I don't have in my namespace

## Screenshots (optional)
