### PR TITLE
properly join all versions of validations for a given feed version

### DIFF
--- a/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_validation_notices.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_validation_notices.sql
@@ -16,24 +16,33 @@ validation_outcomes AS (
     SELECT * FROM {{ ref('stg_gtfs_schedule__validation_outcomes') }}
 ),
 
-outcome_validator_versions AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__outcome_validator_versions') }}
-),
-
 validation_notices AS (
     SELECT * FROM {{ ref('stg_gtfs_schedule__validation_notices') }}
+),
+
+-- For each version of a feed, we use the first time a given version
+-- of the validator was run against that feed; technically we don't
+-- guarantee that the "range" will never have overlapped, for example
+-- a backfill could also produce v4 validations alongside v3
+first_outcome_per_version AS (
+    SELECT *
+    FROM validation_outcomes
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY base64_url, validation_validator_version
+        ORDER BY extract_ts
+    ) = 1
 ),
 
 fct_daily_schedule_feed_validation_notices AS (
     SELECT
         {{ dbt_utils.surrogate_key(['daily_feeds.date',
                                     'daily_feeds.feed_key',
-                                    'versions.gtfs_validator_version',
+                                    'outcomes.validation_validator_version',
                                     'codes.code',
         ]) }} AS key,
         daily_feeds.date,
         daily_feeds.feed_key,
-        versions.gtfs_validator_version,
+        outcomes.validation_validator_version,
         codes.code,
         codes.severity,
         outcomes.validation_success,
@@ -45,14 +54,10 @@ fct_daily_schedule_feed_validation_notices AS (
     FROM fct_daily_schedule_feeds AS daily_feeds
     LEFT JOIN dim_schedule_feeds AS dim_feeds
         ON daily_feeds.feed_key = dim_feeds.key
-    LEFT JOIN validation_outcomes AS outcomes
+    LEFT JOIN first_outcome_per_version AS outcomes
         ON dim_feeds.base64_url = outcomes.base64_url
-        AND dim_feeds._valid_from = outcomes.extract_ts
-    LEFT JOIN outcome_validator_versions AS versions
-        ON outcomes.base64_url = versions.base64_url
-        AND outcomes.extract_ts = versions.ts
     LEFT JOIN validation_codes AS codes
-        ON versions.gtfs_validator_version = codes.gtfs_validator_version
+        ON outcomes.validation_validator_version = codes.gtfs_validator_version
     LEFT JOIN validation_notices AS notices
         ON codes.code = notices.code
         AND outcomes.base64_url = notices.base64_url

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_schedule__validation_outcomes.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_schedule__validation_outcomes.sql
@@ -17,6 +17,7 @@ stg_gtfs_schedule__validation_outcomes AS (
         exception AS validation_exception,
         validation.filename AS validation_filename,
         validation.system_errors AS validation_system_errors,
+        validation.validator_version AS validation_validator_version,
         base64_url,
         `extract`.ts AS extract_ts
     FROM raw_validation_outcomes


### PR DESCRIPTION
# Description

See [Slack](https://cal-itp.slack.com/archives/C02KH3DGZL7/p1673465655505239) and https://github.com/cal-itp/data-infra/pull/2171

Previously, the join logic in daily notices would pull the initial set of validations run for a given feed version, so something like the following could occur.

* feed version starts 2022-10-16 => v3.1.1 validations show up
* validator changes to v4.0.0 on 2022-11-16 => the join still pulls in validations from 2022-10-16
* new feed version starts 2022-01-04 => v4.0.0 validations show up

This PR changes the joins to include the first set of each version's validations per feed version. This also means we will now join in validation notices from anywhere in the feed's validity period rather than explicitly checking for the validations of the extract that started the period, but validation should be deterministic on the same zipfile so it won't change any results.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Building locally, tests pass and the example query now properly returns data.

## Screenshots (optional)
```
SELECT *
FROM `cal-itp-data-infra-staging`.andrew_mart_gtfs_quality.fct_daily_schedule_feed_validation_notices
WHERE date = '2023-01-04'
  AND code IN ('fare_transfer_rule_duration_limit_type_without_duration_limit',
               'fare_transfer_rule_duration_limit_without_type',
               'fare_transfer_rule_invalid_transfer_count',
               'fare_transfer_rule_missing_transfer_count',
               'fare_transfer_rule_with_forbidden_transfer_count',
               'invalid_currency_amount'
    )
  AND feed_key = 'eb2c79558289a6377dc517b7bae8433e'
;
...
494df2ddfe20943dd99c8100456dd7c1	2023-01-04 00:00:00.000000	eb2c79558289a6377dc517b7bae8433e	v4.0.0	fare_transfer_rule_with_forbidden_transfer_count	ERROR	true		0
889a1610aaa110409e80b281211757db	2023-01-04 00:00:00.000000	eb2c79558289a6377dc517b7bae8433e	v4.0.0	invalid_currency_amount	ERROR	true		38
f4cdc4acbeb2a725c1c5262272160a07	2023-01-04 00:00:00.000000	eb2c79558289a6377dc517b7bae8433e	v4.0.0	fare_transfer_rule_missing_transfer_count	ERROR	true		0
```