### PR TITLE
Batch 3: Migrate guideline check indices

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -39,3 +39,4 @@ models:
 # RT URL checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__rt_feeds_present
+  - name: int_gtfs_quality__rt_https

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -18,8 +18,25 @@ models:
   - name: int_gtfs_quality__pathways_valid
   - name: int_gtfs_quality__technical_contact_listed
 
+# Schedule URL checks reindexed
+# TODO: what kind of yaml do we want for these? specifically what tests
+
+  - name: int_gtfs_quality__schedule_url_download_success
+
 # Schedule + RT combined URL checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
+  - name: int_gtfs_quality__feed_aggregator
+
+# RT feed checks reindexed
+# TODO: what kind of yaml do we want for these? specifically what tests
+  - name: int_gtfs_quality__trip_id_alignment
+
+# Service checks reindexed
+# TODO: what kind of yaml do we want for these? specifically what tests
+  - name: int_gtfs_quality__scheduled_trips_in_tu_feed
+
+# RT feed checks
+
   - name: int_gtfs_quality__feed_aggregator
 
 # RT feed checks reindexed

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -27,6 +27,7 @@ models:
   - name: int_gtfs_quality__trip_id_alignment
   - name: int_gtfs_quality__rt_20sec_vp
   - name: int_gtfs_quality__no_rt_validation_errors
+  - name: int_gtfs_quality__no_stale_vehicle_positions
 
 # Service checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -34,16 +34,8 @@ models:
 # Service checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__scheduled_trips_in_tu_feed
-
-# RT feed checks
-
-  - name: int_gtfs_quality__feed_aggregator
-
-# RT feed checks reindexed
-# TODO: what kind of yaml do we want for these? specifically what tests
-  - name: int_gtfs_quality__trip_id_alignment
-
-# Service checks reindexed
-# TODO: what kind of yaml do we want for these? specifically what tests
-  - name: int_gtfs_quality__scheduled_trips_in_tu_feed
   - name: int_gtfs_quality__trip_planners
+
+# RT URL checks reindexed
+# TODO: what kind of yaml do we want for these? specifically what tests
+  - name: int_gtfs_quality__rt_feeds_present

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -25,6 +25,8 @@ models:
 # RT feed checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__trip_id_alignment
+  - name: int_gtfs_quality__rt_20sec_vp
+  - name: int_gtfs_quality__no_rt_validation_errors
 
 # Service checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
@@ -35,5 +37,4 @@ models:
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__rt_feeds_present
   - name: int_gtfs_quality__rt_https
-  - name: int_gtfs_quality__no_rt_validation_errors
   - name: int_gtfs_quality__rt_protobuf_error

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -1,6 +1,7 @@
 version: 2
 
 models:
+<<<<<<< HEAD
 # Schedule URL checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
 
@@ -18,6 +19,8 @@ models:
   - name: int_gtfs_quality__pathways_valid
   - name: int_gtfs_quality__technical_contact_listed
 
+=======
+>>>>>>> 392e819b (delete extra yaml, this may cause merge conflicts later)
 # Schedule URL checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
 
@@ -40,3 +43,4 @@ models:
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__rt_feeds_present
   - name: int_gtfs_quality__rt_https
+  - name: int_gtfs_quality__no_rt_validation_errors

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -44,3 +44,4 @@ models:
   - name: int_gtfs_quality__rt_feeds_present
   - name: int_gtfs_quality__rt_https
   - name: int_gtfs_quality__no_rt_validation_errors
+  - name: int_gtfs_quality__rt_protobuf_error

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -1,7 +1,6 @@
 version: 2
 
 models:
-<<<<<<< HEAD
 # Schedule URL checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
 
@@ -18,13 +17,6 @@ models:
   - name: int_gtfs_quality__shapes_valid
   - name: int_gtfs_quality__pathways_valid
   - name: int_gtfs_quality__technical_contact_listed
-
-=======
->>>>>>> 392e819b (delete extra yaml, this may cause merge conflicts later)
-# Schedule URL checks reindexed
-# TODO: what kind of yaml do we want for these? specifically what tests
-
-  - name: int_gtfs_quality__schedule_url_download_success
 
 # Schedule + RT combined URL checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -20,7 +20,6 @@ models:
 
 # Schedule + RT combined URL checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
