### PR TITLE
Updates to apostrophe formatting and excluded columns for open data publishing

### DIFF
--- a/warehouse/models/docs/gtfs schedule/agency.md
+++ b/warehouse/models/docs/gtfs schedule/agency.md
@@ -29,5 +29,5 @@ URL of a web page that allows a rider to purchase tickets or other fare instrume
 {% enddocs %}
 
 {% docs gtfs_agency__agency_email %}
-Email address actively monitored by the agency’s customer service department. This email address should be a direct contact point where transit riders can reach a customer service representative at the agency.
+Email address actively monitored by the agency's customer service department. This email address should be a direct contact point where transit riders can reach a customer service representative at the agency.
 {% enddocs %}

--- a/warehouse/models/docs/gtfs schedule/attributions.md
+++ b/warehouse/models/docs/gtfs schedule/attributions.md
@@ -25,7 +25,7 @@ Name of the organization that the dataset is attributed to.
 {% docs gtfs_attributions__is_producer %}
 The role of the organization is producer. Valid options are:
 
-0 or empty - Organization doesn’t have this role.
+0 or empty - Organization doesn't have this role.
 1 - Organization does have this role.
 
 At least one of the fields is_producer, is_operator, or is_authority should be set at 1.

--- a/warehouse/models/docs/gtfs schedule/calendar.md
+++ b/warehouse/models/docs/gtfs schedule/calendar.md
@@ -36,9 +36,9 @@ Functions in the same way as monday except applies to Sundays.
 {% enddocs %}
 
 {% docs gtfs_calendar__start_date %}
-Start service day for the service interval.
+Start service day for the service interval in YYYY-MM-DD format.
 {% enddocs %}
 
 {% docs gtfs_calendar__end_date %}
-End service day for the service interval. This service day is included in the interval.
+End service day for the service interval in YYYY-MM-DD format. This service day is included in the interval.
 {% enddocs %}

--- a/warehouse/models/docs/gtfs schedule/calendar_dates.md
+++ b/warehouse/models/docs/gtfs schedule/calendar_dates.md
@@ -5,7 +5,7 @@ Identifies a set of dates when a service exception occurs for one or more routes
 {% enddocs %}
 
 {% docs gtfs_calendar_dates__date %}
-Date when service exception occurs.
+Date when service exception occurs in YYYY-MM-DD format.
 {% enddocs %}
 
 {% docs gtfs_calendar_dates__exception_type %}

--- a/warehouse/models/docs/gtfs schedule/feed_info.md
+++ b/warehouse/models/docs/gtfs schedule/feed_info.md
@@ -18,15 +18,15 @@ original text in the dataset is in the same language, then mul should not be use
 {% enddocs %}
 
 {% docs gtfs_feed_info__default_lang %}
-Defines the language that should be used when the data consumer doesn’t know the language of the rider. It will often be en (English).
+Defines the language that should be used when the data consumer doesn't know the language of the rider. It will often be en (English).
 {% enddocs %}
 
 {% docs gtfs_feed_info__feed_start_date %}
-The dataset provides complete and reliable schedule information for service in the period from the beginning of the feed_start_date day to the end of the feed_end_date day. Both days can be left empty if unavailable. The feed_end_date date must not precede the feed_start_date date if both are given. Dataset providers are encouraged to give schedule data outside this period to advise of likely future service, but dataset consumers should treat it mindful of its non-authoritative status. If feed_start_date or feed_end_date extend beyond the active calendar dates defined in calendar.txt and calendar_dates.txt, the dataset is making an explicit assertion that there is no service for dates within the feed_start_date or feed_end_date range but not included in the active calendar dates.
+YYYY-MM-DD format. The dataset provides complete and reliable schedule information for service in the period from the beginning of the feed_start_date day to the end of the feed_end_date day. Both days can be left empty if unavailable. The feed_end_date date must not precede the feed_start_date date if both are given. Dataset providers are encouraged to give schedule data outside this period to advise of likely future service, but dataset consumers should treat it mindful of its non-authoritative status. If feed_start_date or feed_end_date extend beyond the active calendar dates defined in calendar.txt and calendar_dates.txt, the dataset is making an explicit assertion that there is no service for dates within the feed_start_date or feed_end_date range but not included in the active calendar dates.
 {% enddocs %}
 
 {% docs gtfs_feed_info__feed_end_date %}
-(see above)
+YYYY-MM-DD format. The dataset provides complete and reliable schedule information for service in the period from the beginning of the feed_start_date day to the end of the feed_end_date day. Both days can be left empty if unavailable. The feed_end_date date must not precede the feed_start_date date if both are given. Dataset providers are encouraged to give schedule data outside this period to advise of likely future service, but dataset consumers should treat it mindful of its non-authoritative status. If feed_start_date or feed_end_date extend beyond the active calendar dates defined in calendar.txt and calendar_dates.txt, the dataset is making an explicit assertion that there is no service for dates within the feed_start_date or feed_end_date range but not included in the active calendar dates.
 {% enddocs %}
 
 {% docs gtfs_feed_info__feed_version %}

