### PR TITLE
payments_rides tests revisions

### DIFF
--- a/warehouse/models/payments_views/_payments_views.yml
+++ b/warehouse/models/payments_views/_payments_views.yml
@@ -88,10 +88,6 @@ models:
         description: The transaction_date_time_utc of the first tap transaction
       - name: transaction_date_time_pacific
         description: The transaction_date_time_pacific of the first tap transaction
-        tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-                datepart: day
-                interval: 2
       - name: location_id
         description: The location_id of the first tap transaction
       - name: location_name
@@ -127,3 +123,33 @@ models:
       - name: off_geography
       - name: duration
       - name: distance_meters
+  - name: payments_monthly_transaction_deltas
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: yearmonth
+        description: The month and year of the ridership count calculation
+      - name: ridership_count
+        description: A participant's total ridership in a particular month
+      - name: relative_difference
+        description: The relative change in a participant's ridership count as compared to the previous month
+  - name: payments_weekly_transaction_deltas
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: yearweek
+        description: The week and year of the ridership count calculation
+      - name: ridership_count
+        description: A participant's total ridership in a particular week
+      - name: relative_difference
+        description: The relative change in a participant's ridership count as compared to the previous week
+  - name: payments_daily_transaction_deltas
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: transaction_date
+        description: The day of the ridership count calculation
+      - name: ridership_count
+        description: A participant's total ridership on a particular day
+      - name: relative_difference
+        description: The relative change in a participant's ridership count as compared to the previous day

--- a/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
@@ -1,5 +1,3 @@
-{{ config(store_failures = true) }}
-
 WITH payments_rides AS (
 
     SELECT *

--- a/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
@@ -40,7 +40,7 @@ calculate_relative_difference AS (
 
 ),
 
-test_recent_values AS (
+payments_daily_transaction_deltas AS (
 
     SELECT
 
@@ -50,11 +50,10 @@ test_recent_values AS (
         relative_difference
 
     FROM calculate_relative_difference
-    WHERE ABS(relative_difference) > 25.0
-        AND transaction_date BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 WEEK)
+    WHERE transaction_date BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 WEEK)
         AND DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
     ORDER BY transaction_date
 
 )
 
-SELECT * FROM test_recent_values
+SELECT * FROM payments_daily_transaction_deltas

--- a/warehouse/models/payments_views/payments_monthly_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_monthly_transaction_deltas.sql
@@ -1,5 +1,3 @@
-{{ config(store_failures = true) }}
-
 WITH payments_rides AS (
 
     SELECT *

--- a/warehouse/models/payments_views/payments_monthly_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_monthly_transaction_deltas.sql
@@ -47,7 +47,7 @@ calculate_relative_difference AS (
 
 ),
 
-test_recent_values AS (
+payments_monthly_transaction_deltas AS (
 
     SELECT
 
@@ -66,9 +66,8 @@ test_recent_values AS (
             FROM calculate_relative_difference)
     WHERE rank != 1
         AND rank < 5
-        AND ABS(relative_difference) > 25.0
     ORDER BY yearmonth
 
 )
 
-SELECT * FROM test_recent_values
+SELECT * FROM payments_monthly_transaction_deltas

--- a/warehouse/models/payments_views/payments_weekly_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_weekly_transaction_deltas.sql
@@ -1,5 +1,3 @@
-{{ config(store_failures = true) }}
-
 WITH payments_rides AS (
 
     SELECT *

--- a/warehouse/models/payments_views/payments_weekly_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_weekly_transaction_deltas.sql
@@ -48,7 +48,7 @@ calculate_relative_difference AS (
 
 ),
 
-test_recent_values AS (
+payments_weekly_transaction_deltas AS (
 
     SELECT
 
@@ -67,9 +67,8 @@ test_recent_values AS (
             FROM calculate_relative_difference)
     WHERE rank != 1
         AND rank < 5
-        AND ABS(relative_difference) > 25.0
     ORDER BY yearweek
 
 )
 
-SELECT * FROM test_recent_values
+SELECT * FROM payments_weekly_transaction_deltas


### PR DESCRIPTION
# Description

We've decided to move more of the `payments_rides` test calculations, alerts, and observability into Metabase. This PR accomplishes that by:
* Removing the 3 validations tests on `payments_rides`
  * eg `validate_payments_rides__weekly_transaction_deltas`
* Replacing them with tables in `payments_views` 
  * eg `payments_weekly_transaction_deltas`
* Removing the 25% relative difference thresholds for alerts that were hardcoded into the tests in favor of handling that in Metabase
* Adding documentation for new tables in `_payments_views.yml`
* Removing the great expectations freshness test on `payments_rides` in favor of adding this to Metabase as a custom SQL question/ alert

## Type of change

- [x] New feature
- [x] Documentation

## How has this been tested?
locally with `dbt run` and `dbt test`
