### PR TITLE
add validator version to schedule outcomes external table

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_validations_outcomes.yml
@@ -58,3 +58,5 @@ schema_fields:
           *config_fields
       - name: system_errors
         type: JSON
+      - name: validator_version
+        type: STRING


### PR DESCRIPTION
# Description

Precursor to fixing https://github.com/cal-itp/data-infra/pull/2171

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
```
Deleting external table if exists: cal-itp-data-infra-staging.external_gtfs_schedule.validations_outcomes
Creating external table: cal-itp-data-infra-staging.external_gtfs_schedule.validations_outcomes Table(TableReference(DatasetReference('cal-itp-data-infra-staging', 'external_gtfs_schedule'), 'validations_outcomes')) ['gs://test-calitp-gtfs-schedule-validation/validation_job_results/*.jsonl'] {'mode': 'CUSTOM', 'source_uri_prefix': 'validation_job_results/{dt:DATE}/'}
[2023-01-17 21:00:04,024] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=create_external_tables, task_id=gtfs_schedule_validations_outcomes, execution_date=20221012T000000, start_date=20230117T205959, end_date=20230117T210004
```

## Screenshots (optional)
