### PR TITLE
Bugfix: update manual check logic based on values entered in airtable

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__authentication_acceptable.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__authentication_acceptable.sql
@@ -22,6 +22,7 @@ int_gtfs_quality__authentication_acceptable AS (
         CASE manual_check__authentication_acceptable
             WHEN 'Yes' THEN {{ guidelines_pass_status() }}
             WHEN 'No' THEN {{ guidelines_fail_status() }}
+            WHEN 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__data_license.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__data_license.sql
@@ -23,9 +23,13 @@ int_gtfs_quality__data_license AS (
             WHEN gtfs_datasets.type IN ("vehicle_positions", "trip_updates", "service_alerts") THEN {{ compliance_rt() }}
         END AS feature,
         CASE
-            WHEN manual_check__data_license LIKE ('%Permissive%') THEN {{ guidelines_pass_status() }}
+            WHEN manual_check__data_license LIKE ('%Permissive%')
+                 OR manual_check__data_license LIKE ('%CC-BY%')
+                 OR manual_check__data_license LIKE ('%ODL-BY%')
+                THEN {{ guidelines_pass_status() }}
             WHEN manual_check__data_license LIKE ('%Restrictive%')
-                 OR manual_check__data_license = 'Missing' THEN {{ guidelines_fail_status() }}
+                 OR manual_check__data_license = 'Missing'
+                THEN {{ guidelines_fail_status() }}
             WHEN manual_check__data_license = 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__data_license.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__data_license.sql
@@ -22,9 +22,11 @@ int_gtfs_quality__data_license AS (
             WHEN gtfs_datasets.type = "schedule" THEN {{ compliance_schedule() }}
             WHEN gtfs_datasets.type IN ("vehicle_positions", "trip_updates", "service_alerts") THEN {{ compliance_rt() }}
         END AS feature,
-        CASE manual_check__data_license
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
+        CASE
+            WHEN manual_check__data_license LIKE ('%Permissive%') THEN {{ guidelines_pass_status() }}
+            WHEN manual_check__data_license LIKE ('%Restrictive%')
+                 OR manual_check__data_license = 'Missing' THEN {{ guidelines_fail_status() }}
+            WHEN manual_check__data_license = 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__demand_responsive_routes_match.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__demand_responsive_routes_match.sql
@@ -15,8 +15,9 @@ int_gtfs_quality__demand_responsive_routes_match AS (
         {{ demand_responsive_routes_match() }} AS check,
         {{ demand_responsive_completeness() }} AS feature,
         CASE manual_check__demand_response_completeness
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
+            WHEN 'Complete' THEN {{ guidelines_pass_status() }}
+            WHEN 'Incomplete' THEN {{ guidelines_fail_status() }}
+            WHEN 'N/A' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status,
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__fixed_routes_match.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__fixed_routes_match.sql
@@ -15,8 +15,9 @@ int_gtfs_quality__fixed_routes_match AS (
         {{ fixed_routes_match() }} AS check,
         {{ fixed_route_completeness() }} AS feature,
         CASE manual_check__fixed_route_completeness
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
+            WHEN 'Complete' THEN {{ guidelines_pass_status() }}
+            WHEN 'Incomplete' THEN {{ guidelines_fail_status() }}
+            WHEN 'N/A' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status,
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__link_to_dataset_on_website.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__link_to_dataset_on_website.sql
@@ -22,6 +22,7 @@ int_gtfs_quality__link_to_dataset_on_website AS (
         CASE manual_check__link_to_dataset_on_website
             WHEN 'Yes' THEN {{ guidelines_pass_status() }}
             WHEN 'No' THEN {{ guidelines_fail_status() }}
+            WHEN 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_trip_updates.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_trip_updates.sql
@@ -16,7 +16,7 @@
 WITH
 
 feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index_tu') }}
+    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index') }}
     {% if is_incremental() %}
     WHERE date >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}
@@ -24,8 +24,8 @@ feed_guideline_index AS (
     {% endif %}
 ),
 
-fct_trip_updates_messages AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__trip_updates_no_stop_times') }}
+unioned_parse_outcomes AS (
+    SELECT * FROM {{ ref('int_gtfs_rt__unioned_parse_outcomes') }}
     {% if is_incremental() %}
     WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}
@@ -33,17 +33,16 @@ fct_trip_updates_messages AS (
     {% endif %}
 ),
 
-trip_update_ages AS (
+feed_ages AS (
     SELECT
         dt,
         base64_url,
-        COUNT(*) AS num_trip_updates,
-        MIN(TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND)) AS min_trip_update_age,
-        PERCENTILE_CONT(TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND), 0.5) AS median_trip_update_age,
-        MAX(TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND)) AS max_trip_update_age,
-        MAX(TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND)) AS max_trip_update_feed_age,
-    FROM fct_trip_updates_messages
-    GROUP BY 1, 2
+        feed_type,
+        COUNT(*) AS num_parses,
+        MIN(TIMESTAMP_DIFF(extract_ts, last_modified_timestamp, SECOND)) AS min_feed_age,
+        MAX(TIMESTAMP_DIFF(extract_ts, last_modified_timestamp, SECOND)) AS max_feed_age
+    FROM unioned_parse_outcomes
+    GROUP BY 1, 2, 3
 ),
 
 int_gtfs_quality__no_stale_trip_updates AS (

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__shapes_accurate.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__shapes_accurate.sql
@@ -14,9 +14,10 @@ int_gtfs_quality__shapes_accurate AS (
         idx.gtfs_dataset_key,
         {{ shapes_accurate() }} AS check,
         {{ accurate_service_data() }} AS feature,
-        CASE manual_check__accurate_shapes
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
+        CASE
+            WHEN manual_check__accurate_shapes = 'Yes' THEN {{ guidelines_pass_status() }}
+            WHEN manual_check__accurate_shapes = 'No' THEN {{ guidelines_fail_status() }}
+            WHEN manual_check__accurate_shapes LIKE 'N/A%' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status,
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__stable_url.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__stable_url.sql
@@ -22,9 +22,10 @@ int_gtfs_quality__stable_url AS (
             WHEN gtfs_datasets.type = "schedule" THEN {{ compliance_schedule() }}
             WHEN gtfs_datasets.type IN ("vehicle_positions", "trip_updates", "service_alerts") THEN {{ compliance_rt() }}
         END AS feature,
-        CASE manual_check__stable_url
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
+        CASE
+            WHEN manual_check__stable_url LIKE 'Yes%' THEN {{ guidelines_pass_status() }}
+            WHEN manual_check__stable_url LIKE 'No%' THEN {{ guidelines_fail_status() }}
+            WHEN manual_check__stable_url LIKE 'N/A%' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__stable_url.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__stable_url.sql
@@ -25,7 +25,7 @@ int_gtfs_quality__stable_url AS (
         CASE
             WHEN manual_check__stable_url LIKE 'Yes%' THEN {{ guidelines_pass_status() }}
             WHEN manual_check__stable_url LIKE 'No%' THEN {{ guidelines_fail_status() }}
-            WHEN manual_check__stable_url LIKE 'N/A%' THEN {{ guidelines_na_check_status() }}
+            WHEN manual_check__stable_url = 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_rt.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_rt.sql
@@ -17,6 +17,7 @@ int_gtfs_quality__trip_planner_rt AS (
         CASE manual_check__gtfs_realtime_data_ingested_in_trip_planner
             WHEN 'Yes' THEN {{ guidelines_pass_status() }}
             WHEN 'No' THEN {{ guidelines_fail_status() }}
+            WHEN 'N/A - no fixed-route service' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status,
     FROM idx

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_schedule.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_schedule.sql
@@ -17,6 +17,7 @@ int_gtfs_quality__trip_planner_schedule AS (
         CASE manual_check__gtfs_schedule_data_ingested_in_trip_planner
             WHEN 'Yes' THEN {{ guidelines_pass_status() }}
             WHEN 'No' THEN {{ guidelines_fail_status() }}
+            WHEN 'N/A - no fixed-route service' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status,
     FROM idx


### PR DESCRIPTION
# Description

When I set up the manual checks last month, we didn't have any results in airtable. Now that we do, I've gone through and updated the logic to reflect the actual values for these checks. I did this by looking at distinct values for each manual check and confirming that each case was covered by the corresponding intermediate check table.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I confirmed that each intermediate table runs successfully.

