### PR TITLE
use top-level overview doc instead of for project

### DIFF
--- a/warehouse/models/docs/_docs_overview.md
+++ b/warehouse/models/docs/_docs_overview.md
@@ -1,4 +1,4 @@
-{% docs __calitp_warehouse__ %}
+{% docs __overview__ %}
 # Cal-ITP Data Warehouse
 
 The Cal-ITP Data Warehouse contains four core types of data (a few other data sources are available, but the primary data models are composed of the following):


### PR DESCRIPTION
# Description

Closes https://github.com/cal-itp/data-infra/issues/2328

I'm not sure why it's only erroring on the project-specific overview.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Works locally.

## Screenshots (optional)
