### PR TITLE
stop validation notices from showing past next version's implementation

### DIFF
--- a/warehouse/macros/make_end_of_valid_range.sql
+++ b/warehouse/macros/make_end_of_valid_range.sql
@@ -1,3 +1,7 @@
 {% macro make_end_of_valid_range(timestamp_col) %}
 TIMESTAMP_SUB({{ timestamp_col }}, INTERVAL 1 MICROSECOND)
 {% endmacro %}
+
+{% macro make_end_of_valid_range_date(date_col) %}
+DATE_SUB({{ date_col }}, INTERVAL 1 DAY)
+{% endmacro %}

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -129,7 +129,22 @@ models:
       a lack of validation for that feed on that day.
     columns:
       - *key
-      - *date
+      - name: date
+        tests:
+          - not_null
+          # These tests ensure we only display notices during
+          # the "range" of validator versions.
+          - dbt_utils.accepted_range:
+              min_value: "DATE'2021-04-16'"
+              max_value: "DATE'2022-09-15'"
+              where: validation_validator_version = 'v2.0.0'
+          - dbt_utils.accepted_range:
+              min_value: "DATE'2022-09-16'"
+              max_value: "DATE'2022-11-15'"
+              where: validation_validator_version = 'v3.1.1'
+          - dbt_utils.accepted_range:
+              min_value: "DATE'2022-11-16'"
+              where: validation_validator_version = 'v4.0.0'
       - *schedule_feed_key
       - *base64_url
       - name: outcome_extract_dt
@@ -144,6 +159,8 @@ models:
           See version and release history at https://github.com/MobilityData/gtfs-validator/releases.
         tests:
           - not_null
+          - accepted_values:
+              values: ['v2.0.0', 'v3.1.1', 'v4.0.0']
       - &schedule_validator_code
         name: code
         description: |

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -136,10 +136,10 @@ models:
           # the "range" of validator versions.
           - dbt_utils.accepted_range:
               min_value: "DATE'2021-04-16'"
-              max_value: "DATE'2022-09-15'"
+              max_value: "DATE'2022-09-14'"
               where: validation_validator_version = 'v2.0.0'
           - dbt_utils.accepted_range:
-              min_value: "DATE'2022-09-16'"
+              min_value: "DATE'2022-09-15'"
               max_value: "DATE'2022-11-15'"
               where: validation_validator_version = 'v3.1.1'
           - dbt_utils.accepted_range:

--- a/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_validation_notices.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_validation_notices.sql
@@ -45,7 +45,7 @@ first_outcome_per_feed_per_version AS (
 outcomes_with_end_dt AS (
     SELECT
         *,
-        COALESCE(LEAD(DATE_SUB(extract_dt, INTERVAL 1 DAY)) OVER (PARTITION BY feed_key ORDER BY extract_dt), feed_valid_to_dt) AS outcome_valid_to
+        COALESCE(LEAD({{ make_end_of_valid_range_date('extract_dt') }}) OVER (PARTITION BY feed_key ORDER BY extract_dt), feed_valid_to_dt) AS outcome_valid_to
     FROM first_outcome_per_feed_per_version
 ),
 

--- a/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_validation_notices.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_schedule_feed_validation_notices.sql
@@ -44,7 +44,7 @@ first_outcome_per_feed_per_version AS (
 outcomes_with_end_dt AS (
     SELECT
         *,
-        LAG(extract_dt) OVER (PARTITION BY feed_key ORDER BY extract_dt) AS next_outcome_dt
+        LAG(extract_dt, 1, DATE '2099-01-01') OVER (PARTITION BY feed_key ORDER BY extract_dt) AS next_outcome_dt
     FROM first_outcome_per_feed_per_version
 ),
 

--- a/warehouse/tests/mart/gtfs_quality/test_fct_daily_schedule_validation_notices_one_version_per_date_feed.sql
+++ b/warehouse/tests/mart/gtfs_quality/test_fct_daily_schedule_validation_notices_one_version_per_date_feed.sql
@@ -1,0 +1,15 @@
+WITH daily_notices AS (
+    SELECT * FROM {{ ref('fct_daily_schedule_feed_validation_notices') }}
+),
+
+bad_rows AS (
+    SELECT
+        date,
+        feed_key,
+        COUNT(DISTINCT validation_validator_version) AS num_versions,
+    FROM daily_notices
+    GROUP BY 1, 2
+    HAVING COUNT(DISTINCT validation_validator_version) > 1
+)
+
+SELECT * FROM bad_rows


### PR DESCRIPTION
# Description

Waiting on https://github.com/cal-itp/data-infra/issues/2329 closure first

Finally stops showing validation notices in the future as well as past the next version's start. Adds a custom test to check there is only 1 validator version present per feed per day.

Closes https://github.com/cal-itp/data-infra/issues/2141

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tests pass after rebase!

## Screenshots (optional)
