### PR TITLE
separate exception types for other types of dbt failures and add Sentry env vars

### DIFF
--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -29,6 +29,8 @@ env_vars:
   DBT_PROFILE_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   NETLIFY_SITE_ID: cal-itp-dbt-docs
+  SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
+  SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
 
 secrets:
   - deploy_type: volume

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -30,6 +30,8 @@ env_vars:
   DBT_PROFILE_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   NETLIFY_SITE_ID: cal-itp-dbt-docs
+  SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
+  SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
 
 secrets:
   - deploy_type: volume

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -30,6 +30,7 @@ env_vars:
   DBT_PROFILE_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
+  SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
 
 secrets:
   - deploy_type: volume


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/2290

Adds missing Sentry env vars required for reporting dbt failures; they'd only been set in tests, not runs.

Also, I realized while testing locally that the exception types were not distinguished by resource type. This PR maintains the same fingerprints (since `unique_id` is prefixed with the resource type) but adds new exception types, so we can more easily search for issues.

See [this dev issue](https://sentry.calitp.org/organizations/sentry/issues/40540/events/?environment=development&project=2) as an example of an issue that was erroneously flagged as a test failure when it was really a run failure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I've run the exception reporting directly.

## Screenshots (optional)
