### PR TITLE
remove object memory locations from exception string representation

### DIFF
--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '2023.2.21'
+  newTag: '2023.2.27'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '2023.2.21'
+  newTag: '2023.2.27'

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -4,6 +4,7 @@ Huey's startup hooks are per _worker_ and not the overall consumer process.
 """
 import logging
 import os
+import re
 import sys
 
 import sentry_sdk
@@ -15,6 +16,8 @@ from prometheus_client import start_http_server
 
 from .tasks import RTFetchException, huey
 
+compiled_regex = re.compile("0x[0-9a-fA-F]+")
+
 
 def set_exception_fingerprint(event, hint):
     if "exc_info" not in hint:
@@ -23,7 +26,8 @@ def set_exception_fingerprint(event, hint):
     exception = hint["exc_info"][1]
     if isinstance(exception, RTFetchException):
         event["fingerprint"] = [
-            str(exception),
+            # this is ugly but it's the easiest way to quickly remove the object location hex from the fingerprint
+            compiled_regex.sub("0x...", str(exception)),
             str(exception.url),
         ]
         if exception.status_code:

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -27,6 +27,8 @@ def set_exception_fingerprint(event, hint):
     if isinstance(exception, RTFetchException):
         event["fingerprint"] = [
             # this is ugly but it's the easiest way to quickly remove the object location hex from the fingerprint
+            # without actually messing with the exception chain;
+            # safety net for exceptions that contain a default object str()
             compiled_regex.sub("0x...", str(exception)),
             str(exception.url),
         ]

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "2023.2.21"
+version = "2023.2.27"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/1897

The exception string looks like this post-replacement: `"HTTPSConnectionPool(host='avl.yctd.org', port=443): Max retries exceeded with url: /RealTime/GTFS_TripUpdates.pb (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at ...>, 'Connection to avl.yctd.org timed out. (connect timeout=30)')) (https://avl.yctd.org/RealTime/GTFS_TripUpdates.pb)"`.

I don't want to just use the exception type by itself because the same exception could be caused by different underlying exceptions. Also, this avoids interacting with the underlying exception(s) except for the purpose of Sentry fingerprinting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Running locally, will deploy to test.

## Screenshots (optional)
