### PR TITLE
filter outcomes with missing extract metadata from rt feed files daily

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -1346,7 +1346,9 @@ models:
       tests: *primary_key_tests
     - name: date
       description: Date that data was downloaded.
-    - *base64_url
+    - <<: *base64_url
+      tests:
+        - not_null
     - &feed_type
       name: feed_type
       description: |

--- a/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
@@ -43,6 +43,9 @@ grouped_parse_outcomes AS (
         END AS aggregation_outcome,
         COUNT(*) as file_count
     FROM parse_outcomes
+    -- this can be null if we failed to write metadata on the original extract
+    -- for example gs://calitp-gtfs-rt-raw-v2/trip_updates/dt=2022-12-31/hour=2022-12-31T04:00:00+00:00/ts=2022-12-31T04:17:40+00:00/base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1DTQ==/feed
+    WHERE base64_url IS NOT NULL
     GROUP BY
         dt,
         base64_url,


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/2148

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
```
➜  warehouse git:(ignore-rt-feeds-with-missing-metadata) ✗ poetry run dbt build -s fct_daily_rt_feed_files --full-refresh
18:08:41  Running with dbt=1.3.1
18:08:42  Found 341 models, 1097 tests, 0 snapshots, 0 analyses, 811 macros, 0 operations, 2 seed files, 138 sources, 5 exposures, 0 metrics
18:08:42
18:08:44  Concurrency: 4 threads (target='dev')
18:08:44
18:08:44  1 of 10 START sql incremental model andrew_mart_gtfs.fct_daily_rt_feed_files ... [RUN]
18:08:50  1 of 10 OK created sql incremental model andrew_mart_gtfs.fct_daily_rt_feed_files  [CREATE TABLE (8.2k rows, 38.1 GB processed) in 5.49s]
18:08:50  2 of 10 START test not_null_fct_daily_rt_feed_files_base64_url ................. [RUN]
18:08:50  3 of 10 START test not_null_fct_daily_rt_feed_files_gtfs_dataset_key ........... [RUN]
18:08:50  4 of 10 START test not_null_fct_daily_rt_feed_files_key ........................ [RUN]
18:08:50  5 of 10 START test not_null_fct_daily_rt_feed_files_parse_failure_file_count ... [RUN]
18:08:51  3 of 10 PASS not_null_fct_daily_rt_feed_files_gtfs_dataset_key ................. [PASS in 1.06s]
18:08:51  6 of 10 START test not_null_fct_daily_rt_feed_files_parse_success_file_count ... [RUN]
18:08:51  4 of 10 PASS not_null_fct_daily_rt_feed_files_key .............................. [PASS in 1.07s]
18:08:51  7 of 10 START test relationships_fct_daily_rt_feed_files_gtfs_dataset_key__key__ref_dim_gtfs_datasets_  [RUN]
18:08:51  2 of 10 PASS not_null_fct_daily_rt_feed_files_base64_url ....................... [PASS in 1.08s]
18:08:51  8 of 10 START test relationships_fct_daily_rt_feed_files_schedule_feed_key__key__ref_dim_schedule_feeds_  [RUN]
18:08:51  5 of 10 PASS not_null_fct_daily_rt_feed_files_parse_failure_file_count ......... [PASS in 1.10s]
18:08:51  9 of 10 START test relationships_fct_daily_rt_feed_files_schedule_to_use_for_rt_validation_gtfs_dataset_key__key__ref_dim_gtfs_datasets_  [RUN]
18:08:52  6 of 10 PASS not_null_fct_daily_rt_feed_files_parse_success_file_count ......... [PASS in 0.98s]
18:08:52  10 of 10 START test unique_fct_daily_rt_feed_files_key ......................... [RUN]
18:08:52  7 of 10 PASS relationships_fct_daily_rt_feed_files_gtfs_dataset_key__key__ref_dim_gtfs_datasets_  [PASS in 1.08s]
18:08:52  9 of 10 PASS relationships_fct_daily_rt_feed_files_schedule_to_use_for_rt_validation_gtfs_dataset_key__key__ref_dim_gtfs_datasets_  [PASS in 1.06s]
18:08:52  8 of 10 PASS relationships_fct_daily_rt_feed_files_schedule_feed_key__key__ref_dim_schedule_feeds_  [PASS in 1.10s]
18:08:53  10 of 10 PASS unique_fct_daily_rt_feed_files_key ............................... [PASS in 0.98s]
18:08:53
18:08:53  Finished running 1 incremental model, 9 tests in 0 hours 0 minutes and 11.02 seconds (11.02s).
18:08:53
18:08:53  Completed successfully
18:08:53
18:08:53  Done. PASS=10 WARN=0 ERROR=0 SKIP=0 TOTAL=10
```