### PR TITLE
Override default size for persistent Sentry volume

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -36,3 +36,7 @@ sentry:
     port: 587
     host: "smtp.postmarkapp.com"
     from: "bot@calitp.org"
+filestore:
+  filesystem:
+    persistence:
+      size: 40Gi


### PR DESCRIPTION
# Description

We are currently out of storage in the Postgres instance underlying Sentry. The `postgresql` section of [the default Sentry Helm chart](https://github.com/sentry-kubernetes/charts/blob/develop/sentry/values.yaml) doesn't include an option for volume size, so while the docstrings are a little ambiguous, it appears that `filestore.filesystem.persistence.size` may do the trick.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

At the time of PR creation, this has not been tested.
