### PR TITLE
fix daily guideline checks join

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -171,6 +171,10 @@
 "The Trip updates API endpoint is configured to report the file modification date"
 {% endmacro %}
 
+{% macro organization_has_contact_info() %}
+"The organization has contact information on the website."
+{% endmacro %}
+
 --
 -- FEATURE NAMES
 --

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__contact_on_website.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__contact_on_website.sql
@@ -12,9 +12,8 @@ int_gtfs_quality__contact_on_website AS (
     SELECT
         idx.date,
         idx.organization_key,
-        -- TODO: use real macros
-        'Organization has contact info on website' AS check,
-        'Has contact info' AS feature,
+        {{ organization_has_contact_info() }} AS check,
+        {{ technical_contact_availability() }} AS feature,
         CASE manual_check__contact_on_website
             WHEN 'Yes' THEN 'PASS'
             WHEN 'No' THEN 'FAIL'

--- a/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
@@ -93,6 +93,7 @@ fct_daily_guideline_checks AS (
     LEFT JOIN organization_checks
         ON idx.date = organization_checks.date
         AND idx.organization_key = organization_checks.organization_key
+        AND idx.check = organization_checks.check
 )
 
 SELECT * FROM fct_daily_guideline_checks

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -85,6 +85,10 @@ WITH stg_gtfs_quality__intended_checks AS (
     SELECT {{ modification_date_present_vehicle_positions() }}, {{ best_practices_alignment_rt() }}
     UNION ALL
     SELECT {{ modification_date_present_trip_updates() }}, {{ best_practices_alignment_rt() }}
+
+    -- MANUAL CHECKS
+    UNION ALL
+    SELECT {{ organization_has_contact_info() }}, {{ technical_contact_availability() }}
 )
 
 SELECT * FROM stg_gtfs_quality__intended_checks


### PR DESCRIPTION
# Description

Fixes bug introduced in https://github.com/cal-itp/data-infra/pull/2201

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Built fct_daily_guideline_checks and (soon to be) checked that status is null where expected

```
select *
from `cal-itp-data-infra-staging`.andrew_mart_gtfs_quality.fct_daily_guideline_checks
WHERE organization_key = '87a88b5598e8666c1298092f2cc5df8e' AND date = '2023-01-23' AND check LIKE "%Shapes.txt%"
;
```
Passes on schedule, null on RT

## Screenshots (optional)
