### PR TITLE
Littlepay payments v2 sync and parse

### DIFF
--- a/airflow/dags/create_external_tables/payments/littlepay/authorisations.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/authorisations.yml
@@ -1,0 +1,34 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "authorisations/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.authorisations"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "authorisations/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+   - name: participant_id
+     type: STRING
+   - name: aggregation_id
+     type: STRING
+   - name: acquirer_id
+     type: STRING
+   - name: request_type
+     type: STRING  # (Card_Check, Authorisation, Debt Recovery)
+   - name: transaction_amount
+     type: STRING
+   - name: currency_code
+     type: STRING  # ISO 4217 Numeric Code
+   - name: retrieval_reference_number
+     type: STRING
+   - name: response_code
+     type: STRING
+   - name: status
+     type: STRING  # (Authorised, Declined, Failed, Invalid, Lost, Stolen, Unavailable, Unknown, Verified)
+   - name: authorisation_date_time_utc
+     type: STRING
+   - name: _line_number
+     type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/customer_funding_source.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/customer_funding_source.yml
@@ -1,0 +1,34 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "customer-funding-source/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.customer_funding_source"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "customer-funding-source/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: funding_source_id
+    type: STRING
+  - name: funding_source_vault_id
+    type: STRING
+  - name: customer_id
+    type: STRING
+  - name: bin
+    type: STRING
+  - name: masked_pan
+    type: STRING
+  - name: card_scheme
+    type: STRING
+  - name: issuer
+    type: STRING
+  - name: issuer_country
+    type: STRING
+  - name: form_factor
+    type: STRING
+  - name: principal_customer_id
+    type: STRING
+  - name: _line_number
+    type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/device_transaction_purchases.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/device_transaction_purchases.yml
@@ -1,0 +1,28 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "device-transaction-purchases/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.device_transaction_purchases"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "device-transaction-purchases/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+   - name: littlepay_transaction_id
+     type: STRING
+   - name: purchase_id
+     type: STRING
+   - name: correlated_purchase_id
+     type: STRING
+   - name: product_id
+     type: STRING
+   - name: description
+     type: STRING
+   - name: indicative_amount
+     type: STRING
+   - name: transaction_time
+     type: STRING
+   - name: _line_number
+     type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/device_transactions.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/device_transactions.yml
@@ -1,0 +1,58 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "device-transactions/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.device_transactions"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "device-transactions/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+   - name: participant_id
+     type: STRING
+   - name: customer_id
+     type: STRING
+   - name: device_transaction_id
+     type: STRING
+   - name: littlepay_transaction_id
+     type: STRING
+   - name: device_id
+     type: STRING
+   - name: device_id_issuer
+     type: STRING
+   - name: type
+     type: STRING
+   - name: transaction_outcome
+     type: STRING
+   - name: transction_deny_reason
+     type: STRING
+   - name: transaction_date_time_utc
+     type: STRING
+   - name: location_id
+     type: STRING
+   - name: location_scheme
+     type: STRING
+   - name: location_name
+     type: STRING
+   - name: zone_id
+     type: STRING
+   - name: route_id
+     type: STRING
+   - name: mode
+     type: STRING
+   - name: direction
+     type: STRING
+   - name: latitude
+     type: STRING
+   - name: longitude
+     type: STRING
+   - name: vehicle_id
+     type: STRING
+   - name: granted_zone_ids
+     type: STRING
+   - name: onward_zone_ids
+     type: STRING
+   - name: _line_number
+     type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/micropayment_adjustments.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/micropayment_adjustments.yml
@@ -1,0 +1,36 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "micropayment-adjustments/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.micropayment_adjustments"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "micropayment-adjustments/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: micropayment_id
+    type: STRING
+  - name: adjustment_id
+    type: STRING
+  - name: participant_id
+    type: STRING
+  - name: customer_id
+    type: STRING
+  - name: product_id
+    type: STRING
+  - name: type
+    type: STRING  # Daily_Cap, Weekly_Cap
+  - name: description
+    type: STRING
+  - name: amount
+    type: STRING
+  - name: time_period_type
+    type: STRING  # Peak, Off Peak
+  - name: applied
+    type: STRING
+  - name: zone_ids_us
+    type: STRING
+  - name: _line_number
+    type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/micropayment_device_transactions.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/micropayment_device_transactions.yml
@@ -1,0 +1,18 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "micropayment-device-transactions/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.micropayment_device_transactions"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "micropayment-device-transactions/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: littlepay_transaction_id
+    type: STRING
+  - name: micropayment_id
+    type: STRING
+  - name: _line_number
+    type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/micropayments.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/micropayments.yml
@@ -1,0 +1,38 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "micropayments/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.micropayments"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "micropayments/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: micropayment_id
+    type: STRING
+  - name: aggregation_id
+    type: STRING
+  - name: participant_id
+    type: STRING
+  - name: customer_id
+    type: STRING
+  - name: funding_source_vault_id
+    type: STRING
+  - name: transaction_time
+    type: STRING
+  - name: payment_liability
+    type: STRING
+  - name: charge_amount
+    type: STRING
+  - name: nominal_amount
+    type: STRING
+  - name: currency_code
+    type: STRING
+  - name: type
+    type: STRING
+  - name: charge_type
+    type: STRING
+  - name: _line_number
+    type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/product_data.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/product_data.yml
@@ -1,0 +1,64 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "product-data/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.product_data"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "product-data/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: participant_id
+    type: STRING
+  - name: product_id
+    type: STRING
+  - name: product_code
+    type: STRING
+  - name: product_description
+    type: STRING
+  - name: product_type
+    type: STRING  # (Capping, Discount)
+  - name: activation_type
+    type: STRING  # (Customer, Card)
+  - name: product_status
+    type: STRING  # (Active, Inactive)
+  - name: created_date
+    type: STRING
+  - name: capping_type
+    type: STRING  # (Daily_cap, Weekly_cap, Multiday_cap, Timebased_cap)
+  - name: multi_operator
+    type: STRING
+  - name: capping_start_time
+    type: STRING
+  - name: capping_end_time
+    type: STRING
+  - name: rules_transaction_types
+    type: STRING  # (Autoscan, Flat, Variable)
+  - name: rules_default_limit
+    type: STRING
+  - name: rules_max_fare_value
+    type: STRING
+  - name: scheduled_start_date_time
+    type: STRING
+  - name: scheduled_end_date_time
+    type: STRING
+  - name: all_day
+    type: STRING
+  - name: weekly_cap_start_day
+    type: STRING  # (Monday, Sunday)
+  - name: number_of_days_in_cap_window
+    type: STRING
+  - name: capping_duration
+    type: STRING
+  - name: number_of_transfer
+    type: STRING
+  - name: capping_time_zone
+    type: STRING
+  - name: capping_overlap
+    type: STRING
+  - name: capping_application_level
+    type: STRING  # (Customer, Card)
+  - name: _line_number
+    type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/refunds.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/refunds.yml
@@ -1,0 +1,62 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "refunds/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.refunds"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "refunds/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: refund_id
+    type: STRING
+  - name: participant_id
+    type: STRING
+  - name: customer_id
+    type: STRING
+  - name: micropayment_id
+    type: STRING
+  - name: aggregation_id
+    type: STRING
+  - name: settlement_id
+    type: STRING
+  - name: retrieval_reference_number
+    type: STRING
+  - name: transaction_date
+    type: STRING
+  - name: transaction_amount
+    type: STRING
+  - name: proposed_amount
+    type: STRING
+  - name: refund_amount
+    type: STRING
+  - name: currency_code
+    type: STRING  # ISO 4217 Numeric Code
+  - name: status
+    type: STRING  # (Created, Sent_for_settlement, Settled, Rejected, Sent_for_adjustment, Adjusted)
+  - name: initiator
+    type: STRING  # (Merchant, Customer)
+  - name: reason
+    type: STRING
+  - name: approval_status
+    type: STRING  # (Awaiting, Approved, Refused)
+  - name: issuer
+    type: STRING
+  - name: issuer_comment
+    type: STRING
+  - name: created_time
+    type: STRING
+  - name: approved_time
+    type: STRING
+  - name: settlement_status
+    type: STRING  # (Accepted, Rejected)
+  - name: settlement_status_time
+    type: STRING
+  - name: settlement_reason_code
+    type: STRING
+  - name: settlement_response_text
+    type: STRING
+  - name: _line_number
+    type: STRING

