### PR TITLE
Payments tests date spine

### DIFF
--- a/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
+++ b/warehouse/models/payments_views/payments_daily_transaction_deltas.sql
@@ -5,6 +5,10 @@ WITH payments_rides AS (
 
 ),
 
+payments_tests_date_spine AS (
+    SELECT * FROM {{ payments_tests_date_spine() }}
+),
+
 extract_count_date AS (
 
     SELECT
@@ -42,12 +46,16 @@ payments_daily_transaction_deltas AS (
 
     SELECT
 
-        participant_id,
-        transaction_date,
-        ridership_count,
-        relative_difference
+        t1.participant_id,
+        t1.day,
 
-    FROM calculate_relative_difference
+        t2.ridership_count,
+        t2.relative_difference
+
+    FROM payments_tests_date_spine AS t1
+    LEFT JOIN calculate_relative_difference AS t2
+        ON (t1.day = t2.transaction_date)
+            AND (t1.participant_id = t2.participant_id)
 
 )
 


### PR DESCRIPTION
# Description

This PR adds a date spine to `payments_daily_transaction_deltas` so that it records `n = 0` for days that a participant had no recorded rides

Partially addresses #2208 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
local `dbt run`
