### PR TITLE
Sentry/Grafana infra improvements

### DIFF
--- a/kubernetes/apps/charts/postgresql/.helmignore
+++ b/kubernetes/apps/charts/postgresql/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/apps/charts/postgresql/Chart.yaml
+++ b/kubernetes/apps/charts/postgresql/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: postgresql
+description: Postgres for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.4.2"
+dependencies:
+  - name: postgresql
+    version: 12.1.14
+    repository: https://charts.bitnami.com/bitnami

--- a/kubernetes/apps/values/grafana-prod.yaml
+++ b/kubernetes/apps/values/grafana-prod.yaml
@@ -10,3 +10,15 @@ ingress:
       hosts:
         - monitoring.k8s.calitp.jarv.us
         - monitoring.calitp.org
+
+envFromSecret: grafana-postgresql
+
+# TODO: could use initdb scripts to create this user rather than manual
+
+grafana.ini:
+  database:
+    type: postgres
+    host: postgresql.monitoring-grafana.svc.cluster.local
+    name: grafana
+    user: grafana
+    password: $__env{POSTGRES_PASSWORD}

--- a/kubernetes/apps/values/grafana-prod.yaml
+++ b/kubernetes/apps/values/grafana-prod.yaml
@@ -22,3 +22,5 @@ grafana.ini:
     name: grafana
     user: grafana
     password: $__env{POSTGRES_PASSWORD}
+  server:
+    domain: monitoring.calitp.org

--- a/kubernetes/apps/values/grafana-prod.yaml
+++ b/kubernetes/apps/values/grafana-prod.yaml
@@ -1,6 +1,7 @@
 ingress:
-
   enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
   hosts:
     - monitoring.k8s.calitp.jarv.us
     - monitoring.calitp.org

--- a/kubernetes/apps/values/grafana-prod.yaml
+++ b/kubernetes/apps/values/grafana-prod.yaml
@@ -3,6 +3,7 @@ ingress:
   enabled: true
   hosts:
     - monitoring.k8s.calitp.jarv.us
+    - monitoring.calitp.org
   tls:
     - secretName: grafana-tls
       hosts:

--- a/kubernetes/apps/values/grafana.yaml
+++ b/kubernetes/apps/values/grafana.yaml
@@ -17,6 +17,10 @@ datasources:
         type: prometheus
         url: http://prometheus-server.monitoring-prometheus.svc.cluster.local
         isDefault: true
+#      - name: Loki
+#        type: loki
+#        url: http://loki.monitoring-loki.svc.cluster.local:3100
+
 
 dashboardProviders:
 

--- a/kubernetes/apps/values/grafana.yaml
+++ b/kubernetes/apps/values/grafana.yaml
@@ -17,6 +17,7 @@ datasources:
         type: prometheus
         url: http://prometheus-server.monitoring-prometheus.svc.cluster.local
         isDefault: true
+      # TODO: this was created manually but we can probably define it here
 #      - name: Loki
 #        type: loki
 #        url: http://loki.monitoring-loki.svc.cluster.local:3100

--- a/kubernetes/apps/values/postgresql-backup-grafana.yaml
+++ b/kubernetes/apps/values/postgresql-backup-grafana.yaml
@@ -1,0 +1,31 @@
+cronjob:
+  image: ghcr.io/jarvusinnovations/restic-toolkit:1.3.0
+
+secretMounts:
+  - name: database-backup
+    mountPath: /secrets/database-backup
+
+config:
+  envFrom:
+    - secretRef:
+        name: database-backup
+  env:
+    - name: GOOGLE_PROJECT_ID
+      value: '1005246706141'
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secrets/database-backup/gcs-upload-svcacct.json
+    - name: PGPORT
+      value: '5432'
+    - name: PGDATABASE
+      value: 'grafana'
+    - name: PGUSER
+      value: 'grafana'
+    - name: PGPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: grafana-postgresql
+          key: POSTGRES_PASSWORD
+    - name: RESTIC_REPOSITORY
+      value: gs:calitp-backups-grafana:/
+    - name: PGHOST
+      value: postgresql.monitoring-grafana.svc.cluster.local

--- a/kubernetes/apps/values/postgresql-backup-sentry.yaml
+++ b/kubernetes/apps/values/postgresql-backup-sentry.yaml
@@ -1,0 +1,31 @@
+cronjob:
+  image: ghcr.io/jarvusinnovations/restic-toolkit:1.3.0
+
+secretMounts:
+  - name: database-backup
+    mountPath: /secrets/database-backup
+
+config:
+  envFrom:
+    - secretRef:
+        name: database-backup
+  env:
+    - name: GOOGLE_PROJECT_ID
+      value: '1005246706141'
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secrets/database-backup/gcs-upload-svcacct.json
+    - name: PGPORT
+      value: '5432'
+    - name: PGDATABASE
+      value: 'sentry' # by sentry helm chart
+    - name: PGUSER
+      value: 'postgres' # by sentry helm chart
+    - name: PGPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: sentry-sentry-postgresql
+          key: postgresql-password
+    - name: RESTIC_REPOSITORY
+      value: gs:calitp-backups-sentry:/
+    - name: PGHOST
+      value: sentry-sentry-postgresql.sentry.svc.cluster.local


### PR DESCRIPTION
# Description

* Create backup cronjob for Sentry postgres
* Deploy postgres for use by Grafana
* Create backup cronjob for Grafana postgres
* Add monitoring.calitp.org as host for Grafana

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
