### PR TITLE
Test daily guideline checks

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -21,6 +21,18 @@
 'organization'
 {%- endmacro %}
 
+{% macro organization() -%}
+'service'
+{%- endmacro %}
+
+{% macro organization() -%}
+'gtfs_service_data'
+{%- endmacro %}
+
+{% macro organization() -%}
+'gtfs_dataset'
+{%- endmacro %}
+
 --
 -- CHECK NAMES
 --

--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -21,15 +21,15 @@
 'organization'
 {%- endmacro %}
 
-{% macro organization() -%}
+{% macro service() -%}
 'service'
 {%- endmacro %}
 
-{% macro organization() -%}
+{% macro gtfs_service_data() -%}
 'gtfs_service_data'
 {%- endmacro %}
 
-{% macro organization() -%}
+{% macro gtfs_dataset() -%}
 'gtfs_dataset'
 {%- endmacro %}
 

--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -1,4 +1,29 @@
+--
+-- ENTITIES
+--
+{% macro schedule_feed() %}
+'schedule_feed'
+{% endmacro %}
+
+{% macro schedule_url() %}
+'schedule_url'
+{% endmacro %}
+
+{% macro rt_feed() %}
+'rt_feed'
+{% endmacro %}
+
+{% macro rt_url() %}
+'rt_url'
+{% endmacro %}
+
+{% macro organization() %}
+'organization'
+{% endmacro %}
+
+--
 -- CHECK NAMES
+--
 {% macro static_feed_downloaded_successfully() %}
 "GTFS schedule feed downloads successfully"
 {% endmacro %}

--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -1,25 +1,25 @@
 --
 -- ENTITIES
 --
-{% macro schedule_feed() %}
+{% macro schedule_feed() -%}
 'schedule_feed'
-{% endmacro %}
+{%- endmacro %}
 
-{% macro schedule_url() %}
+{% macro schedule_url() -%}
 'schedule_url'
-{% endmacro %}
+{%- endmacro %}
 
-{% macro rt_feed() %}
+{% macro rt_feed() -%}
 'rt_feed'
-{% endmacro %}
+{%- endmacro %}
 
-{% macro rt_url() %}
+{% macro rt_url() -%}
 'rt_url'
-{% endmacro %}
+{%- endmacro %}
 
-{% macro organization() %}
+{% macro organization() -%}
 'organization'
-{% endmacro %}
+{%- endmacro %}
 
 --
 -- CHECK NAMES

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -213,7 +213,9 @@ models:
       - name: status
       - name: feature
       - name: matches_entity
+        description: Used for testing purposes only.
       - name: num_check_sources
+        description: Used for testing purposes only.
 
   - name: fct_daily_organization_combined_guideline_checks
     description: |

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -170,6 +170,8 @@ models:
     tests:
       - dbt_utils.expression_is_true:
           expression: "num_check_sources IS NULL OR num_check_sources <= 1"
+      - dbt_utils.expression_is_true:
+          expression: "matches_entity IS NULL OR matches_entity"
     columns:
       - *key
       - *date
@@ -210,6 +212,7 @@ models:
       - *check
       - name: status
       - name: feature
+      - name: matches_entity
       - name: num_check_sources
 
   - name: fct_daily_organization_combined_guideline_checks

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -167,6 +167,9 @@ models:
       - name: is_implemented
   - name: fct_daily_guideline_checks
     description: '{{ doc("fct_daily_guideline_checks") }}'
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "num_check_sources IS NULL OR num_check_sources <= 1"
     columns:
       - *key
       - *date
@@ -207,6 +210,8 @@ models:
       - *check
       - name: status
       - name: feature
+      - name: num_check_sources
+
   - name: fct_daily_organization_combined_guideline_checks
     description: |
       **Documentation coming soon**

--- a/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
@@ -76,9 +76,9 @@ fct_daily_guideline_checks AS (
         ) AS status,
         CASE
             WHEN schedule_feed_checks.status IS NOT NULL THEN idx.entity = {{ schedule_feed() }}
-            WHEN rt_feed_checks.status IS NOT NULL THEN idx.entity = {{ schedule_feed() }}
+            WHEN rt_feed_checks.status IS NOT NULL THEN idx.entity = {{ rt_feed() }}
             WHEN schedule_url_checks.status IS NOT NULL THEN idx.entity = {{ schedule_url() }}
-            WHEN rt_url_checks.status IS NOT NULL THEN idx.entity = {{ schedule_url() }}
+            WHEN rt_url_checks.status IS NOT NULL THEN idx.entity = {{ rt_url() }}
             WHEN organization_checks.status IS NOT NULL THEN idx.entity = {{ organization() }}
         END AS matches_entity,
         CASE WHEN schedule_feed_checks.status = 'PASS' THEN 1 ELSE 0 END