--- a/airflow/dags/create_external_tables/payments/littlepay/settlements.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/settlements.yml
@@ -1,0 +1,30 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__LITTLEPAY_PARSED') }}"
+source_objects:
+  - "settlements/*.jsonl.gz"
+destination_project_dataset_table: "external_littlepay.settlements"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "settlements/{instance:STRING}/{extract_filename:STRING}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: settlement_id
+    type: STRING
+  - name: participant_id
+    type: STRING
+  - name: aggregation_id
+    type: STRING
+  - name: customer_id
+    type: STRING
+  - name: funding_source_id
+    type: STRING
+  - name: transaction_amount
+    type: STRING
+  - name: settlement_requested_date_time_utc
+    type: STRING
+  - name: acquirer
+    type: STRING
+  - name: _line_number
+    type: STRING

--- a/airflow/dags/parse_littlepay/METADATA.yml
+++ b/airflow/dags/parse_littlepay/METADATA.yml
@@ -1,0 +1,20 @@
+description: "Parse Littlepay files into JSONL"
+schedule_interval: "0 2 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: "2023-03-12"
+    email:
+      - "laurie.m@jarv.us"
+      - "andrew.v@jarv.us"
+      - "jameelah.y@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    max_active_dag_runs: 6
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: False

--- a/airflow/dags/parse_littlepay/cal-itp.yml
+++ b/airflow/dags/parse_littlepay/cal-itp.yml
@@ -1,0 +1,2 @@
+operator: operators.LittlepayToJSONL
+instance: cal-itp

