### PR TITLE
Fix pendulum date/datetime comparison in schedule validator

### DIFF
--- a/jobs/gtfs-schedule-validator/gtfs_schedule_validator.py
+++ b/jobs/gtfs-schedule-validator/gtfs_schedule_validator.py
@@ -279,6 +279,7 @@ def validate_day(
     )
 
     if missing or invalid:
+        typer.secho(f"valid: {len(extracts)}")
         typer.secho(f"missing: {missing}")
         typer.secho(f"invalid: {invalid}")
         raise RuntimeError("found files with missing or invalid metadata; failing job")

--- a/jobs/gtfs-schedule-validator/gtfs_schedule_validator.py
+++ b/jobs/gtfs-schedule-validator/gtfs_schedule_validator.py
@@ -137,17 +137,18 @@ def execute_schedule_validator(
     if not isinstance(zip_path, Path):
         raise TypeError("must provide a path to the zip file")
 
-    if extract_ts < pendulum.Date(2022, 9, 15):
+    if extract_ts.date() < pendulum.Date(2022, 9, 15):
         versioned_jar_path = V2_VALIDATOR_JAR
         validator_version = "v2.0.0"
-    elif extract_ts < pendulum.Date(2022, 11, 16):
+    elif extract_ts.date() < pendulum.Date(2022, 11, 16):
         versioned_jar_path = V3_VALIDATOR_JAR
         validator_version = "v3.1.1"
     else:
         versioned_jar_path = V4_VALIDATOR_JAR
         validator_version = "v4.0.0"
 
-    assert JAVA_EXECUTABLE and versioned_jar_path  # make mypy happy
+    assert versioned_jar_path
+
     args = [
         JAVA_EXECUTABLE,
         "-jar",


### PR DESCRIPTION
# Description

Fixes bug introduced during mypy work that I didn't catch.

Will need to backfill and re-run dbt models after merge.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Local Airflow.

## Screenshots (optional)
```
[2023-02-03 14:59:36,010] {pod_launcher.py:149} INFO - saving 6 validation notices to gs://test-calitp-gtfs-schedule-validation/validation_notices/dt=2023-02-02/ts=2023-02-02T00:30:57.881473+00:00/base64_url=aHR0cHM6Ly9sYnRyYW5zaXQuYm94LmNvbS9zaGFyZWQvc3RhdGljL2FveWVza3dtc2E5ZzdweWc3OHEzeHVpb2kwbGdxZTRmLnppcA==/validation_notices_v4-0-0.jsonl.gz
[2023-02-03 14:59:37,265] {pod_launcher.py:149} INFO - saving 2 validation notices to gs://test-calitp-gtfs-schedule-validation/validation_notices/dt=2023-02-02/ts=2023-02-02T00:48:40.673559+00:00/base64_url=aHR0cDovL2V0YS5nZXRidXMub3JnL3J0dC9wdWJsaWMvdXRpbGl0eS9ndGZzLmFzcHg=/validation_notices_v4-0-0.jsonl.gz
[2023-02-03 14:59:42,503] {pod_launcher.py:149} INFO - saving 6 validation notices to gs://test-calitp-gtfs-schedule-validation/validation_notices/dt=2023-02-02/ts=2023-02-02T00:48:40.673559+00:00/base64_url=aHR0cDovL3dlYndhdGNoLmxhdnRhLm9yZy90bWd0ZnNyZWFsdGltZXdlYnNlcnZpY2UvZ3Rmcy1zdGF0aWMvZ29vZ2xlX3RyYW5zaXQuemlw/validation_notices_v4-0-0.jsonl.gz
[2023-02-03 14:59:42,936] {pod_launcher.py:149} INFO - got 55 successes and 0 failures
[2023-02-03 14:59:42,936] {pod_launcher.py:149} INFO - saving 55 to gs://test-calitp-gtfs-schedule-validation/validation_job_results/dt=2023-02-02/results.jsonl
[2023-02-03 14:59:45,090] {pod_launcher.py:198} INFO - Event: validate-gtfs-schedule.ee56df85f40f462b9f8d43d36353bddf had an event of type Succeeded
[2023-02-03 14:59:45,090] {pod_launcher.py:311} INFO - Event with job id validate-gtfs-schedule.ee56df85f40f462b9f8d43d36353bddf Succeeded
[2023-02-03 14:59:45,189] {pod_launcher.py:198} INFO - Event: validate-gtfs-schedule.ee56df85f40f462b9f8d43d36353bddf had an event of type Succeeded
[2023-02-03 14:59:45,189] {pod_launcher.py:311} INFO - Event with job id validate-gtfs-schedule.ee56df85f40f462b9f8d43d36353bddf Succeeded
[2023-02-03 14:59:45,341] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=unzip_and_validate_gtfs_schedule, task_id=validate_gtfs_schedule, execution_date=20230202T020000, start_date=20230203T145537, end_date=20230203T145945
```