--- a/warehouse/models/docs/gtfs schedule/frequencies.md
+++ b/warehouse/models/docs/gtfs schedule/frequencies.md
@@ -5,11 +5,11 @@ Identifies a trip to which the specified headway of service applies.
 {% enddocs %}
 
 {% docs gtfs_frequencies__start_time %}
-Time at which the first vehicle departs from the first stop of the trip with the specified headway.
+HH:MM:SS format. Time at which the first vehicle departs from the first stop of the trip with the specified headway.
 {% enddocs %}
 
 {% docs gtfs_frequencies__end_time %}
-Time at which service changes to a different headway (or ceases) at the first stop in the trip.
+HH:MM:SS format. Time at which service changes to a different headway (or ceases) at the first stop in the trip.
 {% enddocs %}
 
 {% docs gtfs_frequencies__headway_secs %}

--- a/warehouse/models/docs/gtfs schedule/routes.md
+++ b/warehouse/models/docs/gtfs schedule/routes.md
@@ -52,7 +52,7 @@ Orders the routes in a way which is ideal for presentation to customers. Routes 
 {% enddocs %}
 
 {% docs gtfs_routes__continuous_pickup %}
-Indicates that the rider can board the transit vehicle at any point along the vehicle’s travel path as described by shapes.txt, on every trip of the route. Valid options are:
+Indicates that the rider can board the transit vehicle at any point along the vehicle's travel path as described by shapes.txt, on every trip of the route. Valid options are:
 
 0 - Continuous stopping pickup.
 1 or empty - No continuous stopping pickup.
@@ -63,7 +63,7 @@ The continuous pickup behavior defined in routes.txt can be overridden in stop_t
 {% enddocs %}
 
 {% docs gtfs_routes__continuous_drop_off %}
-Indicates that the rider can alight from the transit vehicle at any point along the vehicle’s travel path as described by shapes.txt, on every trip of the route. Valid options are:
+Indicates that the rider can alight from the transit vehicle at any point along the vehicle's travel path as described by shapes.txt, on every trip of the route. Valid options are:
 
 0 - Continuous stopping drop off.
 1 or empty - No continuous stopping drop off.

--- a/warehouse/models/docs/gtfs schedule/stop_times.md
+++ b/warehouse/models/docs/gtfs schedule/stop_times.md
@@ -5,13 +5,13 @@ Identifies a trip.
 {% enddocs %}
 
 {% docs gtfs_stop_times__arrival_time %}
-Arrival time at a specific stop for a specific trip on a route. If there are not separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins.
+HH:MM:SS format. Arrival time at a specific stop for a specific trip on a route. If there are not separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins.
 
 Scheduled stops where the vehicle strictly adheres to the specified arrival and departure times are timepoints. If this stop is not a timepoint, it is recommended to provide an estimated or interpolated time. If this is not available, arrival_time can be left empty. Further, indicate that interpolated times are provided with timepoint=0. If interpolated times are indicated with timepoint=0, then time points must be indicated with timepoint=1. Provide arrival times for all stops that are time points. An arrival time must be specified for the first and the last stop in a trip.
 {% enddocs %}
 
 {% docs gtfs_stop_times__departure_time %}
-Departure time from a specific stop for a specific trip on a route. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If there are not separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time. See the arrival_time description for more details about using timepoints correctly.
+HH:MM:SS format. Departure time from a specific stop for a specific trip on a route. For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins. If there are not separate times for arrival and departure at a stop, enter the same value for arrival_time and departure_time. See the arrival_time description for more details about using timepoints correctly.
 
  The departure_time field should specify time values whenever possible, including non-binding estimated or interpolated times between timepoints.
 {% enddocs %}
@@ -49,7 +49,7 @@ Indicates drop off method. Valid options are:
 {% enddocs %}
 
 {% docs gtfs_stop_times__continuous_pickup %}
-Indicates that the rider can board the transit vehicle at any point along the vehicle’s travel path as described by shapes.txt, from this stop_time to the next stop_time in the trip’s stop_sequence. Valid options are:
+Indicates that the rider can board the transit vehicle at any point along the vehicle's travel path as described by shapes.txt, from this stop_time to the next stop_time in the trip's stop_sequence. Valid options are:
 
 0 - Continuous stopping pickup.
 1 or empty - No continuous stopping pickup.
@@ -60,7 +60,7 @@ If this field is populated, it overrides any continuous pickup behavior defined 
 {% enddocs %}
 
 {% docs gtfs_stop_times__continuous_drop_off %}
-Indicates that the rider can alight from the transit vehicle at any point along the vehicle’s travel path as described by shapes.txt, from this stop_time to the next stop_time in the trip’s stop_sequence. Valid options are:
+Indicates that the rider can alight from the transit vehicle at any point along the vehicle's travel path as described by shapes.txt, from this stop_time to the next stop_time in the trip's stop_sequence. Valid options are:
 
 0 - Continuous stopping drop off.
 1 or empty - No continuous stopping drop off.

--- a/warehouse/models/docs/gtfs schedule/stops.md
+++ b/warehouse/models/docs/gtfs schedule/stops.md
@@ -13,7 +13,7 @@ Short text or a number that identifies the location for riders. These codes are 
 {% docs gtfs_stops__stop_name %}
 Name of the location. Use a name that people will understand in the local and tourist vernacular.
 
-When the location is a boarding area (location_type=4), the stop_name should contains the name of the boarding area as displayed by the agency. It could be just one letter (like on some European intercity railway stations), or text like “Wheelchair boarding area” (NYC’s Subway) or “Head of short trains” (Paris’ RER).
+When the location is a boarding area (location_type=4), the stop_name should contains the name of the boarding area as displayed by the agency. It could be just one letter (like on some European intercity railway stations), or text like “Wheelchair boarding area” (NYC's Subway) or “Head of short trains” (Paris' RER).
 
 Conditionally Required:
 • Required for locations which are stops (location_type=0), stations (location_type=1) or entrances/exits (location_type=2).
@@ -79,7 +79,7 @@ Conditionally Required:
 {% enddocs %}
 
 {% docs gtfs_stops__stop_timezone %}
-Timezone of the location. If the location has a parent station, it inherits the parent station’s timezone instead of applying its own. Stations and parentless stops with empty stop_timezone inherit the timezone specified by agency.agency_timezone. If stop_timezone values are provided, the times in stop_times.txt should be entered as the time since midnight in the timezone specified by agency.agency_timezone. This ensures that the time values in a trip always increase over the course of a trip, regardless of which timezones the trip crosses.
+Timezone of the location. If the location has a parent station, it inherits the parent station's timezone instead of applying its own. Stations and parentless stops with empty stop_timezone inherit the timezone specified by agency.agency_timezone. If stop_timezone values are provided, the times in stop_times.txt should be entered as the time since midnight in the timezone specified by agency.agency_timezone. This ensures that the time values in a trip always increase over the course of a trip, regardless of which timezones the trip crosses.
 {% enddocs %}
 
 {% docs gtfs_stops__wheelchair_boarding %}
@@ -106,5 +106,5 @@ Level of the location. The same level can be used by multiple unlinked stations.
 {% enddocs %}
 
 {% docs gtfs_stops__platform_code %}
-Platform identifier for a platform stop (a stop belonging to a station). This should be just the platform identifier (eg. "G" or "3"). Words like “platform” or "track" (or the feed’s language-specific equivalent) should not be included. This allows feed consumers to more easily internationalize and localize the platform identifier into other languages.
+Platform identifier for a platform stop (a stop belonging to a station). This should be just the platform identifier (eg. "G" or "3"). Words like “platform” or "track" (or the feed's language-specific equivalent) should not be included. This allows feed consumers to more easily internationalize and localize the platform identifier into other languages.
 {% enddocs %}

--- a/warehouse/models/docs/gtfs schedule/translations.md
+++ b/warehouse/models/docs/gtfs schedule/translations.md
@@ -47,7 +47,7 @@ Conditionally Required:
 {% enddocs %}
 
 {% docs gtfs_translations__record_sub_id %}
-Helps the record that contains the field to be translated when the table doesn’t
+Helps the record that contains the field to be translated when the table doesn't
 have a unique ID. Therefore, the value in record_sub_id is the secondary ID of
 the table, as defined by the table below:
 • None for agency;
@@ -80,7 +80,7 @@ Conditionally Required:
 {% docs gtfs_translations__field_value %}
 Instead of defining which record should be translated by using record_id and record_sub_id, this field can be used to define the value which should be translated. When used, the translation will be applied when the fields identified by table_name and field_name contains the exact same value defined in field_value.
 
-The field must have exactly the value defined in field_value. If only a subset of the value matches field_value, the translation won’t be applied.
+The field must have exactly the value defined in field_value. If only a subset of the value matches field_value, the translation won't be applied.
 
 If two translation rules match the same record (one with field_value, and the other one with record_id), then the rule with record_id is the one which should be used.
 

--- a/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
+++ b/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
@@ -578,10 +578,14 @@ models:
           Rows with `true` in this column have a duplicate primary key; i.e., the given `trip_id`
           / `stop_sequence` pair is duplicated within an individual feed instance and `key` will
           also be duplicated as a result. Treat these rows with caution. They will cause fanout in joins.
+        meta:
+          publish.ignore: true
       - name: warning_missing_foreign_key_stop_id
         description: |
           Rows with `true` in this column are missing the required `stop_id` value.
           This means they will fail to join with `stop` related information.
+        meta:
+          publish.ignore: true
       - name: arrival_sec
         description: |
           This is a calculated field that does not come from GTFS - it is not a timestamp and can't be treated as such.


### PR DESCRIPTION
# Description

Responsive to feedback from Chad at CDOT during the publishing process, this PR makes some changes to docstrings and exposed columns in the tables that end up published in some form on the state of California data table. This includes substitutions of apostrophes in utf-8 compliant format, plus some other small modifications.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?
Documentation dictionary for publishing regenerated via publish.py and validated against a utf-8 validator.