### PR TITLE
default all our pod operators to wait 300 seconds to start

### DIFF
--- a/airflow/dags/deploy_dbt_docs/deploy_dbt_docs_site.yml
+++ b/airflow/dags/deploy_dbt_docs/deploy_dbt_docs_site.yml
@@ -13,7 +13,6 @@ arguments:
   - '--deploy-docs'
 
 is_delete_operator_pod: true
-startup_timeout_seconds: 300
 get_logs: true
 is_gke: true
 pod_location: us-west1

--- a/airflow/dags/deploy_dbt_docs/sync_dbt_docs_to_metabase.yml
+++ b/airflow/dags/deploy_dbt_docs/sync_dbt_docs_to_metabase.yml
@@ -13,7 +13,6 @@ arguments:
   - '--sync-metabase'
 
 is_delete_operator_pod: true
-startup_timeout_seconds: 300
 get_logs: true
 is_gke: true
 pod_location: us-west1

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -13,7 +13,6 @@ arguments:
   - '--sync-metabase'
 
 is_delete_operator_pod: true
-startup_timeout_seconds: 300
 get_logs: true
 is_gke: true
 pod_location: us-west1

--- a/airflow/dags/transform_warehouse/dbt_test.yml
+++ b/airflow/dags/transform_warehouse/dbt_test.yml
@@ -15,7 +15,6 @@ dependencies:
 trigger_rule: all_done
 
 is_delete_operator_pod: true
-startup_timeout_seconds: 300
 get_logs: true
 is_gke: true
 pod_location: us-west1

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -14,7 +14,6 @@ arguments:
   - '--sync-metabase'
 
 is_delete_operator_pod: true
-startup_timeout_seconds: 300
 get_logs: true
 is_gke: true
 pod_location: us-west1

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -15,7 +15,6 @@ dependencies:
 trigger_rule: all_done
 
 is_delete_operator_pod: true
-startup_timeout_seconds: 300
 get_logs: true
 is_gke: true
 pod_location: us-west1

--- a/airflow/plugins/operators/pod_operator.py
+++ b/airflow/plugins/operators/pod_operator.py
@@ -16,6 +16,9 @@ def PodOperator(*args, **kwargs):
     # TODO: tune this, and add resource limits
     namespace = kwargs.pop("namespace", "default")
 
+    if "startup_timeout_seconds" not in kwargs:
+        kwargs["startup_timeout_seconds"] = 300
+
     is_gke = kwargs.pop("is_gke", False)  # we want to always pop()
 
     if "secrets" in kwargs:


### PR DESCRIPTION
# Description

We've been seeing more pod start timeouts recently. I set our job nodes pool to minimum 1 per zone, but pods are failing to start and force our current nodes up to that minimum. We already use 300 seconds on dbt pods so let's just do that everywhere.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Locally, ran a pod successfully.

## Screenshots (optional)
