### PR TITLE
Fix changed column

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -260,9 +260,3 @@ schema_fields:
   - name: organizations_copy
     type: STRING
     mode: REPEATED
-  - name: dt
-    type: DATE
-    mode: NULLABLE
-  - name: ts
-    type: TIMESTAMP
-    mode: NULLABLE


### PR DESCRIPTION
# Description

forgot to remove the hive partitions from the generated yaml

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
```
Deleting external table if exists: cal-itp-data-infra-staging.external_airtable.california_transit__services
Creating external table: cal-itp-data-infra-staging.external_airtable.california_transit__services Table(TableReference(DatasetReference('cal-itp-data-infra-staging', 'external_airtable'), 'california_transit__services')) ['gs://test-calitp-airtable/california_transit__services/*.jsonl.gz'] {'mode': 'AUTO', 'source_uri_prefix': 'california_transit__services/'}
Successfully ran SELECT *
FROM `cal-itp-data-infra-staging`.external_airtable.california_transit__services
LIMIT 1;
[2023-01-13 17:20:03,361] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=create_external_tables, task_id=external_airtable_california_transit_services, execution_date=20221012T000000, start_date=20230113T155945, end_date=20230113T172003
```