### PR TITLE
Expand rt validator check

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -64,8 +64,16 @@
 "Technical contact is listed in feed_contact_email field within the feed_info.txt file"
 {% endmacro %}
 
-{% macro no_rt_validation_errors() %}
-"No errors in the MobilityData GTFS Realtime Validator"
+{% macro no_rt_validation_errors_vp() %}
+"The Vehicle positions feed produces no errors in the MobilityData GTFS Realtime Validator"
+{% endmacro %}
+
+{% macro no_rt_validation_errors_tu() %}
+"The Trip updates feed produces no errors in the MobilityData GTFS Realtime Validator"
+{% endmacro %}
+
+{% macro no_rt_validation_errors_sa() %}
+"The Service_alerts feed produces no errors in the MobilityData GTFS Realtime Validator"
 {% endmacro %}
 
 {% macro trip_id_alignment() %}

--- a/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_validation_errors.sql
+++ b/warehouse/models/intermediate/gtfs/gtfs_quality/int_gtfs_quality__no_rt_validation_errors.sql
@@ -35,7 +35,10 @@ int_gtfs_quality__no_rt_validation_errors AS (
         idx.date,
         idx.base64_url,
         idx.feed_type,
-        {{ no_rt_validation_errors() }} AS check,
+        CASE WHEN idx.feed_type = 'service_alerts' THEN {{ no_rt_validation_errors_sa() }}
+             WHEN idx.feed_type = 'trip_updates' THEN {{ no_rt_validation_errors_tu() }}
+             WHEN idx.feed_type = 'vehicle_positions' THEN {{ no_rt_validation_errors_vp() }}
+        END AS check,
         {{ compliance_rt() }} AS feature,
         rt_files,
         total_errors,

--- a/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_guideline_checks.md
@@ -63,7 +63,9 @@ Here is a list of currently-implemented checks:
 | Schedule feed is listed on feed aggregator transit.land | Feed Aggregator Availability (Schedule) | Schedule feed is present on the feed aggregator transit.land. |
 | Schedule feed is listed on feed aggregator Mobility Database | Feed Aggregator Availability (Schedule) | Schedule feed is present on the feed aggregator Mobility Database. |
 | Schedule feed downloads successfully | Compliance (Schedule) | On the given date, the schedule feed was downloaded and parsed successfully |
-| No errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for any RT feed extract on that day.|
+|Vehicle positions feed produces no errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The Vehicle positions feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for that feed on that day. |
+|Trip updates feed produces no errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The Trip updates feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for that feed on that day. |
+|Service alerts feed produces no errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The Service alerts feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for that feed on that day. |
 | All trip_ids provided in the GTFS-rt feed exist in the GTFS Schedule feed| Fixed-Route Completeness | Error code E003 does not appear in the MobilityData GTFS Realtime Validator on that day.|
 | Vehicle positions RT feed is present | Compliance (RT) | The vehicle positions RT feed contains at least one file on the given day.|
 | Trip updates RT feed is present | Compliance (RT) | The trip updates RT feed contains at least one file on the given day.|

--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_guideline_checks.md
@@ -10,7 +10,9 @@ Here is a list of currently-implemented checks:
 
 | Check | Feature | Description |
 | ------------------------------------ |---------|------------ |
-|No  errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for any RT feed extract on that day.|
+|Vehicle positions feed produces no errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The Vehicle positions feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for that feed on that day.|
+|Trip updates feed produces no errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The Trip updates feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for that feed on that day.|
+|Service alerts feed produces no errors in the MobilityData GTFS Realtime Validator | Compliance (RT) | The Service alerts feed has at least one GTFS-RT file present on the given day, and GTFS Realtime Validator produced no errors for that feed on that day.|
 |All trip_ids provided in the GTFS-rt feed exist in the GTFS Schedule feed| Fixed-Route Completeness | Error code E003 does not appear in the MobilityData GTFS Realtime Validator on that day.|
 | Vehicle positions RT feed contains updates at least once every 20 seconds | Accurate Service Data | Vehicle positions feed never contains a lag between updates of more than 20 seconds |
 | Trip updates RT feed contains updates at least once every 20 seconds | Accurate Service Data | Trip updates feed never contains a lag between updates of more than 20 seconds |

--- a/warehouse/models/mart/gtfs_quality/fct_implemented_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_implemented_checks.sql
@@ -25,6 +25,41 @@ existing_checks AS (
         check,
         feature
     FROM {{ ref('fct_daily_schedule_url_guideline_checks') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        check,
+        feature
+    FROM {{ ref('fct_daily_rt_url_guideline_checks') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        check,
+        feature
+    FROM {{ ref('fct_daily_organization_guideline_checks') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        check,
+        feature
+    FROM {{ ref('fct_daily_gtfs_dataset_guideline_checks') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        check,
+        feature
+    FROM {{ ref('fct_daily_service_guideline_checks') }}
+
+    UNION ALL
+
+    SELECT DISTINCT
+        check,
+        feature
+    FROM {{ ref('fct_daily_gtfs_service_data_guideline_checks') }}
 ),
 
 fct_implemented_checks AS (

--- a/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -20,7 +20,11 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ no_expired_services() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ no_rt_validation_errors() }}, {{ compliance_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_rt_validation_errors_vp() }}, {{ compliance_rt() }}, {{ rt_feed() }}
+    UNION ALL
+    SELECT {{ no_rt_validation_errors_tu() }}, {{ compliance_rt() }}, {{ rt_feed() }}
+    UNION ALL
+    SELECT {{ no_rt_validation_errors_sa() }}, {{ compliance_rt() }}, {{ rt_feed() }}
     UNION ALL
     SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}, {{ rt_feed() }}
     UNION ALL


### PR DESCRIPTION
# Description

Doing QA, I noticed that our RT validator check used the same check name across the 3 different RT feeds being validated. This PR fixes that. It also fixes the implemented_checks table, which somehow was missing most of the fct tables...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
`./dbt.sh build -s int_gtfs_quality__no_rt_validation_errors+   `

