### PR TITLE
split failure emails into separate task again

### DIFF
--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -8,7 +8,6 @@ import logging
 from typing import ClassVar, List, Optional
 
 import humanize
-import pandas as pd
 import pendulum
 import sentry_sdk
 from calitp_data_infra.auth import get_secrets_by_label
@@ -165,7 +164,9 @@ def download_all(task_instance, execution_date, **kwargs):
         )
         task_instance.xcom_push(
             key="download_failures",
-            value=pd.DataFrame(f.dict() for f in result.failures),
+            value=[
+                json.loads(f.json()) for f in result.failures
+            ],  # use the Pydantic serializer
         )
 
     success_rate = len(result.successes) / len(configs)

--- a/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
+++ b/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
@@ -1,0 +1,53 @@
+# ---
+# python_callable: email_failures
+# provide_context: true
+# dependencies:
+#   - download_schedule_feeds
+# ---
+import datetime
+
+import pandas as pd
+from calitp_data.config import is_development
+
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils.email import send_email
+
+
+def email_failures(task_instance: TaskInstance, execution_date, **kwargs):
+    # use pandas begrudgingly for email HTML since the old task used it
+    failures_df = pd.DataFrame(
+        task_instance.xcom_pull(task_ids="pushing_task", key="download_failures")
+    )
+    if failures_df.empty:
+        html_content = f"All feeds were downloaded successfully on {execution_date}!"
+    else:
+        html_report = failures_df.to_html(border=False)
+
+        html_content = f"""\
+    NOTE: These failures come from the v2 of the GTFS Schedule downloader.
+
+    The following agency GTFS feeds could not be extracted on {execution_date}:
+
+    {html_report}
+    """
+
+    if is_development():
+        print(
+            f"Skipping since in development mode! Would have emailed {failures_df.shape[0]} failures."
+        )
+        print(html_content)
+    else:
+        send_email(
+            to=[
+                "laurie.m@jarv.us",
+                "andrew.v@jarv.us",
+                "evan.siroky@dot.ca.gov",
+                "hunter.owens@dot.ca.gov",
+                "jameelah.y@jarv.us",
+                "olivia.ramacier@dot.ca.gov",
+            ],
+            html_content=html_content,
+            subject=(
+                f"Operator GTFS Errors for {datetime.datetime.now().strftime('%Y-%m-%d')}"
+            ),
+        )

--- a/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
+++ b/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
@@ -3,6 +3,7 @@
 # provide_context: true
 # dependencies:
 #   - download_schedule_feeds
+# trigger_rule: all_done
 # ---
 import datetime
 
@@ -16,7 +17,9 @@ from airflow.utils.email import send_email
 def email_failures(task_instance: TaskInstance, execution_date, **kwargs):
     # use pandas begrudgingly for email HTML since the old task used it
     failures_df = pd.DataFrame(
-        task_instance.xcom_pull(task_ids="pushing_task", key="download_failures")
+        task_instance.xcom_pull(
+            task_ids="download_schedule_feeds", key="download_failures"
+        )
     )
     if failures_df.empty:
         html_content = f"All feeds were downloaded successfully on {execution_date}!"

--- a/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
+++ b/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
@@ -27,8 +27,6 @@ def email_failures(task_instance: TaskInstance, execution_date, **kwargs):
         html_report = failures_df.to_html(border=False)
 
         html_content = f"""\
-    NOTE: These failures come from the v2 of the GTFS Schedule downloader.
-
     The following agency GTFS feeds could not be extracted on {execution_date}:
 
     {html_report}


### PR DESCRIPTION
# Description

Airflow emails via Postmark are not working right now; I'm trying to debug but it's hard locally, so I want to be able to retry just this task. Also, we shouldn't be retrying the actual download task because the failure email failed to send. The v1 pipeline had separate tasks and we just didn't split them up in v2.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally.

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/4305366/221670237-6679672e-3015-4657-b0df-ca8aee83e84a.png)
