### PR TITLE
use trip updates lookback for a trip updates check

### DIFF
--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_stale_trip_updates.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_stale_trip_updates.sql
@@ -20,7 +20,7 @@ feed_guideline_index AS (
     {% if is_incremental() %}
     WHERE date >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}
-    WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('RT_LOOKBACK_DAYS') }} DAY)
+    WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('TRIP_UPDATES_LOOKBACK_DAYS') }} DAY)
     {% endif %}
 ),
 
@@ -29,7 +29,7 @@ fct_trip_updates_messages AS (
     {% if is_incremental() %}
     WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('RT_LOOKBACK_DAYS') }} DAY)
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('TRIP_UPDATES_LOOKBACK_DAYS') }} DAY)
     {% endif %}
 ),
 


### PR DESCRIPTION
# Description

Noticed this while looking at per-dbt model costs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
```
15:25:23  1 of 1 START sql incremental model andrew_staging.int_gtfs_quality__no_stale_trip_updates  [RUN]
15:27:49  1 of 1 OK created sql incremental model andrew_staging.int_gtfs_quality__no_stale_trip_updates  [CREATE TABLE (693.0 rows, 934.6 GB processed) in 146.09s]
15:27:49
15:27:49  Finished running 1 incremental model in 0 hours 2 minutes and 28.34 seconds (148.34s).
15:27:49
15:27:49  Completed successfully
15:27:49
15:27:49  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```