### PR TITLE
increase jupyterhub singleuser resource request

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -15,7 +15,8 @@ jupyterhub:
       # Very roughly I have seen most usage in the 2-3GB range
       guarantee: 3G
     cpu:
-      guarantee: 0.5
+      # this is to put 2 pods per e2-highmem-2 which has 1.93 allocatable
+      guarantee: 0.7
     lifecycleHooks:
       postStart:
         exec:


### PR DESCRIPTION
# Description

I think 3 people were all using conda at once; we really should be requesting ~1 CPU per person but our nodes do have have a full 2 CPU allocatable; 0.7 will stop 3 user pods from being scheduled on 1 node.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Already deployed.

## Screenshots (optional)
