### PR TITLE
Upgrade warehouse deps one more time

### DIFF
--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -16,11 +16,8 @@ WORKDIR /app
 
 COPY ./pyproject.toml /app/pyproject.toml
 COPY ./poetry.lock /app/poetry.lock
-# TODO: This is currently broken https://github.com/python-poetry/poetry-plugin-export/issues/118 so we use requirements.txt for now
-#RUN poetry export -f requirements.txt --without-hashes --output requirements.txt \
-    #&& pip install -r requirements.txt
-COPY ./requirements.txt /app/requirements.txt
-RUN pip install -r /app/requirements.txt
+RUN poetry export -f requirements.txt --without-hashes --output requirements.txt \
+    && pip install -r requirements.txt
 
 COPY ./dbt_project.yml /app/dbt_project.yml
 COPY ./packages.yml /app/packages.yml

--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -16,11 +16,8 @@ WORKDIR /app
 
 COPY ./pyproject.toml /app/pyproject.toml
 COPY ./poetry.lock /app/poetry.lock
-# TODO: This is currently broken https://github.com/python-poetry/poetry-plugin-export/issues/118 so we use requirements.txt for now
-#RUN poetry export -f requirements.txt --without-hashes --output requirements.txt \
-    #&& pip install -r requirements.txt
-COPY ./requirements.txt /app/requirements.txt
-RUN pip install -r /app/requirements.txt
+RUN poetry export -f requirements.txt --without-hashes --output requirements.txt \
+    && pip install -r requirements.txt
 
 COPY ./dbt_project.yml /app/dbt_project.yml
 COPY ./packages.yml /app/packages.yml

--- a/warehouse/poetry.lock
+++ b/warehouse/poetry.lock
@@ -651,13 +651,15 @@ files = [
 
 [[package]]
 name = "dbt-metabase"
-version = "0.8.6.dev32+ge2c8c8f"
+version = "0.9.14"
 description = "Model synchronization from dbt to Metabase."
 category = "main"
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "dbt-metabase-0.9.14.tar.gz", hash = "sha256:5e59c4b1a99f4896457a874502fbd62ecc5d7c279b62402808cb3c4238ab686a"},
+    {file = "dbt_metabase-0.9.14-py3-none-any.whl", hash = "sha256:0dd6c558c25e327652564bc154e3a7f6a4b4e3b6bebb9d86b1096c3d2b7b6dcc"},
+]
 
 [package.dependencies]
 click = ">=8.0.0"
@@ -667,12 +669,6 @@ rich = ">=12.0.0"
 
 [package.extras]
 test = ["black", "mypy", "pylint", "restructuredtext-lint", "setuptools (>=45)", "types-PyYAML", "types-requests", "wheel"]
-
-[package.source]
-type = "git"
-url = "https://github.com/JarvusInnovations/dbt-metabase.git"
-reference = "HEAD"
-resolved_reference = "e2c8c8f842685b0fa0c6921cd4b3b8d8feb636df"
 
 [[package]]
 name = "decorator"
@@ -3421,4 +3417,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "d220fa142ac0580c408b5a5529677a7aa7693f6fe0e43f5758bdcb657f1d9a77"
+content-hash = "83e7d7b5758bde6fd6004bfbee9bf57f1faf348ef6f12b4d2d88d1ff3f20bd1c"

--- a/warehouse/pyproject.toml
+++ b/warehouse/pyproject.toml
@@ -6,8 +6,6 @@ authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "~3.9"
-# Point at the JarvusInnovations fork for new features; long-term we may be able to point at the pypi version
-dbt-metabase = {git = "https://github.com/JarvusInnovations/dbt-metabase.git"}
 colorama = "^0.4.4"
 pydantic = "^1.9.0"
 SQLAlchemy = "1.3.24"
@@ -26,6 +24,7 @@ dbt-core = "^1.3.1"
 dbt-bigquery = "^1.3.0"
 typer = "^0.7.0"
 gcsfs = "^2023.1.0"
+dbt-metabase = "^0.9.14"
 
 [tool.poetry.dev-dependencies]
 sqlfluff = "^1.4.5"

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -160,8 +160,6 @@ def run(
             )
         return cmd
 
-    subprocess.run(get_command("compile")).check_returncode()
-
     results_to_check = []
 
     if dbt_seed:
@@ -188,7 +186,11 @@ def run(
             manifest = Manifest(**json.load(f))
         report_failures_to_sentry(run_results, manifest)
     else:
-        typer.echo("skipping run")
+        typer.secho("skipping run, only compiling", fg=typer.colors.YELLOW)
+        args = ["compile"]
+        if full_refresh:
+            args.append("--full-refresh")
+        subprocess.run(get_command(*args)).check_returncode()
 
     if dbt_test:
         args = ["test"]


### PR DESCRIPTION
# Description

I forgot the warehouse image used requirements.txt; also we can use dbt-metabase directly now so we don't need to point at the Jarvus fork.

This also fixes a bug that can occur when changing incremental tables, where `run` succeeds but `compile` fails. We only need one or the other for docs, etc. to function, so just do one instead of both.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Built image, ran with local Airflow.

## Screenshots (optional)