--- a/airflow/dags/parse_littlepay/ccjpa.yml
+++ b/airflow/dags/parse_littlepay/ccjpa.yml
@@ -1,0 +1,2 @@
+operator: operators.LittlepayToJSONL
+instance: ccjpa

--- a/airflow/dags/parse_littlepay/mst.yml
+++ b/airflow/dags/parse_littlepay/mst.yml
@@ -1,0 +1,2 @@
+operator: operators.LittlepayToJSONL
+instance: mst

--- a/airflow/dags/parse_littlepay/sbmtd.yml
+++ b/airflow/dags/parse_littlepay/sbmtd.yml
@@ -1,0 +1,2 @@
+operator: operators.LittlepayToJSONL
+instance: sbmtd

--- a/airflow/dags/sync_littlepay/METADATA.yml
+++ b/airflow/dags/sync_littlepay/METADATA.yml
@@ -1,0 +1,19 @@
+description: "Syncs Littlepay data from S3 bucket to our buckets"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "andrew.v@jarv.us"
+      - "jameelah.y@jarv.us"
+      - "laurie.m@jarv.us"
+    email_on_failure: True
+    email_on_retry: False
+    retries: 0
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: True

--- a/airflow/dags/sync_littlepay/cal-itp.yml
+++ b/airflow/dags/sync_littlepay/cal-itp.yml
@@ -1,0 +1,4 @@
+operator: operators.LittlepayRawSync
+instance: cal-itp
+access_key_id_secret: LITTLEPAY_CALITP_ACCESS_KEY_ID
+secret_access_key_secret: LITTLEPAY_CALITP_SECRET_ACCESS_KEY

--- a/airflow/dags/sync_littlepay/ccjpa.yml
+++ b/airflow/dags/sync_littlepay/ccjpa.yml
@@ -1,0 +1,4 @@
+operator: operators.LittlepayRawSync
+instance: ccjpa
+access_key_id_secret: LITTLEPAY_CCJPA_ACCESS_KEY_ID
+secret_access_key_secret: LITTLEPAY_CCJPA_SECRET_ACCESS_KEY

