### PR TITLE
Handle __MACOSX folders in zipfiles

### DIFF
--- a/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/unzip_gtfs_schedule.py
@@ -30,6 +30,7 @@ SCHEDULE_RAW_BUCKET = os.environ["CALITP_BUCKET__GTFS_SCHEDULE_RAW"]
 GTFS_UNZIP_LIST_ERROR_THRESHOLD = float(
     os.getenv("GTFS_UNZIP_LIST_ERROR_THRESHOLD", 0.99)
 )
+MACOSX_ZIP_FOLDER = "__MACOSX"
 
 
 def log(*args, err=False, fg=None, pbar=None, **kwargs):
@@ -78,19 +79,27 @@ def summarize_zip_contents(
 ) -> Tuple[List[str], List[str], bool]:
     files = []
     directories = []
-    # TODO: we have to manually handle MACOSX-created zipfiles
-    # see https://superuser.com/questions/104500/what-is-macosx-folder
     for entry in zip.namelist():
         if zipfile.Path(zip, at=entry).is_file():
             files.append(entry)
         if zipfile.Path(zip, at=entry).is_dir():
             directories.append(entry)
     log(f"Found files: {files} and directories: {directories}", pbar=pbar)
-    # the only valid case for any directory inside the zipfile is if there's exactly one and it's the only item at the root of the zipfile
-    # (in which case we can treat that directory's contents as the feed)
+    # the only valid case for any directory inside the zipfile is if there's exactly one
+    # and it's the only item at the root of the zipfile(in which case we can treat that
+    # directory's contents as the feed)
+    # we want to exclude __MACOSX directories from this calculation
+    # see https://superuser.com/questions/104500/what-is-macosx-folder
     is_valid = (not directories) or (
         (len(directories) == 1)
-        and ([item.is_dir() for item in zipfile.Path(zip, at="").iterdir()] == [True])
+        and (
+            [
+                item.is_dir()
+                for item in zipfile.Path(zip, at="").iterdir()
+                if item.name != MACOSX_ZIP_FOLDER
+            ]
+            == [True]
+        )
     )
     return files, directories, is_valid
 
@@ -112,7 +121,9 @@ def process_feed_files(
         )
 
     # sorting is new here, to make the hash deterministic
-    for file in sorted(files):
+    for file in sorted(
+        [file for file in files if not file.startswith(MACOSX_ZIP_FOLDER)]
+    ):
         # make a proper path to access the .name attribute later
         file_path = zipfile.Path(zip, at=file)
         with zip.open(file) as f:
@@ -237,11 +248,13 @@ def unzip_extracts(
     ), f"ended up with {len(outcomes)} outcomes from {len(extracts)} extracts"
 
     success_rate = len(result.successes) / len(extracts)
+    exceptions = [
+        (failure.exception, failure.extract.config.url) for failure in result.failures
+    ]
+    exc_str = "\n".join(str(tup) for tup in exceptions)
+    msg = f"got {len(exceptions)} exceptions from validating {len(extracts)} extracts:\n{exc_str}"
+    typer.secho(msg, err=True, fg=typer.colors.RED)
     if success_rate < GTFS_UNZIP_LIST_ERROR_THRESHOLD:
-        exceptions = [failure.exception for failure in result.failures]
-        exc_str = "\n".join(str(tup) for tup in exceptions)
-        msg = f"got {len(exceptions)} exceptions from validating {len(extracts)} extracts:\n{exc_str}"
-        typer.secho(msg, err=True, fg=typer.colors.RED)
         raise RuntimeError(msg)
 
 


### PR DESCRIPTION
# Description

Ignore MacOS-specific zip file contents for purposes of zipfile validity, but still process them as normal. I've confirmed that the failing feeds no longer throw exceptions in local Airflow. I also set up error reporting to Sentry so we can track and manage invalid zipfiles more easily.

We're going to backfill to 2022-01-25 to fix BART but no further. 

Resolves https://github.com/cal-itp/data-infra/issues/2104

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Local airflow.

## Screenshots (optional)
```
[2023-02-03 18:02:53,092] {storage.py:270} INFO - saving 4.4 MB to gs://test-calitp-gtfs-schedule-unzipped/unzipping_results/dt=2023-02-03/results.jsonl
got 2 exceptions from validating 474 extracts:
(BadZipFile('File is not a zip file'), HttpUrl('https://gtfs.sfmta.com/transitdata/google_transit.zip', scheme='https', host='gtfs.sfmta.com', tld='com', host_type='domain', port='443', path='/transitdata/google_transit.zip'))
(BadZipFile('File is not a zip file'), HttpUrl('https://gtfs.sfmta.com/transitdata/google_transit.zip', scheme='https', host='gtfs.sfmta.com', tld='com', host_type='domain', port='443', path='/transitdata/google_transit.zip'))
[2023-02-03 18:02:57,629] {python.py:151} INFO - Done. Returned value was: None
[2023-02-03 18:02:57,639] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=unzip_and_validate_gtfs_schedule, task_id=unzip_gtfs_schedule, execution_date=20230203T020000, start_date=20230203T171919, end_date=20230203T180257
```
