### PR TITLE
prep for calitp grafana domain

### DIFF
--- a/kubernetes/apps/values/grafana-prod.yaml
+++ b/kubernetes/apps/values/grafana-prod.yaml
@@ -7,3 +7,4 @@ ingress:
     - secretName: grafana-tls
       hosts:
         - monitoring.k8s.calitp.jarv.us
+        - monitoring.calitp.org


### PR DESCRIPTION
# Description

I think Grafana might be the last service we don't have a CNAME for; the current domain is https://monitoring.k8s.calitp.jarv.us. I've looked at Composer and unfortunately they don't seem to support custom domains still https://stackoverflow.com/questions/65354788/custom-domain-for-google-cloud-composer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
