### PR TITLE
back-date regional feed type

### DIFF
--- a/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/_int_gtfs_quality.yml
@@ -234,7 +234,11 @@ models:
           Foreign key to `dim_schedule_feeds`. Because `dim_schedule_feeds` is slowly-
           changing dimension, joins using this key are not subject to the historical
           limitations noted for the other foreign keys in this table.
-
+      - name: backdated_regional_feed_type
+        description: |
+          The `regional_feed_type` value for the *current version* of this GTFS dataset.
+          This allows us to make regional subfeed selections from before the raw data was available in Airtable
+          for reports site assessment purposes.
   - name: int_gtfs_quality__organization_dataset_map
     description: |
       A version of int_gtfs_quality__daily_assessment_candidate_entities collapsed


### PR DESCRIPTION
# Description

Back-dates regional feed type attribute for reports site assessment determination purposes. 

Marking this as `do-not-merge` until Eric is back in office and can make determinations about how we want to proceed; see [this Google doc section](https://docs.google.com/document/d/1RMYSAbiiq1a9zAnQm_MIHAC5Hbc19G4LG-uEOk1wdKk/edit#heading=h.bmgfx8es706)

Resolves #2270

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- will require reports site to be re-generated
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`poetry run dbt run -s int_gtfs_quality__naive_organization_service_dataset_full_join int_gtfs_quality__daily_assessment_candidate_entities idx_monthly_reports_site` and `poetry run dbt test -s int_gtfs_quality__naive_organization_service_dataset_full_join int_gtfs_quality__daily_assessment_candidate_entities idx_monthly_reports_site` -- manually inspected results. 

## Screenshots (optional)
