### PR TITLE
deploy 2 consumers instead of 1 for snuba-events-subscriptions-consumers

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -36,3 +36,6 @@ sentry:
     port: 587
     host: "smtp.postmarkapp.com"
     from: "bot@calitp.org"
+  snuba:
+    subscriptionConsumerEvents:
+      replicas: 2


### PR DESCRIPTION
# Description

Unsure if this would've helped with our outage recovery, but this was the consumer group that fell behind and was unable to start processing kafka events once the clickhouse disk space issue was resolved. One recommendation in [the forum](https://forum.sentry.io/t/kafka-offset-issue-snuba-subscription-consumer-events/12825) was to increase resources if consumers fall behind; again unsure if this would've helped, but it won't hurt to run 2 instead of 1.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Already deployed

## Screenshots (optional)
