### PR TITLE
fix incorrect assert

### DIFF
--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -437,7 +437,7 @@ def _publish_exposure(
                     for name, column in node.columns.items():
                         ckan_precision = column.meta.get("ckan.precision")
                         if ckan_precision:
-                            assert isinstance(ckan_precision, str)
+                            assert isinstance(ckan_precision, (str, int))
                             precisions[name] = int(ckan_precision)
 
                     if precisions:


### PR DESCRIPTION
# Description

YAML can give us integers for CKAN precisions; I'm not sure why I thought they were quoted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Actually ran a full test publish this time.

## Screenshots (optional)
```
would be uploading to https://data.ca.gov 7abe9256-6cd2-4c1f-9b6a-72108022a382 if --publish
handling dim_trips_latest 0e4da89e-9330-43f8-8de9-305cb7d4918f
Downloading: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 545805/545805 [00:39<00:00, 13838.71rows/s]
writing 545805 rows (99.9 MB) from andrew_staging.dim_trips_latest to gs://test-calitp-publish/california_open_data__trips/dt=2023-02-06/ts=2023-02-06T15:35:09.114058Z/trips.csv
would be uploading to https://data.ca.gov 0e4da89e-9330-43f8-8de9-305cb7d4918f if --publish
```