### PR TITLE
Align Sentry source URI format with other external tables

### DIFF
--- a/airflow/dags/create_external_tables/sentry_events.yml
+++ b/airflow/dags/create_external_tables/sentry_events.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__SENTRY_EVENTS') }}"
 suffix_bucket: true
 source_objects:
-  - "*.jsonl.gz"
+  - "events/*.jsonl.gz"
 destination_project_dataset_table: "external_sentry.events"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true


### PR DESCRIPTION
# Description

In production, the wildcard string match for file URIs in `test-calitp-sentry` is not working as it did while testing on my machine, which is likely due to a language, package version, or configuration mismatch causing slightly different behaviors. This PR is an attempt to resolve the issue by aligning the string match with what's present other external table loader YAML configs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
This is a classic case of "works on my machine", even in its pre-changed form, so the assertion doesn't hold a whole lot of weight in this case.