-
   - name: int_gtfs_quality__feed_aggregator
 
 # RT feed checks reindexed

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_rt_validation_errors.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_rt_validation_errors.sql
@@ -16,7 +16,7 @@ errors AS (
         date,
         base64_url,
         -- All error codes start with the letter E (warnings start with W)
-        COUNTIF(code LIKE "E%" and total_notices > 0) > 0 AS had_errors
+        COUNTIF(UPPER(code) LIKE "E%" and total_notices > 0) > 0 AS had_errors
     FROM fct_daily_rt_feed_validation_notices
     GROUP BY 1, 2
 ),

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_vehicle_positions.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_vehicle_positions.sql
@@ -1,72 +1,43 @@
-{{ config(
-    materialized='incremental',
-    incremental_strategy='insert_overwrite',
-    partition_by = {
-        'field': 'date',
-        'data_type': 'date',
-        'granularity': 'day',
-    },
-) }}
-
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='date', order_by = 'date DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
-WITH
-
-feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index_vp') }}
-    {% if is_incremental() %}
-    WHERE date >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE date >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-fct_vehicle_positions_messages AS (
-    SELECT * FROM {{ ref('fct_vehicle_positions_messages') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-vehicle_position_ages AS (
+WITH guideline_index AS (
     SELECT
-        dt,
-        base64_url,
-        COUNT(*) AS num_vehicle_positions,
-        MIN(TIMESTAMP_DIFF(_extract_ts, vehicle_timestamp, SECOND)) AS min_vehicle_position_age,
-        PERCENTILE_CONT(TIMESTAMP_DIFF(_extract_ts, vehicle_timestamp, SECOND), 0.5) AS median_vehicle_position_age,
-        MAX(TIMESTAMP_DIFF(_extract_ts, vehicle_timestamp, SECOND)) AS max_vehicle_position_age,
-        MAX(TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND)) AS max_vehicle_position_feed_age,
-    FROM fct_vehicle_positions_messages
-    GROUP BY 1, 2
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ no_stale_vehicle_positions() }}
+),
+
+vp_message_ages AS (
+    SELECT *
+    FROM {{ ref('fct_daily_vehicle_positions_message_age_summary') }}
+),
+
+check_start AS (
+    SELECT MIN(dt) AS first_check_date
+    FROM vp_message_ages
 ),
 
 int_gtfs_quality__no_stale_vehicle_positions AS (
     SELECT
-        idx.date,
-        idx.base64_url,
-        idx.feed_type,
-        {{ no_stale_vehicle_positions() }} AS check,
-        {{ best_practices_alignment_rt() }} AS feature,
-        min_vehicle_position_age,
-        max_vehicle_position_age,
-        max_vehicle_position_feed_age,
+        idx.* EXCEPT(status),
+        first_check_date,
+        p90_header_message_age,
+        p90_vehicle_message_age,
         CASE
-            WHEN max_vehicle_position_age <= 90 AND max_vehicle_position_feed_age <= 90 THEN {{ guidelines_pass_status() }}
-            WHEN max_vehicle_position_age > 90 OR max_vehicle_position_feed_age > 90 THEN {{ guidelines_fail_status() }}
-            -- If there are no vehicle position updates for that feed for that day, result is N/A
-            -- They will fail other checks for having no feed present
-            WHEN max_vehicle_position_age IS null OR max_vehicle_position_feed_age IS null THEN {{ guidelines_na_check_status() }}
-        END as status
-    FROM feed_guideline_index AS idx
-    LEFT JOIN vehicle_position_ages AS ages
-    ON idx.date = ages.dt
-        AND idx.base64_url = ages.base64_url
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_rt_feed_vp
+                   THEN
+                    CASE
+                        WHEN GREATEST(p90_vehicle_message_age, p90_header_message_age) <= 90 THEN {{ guidelines_pass_status() }}
+                        WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN GREATEST(p90_vehicle_message_age, p90_header_message_age) IS NULL THEN {{ guidelines_na_check_status() }}
+                        WHEN GREATEST(p90_vehicle_message_age, p90_header_message_age) > 90 THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN vp_message_ages
+        ON idx.date = vp_message_ages.dt
+        AND idx.base64_url = vp_message_ages.base64_url
 )
 
 SELECT * FROM int_gtfs_quality__no_stale_vehicle_positions

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_20sec_vp.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_20sec_vp.sql
@@ -1,74 +1,43 @@
-{{ config(
-    materialized='incremental',
-    incremental_strategy='insert_overwrite',
-    partition_by = {
-        'field': 'date',
-        'data_type': 'date',
-        'granularity': 'day',
-    },
-) }}
-
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='date', order_by = 'date DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
-WITH
-
-feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index_vp') }}
-    {% if is_incremental() %}
-    WHERE date >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE date >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+WITH guideline_index AS (
+    SELECT
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ rt_20sec_vp() }}
 ),
 
