### PR TITLE
manual correction for duplicate itp ids

### DIFF
--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -14,7 +14,7 @@ stg_transit_database__organizations AS (
         organization_type,
         roles,
         CASE
-            -- only correct records while they were actively incorrect, don't hard code in genera
+            -- only correct records while they were actively incorrect, don't hard code in general
             -- just in case there are legitimate changes upstream
             -- correct Cloverdale having Long Beach ITP ID
             WHEN id = 'recRM3c9Zfaft4V2B' AND itp_id = 170 THEN 70

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -13,7 +13,15 @@ stg_transit_database__organizations AS (
         {{ trim_make_empty_string_null(column_name = "name") }} AS name,
         organization_type,
         roles,
-        CAST(itp_id AS INTEGER) AS itp_id,
+        CASE
+            -- only correct records while they were actively incorrect, don't hard code in genera
+            -- just in case there are legitimate changes upstream
+            -- correct Cloverdale having Long Beach ITP ID
+            WHEN id = 'recRM3c9Zfaft4V2B' AND itp_id = 170 THEN 70
+            -- correct City of Madera having Madera County ITP ID
+            WHEN id = 'rec2DteW2sfmBJRsH' AND itp_id = 188 THEN 187
+            ELSE CAST(itp_id AS INTEGER)
+        END AS itp_id,
         unnested_ntd_records AS ntd_agency_info_key,
         hubspot_company_record_id,
         alias_ as alias,


### PR DESCRIPTION
# Description

City of Madera and Cloverdale Transit had incorrect ITP IDs that caused them to be duplicates of Madera County and Long Beach Transit (respectively) which was going to cause issues in the report publishing flow. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Ran `poetry run dbt run -s stg_transit_database__organizations+` and `poetry run dbt test -s stg_transit_database__organizations+`, only errors are because I am missing `fct_observed_trips` table locally which does not use ITP ID.
