### PR TITLE
point sentry at existing postgres secret

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -3,6 +3,10 @@
 sentry:
   existingSecret: sentry-secrets
   existingSecretKey: session-secret
+  postgresql:
+    global:
+      postgresql:
+        existingSecret: sentry-sentry-postgresql
   user:
     create: true
     email: general+cal-itp@jarv.us


### PR DESCRIPTION
# Description
 
I re-installed Sentry to fix the GitHub OAuth 404 and ended up in the same situation as happened during our upgrade. Without this, the Sentry chart will manage the secret; uninstalling will delete the secret but the postgres storage stays there (which is good or we'd lose all our data). On install, Sentry will re-create the secret with a new generated password but has no way to actually set it on the postgres user.

This PR will actually point our Sentry chart at an existing Postgres secret so it doesn't delete and re-create it on re-install.

I've saved the secret in vaultwarden.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Upgraded with this changed values file and the db init job succeeded.

## Screenshots (optional)
