### PR TITLE
Fix failing assessment candidate key

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
@@ -19,8 +19,9 @@ WITH full_join AS (
         COALESCE(
             gtfs_service_data_customer_facing,
             gtfs_service_data_category = "primary",
-            -- we do want to assess organizations without GTFS data
-            gtfs_service_data_key IS NULL,
+            -- we do want to assess organizations & services without GTFS data
+            -- but we don't want to assess GTFS data without a service
+            gtfs_service_data_key IS NULL AND gtfs_dataset_key IS NULL AND base64_url IS NULL,
             FALSE
         ) AS gtfs_service_data_assessed
     FROM {{ ref('int_gtfs_quality__naive_organization_service_dataset_full_join') }}

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__naive_organization_service_dataset_full_join.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__naive_organization_service_dataset_full_join.sql
@@ -148,6 +148,13 @@ int_gtfs_quality__naive_organization_service_dataset_full_join AS (
     LEFT JOIN ntd_bridge
         ON orgs.key = ntd_bridge.organization_key
         AND orgs.date = ntd_bridge.date
+    -- rt feeds data comes in earlier than the rest and results in a bunch of rows with nulls
+    WHERE COALESCE(orgs.date,
+            services.date,
+            service_data.date,
+            datasets.date,
+            schedule_feeds.date,
+            rt_feeds.date) < CURRENT_DATE()
 )
 
 SELECT * FROM int_gtfs_quality__naive_organization_service_dataset_full_join

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__naive_organization_service_dataset_full_join.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__naive_organization_service_dataset_full_join.sql
@@ -77,6 +77,7 @@ schedule_feeds AS (
 rt_feeds AS (
     SELECT *
     FROM {{ ref('fct_daily_rt_feed_files') }}
+    WHERE date < CURRENT_DATE()
 ),
 
 int_gtfs_quality__naive_organization_service_dataset_full_join AS (
@@ -148,7 +149,7 @@ int_gtfs_quality__naive_organization_service_dataset_full_join AS (
     LEFT JOIN ntd_bridge
         ON orgs.key = ntd_bridge.organization_key
         AND orgs.date = ntd_bridge.date
-    -- rt feeds data comes in earlier than the rest and results in a bunch of rows with nulls
+    -- just to be on the safe side, double check that we aren't including current date
     WHERE COALESCE(orgs.date,
             services.date,
             service_data.date,


### PR DESCRIPTION
# Description

Fixes two issues, identified by [this Sentry issue](https://sentry.calitp.org/organizations/sentry/issues/40764/) / issue #2320. 

We were getting duplicate keys in `int_gtfs_quality__daily_assessment_candidate_entities`. 

1. The cause was that in #2304 I added a flag for whether there are actually RT files on a given day, and apparently those models update before the rest so we were getting empty rows for the current date with only an RT URL filled in and nothing else. I added two `< CURRENT_DATE()` filters to stop this in the immediate precursor `naive join`.
2. In the course of investigating this, I realized that the logic I added in #2304 for checking `gtfs_service_data_assessed` was too generous and was marking rows with just a URL as `assessed`. Fixed that too.

Resolves #2320

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

`poetry run dbt run -s 1+int_gtfs_quality__daily_assessment_candidate_entities` & `poetry run dbt test -s 1+int_gtfs_quality__daily_assessment_candidate_entities`

## Screenshots (optional)
