### PR TITLE
update 30day expiration check

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_30_day_feed_expiration.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_30_day_feed_expiration.sql
@@ -3,9 +3,11 @@ WITH feed_guideline_index AS (
 ),
 
 -- For this check we are only looking for the 30-day feed expiration warning
-validation_fact_daily_feed_codes_shape_related AS (
+validation_fact_daily_feed_codes_expiration_related AS (
     SELECT * FROM {{ ref('fct_daily_schedule_feed_validation_notices') }}
-     WHERE code = 'feed_expiration_date30_days'
+    -- If the feed expires within 7 days, the 30day notice won't appear.
+    -- In our case we want this check to fail even if the 7day expiration check also fails.
+     WHERE code IN ('feed_expiration_date30_days','feed_expiration_date7_days')
 ),
 
 validation_notices_by_day AS (
@@ -13,7 +15,7 @@ validation_notices_by_day AS (
         feed_key,
         date,
         SUM(total_notices) as validation_notices
-    FROM validation_fact_daily_feed_codes_shape_related
+    FROM validation_fact_daily_feed_codes_expiration_related
     GROUP BY feed_key, date
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_7_day_feed_expiration.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_7_day_feed_expiration.sql
@@ -3,7 +3,7 @@ WITH feed_guideline_index AS (
 ),
 
 -- For this check we are only looking for the 7-day feed expiration warning
-validation_fact_daily_feed_codes_shape_related AS (
+validation_fact_daily_feed_codes_expiration_related AS (
     SELECT * FROM {{ ref('fct_daily_schedule_feed_validation_notices') }}
      WHERE code = 'feed_expiration_date7_days'
 ),
@@ -13,7 +13,7 @@ validation_notices_by_day AS (
         feed_key,
         date,
         SUM(total_notices) as validation_notices
-    FROM validation_fact_daily_feed_codes_shape_related
+    FROM validation_fact_daily_feed_codes_expiration_related
     GROUP BY feed_key, date
 ),
 


### PR DESCRIPTION
# Description

We have two feed-expiration checks: one looks for feeds that expire within 7 days, and one looks for feeds that expire within 30 days. Both rely on gtfs-validator. I discovered that the two notices are mutually-exclusive from the validator ([source code](https://github.com/MobilityData/gtfs-validator/blob/30e6c69f7c7ca500855c9e698d804f7c7f4ddcbb/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java#L64)), which caused our 30day check to pass when the 7day check was failing. This isn't  a validator bug, but it's a bug in the way we're using the validator output. This change causes our 30day expiration check to fail if the 30day OR 7day notice appears in the validator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
It ran successfully, and I confirmed that a feed that was failing the 7day check and passing the 30day check is now failing both.