--- a/airflow/dags/sync_littlepay/mst.yml
+++ b/airflow/dags/sync_littlepay/mst.yml
@@ -1,0 +1,4 @@
+operator: operators.LittlepayRawSync
+instance: mst
+access_key_id_secret: LITTLEPAY_MST_ACCESS_KEY_ID
+secret_access_key_secret: LITTLEPAY_MST_SECRET_ACCESS_KEY

--- a/airflow/dags/sync_littlepay/sbmtd.yml
+++ b/airflow/dags/sync_littlepay/sbmtd.yml
@@ -1,0 +1,4 @@
+operator: operators.LittlepayRawSync
+instance: sbmtd
+access_key_id_secret: LITTLEPAY_SBMTD_ACCESS_KEY_ID
+secret_access_key_secret: LITTLEPAY_SBMTD_SECRET_ACCESS_KEY

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -87,6 +87,7 @@ x-airflow-common:
     CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION: "gs://test-calitp-gtfs-schedule-validation"
     CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED: "gs://test-calitp-gtfs-schedule-unzipped"
     CALITP_BUCKET__GTFS_SCHEDULE_PARSED: "gs://test-calitp-gtfs-schedule-parsed"
+    CALITP_BUCKET__LITTLEPAY_RAW: "gs://test-calitp-payments-littlepay-raw"
     CALITP_BUCKET__PUBLISH: "gs://test-calitp-publish"
     CALITP_BUCKET__SENTRY_EVENTS: "gs://test-calitp-sentry"
 

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -87,6 +87,7 @@ x-airflow-common:
     CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION: "gs://test-calitp-gtfs-schedule-validation"
     CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED: "gs://test-calitp-gtfs-schedule-unzipped"
     CALITP_BUCKET__GTFS_SCHEDULE_PARSED: "gs://test-calitp-gtfs-schedule-parsed"
+    CALITP_BUCKET__LITTLEPAY_PARSED: "gs://test-calitp-payments-littlepay-parsed"
     CALITP_BUCKET__LITTLEPAY_RAW: "gs://test-calitp-payments-littlepay-raw"
     CALITP_BUCKET__PUBLISH: "gs://test-calitp-publish"
     CALITP_BUCKET__SENTRY_EVENTS: "gs://test-calitp-sentry"

--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -4,4 +4,5 @@ from operators.amplitude_to_flattened_json import AmplitudeToFlattenedJSONOperat
 from operators.external_table import ExternalTable
 from operators.gtfs_csv_to_jsonl import GtfsGcsToJsonlOperator
 from operators.littlepay_raw_sync import LittlepayRawSync
+from operators.littlepay_to_jsonl import LittlepayToJSONL
 from operators.pod_operator import PodOperator

--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -3,4 +3,5 @@ from operators.airtable_to_gcs import AirtableToGCSOperator
 from operators.amplitude_to_flattened_json import AmplitudeToFlattenedJSONOperator
 from operators.external_table import ExternalTable
 from operators.gtfs_csv_to_jsonl import GtfsGcsToJsonlOperator
+from operators.littlepay_raw_sync import LittlepayRawSync
 from operators.pod_operator import PodOperator

--- a/airflow/plugins/operators/littlepay_raw_sync.py
+++ b/airflow/plugins/operators/littlepay_raw_sync.py
@@ -244,7 +244,9 @@ class LittlepayRawSync(BaseOperator):
             instance=self.instance,
             ts=start,
             filename="results.jsonl",
-        ).save_content(content="\n".join(e.json() for e in extracted_files).encode())
+        ).save_content(
+            content="\n".join(e.json() for e in extracted_files).encode(), fs=fs
+        )
 
         if failures:
             raise RuntimeError(str(failures))

--- a/airflow/plugins/operators/littlepay_raw_sync.py
+++ b/airflow/plugins/operators/littlepay_raw_sync.py
@@ -1,0 +1,217 @@
+import concurrent
+import json
+import os
+import traceback
+from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime
+from typing import ClassVar, Dict, List
+
+import boto3
+import pendulum
+from calitp_data_infra.auth import get_secret_by_name
+from calitp_data_infra.storage import (
+    PARTITIONED_ARTIFACT_METADATA_KEY,
+    PartitionedGCSArtifact,
+    get_fs,
+    get_latest_file,
+)
+from pydantic.class_validators import validator
+from pydantic.error_wrappers import ValidationError
+from pydantic.main import BaseModel
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+from airflow.models import BaseOperator
+
+LITTLEPAY_RAW_BUCKET = os.getenv("CALITP_BUCKET__LITTLEPAY_RAW")
+
+
+class LittlepayFileKey(str):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        assert len(v.split("/")) == 3 and v.endswith(".psv")
+        return cls(v)
+
+    @property
+    def agency(self) -> str:
+        return self.split("/")[0]
+
+    @property
+    def entity(self) -> str:
+        return self.split("/")[1]
+
+    @property
+    def filename(self) -> str:
+        return self.split("/")[2]
+
+
+class LittlepayS3Object(BaseModel):
+    Key: LittlepayFileKey
+    LastModified: pendulum.DateTime
+    ETag: str
+    Size: int
+    StorageClass: str
+
+
+class RawLittlepayFileExtract(PartitionedGCSArtifact):
+    bucket: ClassVar[str] = LITTLEPAY_RAW_BUCKET
+    partition_names: ClassVar[List[str]] = ["instance", "filename", "ts"]
+    instance: str
+    filename: str
+    ts: pendulum.DateTime
+    s3bucket: str
+    s3object: LittlepayS3Object
+
+    @validator("ts", allow_reuse=True)
+    def coerce_ts(cls, v):
+        if isinstance(v, datetime):
+            return pendulum.instance(v)
+        return v
+
+    @property
+    def table(self) -> str:
+        return self.s3object.Key.entity
+
+    # TODO: why does this not override the parent model field?
+    # @property
+    # def filename(self) -> str:
+    #     return self.s3object.Key.filename
+
+
+def sync_file(src_bucket: str, file: RawLittlepayFileExtract, s3client, fs):
+    try:
+        # TODO: this kinda overlaps with get_latest()
+        fileinfo = get_latest_file(
+            bucket=file.bucket,
+            table=file.table,
+            prefix_partitions={
+                "instance": file.instance,
+                "filename": file.filename,
+            },
+            partition_types={
+                "ts": pendulum.DateTime,
+            },
+        )
+        try:
+            metadata_str = fs.getxattr(
+                path=f"gs://{fileinfo.name}", attr=PARTITIONED_ARTIFACT_METADATA_KEY
+            )
+        except KeyError:
+            print(f"metadata missing on {fileinfo.name}")
+            raise
+        prior = RawLittlepayFileExtract(**json.loads(metadata_str))
+        save = (
+            file.s3object.LastModified != prior.s3object.LastModified
+            or file.s3object.ETag != prior.s3object.ETag
+        )
+    except FileNotFoundError:
+        save = True
+
+    if save:
+        content = s3client.get_object(Bucket=src_bucket, Key=file.s3object.Key)[
+            "Body"
+        ].read()
+        file.save_content(content=content, fs=fs)
+
+
+class LittlepayRawSync(BaseOperator):
+    template_fields = ()
+
+    def __init__(
+        self,
+        *args,
+        instance: str,
+        access_key_id_secret: str,
+        secret_access_key_secret: str,
+        **kwargs,
+    ):
+        self.instance = instance
+        self.src_bucket = f"littlepay-prod-{instance}-datafeed"
+        self.access_key_id_secret = access_key_id_secret
+        self.secret_access_key_secret = secret_access_key_secret
+        super().__init__(**kwargs)
+
+    def execute(self, context):
+        assert LITTLEPAY_RAW_BUCKET is not None
+
+        start = pendulum.now()
+        s3client = boto3.client(
+            "s3",
+            aws_access_key_id=get_secret_by_name(self.access_key_id_secret),
+            aws_secret_access_key=get_secret_by_name(self.secret_access_key_secret),
+        )
+
+        list_kwargs = {
+            "Bucket": self.src_bucket,
+        }
+
+        files: List[RawLittlepayFileExtract] = []
+
+        # 1000 objects per page; just stop us from accidentally going forever
+        for _ in tqdm(range(1000)):
+            resp = s3client.list_objects_v2(**list_kwargs)
+
+            for content in resp["Contents"]:
+                if content["Key"] == self.instance:
+                    # Weird 0-length file(s) that seem to get created everywhere
+                    continue
+                try:
+                    obj = LittlepayS3Object(**content)
+                    file = RawLittlepayFileExtract(
+                        instance=self.instance,
+                        ts=start,
+                        s3bucket=self.src_bucket,
+                        s3object=obj,
+                        filename=obj.Key.filename,
+                    )
+                    files.append(file)
+                except ValidationError:
+                    print(content, flush=True)
+                    raise
+
+            if resp["IsTruncated"]:
+                list_kwargs["ContinuationToken"] = resp["NextContinuationToken"]
+            else:
+                break
+        else:
+            raise RuntimeError("failed to page fully through bucket")
+
+        print(
+            f"Found {len(files)} source files in {self.src_bucket}; diffing and copying to {RawLittlepayFileExtract.bucket}."
+        )
+
+        fs = get_fs()
+        failures = []
+        with logging_redirect_tqdm():
+            pbar = tqdm(total=len(files))
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futures: Dict[Future, RawLittlepayFileExtract] = {
+                    pool.submit(
+                        sync_file,
+                        src_bucket=self.src_bucket,
+                        file=file,
+                        s3client=s3client,
+                        fs=fs,
+                    ): file
+                    for i, file in enumerate(files)
+                }
+                for future in concurrent.futures.as_completed(futures):
+                    pbar.update(1)
+                    try:
+                        future.result()
+                    except KeyboardInterrupt:
+                        raise
+                    except Exception as e:
+                        print(
+                            f"exception during processing of {futures[future].s3object.Key} -> {futures[future].path}: {str(e)}"
+                        )
+                        traceback.print_exc()
+                        failures.append(e)
+            del pbar
+
+        if failures:
+            raise RuntimeError(str(failures))

