### PR TITLE
Update k8s_resources reference in Sentry loader YAML

### DIFF
--- a/airflow/dags/load-sentry-rtfetchexception-events/load-sentry-rtfetchexception-events.yml
+++ b/airflow/dags/load-sentry-rtfetchexception-events/load-sentry-rtfetchexception-events.yml
@@ -30,7 +30,7 @@ secrets:
     secret: jobs-data
     key: service_account.json
 
-resources:
+k8s_resources:
   request_memory: 2.0Gi
   request_cpu: 1
 


### PR DESCRIPTION
# Description

YAML for load-sentry-rtfetchexception-events used a `resources` key instead of the newer `k8s_resources` key. This brings the YAML in line with our current infra versions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml