### PR TITLE
only run dbt-metabase in prod, and do not sync sources

### DIFF
--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -264,7 +264,9 @@ def run(
             results_to_check.append(subprocess.run(args))
 
     # There's a flag called --metabase_sync_skip but it doesn't seem to work as I assumed
-    # so we only want to sync in production
+    # so we only want to sync in production. This makes it hard to test, but we don't really
+    # use the pre-prod Metabase right now; we could theoretically test with that if it
+    # synced schemas created by the staging dbt target.
     if sync_metabase and target and target.startswith("prod"):
         results_to_check.append(
             subprocess.run(

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -263,12 +263,15 @@ def run(
 
             results_to_check.append(subprocess.run(args))
 
-    if sync_metabase:
+    # There's a flag called --metabase_sync_skip but it doesn't seem to work as I assumed
+    # so we only want to sync in production
+    if sync_metabase and target and target.startswith("prod"):
         results_to_check.append(
             subprocess.run(
                 [
                     "dbt-metabase",
                     "models",
+                    "--metabase_exclude_sources",
                     "--dbt_manifest_path",
                     "./target/manifest.json",
                     "--metabase_database",
@@ -283,6 +286,7 @@ def run(
                 [
                     "dbt-metabase",
                     "models",
+                    "--metabase_exclude_sources",
                     "--dbt_manifest_path",
                     "./target/manifest.json",
                     "--metabase_database",


### PR DESCRIPTION
# Description

Follow-up from https://github.com/cal-itp/data-infra/pull/2310, I left out the exclude sources flag. Also, it doesn't run in staging anyways since there's no staging target schemas in Metabase (we could maybe sync them?)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
