### PR TITLE
add basic service level check for whether a feed is present

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -316,6 +316,22 @@
 "100% of trips marked as Scheduled, Canceled, or Added within the Trip updates feed are represented within the Vehicle positions feed"
 {% endmacro %}
 
+{% macro feed_listed_schedule() %}
+"A GTFS Schedule feed is listed"
+{% endmacro %}
+
+{% macro feed_listed_vp() %}
+"A Vehicle positions feed is listed"
+{% endmacro %}
+
+{% macro feed_listed_tu() %}
+"A Trip updates feed is listed"
+{% endmacro %}
+
+{% macro feed_listed_sa() %}
+"A Service alerts feed is listed"
+{% endmacro %}
+
 --
 -- FEATURE NAMES
 --

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -273,6 +273,22 @@ models:
     tests: *stg_gtfs_guideline_tests_service
     columns: *stg_gtfs_guideline_columns
 
+  - name: int_gtfs_quality__feed_listed_schedule
+    tests: *stg_gtfs_guideline_tests_service
+    columns: *stg_gtfs_guideline_columns
+
+  - name: int_gtfs_quality__feed_listed_vp
+    tests: *stg_gtfs_guideline_tests_service
+    columns: *stg_gtfs_guideline_columns
+
+  - name: int_gtfs_quality__feed_listed_tu
+    tests: *stg_gtfs_guideline_tests_service
+    columns: *stg_gtfs_guideline_columns
+
+  - name: int_gtfs_quality__feed_listed_sa
+    tests: *stg_gtfs_guideline_tests_service
+    columns: *stg_gtfs_guideline_columns
+
 # --- GTFS-service-data-level
 # ----- Schedule only
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_sa.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_sa.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.customer_facing
+       AND quartet.gtfs_service_data_customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_sa.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_sa.sql
@@ -1,0 +1,38 @@
+WITH
+
+idx AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__services_guideline_index') }}
+),
+
+dim_provider_gtfs_data AS (
+    SELECT * FROM {{ ref('dim_provider_gtfs_data') }}
+),
+
+joined AS (
+    SELECT
+        idx.date,
+        idx.service_key,
+        -- Some services are mapped to multiple service_alerts_gtfs_dataset_key values at the same time.
+        -- This is one way to address that, open to better solutions!
+        ANY_VALUE(service_alerts_gtfs_dataset_key) AS gtfs_dataset_key
+    FROM idx
+    LEFT JOIN dim_provider_gtfs_data AS quartet
+        ON idx.service_key = quartet.service_key
+       AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
+       AND quartet.guidelines_assessed
+    GROUP BY 1,2
+),
+
+int_gtfs_quality__feed_listed_sa AS (
+    SELECT
+        date,
+        service_key,
+        {{ feed_listed_sa() }} AS check,
+        {{ compliance_rt() }} AS feature,
+        CASE WHEN gtfs_dataset_key IS NOT null THEN {{ guidelines_pass_status() }}
+             ELSE {{ guidelines_fail_status() }}
+        END AS status,
+    FROM joined
+)
+
+SELECT * FROM int_gtfs_quality__feed_listed_sa

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_sa.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_sa.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.guidelines_assessed
+       AND quartet.customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_schedule.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_schedule.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.customer_facing
+       AND quartet.gtfs_service_data_customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_schedule.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_schedule.sql
@@ -1,0 +1,38 @@
+WITH
+
+idx AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__services_guideline_index') }}
+),
+
+dim_provider_gtfs_data AS (
+    SELECT * FROM {{ ref('dim_provider_gtfs_data') }}
+),
+
+joined AS (
+    SELECT
+        idx.date,
+        idx.service_key,
+        -- Some services are mapped to multiple associated_schedule_gtfs_dataset_key values at the same time.
+        -- This is one way to address that, open to better solutions!
+        ANY_VALUE(associated_schedule_gtfs_dataset_key) AS gtfs_dataset_key
+    FROM idx
+    LEFT JOIN dim_provider_gtfs_data AS quartet
+        ON idx.service_key = quartet.service_key
+       AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
+       AND quartet.guidelines_assessed
+    GROUP BY 1,2
+),
+
+int_gtfs_quality__feed_listed_schedule AS (
+    SELECT
+        date,
+        service_key,
+        {{ feed_listed_schedule() }} AS check,
+        {{ compliance_schedule() }} AS feature,
+        CASE WHEN gtfs_dataset_key IS NOT null THEN {{ guidelines_pass_status() }}
+             ELSE {{ guidelines_fail_status() }}
+        END AS status,
+    FROM joined
+)
+
+SELECT * FROM int_gtfs_quality__feed_listed_schedule

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_schedule.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_schedule.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.guidelines_assessed
+       AND quartet.customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_tu.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_tu.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.customer_facing
+       AND quartet.gtfs_service_data_customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_tu.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_tu.sql
@@ -1,0 +1,38 @@
+WITH
+
+idx AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__services_guideline_index') }}
+),
+
+dim_provider_gtfs_data AS (
+    SELECT * FROM {{ ref('dim_provider_gtfs_data') }}
+),
+
+joined AS (
+    SELECT
+        idx.date,
+        idx.service_key,
+        -- Some services are mapped to multiple trip_updates_gtfs_dataset_key values at the same time.
+        -- This is one way to address that, open to better solutions!
+        ANY_VALUE(trip_updates_gtfs_dataset_key) AS gtfs_dataset_key
+    FROM idx
+    LEFT JOIN dim_provider_gtfs_data AS quartet
+        ON idx.service_key = quartet.service_key
+       AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
+       AND quartet.guidelines_assessed
+    GROUP BY 1,2
+),
+
+int_gtfs_quality__feed_listed_tu AS (
+    SELECT
+        date,
+        service_key,
+        {{ feed_listed_tu() }} AS check,
+        {{ compliance_rt() }} AS feature,
+        CASE WHEN gtfs_dataset_key IS NOT null THEN {{ guidelines_pass_status() }}
+             ELSE {{ guidelines_fail_status() }}
+        END AS status,
+    FROM joined
+)
+
+SELECT * FROM int_gtfs_quality__feed_listed_tu

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_tu.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_tu.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.guidelines_assessed
+       AND quartet.customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_vp.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_vp.sql
@@ -1,0 +1,38 @@
+WITH
+
+idx AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__services_guideline_index') }}
+),
+
+dim_provider_gtfs_data AS (
+    SELECT * FROM {{ ref('dim_provider_gtfs_data') }}
+),
+
+joined AS (
+    SELECT
+        idx.date,
+        idx.service_key,
+        -- Some services are mapped to multiple vehicle_positions_gtfs_dataset_key values at the same time.
+        -- This is one way to address that, open to better solutions!
+        ANY_VALUE(vehicle_positions_gtfs_dataset_key) AS gtfs_dataset_key
+    FROM idx
+    LEFT JOIN dim_provider_gtfs_data AS quartet
+        ON idx.service_key = quartet.service_key
+       AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
+       AND quartet.guidelines_assessed
+    GROUP BY 1,2
+),
+
+int_gtfs_quality__feed_listed_vp AS (
+    SELECT
+        date,
+        service_key,
+        {{ feed_listed_vp() }} AS check,
+        {{ compliance_rt() }} AS feature,
+        CASE WHEN gtfs_dataset_key IS NOT null THEN {{ guidelines_pass_status() }}
+             ELSE {{ guidelines_fail_status() }}
+        END AS status,
+    FROM joined
+)
+
+SELECT * FROM int_gtfs_quality__feed_listed_vp

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_vp.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_vp.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.customer_facing
+       AND quartet.gtfs_service_data_customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_vp.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__feed_listed_vp.sql
@@ -19,7 +19,7 @@ joined AS (
     LEFT JOIN dim_provider_gtfs_data AS quartet
         ON idx.service_key = quartet.service_key
        AND TIMESTAMP(idx.date) BETWEEN quartet._valid_from AND quartet._valid_to
-       AND quartet.guidelines_assessed
+       AND quartet.customer_facing
     GROUP BY 1,2
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_rt.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_rt.sql
@@ -25,6 +25,8 @@ int_gtfs_quality__trip_planner_rt AS (
         {{ trip_planner_rt() }} AS check,
         {{ compliance_rt() }} AS feature,
         CASE
+            -- If there are no RT feeds listed, the service should not fail this check, instead it should be "N/A"
+            -- Note that we're only looking at VP and TU, since that's what it being checked for in this manual check.
             WHEN tu.status = 'FAIL' AND vp.status = 'FAIL' THEN {{ guidelines_na_check_status() }}
             WHEN rt_in_trip_planner = 'Yes' THEN {{ guidelines_pass_status() }}
             WHEN rt_in_trip_planner = 'No' THEN {{ guidelines_fail_status() }}

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_rt.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_rt.sql
@@ -4,8 +4,18 @@ idx AS (
     SELECT * FROM {{ ref('int_gtfs_quality__services_guideline_index') }}
 ),
 
+feed_listed_vp AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__feed_listed_vp') }}
+),
+
+feed_listed_tu AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__feed_listed_tu') }}
+),
+
 services AS (
-    SELECT * FROM {{ ref('dim_services') }}
+    SELECT *,
+           manual_check__gtfs_realtime_data_ingested_in_trip_planner AS rt_in_trip_planner
+      FROM {{ ref('dim_services') }}
 ),
 
 int_gtfs_quality__trip_planner_rt AS (
@@ -14,15 +24,22 @@ int_gtfs_quality__trip_planner_rt AS (
         idx.service_key,
         {{ trip_planner_rt() }} AS check,
         {{ compliance_rt() }} AS feature,
-        CASE manual_check__gtfs_realtime_data_ingested_in_trip_planner
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
-            WHEN 'N/A - no fixed-route service' THEN {{ guidelines_na_check_status() }}
+        CASE
+            WHEN tu.status = 'FAIL' AND vp.status = 'FAIL' THEN {{ guidelines_na_check_status() }}
+            WHEN rt_in_trip_planner = 'Yes' THEN {{ guidelines_pass_status() }}
+            WHEN rt_in_trip_planner = 'No' THEN {{ guidelines_fail_status() }}
+            WHEN rt_in_trip_planner = 'N/A - no fixed-route service' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status,
     FROM idx
     LEFT JOIN services
-        ON idx.service_key = services.key
+    ON idx.service_key = services.key
+    LEFT JOIN feed_listed_vp vp
+    ON idx.service_key = vp.service_key
+    AND idx.date = vp.date
+    LEFT JOIN feed_listed_tu tu
+    ON idx.service_key = tu.service_key
+    AND idx.date = tu.date
 )
 
 SELECT * FROM int_gtfs_quality__trip_planner_rt

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_schedule.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_schedule.sql
@@ -21,6 +21,7 @@ int_gtfs_quality__trip_planner_schedule AS (
         {{ trip_planner_schedule() }} AS check,
         {{ compliance_schedule() }} AS feature,
         CASE
+            -- If there is no schedule feed listed, the service should not fail this check, instead it should be "N/A"
             WHEN schedule.status = 'FAIL' THEN {{ guidelines_na_check_status() }}
             WHEN schedule_in_trip_planner = 'Yes' THEN {{ guidelines_pass_status() }}
             WHEN schedule_in_trip_planner = 'No' THEN {{ guidelines_fail_status() }}

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_schedule.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__trip_planner_schedule.sql
@@ -5,7 +5,13 @@ idx AS (
 ),
 
 services AS (
-    SELECT * FROM {{ ref('dim_services') }}
+    SELECT *,
+           manual_check__gtfs_schedule_data_ingested_in_trip_planner AS schedule_in_trip_planner
+      FROM {{ ref('dim_services') }}
+),
+
+feed_listed_schedule AS (
+    SELECT * FROM {{ ref('int_gtfs_quality__feed_listed_schedule') }}
 ),
 
 int_gtfs_quality__trip_planner_schedule AS (
@@ -14,15 +20,19 @@ int_gtfs_quality__trip_planner_schedule AS (
         idx.service_key,
         {{ trip_planner_schedule() }} AS check,
         {{ compliance_schedule() }} AS feature,
-        CASE manual_check__gtfs_schedule_data_ingested_in_trip_planner
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
-            WHEN 'N/A - no fixed-route service' THEN {{ guidelines_na_check_status() }}
+        CASE
+            WHEN schedule.status = 'FAIL' THEN {{ guidelines_na_check_status() }}
+            WHEN schedule_in_trip_planner = 'Yes' THEN {{ guidelines_pass_status() }}
+            WHEN schedule_in_trip_planner = 'No' THEN {{ guidelines_fail_status() }}
+            WHEN schedule_in_trip_planner = 'N/A - no fixed-route service' THEN {{ guidelines_na_check_status() }}
             ELSE {{ guidelines_manual_check_needed_status() }}
         END AS status,
     FROM idx
     LEFT JOIN services
         ON idx.service_key = services.key
+    LEFT JOIN feed_listed_schedule schedule
+    ON idx.service_key = schedule.service_key
+    AND idx.date = schedule.date
 )
 
 SELECT * FROM int_gtfs_quality__trip_planner_schedule

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long.md
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long.md
@@ -113,4 +113,8 @@ Here is a list of currently-implemented checks:
 | Static and RT feeds are representative of all demand-responsive transit services under the transit providers’ purview | Demand-Responsive Completeness | All demand-responsive routes represented on the agency website are represented in the GTFS feeds. |
 | 100% of scheduled trips on a given day are represented within the Trip updates feed | Fixed-Route Completeness | 100% of scheduled trips on a given day are represented within the Trip Updates feed. This includes canceled trips, which should be accounted for by either marking a trip as canceled or adjusting the estimated arrival times. |
 | 100% of trips marked as “Scheduled”, “Canceled”, or “Added” within the Trip updates feed are represented within the Vehicle positions feed | Fixed-Route Completeness | 100% of trips marked as “Scheduled”, “Canceled”, or “Added” within the Trip updates feed are represented within the Vehicle positions feed. |
+| A schedule feed is listed | Compliance (Schedule) | A schedule feed is listed for this service. |
+| A Vehicle positions feed is listed | Compliance (RT) | A Vehicle positions feed is listed for this service. |
+| A Trip updates feed is listed | Compliance (RT) | A Trip updates feed is listed for this service. |
+| A Service alerts feed is listed | Compliance (RT) | A Service alerts feed is listed for this service. |
 {% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_guideline_checks.md
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_guideline_checks.md
@@ -13,4 +13,8 @@ Here is a list of currently-implemented checks:
 | Realtime feeds ingested by Google Maps and/or a combination of Apple Maps, Transit App, Bing Maps, Moovit or local Open Trip Planner services. | Compliance (RT) | Transit riders are able to access live trip statuses within commonly-used trip planning apps. |
 | 100% of scheduled trips on a given day are represented within the Trip updates feed | Fixed-Route Completeness | 100% of scheduled trips on a given day are represented within the Trip Updates feed. This includes canceled trips, which should be accounted for by either marking a trip as canceled or adjusting the estimated arrival times. |
 | 100% of trips marked as “Scheduled”, “Canceled”, or “Added” within the Trip updates feed are represented within the Vehicle positions feed | Fixed-Route Completeness | 100% of trips marked as “Scheduled”, “Canceled”, or “Added” within the Trip updates feed are represented within the Vehicle positions feed. |
+| A schedule feed is listed | Compliance (Schedule) | A schedule feed is listed for this service. |
+| A Vehicle positions feed is listed | Compliance (RT) | A Vehicle positions feed is listed for this service. |
+| A Trip updates feed is listed | Compliance (RT) | A Trip updates feed is listed for this service. |
+| A Service alerts feed is listed | Compliance (RT) | A Service alerts feed is listed for this service. |
 {% enddocs %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_guideline_checks.sql
@@ -9,6 +9,10 @@ unioned AS (
             ref('int_gtfs_quality__trip_planner_rt'),
             ref('int_gtfs_quality__scheduled_trips_in_tu_feed'),
             ref('int_gtfs_quality__all_tu_in_vp'),
+            ref('int_gtfs_quality__feed_listed_schedule'),
+            ref('int_gtfs_quality__feed_listed_vp'),
+            ref('int_gtfs_quality__feed_listed_tu'),
+            ref('int_gtfs_quality__feed_listed_sa'),
         ],
     ) }}
 ),

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -93,7 +93,14 @@ WITH stg_gtfs_quality__intended_checks AS (
     SELECT {{ scheduled_trips_in_tu_feed() }}, {{ fixed_route_completeness() }}, {{ service() }}
     UNION ALL
     SELECT {{ all_tu_in_vp() }}, {{ fixed_route_completeness() }}, {{ service() }}
-
+    UNION ALL
+    SELECT {{ feed_listed_schedule() }}, {{ compliance_schedule() }}, {{ service() }}
+    UNION ALL
+    SELECT {{ feed_listed_vp() }}, {{ compliance_rt() }}, {{ service() }}
+    UNION ALL
+    SELECT {{ feed_listed_tu() }}, {{ compliance_rt() }}, {{ service() }}
+    UNION ALL
+    SELECT {{ feed_listed_sa() }}, {{ compliance_rt() }}, {{ service() }}
     -- MANUAL CHECKS
     UNION ALL
     SELECT {{ organization_has_contact_info() }}, {{ technical_contact_availability() }}, {{ organization() }}


### PR DESCRIPTION
# Description

Create service-level check that says whether each feed is listed.

Resolves #2311 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
ran dbt build on all four, and everything down stream.
Looked at aggregate results for 2 days ago:
33% of services pass the schedule check
17% of services pass the trip updates check
17% of services pass the service alerts check
17% of services pass the vehicle positions check
(the above 3 all round to 17&, but are not equactly equal)

## Screenshots (optional)
