### PR TITLE
Connect new open data publication tables to mart

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -77,3 +77,5 @@ models:
         schema: mart_ad_hoc
       audit:
         schema: mart_audit
+      gtfs_schedule_latest:
+        schema: mart_gtfs_schedule_latest


### PR DESCRIPTION
# Description

Makes models under mart/gtfs_schedule_latest available in the mart_gtfs_schedule_latest dataset in BigQuery.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml
