### PR TITLE
disable extreme-results test for check that is easy to pass

### DIFF
--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -368,7 +368,6 @@ models:
             - base64_url
       - dbt_utils.equal_rowcount:
           compare_model: ref('int_gtfs_quality__schedule_url_guideline_index')
-      - extreme_results
     columns: *stg_gtfs_guideline_columns
 
 # RT feed checks


### PR DESCRIPTION
# Description

Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies.
This check should pass for all feeds - so we shouldn't be surprised when 100% pass every day. Disabling the "extreme results" test for this check.

Resolves: https://sentry.calitp.org/organizations/sentry/issues/39640/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
