### PR TITLE
split dbt build and visualize CI jobs

### DIFF
--- a/.github/workflows/build-warehouse-image.yml
+++ b/.github/workflows/build-warehouse-image.yml
@@ -54,7 +54,7 @@ jobs:
           poetry install
           poetry run dbt deps
           poetry run dbt compile --target prod
-          poetry run dbt docs generate
+          poetry run dbt docs generate --target prod
       - uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: './warehouse/logs/'

--- a/.github/workflows/build-warehouse-image.yml
+++ b/.github/workflows/build-warehouse-image.yml
@@ -53,7 +53,7 @@ jobs:
           cd warehouse
           poetry install
           poetry run dbt deps
-          poetry run dbt compile
+          poetry run dbt compile --target prod
           poetry run dbt docs generate
       - uses: 'google-github-actions/upload-cloud-storage@v1'
         with:

--- a/.github/workflows/build-warehouse-image.yml
+++ b/.github/workflows/build-warehouse-image.yml
@@ -34,8 +34,8 @@ jobs:
       - run: curl -sSL https://install.python-poetry.org | python -
       - run: cd warehouse && poetry install && poetry run mypy scripts
 
-  visualize:
-    name: Visualize DAG
+  compile:
+    name: Compile dbt project
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install -y libgraphviz-dev graphviz graphviz-dev
@@ -64,22 +64,6 @@ jobs:
           path: './warehouse/target/'
           glob: '*.json'
           destination: 'calitp-ci-artifacts/${{github.workflow}}/run_id=${{github.run_id}}/job=${{github.job}}/target/'
-      - uses: iterative/setup-cml@v1
-      - name: GitHub comment
-        env:
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd warehouse
-          gsutil cp -r gs://calitp-dbt-artifacts/latest/ .
-          echo "# Warehouse report 📦" >> report.md
-          echo "## New models 🆕" >> report.md
-          poetry run dbt --no-use-colors ls --resource-type model --select state:new --state ./latest | sed "s/calitp_warehouse\.//g" >> report.md
-          echo "## Changed models 🛠️" >> report.md
-          poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | sed "s/calitp_warehouse\.//g" >> report.md
-          poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | sed 's/^/--include /g' | xargs poetry run python scripts/visualize.py viz man --output=target/dag.png
-          echo "" >> report.md
-          echo '![](./target/dag.png "Changed models")' >> report.md
-          cml comment update report.md
 
   build_push:
     name: Package docker image

--- a/.github/workflows/visualize-warehouse-changes.yml
+++ b/.github/workflows/visualize-warehouse-changes.yml
@@ -46,7 +46,7 @@ jobs:
           cd warehouse
           poetry install
           poetry run dbt deps
-          poetry run dbt compile
+          poetry run dbt compile --target prod
       - uses: iterative/setup-cml@v1
       - name: GitHub comment
         env:

--- a/.github/workflows/visualize-warehouse-changes.yml
+++ b/.github/workflows/visualize-warehouse-changes.yml
@@ -6,20 +6,18 @@ on:
       - 'main'
     paths:
       - '.github/workflows/visualize-warehouse-changes.yml'
-      - 'warehouse/**'
+      - 'warehouse/analyses/**'
+      - 'warehouse/models/**'
+      - 'warehouse/seeds/**'
+      - 'warehouse/snapshots/**'
+      - 'warehouse/tests/**'
   pull_request:
     paths:
       - '.github/workflows/visualize-warehouse-changes.yml'
       - 'warehouse/analyses/**'
       - 'warehouse/models/**'
-      - 'warehouse/packages.yml'
-      - 'warehouse/poetry.lock'
-      - 'warehouse/pyproject.yml'
-      - 'warehouse/requirements.txt'
-      - 'warehouse/scripts/visualize.py'
       - 'warehouse/seeds/**'
       - 'warehouse/snapshots/**'
-      - 'warehouse/tests/**'
       - 'warehouse/tests/**'
 
 concurrency:

--- a/.github/workflows/visualize-warehouse-changes.yml
+++ b/.github/workflows/visualize-warehouse-changes.yml
@@ -6,19 +6,11 @@ on:
       - 'main'
     paths:
       - '.github/workflows/visualize-warehouse-changes.yml'
-      - 'warehouse/analyses/**'
       - 'warehouse/models/**'
-      - 'warehouse/seeds/**'
-      - 'warehouse/snapshots/**'
-      - 'warehouse/tests/**'
   pull_request:
     paths:
       - '.github/workflows/visualize-warehouse-changes.yml'
-      - 'warehouse/analyses/**'
       - 'warehouse/models/**'
-      - 'warehouse/seeds/**'
-      - 'warehouse/snapshots/**'
-      - 'warehouse/tests/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/visualize-warehouse-changes.yml
+++ b/.github/workflows/visualize-warehouse-changes.yml
@@ -1,0 +1,65 @@
+name: Visualize dbt DAG changes
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/visualize-warehouse-changes.yml'
+      - 'warehouse/**'
+  pull_request:
+    paths:
+      - '.github/workflows/visualize-warehouse-changes.yml'
+      - 'warehouse/analyses/**'
+      - 'warehouse/models/**'
+      - 'warehouse/packages.yml'
+      - 'warehouse/poetry.lock'
+      - 'warehouse/pyproject.yml'
+      - 'warehouse/requirements.txt'
+      - 'warehouse/scripts/visualize.py'
+      - 'warehouse/seeds/**'
+      - 'warehouse/snapshots/**'
+      - 'warehouse/tests/**'
+      - 'warehouse/tests/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  visualize:
+    name: Visualize DAG
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get install -y libgraphviz-dev graphviz graphviz-dev
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - run: curl -sSL https://install.python-poetry.org | python -
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          export_default_credentials: true
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Compile dbt project
+        run: |
+          cd warehouse
+          poetry install
+          poetry run dbt deps
+          poetry run dbt compile
+      - uses: iterative/setup-cml@v1
+      - name: GitHub comment
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd warehouse
+          gsutil cp -r gs://calitp-dbt-artifacts/latest/ .
+          echo "# Warehouse report 📦" >> report.md
+          echo "## New models 🆕" >> report.md
+          poetry run dbt --no-use-colors ls --resource-type model --select state:new --state ./latest | sed "s/calitp_warehouse\.//g" >> report.md
+          echo "## Changed models 🛠️" >> report.md
+          poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | sed "s/calitp_warehouse\.//g" >> report.md
+          poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | sed 's/^/--include /g' | xargs poetry run python scripts/visualize.py viz man --output=target/dag.png
+          echo "" >> report.md
+          echo '![](./target/dag.png "Changed models")' >> report.md
+          cml comment update report.md


### PR DESCRIPTION
# Description

I only realized on a new PR that the visualize code would not run on warehouse model changes; it needs to be split from the image/script checks.

Also I changed the project profiles to use 8 threads instead of 4, which I'd been meaning to do for awhile.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Both should run on this PR; the DAG visualization does not gracefully handle a lack of changed models but in the future it'll only really run when models _have_ changed.

## Screenshots (optional)
