### PR TITLE
dbt-metabase does not check for hanging slash in url

### DIFF
--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -278,7 +278,7 @@ def run(
                         "--dbt_manifest_path",
                         "./target/manifest.json",
                         "--dbt_docs_url",
-                        "https://dbt-docs.calitp.org/",
+                        "https://dbt-docs.calitp.org",
                         "--metabase_database",
                         "Data Marts (formerly Warehouse Views)",
                         "--dbt_schema_excludes",


### PR DESCRIPTION
# Description

last one

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested
n/a

## Screenshots (optional)