--- a/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.sql
@@ -81,11 +81,11 @@ fct_daily_guideline_checks AS (
             WHEN rt_url_checks.status IS NOT NULL THEN idx.entity = {{ rt_url() }}
             WHEN organization_checks.status IS NOT NULL THEN idx.entity = {{ organization() }}
         END AS matches_entity,
-        CASE WHEN schedule_feed_checks.status = 'PASS' THEN 1 ELSE 0 END
-        + CASE WHEN rt_feed_checks.status = 'PASS' THEN 1 ELSE 0 END
-        + CASE WHEN schedule_url_checks.status = 'PASS' THEN 1 ELSE 0 END
-        + CASE WHEN rt_url_checks.status = 'PASS' THEN 1 ELSE 0 END
-        + CASE WHEN organization_checks.status = 'PASS' THEN 1 ELSE 0 END
+        CASE WHEN schedule_feed_checks.status IS NOT NULL THEN 1 ELSE 0 END
+        + CASE WHEN rt_feed_checks.status IS NOT NULL THEN 1 ELSE 0 END
+        + CASE WHEN schedule_url_checks.status IS NOT NULL THEN 1 ELSE 0 END
+        + CASE WHEN rt_url_checks.status IS NOT NULL THEN 1 ELSE 0 END
+        + CASE WHEN organization_checks.status IS NOT NULL THEN 1 ELSE 0 END
         AS num_check_sources,
     FROM idx
     LEFT JOIN schedule_feed_checks

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.sql
@@ -6,7 +6,6 @@ unioned AS (
     {{ dbt_utils.union_relations(
         relations=[
             ref('int_gtfs_quality__no_rt_validation_errors'),
-            ref('int_gtfs_quality__rt_feeds_present'),
             ref('int_gtfs_quality__trip_id_alignment'),
             ref('int_gtfs_quality__rt_https'),
             ref('int_gtfs_quality__rt_20sec_vp'),

--- a/warehouse/models/staging/gtfs/gtfs_quality/_stg_gtfs_quality.yml
+++ b/warehouse/models/staging/gtfs/gtfs_quality/_stg_gtfs_quality.yml
@@ -10,6 +10,16 @@ models:
           combination_of_columns:
             - check
             - feature
+    columns:
+      - name: check
+        tests:
+          - not_null
+      - name: feature
+        tests:
+          - not_null
+      - name: entity
+        tests:
+          - not_null
 
   - name: stg_gtfs_quality__rt_validation_code_descriptions
     description: |

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -22,7 +22,7 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ no_rt_validation_errors() }}, {{ compliance_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}, {{ schedule_feed() }}
+    SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}, {{ rt_feed() }}
     UNION ALL
     SELECT {{ feed_present_vehicle_positions() }}, {{ compliance_rt() }}, {{ rt_url() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -1,94 +1,94 @@
 {{ config(materialized='ephemeral') }}
 WITH stg_gtfs_quality__intended_checks AS (
-    SELECT {{ static_feed_downloaded_successfully() }} AS check, {{ compliance_schedule() }} AS feature
+    SELECT {{ static_feed_downloaded_successfully() }} AS check, {{ compliance_schedule() }} AS feature, {{ schedule_url() }} AS entity
     UNION ALL
-    SELECT {{ no_validation_errors() }} AS check, {{ compliance_schedule() }} AS feature
+    SELECT {{ no_validation_errors() }}, {{ compliance_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ shapes_file_present() }}, {{ accurate_service_data() }}
+    SELECT {{ shapes_file_present() }}, {{ accurate_service_data() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ complete_wheelchair_accessibility_data() }}, {{ accurate_accessibility_data() }}
+    SELECT {{ complete_wheelchair_accessibility_data() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ shapes_for_all_trips() }}, {{ accurate_service_data() }}
+    SELECT {{ shapes_for_all_trips() }}, {{ accurate_service_data() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ include_tts() }}, {{ accurate_accessibility_data() }}
+    SELECT {{ include_tts() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ shapes_valid() }}, {{ accurate_service_data() }}
+    SELECT {{ shapes_valid() }}, {{ accurate_service_data() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ pathways_valid() }}, {{ accurate_accessibility_data() }}
+    SELECT {{ pathways_valid() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ technical_contact_listed() }}, {{ technical_contact_availability() }}
+    SELECT {{ technical_contact_listed() }}, {{ technical_contact_availability() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ no_expired_services() }}, {{ best_practices_alignment_schedule() }}
+    SELECT {{ no_expired_services() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ no_rt_validation_errors() }}, {{ compliance_rt() }}
+    SELECT {{ no_rt_validation_errors() }}, {{ compliance_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}
+    SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ feed_present_vehicle_positions() }}, {{ compliance_rt() }}
+    SELECT {{ feed_present_vehicle_positions() }}, {{ compliance_rt() }}, {{ rt_url() }}
     UNION ALL
-    SELECT {{ feed_present_trip_updates() }}, {{ compliance_rt() }}
+    SELECT {{ feed_present_trip_updates() }}, {{ compliance_rt() }}, {{ rt_url() }}
     UNION ALL
-    SELECT {{ feed_present_service_alerts() }}, {{ compliance_rt() }}
+    SELECT {{ feed_present_service_alerts() }}, {{ compliance_rt() }}, {{ rt_url() }}
     UNION ALL
-    SELECT {{ rt_https_trip_updates() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ rt_https_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ rt_https_vehicle_positions() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ rt_https_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ rt_https_service_alerts() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ rt_https_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ no_pb_error_tu() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ no_pb_error_tu() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ no_pb_error_vp() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ no_pb_error_vp() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ no_pb_error_sa() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ no_pb_error_sa() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ no_7_day_feed_expiration() }}, {{ best_practices_alignment_schedule() }}
+    SELECT {{ no_7_day_feed_expiration() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ no_30_day_feed_expiration() }}, {{ best_practices_alignment_schedule() }}
+    SELECT {{ no_30_day_feed_expiration() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ passes_fares_validator() }}, {{ fare_completeness() }}
+    SELECT {{ passes_fares_validator() }}, {{ fare_completeness() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ rt_20sec_vp() }}, {{ accurate_service_data() }}
+    SELECT {{ rt_20sec_vp() }}, {{ accurate_service_data() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ rt_20sec_tu() }}, {{ accurate_service_data() }}
+    SELECT {{ rt_20sec_tu() }}, {{ accurate_service_data() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ persistent_ids_schedule() }}, {{ best_practices_alignment_schedule() }}
+    SELECT {{ persistent_ids_schedule() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ lead_time() }}, {{ up_to_dateness() }}
+    SELECT {{ lead_time() }}, {{ up_to_dateness() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ no_stale_vehicle_positions() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ no_stale_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ no_stale_trip_updates() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ no_stale_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ no_stale_service_alerts() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ no_stale_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ modification_date_present() }}, {{ best_practices_alignment_schedule() }}
+    SELECT {{ modification_date_present() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ schedule_feed_on_transitland() }}, {{ feed_aggregator_availability_schedule() }}
+    SELECT {{ schedule_feed_on_transitland() }}, {{ feed_aggregator_availability_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ vehicle_positions_feed_on_transitland() }}, {{ feed_aggregator_availability_rt() }}
+    SELECT {{ vehicle_positions_feed_on_transitland() }}, {{ feed_aggregator_availability_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ trip_updates_feed_on_transitland() }}, {{ feed_aggregator_availability_rt() }}
+    SELECT {{ trip_updates_feed_on_transitland() }}, {{ feed_aggregator_availability_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ service_alerts_feed_on_transitland() }}, {{ feed_aggregator_availability_rt() }}
+    SELECT {{ service_alerts_feed_on_transitland() }}, {{ feed_aggregator_availability_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ schedule_feed_on_mobility_database() }}, {{ feed_aggregator_availability_schedule() }}
+    SELECT {{ schedule_feed_on_mobility_database() }}, {{ feed_aggregator_availability_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ vehicle_positions_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}
+    SELECT {{ vehicle_positions_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ trip_updates_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}
+    SELECT {{ trip_updates_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ service_alerts_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}
+    SELECT {{ service_alerts_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ modification_date_present_service_alerts() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ modification_date_present_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ modification_date_present_vehicle_positions() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ modification_date_present_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ modification_date_present_trip_updates() }}, {{ best_practices_alignment_rt() }}
+    SELECT {{ modification_date_present_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
 
     -- MANUAL CHECKS
     UNION ALL
-    SELECT {{ organization_has_contact_info() }}, {{ technical_contact_availability() }}
+    SELECT {{ organization_has_contact_info() }}, {{ technical_contact_availability() }}, {{ organization() }}
 )
 
 SELECT * FROM stg_gtfs_quality__intended_checks


### PR DESCRIPTION
# Description

Adds a test to help flag potential bugs in `fct_daily_guideline_checks`; tests that checks can only come from one "source" and that the entities match up as we expect. For example, a check for schedule feeds ends up living on a schedule feed entity grained record, etc.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
dbt runs and passes on the changed tables

## Screenshots (optional)
