### PR TITLE
Sentry Pipeline List Cleaning Automation and Docs Updates

### DIFF
--- a/jobs/sentry-error-loader/sentry_error_loader.py
+++ b/jobs/sentry-error-loader/sentry_error_loader.py
@@ -60,24 +60,9 @@ def fetch_and_clean_from_clickhouse(project_slug, target_date):
 
     cleaned_df = all_rows.rename(make_name_bq_safe, axis="columns")
 
-    # TODO: convert to smarter detection of which columns have arrays
-    cols_with_nulls_in_arrays = [
-        "exception_frames_abs_path",
-        "exception_frames_colno",
-        "exception_frames_filename",
-        "exception_frames_function",
-        "exception_frames_lineno",
-        "exception_frames_in_app",
-        "exception_frames_package",
-        "exception_frames_module",
-        "exception_frames_stack_level",
-        "exception_stacks_mechanism_type",
-        "exception_stacks_mechanism_handled",
-        "exception_stacks_type",
-        "exception_stacks_value",
-    ]
-
-    for col_name in cols_with_nulls_in_arrays:
+    # Determine which columns contain list types, and process BQ-disallowed nulls in lists
+    array_cols = [x for x in list(cleaned_df) if isinstance(cleaned_df[x][0], list)]
+    for col_name in array_cols:
         cleaned_df[col_name] = cleaned_df[col_name].apply(process_arrays_for_nulls)
 
     """

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -347,22 +347,65 @@ models:
   - name: fct_rt_feed_fetch_errors
     description: Events from Sentry corresponding to RTFetchException errors
     columns:
-      - name: id
-      - name: event_type
-      - name: groupid
-      - name: eventid
-      - name: projectid
+      - name: project_id
+      - name: timestamp
+      - name: event_id
+      - name: platform
+      - name: environment
+      - name: release
+      - name: dist
+      - name: ip_address_v4
+      - name: ip_address_v6
+      - name: user
+      - name: user_id
+      - name: user_name
+      - name: user_email
+      - name: sdk_name
+      - name: sdk_version
+      - name: http_method
+      - name: http_referer
+      - name: tags_key
+      - name: tags_value
+      - name: contexts_key
+      - name: contexts_value
+      - name: transaction_name
+      - name: span_id
+      - name: trace_id
+      - name: partition
+      - name: offset
+      - name: message_timestamp
+      - name: retention_days
+      - name: deleted
+      - name: group_id
+      - name: primary_hash
+      - name: hierarchical_hashes
+      - name: received
       - name: message
       - name: title
-      - name: location
       - name: culprit
-      - name: user
-      - name: tags
-      - name: platform
-      - name: datecreated
-      - name: crashfile
+      - name: level
+      - name: location
+      - name: version
+      - name: type
+      - name: exception_stacks_type
+      - name: exception_stacks_value
+      - name: exception_stacks_mechanism_type
+      - name: exception_stacks_mechanism_handled
+      - name: exception_frames_abs_path
+      - name: exception_frames_colno
+      - name: exception_frames_filename
+      - name: exception_frames_function
+      - name: exception_frames_lineno
+      - name: exception_frames_in_app
+      - name: exception_frames_package
+      - name: exception_frames_module
+      - name: exception_frames_stack_level
+      - name: sdk_integrations
+      - name: modules_name
+      - name: modules_version
+      - name: project_slug
       - name: dt
-      - name: ts
+      - name: execution_ts
   - name: fct_daily_reports_site_organization_scheduled_service_summary
     description: |
       Daily service summary of all feeds that are associated with the given organization with

--- a/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
+++ b/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
@@ -22,9 +22,9 @@ sources:
       - name: vehicle_positions_validations
       - name: vehicle_positions_validations_outcomes
   - name: sentry_external_tables
-    description: Hive-partitioned external tables reading Sentry feed fetch errors from GCS.
+    description: Hive-partitioned external tables reading Sentry events from GCS.
     database: "{{ var('SOURCE_DATABASE') }}"
     schema: external_sentry
     tables:
       - name: events
-        description: Event logs from Sentry corresponding to RTFetchException errors
+        description: Events from Sentry corresponding to logged errors

--- a/warehouse/models/staging/rt/_stg_rt.yml
+++ b/warehouse/models/staging/rt/_stg_rt.yml
@@ -25,7 +25,7 @@ models:
     columns:
       - *rt_key
   - name: stg_rt__feed_fetch_errors
-    description: Event logs from Sentry corresponding to RTFetchException errors
+    description: Events from Sentry corresponding to logged errors
     columns:
       - name: project_id
       - name: timestamp


### PR DESCRIPTION
# Description
Two sets of changes contained within:

1. Updates the list cleaning behavior of the Sentry loader script to detect which columns contain list objects, rather than relying on a manual column list as discussed [here](https://github.com/cal-itp/data-infra/pull/2360). Note that we don't just check the datatype of the Pandas column, which interprets lists as an ambiguous `object` type - we check the first element of the column to determine whether it's a list type.
2. Updates the Sentry table docs to fully align with the current schema - there were some leftover outdated docs on the `fct_` table from when we were bringing data through Sentry's API rather than Clickhouse.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?
The script was tested via local runs into a real bucket, using several example days of Sentry data (including a day that had empty results for data).