### PR TITLE
Fix scheduled in TU check bug #2373

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__scheduled_trips_in_tu_feed.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__scheduled_trips_in_tu_feed.sql
@@ -25,17 +25,15 @@ compare_trips AS (
         scheduled_trips.service_date AS date,
         scheduled_trips.gtfs_dataset_key AS schedule_gtfs_dataset_key,
         scheduled_trips.feed_key AS schedule_feed_key,
-        observed_trips.tu_gtfs_dataset_key,
-        observed_trips.tu_base64_url,
         COUNT(DISTINCT scheduled_trips.trip_id) AS scheduled_trips,
-        COUNTIF(observed_trips.trip_id IS NOT NULL) AS observed_trips,
+        COUNT(DISTINCT observed_trips.trip_id) AS observed_trips,
     FROM fct_daily_scheduled_trips AS scheduled_trips
     LEFT JOIN fct_observed_trips AS observed_trips
       -- should this be activity date or service date? will depend on fix for https://github.com/cal-itp/data-infra/issues/2347
       ON scheduled_trips.service_date = observed_trips.dt
       AND scheduled_trips.gtfs_dataset_key = observed_trips.schedule_to_use_for_rt_validation_gtfs_dataset_key
       AND scheduled_trips.trip_id = observed_trips.trip_id
-    GROUP BY 1, 2, 3, 4, 5
+    GROUP BY 1, 2, 3
 ),
 
 check_start AS (
@@ -43,7 +41,7 @@ check_start AS (
     FROM fct_observed_trips
 ),
 
--- take the individual schedule/TU feed comparisons and roll them up to the service level
+-- take the individual schedule/TU comparison and roll them up to the service level
 map_trips_to_services AS (
     SELECT
         idx.date,
@@ -64,7 +62,6 @@ map_trips_to_services AS (
     LEFT JOIN compare_trips
         ON idx.date = compare_trips.date
         AND quartet.schedule_gtfs_dataset_key = compare_trips.schedule_gtfs_dataset_key
-        AND quartet.trip_updates_gtfs_dataset_key = compare_trips.tu_gtfs_dataset_key
     WHERE idx.service_key IS NOT NULL
     GROUP BY 1, 2, 3
 ),


### PR DESCRIPTION
# Description
Fixes #2373:

* The specific issue described in the ticket was actually caused by trips on the same `dt` with different `trip_start_date`, see https://github.com/cal-itp/data-infra/issues/2347#issuecomment-1464500392. I think we might need more refinement on this as #2347 is addressed, but I think the switch to `COUNT(DISTINCT trip_id))` for observed trips should work. 
* I also think that some issues here were being caused by grouping by both schedule and trip updates dataset key as opposed to just schedule in the `compare_trips` CTE, so I simplified that.
* I also did more spot checks and some of the behavior changes here are caused by the fact that the original version filtered to only `guidelines_assessed` quartets, whereas this preserves basically as much as possible. So in the original version a service would have one determination (based on its guidelines assessed quartet), here you can have multiple outcomes for the same service depending on its different quartets. 

Resolves #2373

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Run locally & inspected results. Confirmed the specific issue identified with Commerce Municipal Bus Lines is fixed. 

