### PR TITLE
switch rt feed presence check to new daily rt url index

### DIFF
--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -21,6 +21,26 @@ models:
             - base64_url
             - date
 
+  - name: int_gtfs_quality__rt_feed_guideline_index
+    description: |
+      Daily index of v2 RT feeds. Provides structure for
+      individual check models to be joined together by day.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - base64_url
+            - date
+
+  - name: int_gtfs_quality__rt_url_guideline_index
+    description: |
+      Daily index of v2 schedule urls. Provides structure for
+      individual check models to be joined together by day.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - base64_url
+            - date
+
   - name: int_gtfs_quality__rt_validation_outcomes
     description: |
       Unioned, incremental table of RT validation outcomes.
@@ -218,6 +238,19 @@ models:
       - extreme_results
     columns: *stg_gtfs_guideline_columns
 
+# Schedule URL checks
+
+  - name: int_gtfs_quality__schedule_download_success
+    tests: &stg_gtfs_guideline_tests_schedule_url
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date
+            - base64_url
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('int_gtfs_quality__schedule_url_guideline_index')
+      - extreme_results
+    columns: *stg_gtfs_guideline_columns
+
 # RT feed checks
 
   - name: int_gtfs_quality__no_rt_validation_errors
@@ -232,10 +265,6 @@ models:
     columns: *stg_gtfs_guideline_columns
 
   - name: int_gtfs_quality__trip_id_alignment
-    tests: *stg_gtfs_guideline_tests_rt
-    columns: *stg_gtfs_guideline_columns
-
-  - name: int_gtfs_quality__rt_feeds_present
     tests: *stg_gtfs_guideline_tests_rt
     columns: *stg_gtfs_guideline_columns
 
@@ -289,13 +318,16 @@ models:
     tests: *stale_rt_guideline_check_tests
     columns: *stale_rt_guideline_check_columns
 
-  - name: int_gtfs_quality__schedule_download_success
-    tests: &stg_gtfs_guideline_tests_schedule_url
+
+# RT URL checks
+
+  - name: int_gtfs_quality__rt_feeds_present
+    tests: &stg_gtfs_guideline_tests_rt_url
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - date
             - base64_url
       - dbt_utils.equal_rowcount:
-          compare_model: ref('int_gtfs_quality__schedule_url_guideline_index')
+          compare_model: ref('int_gtfs_quality__rt_url_guideline_index')
       - extreme_results
     columns: *stg_gtfs_guideline_columns

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feeds_present.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_feeds_present.sql
@@ -1,5 +1,5 @@
 WITH feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index') }}
+    SELECT * FROM {{ ref('int_gtfs_quality__rt_url_guideline_index') }}
 ),
 
 fct_daily_rt_feed_files AS (
@@ -29,7 +29,7 @@ int_gtfs_quality__rt_feeds_present AS (
         rt_files,
         CASE
             WHEN rt_files > 0 THEN "PASS"
-            WHEN rt_files = 0 THEN "FAIL"
+            WHEN COALESCE(rt_files,0) = 0 THEN "FAIL"
         END AS status,
     FROM feed_guideline_index AS idx
     LEFT JOIN count_files AS files

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_url_guideline_index.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_url_guideline_index.sql
@@ -1,0 +1,17 @@
+{{ config(materialized='ephemeral') }}
+
+WITH int_gtfs_rt__daily_url_index  AS (
+    SELECT * FROM {{ ref('int_gtfs_rt__daily_url_index') }}
+),
+
+-- we never want results from the current date, as data will be incomplete
+int_gtfs_quality__rt_url_guideline_index AS (
+    SELECT
+        dt AS date,
+        base64_url,
+        type AS feed_type
+    FROM int_gtfs_rt__daily_url_index
+    WHERE dt < CURRENT_DATE
+)
+
+SELECT * FROM int_gtfs_quality__rt_url_guideline_index

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -67,8 +67,8 @@ models:
       - *base64_url
       - *check
 
-  - name: fct_daily_schedule_rt_guideline_checks
-    description: '{{ doc("fct_daily_schedule_rt_guideline_checks") }}'
+  - name: fct_daily_rt_url_guideline_checks
+    description: '{{ doc("fct_daily_rt_url_guideline_checks") }}'
     columns:
       - *key
       - *date

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -67,6 +67,14 @@ models:
       - *base64_url
       - *check
 
+  - name: fct_daily_schedule_rt_guideline_checks
+    description: '{{ doc("fct_daily_schedule_rt_guideline_checks") }}'
+    columns:
+      - *key
+      - *date
+      - *base64_url
+      - *check
+
   - name: fct_daily_rt_feed_validation_notices
     description: |
       A daily model of validation notices found per feed. Data

--- a/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
@@ -26,6 +26,11 @@ schedule_url_checks AS (
     FROM {{ ref('fct_daily_schedule_url_guideline_checks') }}
 ),
 
+rt_url_checks AS (
+    SELECT *
+    FROM {{ ref('fct_daily_rt_url_guideline_checks') }}
+),
+
 idx AS (
     SELECT
         implemented_checks.*,
@@ -75,6 +80,10 @@ fct_daily_guideline_checks AS (
         ON idx.date = schedule_url_checks.date
         AND idx.base64_url = schedule_url_checks.base64_url
         AND idx.check = schedule_url_checks.check
+    LEFT JOIN rt_url_checks
+        ON idx.date = rt_url_checks.date
+        AND idx.base64_url = rt_url_checks.base64_url
+        AND idx.check = rt_url_checks.check
 )
 
 SELECT * FROM fct_daily_guideline_checks

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_url_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_url_guideline_checks.md
@@ -1,0 +1,16 @@
+{% docs fct_daily_rt_url_guideline_checks %}
+
+Each row represents a date/guideline check/RT url combination, with pass/fail
+information indicating whether that RT url complied with that check on that date.
+A row will exist for every check, for every row from the index which is driven
+by int_gtfs_rt__daily_url_index. Only contains checks that are performed at the RT url
+level.
+
+Here is a list of currently-implemented checks:
+
+| Check | Feature | Description |
+| ------------------------------------ |---------|------------ |
+|Vehicle positions RT feed is present | Compliance (RT) | The vehicle positions RT feed contains at least one file on the given day.|
+| Trip updates RT feed is present | Compliance (RT) | The trip updates RT feed contains at least one file on the given day.|
+| Service alerts RT feed is present | Compliance (RT) | The service alerts RT feed contains at least one file on the given day.|
+{% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_url_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_url_guideline_checks.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+WITH
+
+unioned AS (
+    {{ dbt_utils.union_relations(
+        relations=[
+            ref('int_gtfs_quality__rt_feeds_present'),
+        ],
+    ) }}
+),
+
+fct_daily_rt_url_guideline_checks AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['date', 'base64_url', 'check']) }} AS key,
+        *
+    FROM unioned
+)
+
+SELECT * FROM fct_daily_rt_url_guideline_checks


### PR DESCRIPTION
# Description

New RT url index table to fix rt_feeds_present check. Related to #2192 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I ran `dbt build` on each of the new & updated tables.
Reviewed a failing feed and confirmed it was a bad URL (old GRaaS URL)
