### PR TITLE
Removing `payments_rides` tests filters that should be in metabase

### DIFF
--- a/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
@@ -48,9 +48,6 @@ payments_daily_transaction_deltas AS (
         relative_difference
 
     FROM calculate_relative_difference
-    WHERE transaction_date BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 1 WEEK)
-        AND DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
-    ORDER BY transaction_date
 
 )
 

--- a/warehouse/models/payments_views/payments_monthly_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_monthly_transaction_deltas.sql
@@ -52,7 +52,8 @@ payments_monthly_transaction_deltas AS (
         participant_id,
         yearmonth,
         ridership_count,
-        relative_difference
+        relative_difference,
+        recency_rank
 
     FROM
         (SELECT
@@ -60,11 +61,8 @@ payments_monthly_transaction_deltas AS (
             yearmonth,
             ridership_count,
             relative_difference,
-            RANK() OVER (PARTITION BY participant_id ORDER BY yearmonth DESC) AS rank
+            RANK() OVER (PARTITION BY participant_id ORDER BY yearmonth DESC) AS recency_rank
             FROM calculate_relative_difference)
-    WHERE rank != 1
-        AND rank < 5
-    ORDER BY yearmonth
 
 )
 

--- a/warehouse/models/payments_views/payments_weekly_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_weekly_transaction_deltas.sql
@@ -53,7 +53,8 @@ payments_weekly_transaction_deltas AS (
         participant_id,
         yearweek,
         ridership_count,
-        relative_difference
+        relative_difference,
+        recency_rank
 
     FROM
         (SELECT
@@ -61,11 +62,8 @@ payments_weekly_transaction_deltas AS (
             yearweek,
             ridership_count,
             relative_difference,
-            RANK() OVER (PARTITION BY participant_id ORDER BY yearweek DESC) AS rank
+            RANK() OVER (PARTITION BY participant_id ORDER BY yearweek DESC) AS recency_rank
             FROM calculate_relative_difference)
-    WHERE rank != 1
-        AND rank < 5
-    ORDER BY yearweek
 
 )
 


### PR DESCRIPTION
# Description

We recently merged in #2164 which revised the way we handled tests on `payments_rides` (in favor of doing most of the work in Metabase). There were still a couple remaining filters in the warehouse tables that needed to be removed in favor of handling this at the Metabase-level.

Tables modified:
* payments_dailly_transaction_deltas
  * Removed the recency filter from warehouse table, added recency column to filter in Metabase instead
* payments_weekly_transaction_deltas
  * Removed the recency filter from warehouse table, added recency column to filter in Metabase instead
* payments_monthly_transaction_deltas
  * Removed the recency filter from warehouse table, added recency column to filter in Metabase instead

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Locally with `dbt run` and `dbt test`