--- a/airflow/plugins/operators/littlepay_to_jsonl.py
+++ b/airflow/plugins/operators/littlepay_to_jsonl.py
@@ -1,0 +1,132 @@
+import csv
+import gzip
+import json
+import os
+from io import StringIO
+from typing import ClassVar, List
+
+import pendulum
+from calitp_data_infra.storage import (
+    PartitionedGCSArtifact,
+    fetch_all_in_partition,
+    get_fs,
+)
+from operators.littlepay_raw_sync import RawLittlepayFileExtract
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+from airflow.models import BaseOperator
+
+LITTLEPAY_RAW_BUCKET = os.getenv("CALITP_BUCKET__LITTLEPAY_RAW")
+LITTLEPAY_PARSED_BUCKET = os.getenv("CALITP_BUCKET__LITTLEPAY_PARSED")
+
+
+class LittlepayFileJSONL(PartitionedGCSArtifact):
+    bucket: ClassVar[str] = LITTLEPAY_PARSED_BUCKET
+    partition_names: ClassVar[List[str]] = ["instance", "extract_filename", "ts"]
+    extract: RawLittlepayFileExtract
+    filename: str
+
+    @property
+    def table(self) -> str:
+        return self.extract.table
+
+    @property
+    def instance(self) -> str:
+        return self.extract.instance
+
+    @property
+    def extract_filename(self) -> str:
+        return self.extract.filename
+
+    @property
+    def ts(self) -> pendulum.DateTime:
+        return self.extract.ts
+
+
+# TODO: outcome type; track unknown file types
+
+
+def parse_raw_file(file: RawLittlepayFileExtract, fs):
+    # mostly stolen from the Schedule job, we could probably abstract this
+    # assume this is PSV for now, but we could sniff the delimiter
+    filename, extension = os.path.splitext(file.filename)
+    assert extension == ".psv"
+    with fs.open(file.path) as f:
+        reader = csv.DictReader(
+            StringIO(f.read().decode("utf-8-sig")),
+            restkey="calitp_unknown_fields",
+            delimiter="|",
+        )
+    lines = [
+        {**row, "_line_number": line_number}
+        for line_number, row in enumerate(reader, start=1)
+    ]
+    jsonl_file = LittlepayFileJSONL(
+        extract=file,
+        filename=f"{filename}.jsonl.gz",
+    )
+    jsonl_file.save_content(
+        content=gzip.compress("\n".join(json.dumps(line) for line in lines).encode()),
+        fs=fs,
+    )
+
+
+class LittlepayToJSONL(BaseOperator):
+    template_fields = ()
+
+    def __init__(
+        self,
+        *args,
+        instance: str,
+        **kwargs,
+    ):
+        self.instance = instance
+        super().__init__(**kwargs)
+
+    def execute(self, context):
+        assert LITTLEPAY_RAW_BUCKET is not None and LITTLEPAY_PARSED_BUCKET is not None
+
+        fs = get_fs()
+
+        entities = [
+            "authorisations",
+            "customer-funding-source",
+            "device-transaction-purchases",
+            "device-transactions",
+            "micropayment-adjustments",
+            "micropayment-device-transactions",
+            "micropayments",
+            "product-data",
+            "refunds",
+            "settlements",
+        ]
+
+        with logging_redirect_tqdm():
+            for entity in tqdm(entities):
+                files_to_process: List[RawLittlepayFileExtract]
+                # This is not very efficient but it should be approximately 1 file per day
+                # since the instance began
+                files_to_process, _, _ = fetch_all_in_partition(
+                    cls=RawLittlepayFileExtract,
+                    table=entity,
+                    partitions={
+                        "instance": self.instance,
+                    },
+                    verbose=True,
+                )
+                print(f"found {len(files_to_process)} files to check")
+
+                dt = context["execution_date"].date()
+
+                print(f"filtering files created on {dt}")
+
+                files_to_process = [
+                    file
+                    for file in files_to_process
+                    if file.ts.date() == context["execution_date"].date()
+                ]
+
+                file: RawLittlepayFileExtract
+                for file in tqdm(files_to_process, desc=entity):
+                    parse_raw_file(file, fs=fs)

--- a/airflow/plugins/operators/littlepay_to_jsonl.py
+++ b/airflow/plugins/operators/littlepay_to_jsonl.py
@@ -89,6 +89,7 @@ class LittlepayToJSONL(BaseOperator):
 
         fs = get_fs()
 
+        # TODO: this could be worth splitting into separate tasks
         entities = [
             "authorisations",
             "customer-funding-source",

--- a/airflow/requirements-dev.txt
+++ b/airflow/requirements-dev.txt
@@ -1,2 +1,3 @@
 apache-airflow==2.4.3
 black==22.3.0
+boto3-stubs-lite[essential]==1.26.88

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -4,3 +4,4 @@ pyairtable==1.0.0
 typer==0.4.1
 sentry-sdk==1.9.8
 platformdirs<3,>=2.5
+boto3==1.26.87


### PR DESCRIPTION
# Description

I'm using one bucket each for raw and parsed data, partitioned by instance. Files are also versioned by extract time, and a new version is only created if the etag or last-modified timestamp changes (avoids having to read the whole file and compare hashes, but assumes one of those two fields will change). All external tables use string types, and the staging models will safe_cast to the appropriate type.

Follow-up PR is https://github.com/cal-itp/data-infra/pull/2398

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tested locally.

## Screenshots (optional)