### PR TITLE
make trip update quality checks cheaper

### DIFF
--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -512,3 +512,11 @@ models:
         description: |
           Timestamp for when the given row was inserted into the table.
           Primarily useful for debugging, not meaningful for general use.
+
+  - name: int_gtfs_rt__trip_updates_summaries
+    description: |
+      This is really intended to be a temporary table until
+      this work is done at the Airflow level, most likely.
+      Incrementally materialized trip updates data for use
+      downstream to minimize amount of raw data read from
+      GCS.

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_stale_trip_updates.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_stale_trip_updates.sql
@@ -25,7 +25,7 @@ feed_guideline_index AS (
 ),
 
 fct_trip_updates_messages AS (
-    SELECT * FROM {{ ref('fct_trip_updates_messages') }}
+    SELECT * FROM {{ ref('int_gtfs_rt__trip_updates_summaries') }}
     {% if is_incremental() %}
     WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_20sec_tu.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__rt_20sec_tu.sql
@@ -25,7 +25,7 @@ feed_guideline_index AS (
 ),
 
 trip_updates AS (
-    SELECT * FROM {{ ref('stg_gtfs_rt__trip_updates') }}
+    SELECT * FROM {{ ref('int_gtfs_rt__trip_updates_summaries') }}
     {% if is_incremental() %}
     WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}
@@ -34,23 +34,23 @@ trip_updates AS (
 ),
 
 lag_ts AS (
-  SELECT
-          dt AS date,
-          base64_url,
-          header_timestamp,
-          LAG (header_timestamp) OVER (PARTITION BY base64_url ORDER BY header_timestamp) AS prev_header_timestamp
+    SELECT
+        dt AS date,
+        base64_url,
+        header_timestamp,
+        LAG(header_timestamp) OVER (PARTITION BY base64_url ORDER BY header_timestamp) AS prev_header_timestamp
     FROM trip_updates
 ),
 
 -- Note that since the header_timestamp will repeat when it hasn't been updated, the DATE_DIFF will be 0 seconds for some.
 -- This would affect us if we were measuring the AVG(), but it doesn't since we're only looking at MAX()
 daily_max_lag AS (
-SELECT
-      date,
-      base64_url,
-      MAX(DATE_DIFF(header_timestamp, prev_header_timestamp, SECOND)) AS max_lag
-  FROM lag_ts
- GROUP BY 1,2
+    SELECT
+        date,
+        base64_url,
+        MAX(DATE_DIFF(header_timestamp, prev_header_timestamp, SECOND)) AS max_lag
+    FROM lag_ts
+    GROUP BY 1, 2
 ),
 
 int_gtfs_quality__rt_20sec_tu AS (

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_summaries.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_summaries.sql
@@ -1,0 +1,32 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by = {
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
+
+{% if is_incremental() %}
+    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set max_dt = dates[0] %}
+{% endif %}
+
+WITH
+
+trip_updates AS (
+    SELECT * FROM {{ ref('fct_trip_updates_messages') }}
+    {% if is_incremental() %}
+    WHERE dt >= '{{ max_dt }}'
+    {% else %}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL {{ var('TRIP_UPDATES_LOOKBACK_DAYS') }} DAY)
+    {% endif %}
+),
+
+int_gtfs_rt__trip_updates_summaries AS (
+    SELECT * EXCEPT (stop_time_updates)
+    FROM trip_updates
+)
+
+SELECT * FROM int_gtfs_rt__trip_updates_summaries


### PR DESCRIPTION
# Description

Doing this in advance of two other checks as well, that will query trip updates. Since the `stop_times_updates` are a large portion of trip update messages, it's relatively performant to incrementally materialize the rest of the fields and use that model for any quality checks that need trip updates. Otherwise, each check would re-read the raw data for each check model, even if those individual check models are made incremental.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Local dbt run; main tests pass on the downstream models

## Screenshots (optional)
