### PR TITLE
handle incremental schedule dimensions if the existing table is empty

### DIFF
--- a/warehouse/macros/make_schedule_file_dimension_from_dim_schedule_feeds.sql
+++ b/warehouse/macros/make_schedule_file_dimension_from_dim_schedule_feeds.sql
@@ -16,7 +16,8 @@
 WITH dim_schedule_feeds AS (
     SELECT *
     FROM {{ dim_schedule_feeds }}
-    {% if is_incremental() %}
+    -- if the table is currently empty, max_ts is empty
+    {% if is_incremental() and max_ts %}
     WHERE _valid_from > '{{ max_ts }}'
     {% endif %}
 ),
@@ -24,7 +25,8 @@ WITH dim_schedule_feeds AS (
 {{ gtfs_file_table.identifier }} AS (
     SELECT *
     FROM {{ gtfs_file_table }}
-    {% if is_incremental() %}
+    -- if the table is currently empty, max_ts is empty
+    {% if is_incremental() and max_ts %}
     WHERE _dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}
     WHERE _dt >= '{{ var("GTFS_SCHEDULE_START") }}'

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1037,19 +1037,25 @@ models:
       # foreign keys
       - name: tu_gtfs_dataset_key
         tests:
-          - relationships:
+          - dbt_utils.relationships_where:
               to: ref('dim_gtfs_datasets')
               field: key
+              to_condition: "type = 'trip_updates'"
+      - name: tu_base64_url
       - name: vp_gtfs_dataset_key
         tests:
-          - relationships:
+          - dbt_utils.relationships_where:
               to: ref('dim_gtfs_datasets')
               field: key
+              to_condition: "type = 'vehicle_positions'"
+      - name: vp_base64_url
       - name: sa_gtfs_dataset_key
         tests:
-          - relationships:
+          - dbt_utils.relationships_where:
               to: ref('dim_gtfs_datasets')
               field: key
+              to_condition: "type = 'service_alerts'"
+      - name: sa_base64_url
       # trip update facts
       - name: tu_num_distinct_message_ids
         description: Count of distinct trip update message IDs referencing this trip.

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1012,7 +1012,11 @@ models:
       per "trip_identifier" which is a hash of the fields that make up
       a GTFS RT TripDescriptor. See https://gtfs.org/realtime/reference/#message-tripdescriptor
       for more details.
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "COALESCE(tu_gtfs_dataset_key, vp_gtfs_dataset_key, sa_gtfs_dataset_key) IS NOT NULL"
     columns:
+      # keys and identifiers
       - name: key
         tests: *primary_key_tests
       - name: dt
@@ -1030,6 +1034,22 @@ models:
         description: Part of a TripDescriptor.
       - name: trip_start_date
         description: Part of a TripDescriptor.
+      # foreign keys
+      - name: tu_gtfs_dataset_key
+        tests:
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
+      - name: vp_gtfs_dataset_key
+        tests:
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
+      - name: sa_gtfs_dataset_key
+        tests:
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
       # trip update facts
       - name: tu_num_distinct_message_ids
         description: Count of distinct trip update message IDs referencing this trip.

--- a/warehouse/models/mart/gtfs/fct_observed_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_observed_trips.sql
@@ -56,6 +56,7 @@ trip_updates_with_associated_schedule AS (
     SELECT
         trip_updates.*,
         {{ dbt_utils.surrogate_key(['trip_id', 'trip_route_id', 'trip_direction_id', 'trip_start_time', 'trip_start_date']) }} AS trip_identifier,
+        urls_to_datasets.gtfs_dataset_key,
         trip_updates_to_schedule.schedule_to_use_for_rt_validation_gtfs_dataset_key,
     FROM trip_updates
     LEFT JOIN urls_to_datasets
@@ -69,6 +70,7 @@ vehicle_positions_with_associated_schedule AS (
     SELECT
         vehicle_positions.*,
         {{ dbt_utils.surrogate_key(['trip_id', 'trip_route_id', 'trip_direction_id', 'trip_start_time', 'trip_start_date']) }} AS trip_identifier,
+        urls_to_datasets.gtfs_dataset_key,
         vehicle_positions_to_schedule.schedule_to_use_for_rt_validation_gtfs_dataset_key,
     FROM vehicle_positions
     LEFT JOIN urls_to_datasets
@@ -109,6 +111,11 @@ fct_observed_trips AS (
         COALESCE(tu.trip_direction_id, vp.trip_direction_id, sa.trip_direction_id) AS trip_direction_id,
         COALESCE(tu.trip_start_time, vp.trip_start_time, sa.trip_start_time) AS trip_start_time,
         COALESCE(tu.trip_start_date, vp.trip_start_date, sa.trip_start_date) AS trip_start_date,
+
+        -- foreign keys
+        tu.gtfs_dataset_key AS tu_gtfs_dataset_key,
+        vp.gtfs_dataset_key AS vp_gtfs_dataset_key,
+        sa.gtfs_dataset_key AS sa_gtfs_dataset_key,
 
         -- trip updates facts
         tu.num_distinct_message_ids AS tu_num_distinct_message_ids,

--- a/warehouse/models/mart/gtfs/fct_observed_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_observed_trips.sql
@@ -114,8 +114,11 @@ fct_observed_trips AS (
 
         -- foreign keys
         tu.gtfs_dataset_key AS tu_gtfs_dataset_key,
+        tu.base64_url AS tu_base64_url,
         vp.gtfs_dataset_key AS vp_gtfs_dataset_key,
+        vp.base64_url AS vp_base64_url,
         sa.gtfs_dataset_key AS sa_gtfs_dataset_key,
+        sa.base64_url AS sa_base64_url,
 
         -- trip updates facts
         tu.num_distinct_message_ids AS tu_num_distinct_message_ids,


### PR DESCRIPTION
# Description

Resolves failing dbt model from last night; have to handle incremental schedule dimensions if the existing table is empty e.g. dim_translations.

Also adds FKs to fct_observed_trips for use in quality checks as requested by @lauriemerrell 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Both full refresh and incremental pass locally.

## Screenshots (optional)
