### PR TITLE
fix missing dim service component rows and fix erroring test

### DIFF
--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -9,7 +9,7 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - key
+            - id
             - service_key
             - product_key
             - component_key

--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__service_components_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__service_components_dim.sql
@@ -96,7 +96,7 @@ join_orgs AS (
         ntd_certified,
         product_component_valid,
         notes,
-        (join_products._is_current AND dim_organizations._is_current) AS _is_current,
+        (join_products._is_current AND COALESCE(dim_organizations._is_current, TRUE)) AS _is_current,
         GREATEST(join_products._valid_from, COALESCE(dim_organizations._valid_from, "1900-01-01")) AS _valid_from,
         LEAST(join_products._valid_to, COALESCE(dim_organizations._valid_to, "2099-01-01")) AS _valid_to
     FROM join_products

--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__service_components_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__service_components_dim.sql
@@ -97,16 +97,16 @@ join_orgs AS (
         product_component_valid,
         notes,
         (join_products._is_current AND dim_organizations._is_current) AS _is_current,
-        GREATEST(join_products._valid_from, dim_organizations._valid_from) AS _valid_from,
-        LEAST(join_products._valid_to, dim_organizations._valid_to) AS _valid_to
+        GREATEST(join_products._valid_from, COALESCE(dim_organizations._valid_from, "1900-01-01")) AS _valid_from,
+        LEAST(join_products._valid_to, COALESCE(dim_organizations._valid_to, "2099-01-01")) AS _valid_to
     FROM join_products
-    INNER JOIN dim_organizations
+    LEFT JOIN dim_organizations
         ON join_products.vendor_organization_source_record_id = dim_organizations.source_record_id
         AND join_products._valid_from < dim_organizations._valid_to
         AND join_products._valid_to > dim_organizations._valid_from
 ),
 
-dim_service_components AS (
+int_transit_database__service_components_dim AS (
     SELECT
         {{ dbt_utils.surrogate_key(['join_orgs.source_record_id',
             'service_key',
@@ -148,4 +148,4 @@ dim_service_components AS (
         dim_components.key  ORDER BY join_orgs.name) = 1
 )
 
-SELECT * FROM dim_service_components
+SELECT * FROM int_transit_database__service_components_dim


### PR DESCRIPTION
# Description

This addresses an issue reported in Slack by @edasmalchi about how certain service/product relationships were not appearing in `dim_service_components`. Also cleans up #2367.

Resolves #2367

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Confirmed no new test failures in the updated table or downstream. Confirmed that the specific missing data cited by Eric is now present in my table: `cal-itp-data-infra-staging.laurie_mart_transit_database.dim_service_components`

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/55149902/224129764-15e62186-8676-4686-8849-d68121bf75e3.png)

