### PR TITLE
Post composer upgrade

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.1.4-python3.8
+FROM apache/airflow:2.4.3-python3.8
 
 # install gcloud as root, then switch back to airflow
 USER root

--- a/airflow/dags/parse_and_validate_rt_v2/parse_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/parse_rt_service_alerts.yml
@@ -39,7 +39,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/parse_and_validate_rt_v2/parse_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/parse_rt_trip_updates.yml
@@ -40,7 +40,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/parse_and_validate_rt_v2/parse_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/parse_rt_vehicle_positions.yml
@@ -39,7 +39,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/parse_and_validate_rt_v2/validate_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/validate_rt_service_alerts.yml
@@ -40,7 +40,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 5.0Gi
   request_cpu: 2
 

--- a/airflow/dags/parse_and_validate_rt_v2/validate_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/validate_rt_trip_updates.yml
@@ -40,7 +40,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 5.0Gi
   request_cpu: 2
 

--- a/airflow/dags/parse_and_validate_rt_v2/validate_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/validate_rt_vehicle_positions.yml
@@ -40,7 +40,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 5.0Gi
   request_cpu: 2
 

--- a/airflow/dags/publish_open_data/publish_california_open_data.yml
+++ b/airflow/dags/publish_open_data/publish_california_open_data.yml
@@ -32,7 +32,7 @@ secrets:
     secret: jobs-data
     key: calitp-ckan-gtfs-schedule-key
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -52,7 +52,7 @@ secrets:
     secret: jobs-data
     key: netlify-auth-token
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/transform_warehouse/dbt_test.yml
+++ b/airflow/dags/transform_warehouse/dbt_test.yml
@@ -38,7 +38,7 @@ secrets:
     secret: jobs-data
     key: service-account.json
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -53,7 +53,7 @@ secrets:
     secret: jobs-data
     key: netlify-auth-token
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -38,7 +38,7 @@ secrets:
     secret: jobs-data
     key: service-account.json
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/validate_gtfs_schedule.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/validate_gtfs_schedule.yml
@@ -35,7 +35,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 5.0Gi
   request_cpu: 1
 

--- a/airflow/requirements-dev.txt
+++ b/airflow/requirements-dev.txt
@@ -1,2 +1,2 @@
-apache-airflow==2.1.4
+apache-airflow==2.4.3
 black==22.3.0


### PR DESCRIPTION
# Description

There was a [breaking change](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html#id22) during the upgrade, so we have to use the new param name for providing PodOperators their resource requests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Works locally after fix; had reproduce issue pre-fix.

## Screenshots (optional)
