### PR TITLE
new check for rt modification date presence

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -151,6 +151,18 @@
 "The GTFS Schedule API endpoint is configured to report the file modification date"
 {% endmacro %}
 
+{% macro modification_date_present_service_alerts() %}
+"The Service alerts API endpoint is configured to report the file modification date"
+{% endmacro %}
+
+{% macro modification_date_present_vehicle_positions() %}
+"The Vehicle positions API endpoint is configured to report the file modification date"
+{% endmacro %}
+
+{% macro modification_date_present_trip_updates() %}
+"The Trip updates API endpoint is configured to report the file modification date"
+{% endmacro %}
+
 --
 -- FEATURE NAMES
 --

--- a/warehouse/macros/gtfs_rt_stg_outcomes.sql
+++ b/warehouse/macros/gtfs_rt_stg_outcomes.sql
@@ -25,10 +25,10 @@ stg_gtfs_rt__agg_outcomes AS (
         base64_url,
         {% if step == 'parse' %}
         header,
-        JSON_VALUE(`extract`.response_headers, '$."Last-Modified"') AS last_modified_string,
-        CASE WHEN JSON_VALUE(`extract`.response_headers, '$."Last-Modified"') like '%GMT' THEN PARSE_TIMESTAMP("%a, %d %b %Y %H:%M:%S GMT", JSON_VALUE(`extract`.response_headers, '$."Last-Modified"'))
+        JSON_VALUE(`extract`.response_headers, '$."last_modified"') AS last_modified_string,
+        CASE WHEN JSON_VALUE(`extract`.response_headers, '$."last_modified"') like '%GMT' THEN PARSE_TIMESTAMP("%a, %d %b %Y %H:%M:%S GMT", JSON_VALUE(`extract`.response_headers, '$."last_modified"'))
              -- 1/28/2020 6:29:01 PM
-             WHEN JSON_VALUE(`extract`.response_headers, '$."Last-Modified"') like '%PM' THEN PARSE_TIMESTAMP("%m/%d/%Y %I:%M:%S %p", JSON_VALUE(`extract`.response_headers, '$."Last-Modified"'))
+             WHEN JSON_VALUE(`extract`.response_headers, '$."last_modified"') like '%PM' THEN PARSE_TIMESTAMP("%m/%d/%Y %I:%M:%S %p", JSON_VALUE(`extract`.response_headers, '$."last_modified"'))
         END AS last_modified_timestamp,
         {% endif %}
         `extract`.ts AS extract_ts

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -251,6 +251,14 @@ models:
     tests: *stg_gtfs_guideline_tests_rt
     columns: *stg_gtfs_guideline_columns
 
+  - name: int_gtfs_quality__rt_protobuf_error
+    tests: *stg_gtfs_guideline_tests_rt
+    columns: *stg_gtfs_guideline_columns
+
+  - name: int_gtfs_quality__modification_date_present_rt
+    tests: *stg_gtfs_guideline_tests_rt
+    columns: *stg_gtfs_guideline_columns
+
   - name: int_gtfs_quality__rt_https
     tests: *stg_gtfs_guideline_tests_rt
     # Reducing null_proportion minimum due to missing rows in rt_https check, due to missing data before Nov 22
@@ -270,10 +278,6 @@ models:
             - aggregator
       - dbt_utils.equal_rowcount:
           compare_model: ref('int_gtfs_quality__rt_feed_guideline_index_aggregator')
-    columns: *stg_gtfs_guideline_columns
-
-  - name: int_gtfs_quality__rt_protobuf_error
-    tests: *stg_gtfs_guideline_tests_rt
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__no_stale_vehicle_positions

--- a/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.md
@@ -45,5 +45,7 @@ Here is a list of currently-implemented checks:
 | Vehicle positions RT feed is listed on feed aggregator Mobility Database | Feed Aggregator Availability (RT) | Vehicle positions RT feed is present on the feed aggregator Mobility Database. |
 | Trip updates RT feed is listed on feed aggregator Mobility Database | Feed Aggregator Availability (RT) | Trip updates RT feed is present on the feed aggregator Mobility Database. |
 | Service alerts RT feed is listed on feed aggregator Mobility Database | Feed Aggregator Availability (RT) | Service alerts RT feed is present on the feed aggregator Mobility Database. |
-
+| The Service alerts API endpoint is configured to report the file modification date | Best Practices Alignment (RT) | When the Service alerts API endpoint is requested, the response header includes a field called "Last-Modified". |
+| The Vehicle positions API endpoint is configured to report the file modification date | Best Practices Alignment (RT) | When the Vehicle Positions API endpoint is requested, the response header includes a field called "Last-Modified". |
+| The Trip updates API endpoint is configured to report the file modification date | Best Practices Alignment (RT) | When the Trip updates API endpoint is requested, the response header includes a field called "Last-Modified". |
 {% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
@@ -30,5 +30,7 @@ Here is a list of currently-implemented checks:
 | Vehicle positions RT feed is listed on feed aggregator Mobility Database | Feed Aggregator Availability (RT) | Vehicle positions RT feed is present on the feed aggregator Mobility Database. |
 | Trip updates RT feed is listed on feed aggregator Mobility Database | Feed Aggregator Availability (RT) | Trip updates RT feed is present on the feed aggregator Mobility Database. |
 | Service alerts RT feed is listed on feed aggregator Mobility Database | Feed Aggregator Availability (RT) | Service alerts RT feed is present on the feed aggregator Mobility Database. |
-
+| The Service alerts API endpoint is configured to report the file modification date | Best Practices Alignment (RT) | When the Service alerts API endpoint is requested, the response header includes a field called "Last-Modified". |
+| The Vehicle positions API endpoint is configured to report the file modification date | Best Practices Alignment (RT) | When the Vehicle Positions API endpoint is requested, the response header includes a field called "Last-Modified". |
+| The Trip updates API endpoint is configured to report the file modification date | Best Practices Alignment (RT) | When the Trip updates API endpoint is requested, the response header includes a field called "Last-Modified". |
 {% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.sql
@@ -14,6 +14,7 @@ unioned AS (
             ref('int_gtfs_quality__no_stale_service_alerts'),
             ref('int_gtfs_quality__no_stale_trip_updates'),
             ref('int_gtfs_quality__feed_aggregator_rt'),
+            ref('int_gtfs_quality__modification_date_present_rt'),
         ],
     ) }}
 ),

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -74,7 +74,13 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ trip_updates_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}
     UNION ALL
-    SELECT {{ service_alerts_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }} #}
+    SELECT {{ service_alerts_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}
+    UNION ALL
+    SELECT {{ modification_date_present_service_alerts() }}, {{ best_practices_alignment_rt() }}
+    UNION ALL
+    SELECT {{ modification_date_present_vehicle_positions() }}, {{ best_practices_alignment_rt() }}
+    UNION ALL
+    SELECT {{ modification_date_present_trip_updates() }}, {{ best_practices_alignment_rt() }}
 )
 
 SELECT * FROM stg_gtfs_quality__intended_checks


### PR DESCRIPTION
# Description

Checks for presence of modification date for each RT file.
Update macro to properly assign last-modified timestamp (i confirmed that they are being pulled through)

Resolves # [issue]

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
`./dbt.sh build -s int_gtfs_quality__modification_date_present_rt+`

