### PR TITLE
Add Redwood Coast Transit Swiftly RT URLs

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -998,9 +998,9 @@ redwood-coast-transit:
   agency_name: Redwood Coast Transit
   feeds:
     - gtfs_schedule_url: https://data.trilliumtransit.com/gtfs/delnorte-ca-us/delnorte-ca-us.zip
-      gtfs_rt_vehicle_positions_url: null
-      gtfs_rt_service_alerts_url: null
-      gtfs_rt_trip_updates_url: null
+      gtfs_rt_vehicle_positions_url: https://api.goswift.ly/real-time/redwood-coast-rct/gtfs-rt-vehicle-positions
+      gtfs_rt_service_alerts_url: https://api.goswift.ly/real-time/redwood-coast-rct/gtfs-rt-alerts
+      gtfs_rt_trip_updates_url: https://api.goswift.ly/real-time/redwood-coast-rct/gtfs-rt-trip-updates
   itp_id: 261
 ridgecrest-transit:
   agency_name: Ridgecrest Transit

--- a/airflow/data/headers.yml
+++ b/airflow/data/headers.yml
@@ -66,6 +66,12 @@
         - gtfs_rt_vehicle_positions_url
         - gtfs_rt_service_alerts_url
         - gtfs_rt_trip_updates_url
+    - itp_id: 261 # Redwood Coast Transit
+      url_number: 0
+      rt_urls:
+        - gtfs_rt_vehicle_positions_url
+        - gtfs_rt_service_alerts_url
+        - gtfs_rt_trip_updates_url
     - itp_id: 284 # San Joaquin Regional Transit District
       url_number: 0
       rt_urls:


### PR DESCRIPTION
# Description

Adds Swiftly RT URLs for Redwood Coast Transit

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] agencies.yml

## How has this been tested?

Downloaded locally
