### PR TITLE
Add more RT metrics and add a download feed request timeout

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/redis.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/redis.yaml
@@ -29,6 +29,9 @@ spec:
       app: redis
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9121"
       labels:
         app: redis
     spec:
@@ -41,6 +44,21 @@ spec:
               cpu: 1
             limits:
               memory: 1Gi
+        - name: redis-exporter
+          image: oliver006/redis_exporter:latest
+          securityContext:
+            runAsUser: 59000
+            runAsGroup: 59000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+          - containerPort: 9121
       tolerations:
         - key: resource-domain
           operator: Equal

--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/redis.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/redis.yaml
@@ -44,6 +44,7 @@ spec:
               cpu: 1
             limits:
               memory: 1Gi
+        # from https://github.com/oliver006/redis_exporter
         - name: redis-exporter
           image: oliver006/redis_exporter:latest
           securityContext:

--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/redis.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/redis.yaml
@@ -46,7 +46,7 @@ spec:
               memory: 1Gi
         # from https://github.com/oliver006/redis_exporter
         - name: redis-exporter
-          image: oliver006/redis_exporter:latest
+          image: oliver006/redis_exporter:v1.46.0
           securityContext:
             runAsUser: 59000
             runAsGroup: 59000

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '2023.2.1'
+  newTag: '2023.2.2'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '2023.2.1'
+  newTag: '2023.2.2'

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
@@ -1,8 +1,6 @@
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram, utils
 
-# TODO: these should have config_ as a prefix now
-from prometheus_client.utils import INF
-
+# TODO: maybe these could live on GTFSDownloadConfig?
 standard_labels = (
     "record_name",
     "record_uri",
@@ -49,7 +47,7 @@ FETCH_PROCESSING_TIME = Histogram(
         20.0,
         25.0,
         30.0,
-        INF,
+        utils.INF,
     ),
 )
 FETCH_DOWNLOADING_TIME = Histogram(
@@ -70,7 +68,7 @@ FETCH_DOWNLOADING_TIME = Histogram(
         20.0,
         25.0,
         30.0,
-        INF,
+        utils.INF,
     ),
 )
 FETCH_UPLOADING_TIME = Histogram(
@@ -91,6 +89,6 @@ FETCH_UPLOADING_TIME = Histogram(
         20.0,
         25.0,
         30.0,
-        INF,
+        utils.INF,
     ),
 )

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
@@ -1,6 +1,6 @@
 from prometheus_client import Counter, Gauge, Histogram
 
-# TODO: these should probably be config_ now
+# TODO: these should have config_ as a prefix now
 standard_labels = (
     "record_name",
     "record_uri",
@@ -31,6 +31,16 @@ FETCH_PROCESSING_DELAY = Histogram(
 )
 FETCH_PROCESSING_TIME = Histogram(
     name="fetch_processing_time_seconds",
-    documentation="Time spent processing a single fetch.",
+    documentation="Time spent processing a single fetch (end to end).",
+    labelnames=standard_labels,
+)
+FETCH_DOWNLOADING_TIME = Histogram(
+    name="fetch_downloading_time_seconds",
+    documentation="Time spent downloading a single fetch.",
+    labelnames=standard_labels,
+)
+FETCH_UPLOADING_TIME = Histogram(
+    name="fetch_uploading_time_seconds",
+    documentation="Time spent uploading a single fetch.",
     labelnames=standard_labels,
 )

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
@@ -35,6 +35,22 @@ FETCH_PROCESSING_TIME = Histogram(
     name="fetch_processing_time_seconds",
     documentation="Time spent processing a single fetch (end to end).",
     labelnames=standard_labels,
+    buckets=(
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        15.0,
+        20.0,
+        25.0,
+        30.0,
+        INF,
+    ),
 )
 FETCH_DOWNLOADING_TIME = Histogram(
     name="fetch_downloading_time_seconds",

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/metrics.py
@@ -1,6 +1,8 @@
 from prometheus_client import Counter, Gauge, Histogram
 
 # TODO: these should have config_ as a prefix now
+from prometheus_client.utils import INF
+
 standard_labels = (
     "record_name",
     "record_uri",
@@ -38,9 +40,41 @@ FETCH_DOWNLOADING_TIME = Histogram(
     name="fetch_downloading_time_seconds",
     documentation="Time spent downloading a single fetch.",
     labelnames=standard_labels,
+    buckets=(
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        15.0,
+        20.0,
+        25.0,
+        30.0,
+        INF,
+    ),
 )
 FETCH_UPLOADING_TIME = Histogram(
     name="fetch_uploading_time_seconds",
     documentation="Time spent uploading a single fetch.",
     labelnames=standard_labels,
+    buckets=(
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        15.0,
+        20.0,
+        25.0,
+        30.0,
+        INF,
+    ),
 )

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -23,7 +23,8 @@ from .metrics import (
     TASK_SIGNALS,
 )
 
-FETCH_TIMEOUT = int(os.getenv("CALITP_FETCH_REQUEST_TIMEOUT_SECONDS", 10))
+# 30 is ridiculously high for a default, but there's a few feeds that commonly take 10+ seconds
+FETCH_TIMEOUT_SECONDS = int(os.getenv("CALITP_FETCH_REQUEST_TIMEOUT_SECONDS", 30))
 
 
 class RedisHueyWithMetrics(RedisHuey):
@@ -135,7 +136,7 @@ def fetch(tick: datetime, config: GTFSDownloadConfig):
                     config=config,
                     auth_dict=auth_dict,
                     ts=tick,
-                    timeout=FETCH_TIMEOUT,
+                    timeout=FETCH_TIMEOUT_SECONDS,
                 )
         except Exception as e:
             status_code = None

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -133,6 +133,7 @@ def fetch(tick: datetime, config: GTFSDownloadConfig):
                     config=config,
                     auth_dict=auth_dict,
                     ts=tick,
+                    timeout=5,
                 )
         except Exception as e:
             status_code = None

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -23,6 +23,8 @@ from .metrics import (
     TASK_SIGNALS,
 )
 
+FETCH_TIMEOUT = int(os.getenv("CALITP_FETCH_REQUEST_TIMEOUT_SECONDS", 10))
+
 
 class RedisHueyWithMetrics(RedisHuey):
     pass
@@ -133,7 +135,7 @@ def fetch(tick: datetime, config: GTFSDownloadConfig):
                     config=config,
                     auth_dict=auth_dict,
                     ts=tick,
-                    timeout=5,
+                    timeout=FETCH_TIMEOUT,
                 )
         except Exception as e:
             status_code = None

--- a/services/gtfs-rt-archiver-v3/poetry.lock
+++ b/services/gtfs-rt-archiver-v3/poetry.lock
@@ -99,7 +99,7 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "calitp"
-version = "2023.1.3"
+version = "2023.2.1"
 description = "Shared code for the Cal-ITP data codebases"
 category = "main"
 optional = false
@@ -1237,7 +1237,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "525b6d841923400a05958a8a36e9f5d094df2fe2366d7fe17c9c88594363e7c4"
+content-hash = "fb82eb3281aa0ad80dd3da72c2aa82aa6735b7ddd1c56de377d0b5166d841b8b"
 
 [metadata.files]
 aiohttp = []

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -22,7 +22,7 @@ structlog = "^22.1.0"
 python-json-logger = "^2.0.4"
 backoff = "^2.1.2"
 sentry-sdk = "^1.9.8"
-calitp = "2023.1.3"
+calitp = "2023.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "2023.2.1"
+version = "2023.2.2"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/2046

Adds redis metrics via a k8s sidecar, more archiver app metrics, and adds a timeout to feed requests. I'm also adjusting the buckets for our Histograms since we don't really care about anything under 100ms.

calitp PR: https://github.com/cal-itp/calitp-py/pull/97

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Deployed to test.

## Screenshots (optional)
[Redis dashboard](https://monitoring.k8s.calitp.jarv.us/d/Qnp8YdAVz/redis-dashboard-for-prometheus-redis-exporter-1-x?orgId=1)
[Updated archiver dashboard](https://monitoring.k8s.calitp.jarv.us/d/N1XVLOe7z/gtfs-rt-archiver-v3?orgId=1&var-namespace=gtfs-rt-v3-test&refresh=30s&from=now-15m&to=now)