### PR TITLE
Add destination bucket reference to DAG definition for Sentry loader

### DIFF
--- a/airflow/dags/load-sentry-rtfetchexception-events/load-sentry-rtfetchexception-events.yml
+++ b/airflow/dags/load-sentry-rtfetchexception-events/load-sentry-rtfetchexception-events.yml
@@ -23,6 +23,7 @@ env_vars:
   GOOGLE_APPLICATION_CREDENTIALS: /secrets/jobs-data/service_account.json
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
+  CALITP_BUCKET__SENTRY_EVENTS: "{{ env_var('CALITP_BUCKET__SENTRY_EVENTS') }}"
 
 secrets:
   - deploy_type: volume


### PR DESCRIPTION
# Description

Maps the `CALITP_BUCKET__SENTRY_EVENTS` environment variable onto the Sentry -> GCS DAG in Airflow

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml
