### PR TITLE
do not retry transform_warehouse and do not fail if dbt-metabase fails

### DIFF
--- a/airflow/dags/transform_warehouse/METADATA.yml
+++ b/airflow/dags/transform_warehouse/METADATA.yml
@@ -12,7 +12,7 @@ default_args:
       - "laurie.m@jarv.us"
     email_on_failure: True
     email_on_retry: False
-    retries: 1
+    retries: 0
     retry_delay: !timedelta 'minutes: 2'
     concurrency: 50
     #sla: !timedelta 'hours: 2'

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -269,23 +269,22 @@ def run(
     # synced schemas created by the staging dbt target.
     if sync_metabase:
         if target and target.startswith("prod"):
-            results_to_check.append(
-                subprocess.run(
-                    [
-                        "dbt-metabase",
-                        "models",
-                        "--metabase_exclude_sources",
-                        "--dbt_manifest_path",
-                        "./target/manifest.json",
-                        "--dbt_docs_url",
-                        "https://dbt-docs.calitp.org",
-                        "--metabase_database",
-                        "Data Marts (formerly Warehouse Views)",
-                        "--dbt_schema_excludes",
-                        "staging",
-                        "payments",
-                    ]
-                )
+            # TODO: we should be logging each misaligned model to Sentry
+            subprocess.run(
+                [
+                    "dbt-metabase",
+                    "models",
+                    "--metabase_exclude_sources",
+                    "--dbt_manifest_path",
+                    "./target/manifest.json",
+                    "--dbt_docs_url",
+                    "https://dbt-docs.calitp.org",
+                    "--metabase_database",
+                    "Data Marts (formerly Warehouse Views)",
+                    "--dbt_schema_excludes",
+                    "staging",
+                    "payments",
+                ]
             )
         else:
             typer.secho(


### PR DESCRIPTION
# Description

Follow-up ticket to do next sprint maybe: https://github.com/cal-itp/data-infra/issues/2362

Removes retry on regular transform job, and stops failing the job if dbt-metabase fails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tested locally

## Screenshots (optional)
