### PR TITLE
Fix schedule feed versioning when URL deleted or data changed while offline

### DIFF
--- a/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
+++ b/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
@@ -15,7 +15,12 @@ WITH int_gtfs_schedule__joined_feed_outcomes AS (
     SELECT *
     FROM {{ ref('int_gtfs_schedule__joined_feed_outcomes') }}
     WHERE EXTRACT(DATE FROM ts) <= EXTRACT(DATE FROM TIMESTAMP '{{ latest_processed_timestamp }}')
-        AND download_success AND unzip_success
+),
+
+successful_downloads AS (
+    SELECT *
+    FROM int_gtfs_schedule__joined_feed_outcomes
+    WHERE download_success AND unzip_success
 ),
 
 hashed AS (
@@ -29,7 +34,7 @@ hashed AS (
         MAX(ts) OVER(PARTITION BY base64_url ORDER BY ts DESC) AS latest_extract,
         {{ dbt_utils.surrogate_key(['download_success', 'unzip_success',
          'zipfile_extract_md5hash']) }} AS content_hash
-    FROM int_gtfs_schedule__joined_feed_outcomes
+    FROM successful_downloads
 ),
 
 next_valid_extract AS (
@@ -48,38 +53,59 @@ first_instances AS (
         latest_extract,
         download_success,
         unzip_success,
+        content_hash,
         zipfile_extract_md5hash,
         (DENSE_RANK() OVER (ORDER BY latest_extract DESC)) = 1 AS in_latest,
         next_ts,
-        (LAG(content_hash) OVER (PARTITION BY base64_url ORDER BY hashed.ts) != content_hash)
-            OR (LAG(content_hash) OVER (PARTITION BY base64_url ORDER BY hashed.ts) IS NULL) AS is_first
+        LAG(content_hash) OVER (PARTITION BY base64_url ORDER BY hashed.ts) != content_hash AS continuous_first,
+        LAG(content_hash) OVER (PARTITION BY base64_url ORDER BY hashed.ts) IS NULL AS discontinuous_first
     FROM hashed
-    LEFT JOIN next_valid_extract AS next
-        ON hashed.latest_extract = next.ts
-    QUALIFY is_first
+    LEFT JOIN next_valid_extract AS next_global
+        ON hashed.latest_extract = next_global.ts
+    QUALIFY continuous_first OR discontinuous_first
 ),
 
-all_versioned AS (
+-- because URLs can be deleted from our list but then reoccur
+-- (which is nonstandard for keys in this kind of SCD logic)
+-- we need to add specific checks to figure out whether the URL was deleted between instances
+get_next_first AS (
     SELECT
         base64_url,
         download_success,
         unzip_success,
+        content_hash,
         zipfile_extract_md5hash,
-        ts AS _valid_from,
-        CASE
-            -- if there's a subsequent extract, use that extract time as end date
-            WHEN LEAD(ts) OVER (PARTITION BY base64_url ORDER BY ts) IS NOT NULL
-                THEN {{ make_end_of_valid_range('LEAD(ts) OVER (PARTITION BY base64_url ORDER BY ts)') }}
-            ELSE
-            -- if there's no subsequent extract, it was either deleted or it's current
-            -- if it was in the latest extract, call it current (even if it errored)
-            -- if it was not in the latest extract, call it deleted at the last time it was extracted
-                CASE
-                    WHEN in_latest THEN {{ make_end_of_valid_range('CAST("2099-01-01" AS TIMESTAMP)') }}
-                    ELSE {{ make_end_of_valid_range('next_ts') }}
-                END
-        END AS _valid_to
+        ts,
+        LEAD(ts) OVER(PARTITION BY base64_url ORDER BY ts) AS next_first_ts
     FROM first_instances
+),
+
+all_versioned AS (
+    SELECT
+        get_next_first.base64_url,
+        get_next_first.download_success,
+        get_next_first.unzip_success,
+        get_next_first.content_hash,
+        get_next_first.zipfile_extract_md5hash,
+        get_next_first.ts AS _valid_from,
+        COALESCE(
+                (
+                -- this is the first (global) extract after the last successful instance of the current version
+                LAST_VALUE(next_valid_extract.next_ts)
+                    OVER(PARTITION BY get_next_first.base64_url, get_next_first.ts
+                        ORDER BY successful_downloads.ts
+                        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+                ),
+                "2099-01-01")
+            AS _valid_to_raw
+    FROM get_next_first
+    LEFT JOIN successful_downloads
+        ON get_next_first.base64_url = successful_downloads.base64_url
+        AND successful_downloads.ts BETWEEN get_next_first.ts AND {{ make_end_of_valid_range(COALESCE(get_next_first.next_first_ts, "2099-01-01")) }}
+    LEFT JOIN next_valid_extract
+        ON successful_downloads.ts = next_valid_extract.ts
+    -- filter to only the last successful appearance of the current version
+    QUALIFY successful_downloads.ts =  LAST_VALUE(successful_downloads.ts) OVER(PARTITION BY get_next_first.base64_url, get_next_first.ts ORDER BY successful_downloads.ts ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 ),
 
 actual_data_only AS (
@@ -89,10 +115,9 @@ actual_data_only AS (
         unzip_success,
         zipfile_extract_md5hash,
         _valid_from,
-        _valid_to,
+        {{ make_end_of_valid_range(_valid_to_raw) }} AS _valid_to,
         _valid_to = {{ make_end_of_valid_range('CAST("2099-01-01" AS TIMESTAMP)') }} AS _is_current
     FROM all_versioned
-    WHERE download_success AND unzip_success
 ),
 
 dim_schedule_feeds AS (


### PR DESCRIPTION
# Description

Fixing #2329 which is blocking #2249.

This changes the logic in `dim_schedule_feeds` for this situation, where a feed "goes dark" for a bit and then comes back with different data:

Date | Feed | Result | Zipfile version
--- | --- | --- | ---
1/1 | A | Success | abc
1/2 | A | Success | abc
1/3 | A | Fails | 
1/4 | A | Fails | 
1/5 | A | Fails | 
1/6 | A | Success | def

Previously you would get the following (we would interpolate right up to the beginning of the new version): 

Version | _valid_from | _valid_to
--- | --- | ---
abc | 1/1 | 1/5
def | 1/6 | *future*

Now we get this (don't interpolate past the first extract where it fails):

Version | _valid_from | _valid_to
--- | --- | ---
abc | 1/1 | 1/3
def | 1/6 | *future*

Resolves #2329 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran the following SQL and did spot checks, confirmed that the new gaps are things we want.
<details><summary>General full outer join</summary>

```
WITH old_version AS (
  SELECT * FROM `cal-itp-data-infra.mart_gtfs.dim_schedule_feeds`
),

new_version AS (
  SELECT * FROM `cal-itp-data-infra-staging.laurie_mart_gtfs.dim_schedule_feeds`
)

SELECT 
  old_version.*,
  new_version.*
FROM old_version
FULL OUTER JOIN new_version
USING (key, _valid_from, _valid_to, _is_current)
WHERE old_version.key IS NULL OR new_version.key IS NULL
ORDER BY COALESCE(old_version.base64_url, new_version.base64_url), COALESCE(old_version._valid_from, new_version._valid_from)
```
</details>

Confirmed that when the above SQL is modified to only join on `key, _valid_from` there are no mismatches, which is what we would expect (these changes should only change the **end** date, not the **start** date). Which incidentally means that I think (?) we may not need to run a full refresh as a result of this. 

Confirmed via Glendale Schedule that if the feed comes back with the same zipfile version we do successfully keep extending the dates. 

Confirmed that overall row count is identical between old and new. 