-vehicle_positions AS (
-    SELECT * FROM {{ ref('stg_gtfs_rt__vehicle_positions') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+
+vp_message_ages AS (
+    SELECT *
+    FROM {{ ref('fct_daily_vehicle_positions_message_age_summary') }}
 ),
 
-lag_ts AS (
-  SELECT
-          dt AS date,
-          base64_url,
-          header_timestamp,
-          LAG(header_timestamp) OVER(PARTITION BY base64_url ORDER BY header_timestamp) AS prev_header_timestamp
-    FROM vehicle_positions
-),
-
--- Note that since the header_timestamp will repeat when it hasn't been updated, the DATE_DIFF will be 0 seconds for some.
--- This would affect us if we were measuring the AVG(), but it doesn't since we're only looking at MAX()
-daily_max_lag AS (
-SELECT
-      date,
-      base64_url,
-      MAX(DATE_DIFF(header_timestamp, prev_header_timestamp, SECOND)) AS max_lag
-  FROM lag_ts
- GROUP BY 1, 2
+check_start AS (
+    SELECT MIN(dt) AS first_check_date
+    FROM vp_message_ages
 ),
 
 int_gtfs_quality__rt_20sec_vp AS (
     SELECT
-        idx.date,
-        idx.base64_url,
-        idx.feed_type,
-        {{ rt_20sec_vp() }} AS check,
-        {{ accurate_service_data() }} AS feature,
-        max_lag,
+        idx.* EXCEPT(status),
+        first_check_date,
+        p90_header_message_age,
         CASE
-            WHEN max_lag > 20 THEN {{ guidelines_fail_status() }}
-            WHEN max_lag <= 20 THEN {{ guidelines_pass_status() }}
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_rt_feed_vp
+                   THEN
+                    CASE
+                        WHEN p90_header_message_age <= 20 THEN {{ guidelines_pass_status() }}
+                        WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN p90_header_message_age IS NULL THEN {{ guidelines_na_check_status() }}
+                        WHEN p90_header_message_age > 20 THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
         END AS status,
-    FROM feed_guideline_index AS idx
-    LEFT JOIN daily_max_lag AS files
-           ON idx.date = files.date
-          AND idx.base64_url = files.base64_url
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN vp_message_ages
+        ON idx.date = vp_message_ages.dt
+        AND idx.base64_url = vp_message_ages.base64_url
 )
 
 SELECT * FROM int_gtfs_quality__rt_20sec_vp

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_https.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_https.sql
@@ -31,7 +31,7 @@ int_gtfs_quality__rt_https AS (
                 OR (idx.has_rt_url_sa AND check = {{ rt_https_service_alerts() }})
                    THEN
                     CASE
-                        WHEN string_url LIKE 'https%' THEN {{ guidelines_pass_status() }}
+                        WHEN LOWER(string_url) LIKE 'https%' THEN {{ guidelines_pass_status() }}
                         WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
                         WHEN string_url IS NULL THEN {{ guidelines_na_check_status() }}
                         WHEN string_url NOT LIKE 'https%' THEN {{ guidelines_fail_status() }}

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_https.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_https.sql
@@ -1,30 +1,48 @@
-WITH feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index') }}
+WITH guideline_index AS (
+    SELECT
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check IN ({{ rt_https_trip_updates() }},
+        {{ rt_https_vehicle_positions() }},
+        {{ rt_https_service_alerts() }})
 ),
 
 rt_daily_url_index AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__daily_url_index') }}
+    SELECT DISTINCT
+        dt,
+        string_url,
+        base64_url
+    FROM {{ ref('int_gtfs_rt__daily_url_index') }}
+),
+
+check_start AS (
+    SELECT MIN(dt) AS first_check_date
+    FROM rt_daily_url_index
 ),
 
 int_gtfs_quality__rt_https AS (
     SELECT
-        idx.date,
-        idx.base64_url,
-        idx.feed_type,
-        CASE WHEN idx.feed_type = 'service_alerts' THEN {{ rt_https_service_alerts() }}
-             WHEN idx.feed_type = 'trip_updates' THEN {{ rt_https_trip_updates() }}
-             WHEN idx.feed_type = 'vehicle_positions' THEN {{ rt_https_vehicle_positions() }}
-        END AS check,
-        {{ best_practices_alignment_rt() }} AS feature,
+        idx.* EXCEPT(status),
+        first_check_date,
         CASE
-            WHEN string_url LIKE 'https%' THEN {{ guidelines_pass_status() }}
-            WHEN string_url IS NOT null AND string_url NOT LIKE 'https%' THEN {{ guidelines_fail_status() }}
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN (idx.has_rt_url_tu AND check = {{ rt_https_trip_updates() }})
+                OR (idx.has_rt_url_vp AND check = {{ rt_https_vehicle_positions() }})
+                OR (idx.has_rt_url_sa AND check = {{ rt_https_service_alerts() }})
+                   THEN
+                    CASE
+                        WHEN string_url LIKE 'https%' THEN {{ guidelines_pass_status() }}
+                        WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN string_url IS NULL THEN {{ guidelines_na_check_status() }}
+                        WHEN string_url NOT LIKE 'https%' THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
         END AS status,
-    FROM feed_guideline_index AS idx
-    LEFT JOIN rt_daily_url_index AS url_index
-    ON idx.date = url_index.dt
-   AND idx.base64_url = url_index.base64_url
-   AND idx.feed_type = url_index.type
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN rt_daily_url_index AS urls
+        ON idx.date = urls.dt
+        AND idx.base64_url = urls.base64_url
 )
 
 SELECT * FROM int_gtfs_quality__rt_https

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -23,6 +23,7 @@ WITH unioned AS (
             ref('int_gtfs_quality__rt_https'),
             ref('int_gtfs_quality__no_rt_validation_errors'),
             ref('int_gtfs_quality__rt_protobuf_error'),
+            ref('int_gtfs_quality__rt_20sec_vp')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -20,7 +20,6 @@ WITH unioned AS (
             ref('int_gtfs_quality__pathways_valid'),
             ref('int_gtfs_quality__technical_contact_listed')
             ref('int_gtfs_quality__rt_feeds_present')
-            ref('int_gtfs_quality__rt_feeds_present'),
             ref('int_gtfs_quality__rt_https')
         ],
     ) }}

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -21,6 +21,7 @@ WITH unioned AS (
             ref('int_gtfs_quality__technical_contact_listed')
             ref('int_gtfs_quality__rt_feeds_present')
             ref('int_gtfs_quality__rt_https')
+            ref('int_gtfs_quality__no_rt_validation_errors')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -18,11 +18,11 @@ WITH unioned AS (
             ref('int_gtfs_quality__include_tts'),
             ref('int_gtfs_quality__shapes_valid'),
             ref('int_gtfs_quality__pathways_valid'),
-            ref('int_gtfs_quality__technical_contact_listed')
-            ref('int_gtfs_quality__rt_feeds_present')
-            ref('int_gtfs_quality__rt_https')
-            ref('int_gtfs_quality__no_rt_validation_errors')
-            ref('int_gtfs_quality__rt_protobuf_error')
+            ref('int_gtfs_quality__technical_contact_listed'),
+            ref('int_gtfs_quality__rt_feeds_present'),
+            ref('int_gtfs_quality__rt_https'),
+            ref('int_gtfs_quality__no_rt_validation_errors'),
+            ref('int_gtfs_quality__rt_protobuf_error'),
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -19,6 +19,7 @@ WITH unioned AS (
             ref('int_gtfs_quality__shapes_valid'),
             ref('int_gtfs_quality__pathways_valid'),
             ref('int_gtfs_quality__technical_contact_listed')
+            ref('int_gtfs_quality__rt_feeds_present')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -23,7 +23,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__rt_https'),
             ref('int_gtfs_quality__no_rt_validation_errors'),
             ref('int_gtfs_quality__rt_protobuf_error'),
-            ref('int_gtfs_quality__rt_20sec_vp')
+            ref('int_gtfs_quality__rt_20sec_vp'),
+            ref('int_gtfs_quality__no_stale_vehicle_positions')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -22,6 +22,7 @@ WITH unioned AS (
             ref('int_gtfs_quality__rt_feeds_present')
             ref('int_gtfs_quality__rt_https')
             ref('int_gtfs_quality__no_rt_validation_errors')
+            ref('int_gtfs_quality__rt_protobuf_error')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -20,6 +20,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__pathways_valid'),
             ref('int_gtfs_quality__technical_contact_listed')
             ref('int_gtfs_quality__rt_feeds_present')
+            ref('int_gtfs_quality__rt_feeds_present'),
+            ref('int_gtfs_quality__rt_https')
         ],
     ) }}
 ),

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -218,21 +218,23 @@ models:
       - name: _header_message_age
         description: |
           Difference between `_extract_ts` (time at which we scraped the message) and `header_timestamp` (timestamp
-          of overall message from producer). Because of delay in the request process, the actual scrape request may occur up to a few
+          of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader).
+          Because of delay in the request process, the actual scrape request may occur up to a few
           seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
-          this field should only be interpreted as accurate within about 5 seconds (do not try to do extremely precise
+          this field should only be interpreted as accurate within 3-4 seconds (do not try to do extremely precise
           measurements below that level.)
       - name: _vehicle_message_age
         description: |
           Difference between `_extract_ts` (time at which we scraped the message) and `vehicle_timestamp` (timestamp
-          of individual vehicle message from producer). Because of delay in the request process, the actual scrape request may occur up to a few
+          of individual vehicle message from producer; see https://gtfs.org/realtime/reference/#message-vehicleposition).
+          Because of delay in the request process, the actual scrape request may occur up to a few
           seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
-          this field should only be interpreted as accurate within about 5 seconds (do not try to do extremely precise
+          this field should only be interpreted as accurate within 3-4 seconds (do not try to do extremely precise
           measurements below that level.)
       - name: _vehicle_message_age_vs_header
         description: |
-          Difference between `header_timestamp` (timestamp of overall message from producer) and `vehicle_timestamp`
-          (timestamp of individual vehicle message from producer).
+          Difference between `header_timestamp` (timestamp of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader)
+          and `vehicle_timestamp` (timestamp of individual vehicle message from producer; see https://gtfs.org/realtime/reference/#message-vehicleposition).
       - name: _gtfs_dataset_name
         description: |
           String name of the GTFS dataset of which this message is a part.

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -217,7 +217,7 @@ models:
           Time at which this message was scraped.
       - name: _header_message_age
         description: |
-          Difference between `_extract_ts` (time at which we scraped the message) and `header_timestamp` (timestamp
+          Difference in seconds between `_extract_ts` (time at which we scraped the message) and `header_timestamp` (timestamp
           of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader).
           Because of delay in the request process, the actual scrape request may occur up to a few
           seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
@@ -225,7 +225,7 @@ models:
           measurements below that level.)
       - name: _vehicle_message_age
         description: |
-          Difference between `_extract_ts` (time at which we scraped the message) and `vehicle_timestamp` (timestamp
+          Difference in seconds between `_extract_ts` (time at which we scraped the message) and `vehicle_timestamp` (timestamp
           of individual vehicle message from producer; see https://gtfs.org/realtime/reference/#message-vehicleposition).
           Because of delay in the request process, the actual scrape request may occur up to a few
           seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
@@ -233,7 +233,7 @@ models:
           measurements below that level.)
       - name: _vehicle_message_age_vs_header
         description: |
-          Difference between `header_timestamp` (timestamp of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader)
+          Difference in seconds between `header_timestamp` (timestamp of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader)
           and `vehicle_timestamp` (timestamp of individual vehicle message from producer; see https://gtfs.org/realtime/reference/#message-vehicleposition).
       - name: _gtfs_dataset_name
         description: |

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -215,6 +215,24 @@ models:
       - name: _extract_ts
         description: |
           Time at which this message was scraped.
+      - name: _header_message_age
+        description: |
+          Difference between `_extract_ts` (time at which we scraped the message) and `header_timestamp` (timestamp
+          of overall message from producer). Because of delay in the request process, the actual scrape request may occur up to a few
+          seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
+          this field should only be interpreted as accurate within about 5 seconds (do not try to do extremely precise
+          measurements below that level.)
+      - name: _vehicle_message_age
+        description: |
+          Difference between `_extract_ts` (time at which we scraped the message) and `vehicle_timestamp` (timestamp
+          of individual vehicle message from producer). Because of delay in the request process, the actual scrape request may occur up to a few
+          seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
+          this field should only be interpreted as accurate within about 5 seconds (do not try to do extremely precise
+          measurements below that level.)
+      - name: _vehicle_message_age_vs_header
+        description: |
+          Difference between `header_timestamp` (timestamp of overall message from producer) and `vehicle_timestamp`
+          (timestamp of individual vehicle message from producer).
       - name: _gtfs_dataset_name
         description: |
           String name of the GTFS dataset of which this message is a part.

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -38,6 +38,11 @@ fct_vehicle_positions_messages AS (
         _config_extract_ts,
         _gtfs_dataset_name,
 
+        TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND) AS _header_message_age,
+        TIMESTAMP_DIFF(_extract_ts, vehicle_timestamp, SECOND) AS _vehicle_message_age,
+        TIMESTAMP_DIFF(header_timestamp, vehicle_timestamp, SECOND) AS _vehicle_message_age_vs_header,
+
+
         header_timestamp,
         header_version,
         header_incrementality,

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -628,6 +628,29 @@ models:
       - name: change_status
       - name: n
 
+  - name: fct_daily_vehicle_positions_message_age_summary
+    description: |
+      Table summarizing the age of various message components by RT URL by date.
+      Terms:
+      - For definitions of the underlying `header_message_age`, `vehicle_message_age`, and `vehice_message_age_vs_header`
+        values, see `fct_vehicle_positions_messages`. In particular, note that a negative value indicates that the
+        referenced item happened *after* the item it's being compared to; i.e., a negative `header_message_age` indicates
+        that the `header_timestamp` was later than `_extract_ts`.
+      - `pX` refers to a percentile, so `p25` refers to 25th percentile.
+      - `avg` refers to the mean.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - dt
+            - base64_url
+    columns:
+      - name: dt
+        tests:
+          - not_null
+      - name: base64_url
+        tests:
+          - not_null
+
 exposures:
  - name: calitp_reports_site
    type: application

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -630,7 +630,7 @@ models:
 
   - name: fct_daily_vehicle_positions_message_age_summary
     description: |
-      Table summarizing the age of various message components by RT URL by date.
+      Table summarizing the age in seconds of various message components by RT URL by date.
       Terms:
       - For definitions of the underlying `header_message_age`, `vehicle_message_age`, and `vehice_message_age_vs_header`
         values, see `fct_vehicle_positions_messages`. In particular, note that a negative value indicates that the

--- a/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
@@ -107,34 +107,6 @@ summarize_vehicle_ages AS (
     GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
 ),
 
--- intra_message_age_percentiles AS (
---     SELECT
---         *,
---         -- calculate median: https://stackoverflow.com/a/66213692
---         PERCENTILE_CONT(_vehicle_message_age_vs_header, .5) OVER(PARTITION BY dt, base64_url) AS median_vehicle_message_age_vs_header,
---         PERCENTILE_CONT(_vehicle_message_age_vs_header, .25) OVER(PARTITION BY dt, base64_url) AS p25_vehicle_message_age_vs_header,
---         PERCENTILE_CONT(_vehicle_message_age_vs_header, .75) OVER(PARTITION BY dt, base64_url) AS p75_vehicle_message_age_vs_header,
---         PERCENTILE_CONT(_vehicle_message_age_vs_header, .90) OVER(PARTITION BY dt, base64_url) AS p90_vehicle_message_age_vs_header,
---         PERCENTILE_CONT(_vehicle_message_age_vs_header, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_vehicle_message_age_vs_header
---     FROM vehicle_positions_ages
--- ),
-
--- summarize_intra_message_ages AS (
---     SELECT
---         dt,
---         base64_url,
---         median_vehicle_message_age_vs_header,
---         p25_vehicle_message_age_vs_header,
---         p75_vehicle_message_age_vs_header,
---         p90_vehicle_message_age_vs_header,
---         p99_quartile_vehicle_message_age_vs_header,
---         MAX(_vehicle_message_age_vs_header) AS max_vehicle_message_age_vs_header,
---         MIN(_vehicle_message_age_vs_header) AS min_vehicle_message_age_vs_header,
---         AVG(_vehicle_message_age_vs_header) AS avg_vehicle_message_age_vs_header,
---     FROM intra_message_age_percentiles
---     GROUP BY 1, 2, 3, 4, 5, 6, 7
--- ),
-
 fct_daily_vehicle_positions_message_age_summary AS (
     SELECT
         {{ dbt_utils.surrogate_key(['dt', 'base64_url']) }} AS key,
@@ -167,8 +139,6 @@ fct_daily_vehicle_positions_message_age_summary AS (
     FROM summarize_header_ages
     LEFT JOIN summarize_vehicle_ages
         USING (dt, base64_url)
-    -- LEFT JOIN summarize_intra_message_ages
-    --     USING (dt, base64_url)
 )
 
 SELECT * FROM fct_daily_vehicle_positions_message_age_summary

--- a/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
@@ -1,0 +1,174 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by = {
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
+
+{% if is_incremental() %}
+    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set max_ts = timestamps[0] %}
+{% endif %}
+
+WITH vehicle_positions_ages AS (
+    SELECT DISTINCT
+        dt,
+        base64_url,
+        _header_message_age,
+        _vehicle_message_age,
+        _vehicle_message_age_vs_header,
+    FROM {{ ref('fct_vehicle_positions_messages') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >=  {{ var('GTFS_RT_START') }}
+    {% endif %}
+),
+
+-- these values are repeated because one row in the source table is one vehicle message so the header is identical for all messages on a given request
+-- select distinct to deduplicate these to the overall message level to make summary statistics more meaningful
+distinct_headers AS (
+    SELECT DISTINCT
+        dt,
+        base64_url,
+        _header_message_age,
+    FROM vehicle_positions_ages
+),
+
+header_age_percentiles AS (
+    SELECT
+        *,
+        -- calculate median: https://stackoverflow.com/a/66213692
+        PERCENTILE_CONT(_header_message_age, .5) OVER(PARTITION BY dt, base64_url) AS median_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .25) OVER(PARTITION BY dt, base64_url) AS p25_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .75) OVER(PARTITION BY dt, base64_url) AS p75_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .90) OVER(PARTITION BY dt, base64_url) AS p90_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_header_message_age
+    FROM distinct_headers
+),
+
+summarize_header_ages AS (
+    SELECT
+        dt,
+        base64_url,
+        median_header_message_age,
+        p25_header_message_age,
+        p75_header_message_age,
+        p90_header_message_age,
+        p99_quartile_header_message_age,
+        MAX(_header_message_age) AS max_header_message_age,
+        MIN(_header_message_age) AS min_header_message_age,
+        AVG(_header_message_age) AS avg_header_message_age,
+    FROM header_age_percentiles
+    GROUP BY 1, 2, 3, 4, 5, 6, 7
+),
+
+vehicle_age_percentiles AS (
+    SELECT
+        *,
+        -- calculate median: https://stackoverflow.com/a/66213692
+        PERCENTILE_CONT(_vehicle_message_age, .5) OVER(PARTITION BY dt, base64_url) AS median_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, .25) OVER(PARTITION BY dt, base64_url) AS p25_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, .75) OVER(PARTITION BY dt, base64_url) AS p75_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, .90) OVER(PARTITION BY dt, base64_url) AS p90_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age_vs_header, .5) OVER(PARTITION BY dt, base64_url) AS median_vehicle_message_age_vs_header,
+        PERCENTILE_CONT(_vehicle_message_age_vs_header, .25) OVER(PARTITION BY dt, base64_url) AS p25_vehicle_message_age_vs_header,
+        PERCENTILE_CONT(_vehicle_message_age_vs_header, .75) OVER(PARTITION BY dt, base64_url) AS p75_vehicle_message_age_vs_header,
+        PERCENTILE_CONT(_vehicle_message_age_vs_header, .90) OVER(PARTITION BY dt, base64_url) AS p90_vehicle_message_age_vs_header,
+        PERCENTILE_CONT(_vehicle_message_age_vs_header, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_vehicle_message_age_vs_header
+    FROM vehicle_positions_ages
+),
+
+summarize_vehicle_ages AS (
+    SELECT
+        dt,
+        base64_url,
+        median_vehicle_message_age,
+        p25_vehicle_message_age,
+        p75_vehicle_message_age,
+        p90_vehicle_message_age,
+        p99_quartile_vehicle_message_age,
+        median_vehicle_message_age_vs_header,
+        p25_vehicle_message_age_vs_header,
+        p75_vehicle_message_age_vs_header,
+        p90_vehicle_message_age_vs_header,
+        p99_quartile_vehicle_message_age_vs_header,
+        MAX(_vehicle_message_age) AS max_vehicle_message_age,
+        MIN(_vehicle_message_age) AS min_vehicle_message_age,
+        AVG(_vehicle_message_age) AS avg_vehicle_message_age,
+        MAX(_vehicle_message_age_vs_header) AS max_vehicle_message_age_vs_header,
+        MIN(_vehicle_message_age_vs_header) AS min_vehicle_message_age_vs_header,
+        AVG(_vehicle_message_age_vs_header) AS avg_vehicle_message_age_vs_header,
+    FROM vehicle_age_percentiles
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+),
+
+-- intra_message_age_percentiles AS (
+--     SELECT
+--         *,
+--         -- calculate median: https://stackoverflow.com/a/66213692
+--         PERCENTILE_CONT(_vehicle_message_age_vs_header, .5) OVER(PARTITION BY dt, base64_url) AS median_vehicle_message_age_vs_header,
+--         PERCENTILE_CONT(_vehicle_message_age_vs_header, .25) OVER(PARTITION BY dt, base64_url) AS p25_vehicle_message_age_vs_header,
+--         PERCENTILE_CONT(_vehicle_message_age_vs_header, .75) OVER(PARTITION BY dt, base64_url) AS p75_vehicle_message_age_vs_header,
+--         PERCENTILE_CONT(_vehicle_message_age_vs_header, .90) OVER(PARTITION BY dt, base64_url) AS p90_vehicle_message_age_vs_header,
+--         PERCENTILE_CONT(_vehicle_message_age_vs_header, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_vehicle_message_age_vs_header
+--     FROM vehicle_positions_ages
+-- ),
+
+-- summarize_intra_message_ages AS (
+--     SELECT
+--         dt,
+--         base64_url,
+--         median_vehicle_message_age_vs_header,
+--         p25_vehicle_message_age_vs_header,
+--         p75_vehicle_message_age_vs_header,
+--         p90_vehicle_message_age_vs_header,
+--         p99_quartile_vehicle_message_age_vs_header,
+--         MAX(_vehicle_message_age_vs_header) AS max_vehicle_message_age_vs_header,
+--         MIN(_vehicle_message_age_vs_header) AS min_vehicle_message_age_vs_header,
+--         AVG(_vehicle_message_age_vs_header) AS avg_vehicle_message_age_vs_header,
+--     FROM intra_message_age_percentiles
+--     GROUP BY 1, 2, 3, 4, 5, 6, 7
+-- ),
+
+fct_daily_vehicle_positions_message_age_summary AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['dt', 'base64_url']) }} AS key,
+        dt,
+        base64_url,
+        median_header_message_age,
+        p25_header_message_age,
+        p75_header_message_age,
+        p90_header_message_age,
+        p99_quartile_header_message_age,
+        max_header_message_age,
+        min_header_message_age,
+        avg_header_message_age,
+        median_vehicle_message_age,
+        p25_vehicle_message_age,
+        p75_vehicle_message_age,
+        p90_vehicle_message_age,
+        p99_quartile_vehicle_message_age,
+        max_vehicle_message_age,
+        min_vehicle_message_age,
+        avg_vehicle_message_age,
+        median_vehicle_message_age_vs_header,
+        p25_vehicle_message_age_vs_header,
+        p75_vehicle_message_age_vs_header,
+        p90_vehicle_message_age_vs_header,
+        p99_quartile_vehicle_message_age_vs_header,
+        max_vehicle_message_age_vs_header,
+        min_vehicle_message_age_vs_header,
+        avg_vehicle_message_age_vs_header
+    FROM summarize_header_ages
+    LEFT JOIN summarize_vehicle_ages
+        USING (dt, base64_url)
+    -- LEFT JOIN summarize_intra_message_ages
+    --     USING (dt, base64_url)
+)
+
+SELECT * FROM fct_daily_vehicle_positions_message_age_summary

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -40,11 +40,11 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ rt_https_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_url_sa() }}
     UNION ALL
