### PR TITLE
add pin to fix version conflicts

### DIFF
--- a/airflow/Dockerfile.composer
+++ b/airflow/Dockerfile.composer
@@ -15,8 +15,10 @@ RUN gcloud components install gke-gcloud-auth-plugin
 
 USER airflow
 
-COPY requirements-composer-1.20.5-airflow-2.4.3.txt /tmp/requirements-composer-1.20.5-airflow-2.4.3.txt
-RUN pip install --no-cache-dir --user -r /tmp/requirements-composer-1.20.5-airflow-2.4.3.txt
+COPY requirements-composer-1.17.7.txt /tmp/requirements-composer-1.17.7.txt
+RUN pip install --no-cache-dir --user -r /tmp/requirements-composer-1.17.7.txt
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --user -r /tmp/requirements.txt
+
+RUN python3 -m pip check

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,5 +1,6 @@
-calitp-data-infra==2023.2.13.1
+calitp-data-infra==2023.2.15
 gusty==0.6.0
 pyairtable==1.0.0
-typer==0.4.0
+typer==0.4.1
 sentry-sdk==1.9.8
+platformdirs<3,>=2.5


### PR DESCRIPTION
# Description

jupyter-core via gusty was installing platformdirs 3 but we need to keep it below 3. Also update typer and calitp-data-infra while at it, just for responsibility.

Adds pip3 check call in Dockerfile.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
This is already deployed.

## Screenshots (optional)
