### PR TITLE
Patch Missing Docstrings for Open Data Publication

### DIFF
--- a/warehouse/models/docs/gtfs schedule/transfers.md
+++ b/warehouse/models/docs/gtfs schedule/transfers.md
@@ -19,15 +19,19 @@ Indicates the type of connection for the specified (from_stop_id, to_stop_id) pa
 
 {% docs gtfs_transfers__min_transfer_time %}
 Amount of time, in seconds, that must be available to permit a transfer between routes at the specified stops. The min_transfer_time should be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route.
+{% enddocs %}
 
 {% docs gtfs_transfers__from_route_id %}
 Identifies a route where a connection begins. If from_route_id is defined, the transfer will apply to the arriving trip on the route for the given from_stop_id. If both from_trip_id and from_route_id are defined, the trip_id must belong to the route_id, and from_trip_id will take precedence.
+{% enddocs %}
 
 {% docs gtfs_transfers__to_route_id %}
 Identifies a route where a connection ends. If to_route_id is defined, the transfer will apply to the departing trip on the route for the given to_stop_id. If both to_trip_id and to_route_id are defined, the trip_id must belong to the route_id, and to_trip_id will take precedence.
+{% enddocs %}
 
 {% docs gtfs_transfers__from_trip_id %}
 Identifies a trip where a connection between routes begins. If from_trip_id is defined, the transfer will apply to the arriving trip for the given from_stop_id. If both from_trip_id and from_route_id are defined, the trip_id must belong to the route_id, and from_trip_id will take precedence. REQUIRED if transfer_type is 4 or 5.
+{% enddocs %}
 
 {% docs gtfs_transfers__to_trip_id %}
 Identifies a trip where a connection between routes ends. If to_trip_id is defined, the transfer will apply to the departing trip for the given to_stop_id. If both to_trip_id and to_route_id are defined, the trip_id must belong to the route_id, and to_trip_id will take precedence. REQUIRED if transfer_type is 4 or 5.

--- a/warehouse/models/docs/gtfs schedule/transfers.md
+++ b/warehouse/models/docs/gtfs schedule/transfers.md
@@ -19,4 +19,16 @@ Indicates the type of connection for the specified (from_stop_id, to_stop_id) pa
 
 {% docs gtfs_transfers__min_transfer_time %}
 Amount of time, in seconds, that must be available to permit a transfer between routes at the specified stops. The min_transfer_time should be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route.
+
+{% docs gtfs_transfers__from_route_id %}
+Identifies a route where a connection begins. If from_route_id is defined, the transfer will apply to the arriving trip on the route for the given from_stop_id. If both from_trip_id and from_route_id are defined, the trip_id must belong to the route_id, and from_trip_id will take precedence.
+
+{% docs gtfs_transfers__to_route_id %}
+Identifies a route where a connection ends. If to_route_id is defined, the transfer will apply to the departing trip on the route for the given to_stop_id. If both to_trip_id and to_route_id are defined, the trip_id must belong to the route_id, and to_trip_id will take precedence.
+
+{% docs gtfs_transfers__from_trip_id %}
+Identifies a trip where a connection between routes begins. If from_trip_id is defined, the transfer will apply to the arriving trip for the given from_stop_id. If both from_trip_id and from_route_id are defined, the trip_id must belong to the route_id, and from_trip_id will take precedence. REQUIRED if transfer_type is 4 or 5.
+
+{% docs gtfs_transfers__to_trip_id %}
+Identifies a trip where a connection between routes ends. If to_trip_id is defined, the transfer will apply to the departing trip for the given to_stop_id. If both to_trip_id and to_route_id are defined, the trip_id must belong to the route_id, and to_trip_id will take precedence. REQUIRED if transfer_type is 4 or 5.
 {% enddocs %}

--- a/warehouse/models/mart/gtfs/_mart_gtfs.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs.yml
@@ -1006,9 +1006,13 @@ models:
       - name: min_transfer_time
         description: '{{ doc("gtfs_transfers__min_transfer_time") }}'
       - name: from_route_id
+        description: '{{ doc("gtfs_transfers__from_route_id") }}'
       - name: to_route_id
+        description: '{{ doc("gtfs_transfers__to_route_id") }}'
       - name: from_trip_id
+        description: '{{ doc("gtfs_transfers__from_trip_id") }}'
       - name: to_trip_id
+        description: '{{ doc("gtfs_transfers__to_trip_id") }}'
       - *_valid_from
       - *_valid_to
       - *_is_current
@@ -1196,9 +1200,8 @@ models:
           where: "not warning_duplicate_primary_key"
           gaps: required
     columns:
-      - name: base64_url
       - *feed_key
-      - name: ts
+      - *base64_url
       - name: key
         description: |
           Synthetic primary key constructed from `feed_key`, `trip_id`, and `stop_sequence`.

--- a/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
+++ b/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
@@ -28,6 +28,8 @@ models:
           - relationships:
               to: ref('dim_schedule_feeds')
               field: key
+        meta:
+          publish.ignore: true
       - &base64_url
         name: base64_url
         description: |
@@ -532,9 +534,8 @@ models:
       ckan.authority: https://gtfs.org/reference/static#stop_timestxt
       publish.gis_coordinate_system_epsg: WGS84
     columns:
-      - name: base64_url
       - *feed_key
-      - name: ts
+      - *base64_url
       - name: key
         description: |
           Synthetic primary key constructed from `feed_key`, `trip_id`, and `stop_sequence`.
@@ -694,9 +695,13 @@ models:
       - name: min_transfer_time
         description: '{{ doc("gtfs_transfers__min_transfer_time") }}'
       - name: from_route_id
+        description: '{{ doc("gtfs_transfers__from_route_id") }}'
       - name: to_route_id
+        description: '{{ doc("gtfs_transfers__to_route_id") }}'
       - name: from_trip_id
+        description: '{{ doc("gtfs_transfers__from_trip_id") }}'
       - name: to_trip_id
+        description: '{{ doc("gtfs_transfers__to_trip_id") }}'
       - *_valid_from
       - *_valid_to
       - *_is_current


### PR DESCRIPTION
# Description

This PR makes some small changes to the columns available for open data publication (namely, ignoring feed_key), and makes sure that field descriptions are filled in for the remaining published fields.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

Documentation regenerated locally and provided to CDOT prior to publication