-    SELECT {{ no_pb_error_tu() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_pb_error_tu() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_tu() }}
     UNION ALL
-    SELECT {{ no_pb_error_vp() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_pb_error_vp() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_vp() }}
     UNION ALL
-    SELECT {{ no_pb_error_sa() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_pb_error_sa() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_sa() }}
     UNION ALL
     SELECT {{ no_7_day_feed_expiration() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -34,11 +34,11 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ feed_present_service_alerts() }}, {{ compliance_rt() }}, {{ rt_url_sa() }}
     UNION ALL
-    SELECT {{ rt_https_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ rt_https_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_url_tu() }}
     UNION ALL
-    SELECT {{ rt_https_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ rt_https_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_url_vp() }}
     UNION ALL
-    SELECT {{ rt_https_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ rt_https_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_url_sa() }}
     UNION ALL
     SELECT {{ no_pb_error_tu() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -28,11 +28,11 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}, {{ rt_feed() }}
     UNION ALL
-    SELECT {{ feed_present_vehicle_positions() }}, {{ compliance_rt() }}, {{ rt_url() }}
+    SELECT {{ feed_present_vehicle_positions() }}, {{ compliance_rt() }}, {{ rt_url_vp() }}
     UNION ALL
-    SELECT {{ feed_present_trip_updates() }}, {{ compliance_rt() }}, {{ rt_url() }}
+    SELECT {{ feed_present_trip_updates() }}, {{ compliance_rt() }}, {{ rt_url_tu() }}
     UNION ALL
-    SELECT {{ feed_present_service_alerts() }}, {{ compliance_rt() }}, {{ rt_url() }}
+    SELECT {{ feed_present_service_alerts() }}, {{ compliance_rt() }}, {{ rt_url_sa() }}
     UNION ALL
     SELECT {{ rt_https_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -52,7 +52,7 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ passes_fares_validator() }}, {{ fare_completeness() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ rt_20sec_vp() }}, {{ accurate_service_data() }}, {{ rt_feed() }}
+    SELECT {{ rt_20sec_vp() }}, {{ accurate_service_data() }}, {{ rt_feed_vp() }}
     UNION ALL
     SELECT {{ rt_20sec_tu() }}, {{ accurate_service_data() }}, {{ rt_feed() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -1,4 +1,5 @@
 {{ config(materialized='ephemeral') }}
+
 WITH stg_gtfs_quality__intended_checks AS (
     SELECT {{ static_feed_downloaded_successfully() }} AS check, {{ compliance_schedule() }} AS feature, {{ schedule_url() }} AS entity
     UNION ALL
@@ -60,7 +61,7 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ lead_time() }}, {{ up_to_dateness() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ no_stale_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_stale_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_vp() }}
     UNION ALL
     SELECT {{ no_stale_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -20,11 +20,11 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ no_expired_services() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL
-    SELECT {{ no_rt_validation_errors_vp() }}, {{ compliance_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_rt_validation_errors_vp() }}, {{ compliance_rt() }}, {{ rt_feed_vp() }}
     UNION ALL
-    SELECT {{ no_rt_validation_errors_tu() }}, {{ compliance_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_rt_validation_errors_tu() }}, {{ compliance_rt() }}, {{ rt_feed_tu() }}
     UNION ALL
-    SELECT {{ no_rt_validation_errors_sa() }}, {{ compliance_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_rt_validation_errors_sa() }}, {{ compliance_rt() }}, {{ rt_feed_sa() }}
     UNION ALL
     SELECT {{ trip_id_alignment() }}, {{ fixed_route_completeness() }}, {{ rt_feed() }}
     UNION ALL


### PR DESCRIPTION
# Description

See [Google Doc](https://docs.google.com/spreadsheets/d/15eYntYFoYyHuXYyp4dmqM3g5N18tw2r8dU2S7wDDM4E/edit#gid=1437513597) for list of models migrated here, those with #2379 in the PR column. Once again merging into staging branch, which will merge in #2371.

Notes:
* For RT feed checks on dates before RT files history are available, we might end up with `N/A - NO APPLICABLE ENTITY` instead of `BEFORE CHECK ASSESSED` because they will show has not having RT files (and therefore having no assessed entity). Not sure if this is a problem. 🤔 
* For the vehicle positions & trip updates freshness checks (updates every 20 sec/no updates older than 90 sec), we are creating new incremental fact models so that the check models themselves are not incremental. This should give more flexibility in future and keep the check models consistent across the board.
* For the updates every 20 seconds, we have discussed extensively offline. We have changed the measure from comparing one header timestamp to the subsequent header timestamp (which might be subject to flakiness if our scraper went down) to comparing a given header timestamp to the timestamp at which it was requested, showing the freshness of the data at the time it was received (this is already closer to the metric we were using for the `no stale` checks). Instead of checking that the maximum such value is < 20sec, we are checking that the 90th percentile is < 20sec, to account for the fact that this check seemed fairly noisy and we assume the intention is to capture the capacity to update every 20sec rather than to penalize a small number of lags during the day. 

Progress on #2263

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Tested each model individually to confirm that new statuses seem reasonable vs. old statuses. Also checked 
```
SELECT check, COUNT(*)
FROM `cal-itp-data-infra-staging.laurie_staging.int_gtfs_quality__guideline_checks_long_new_index`
GROUP BY check
```
to confirm that all checks have the same number of results (no fanout).