### PR TITLE
add base64_url to candidate entities key to resolve duplicate key issue

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
@@ -32,6 +32,7 @@ initial_assessed AS (
         {{ dbt_utils.surrogate_key([
             'organization_key',
             'service_key',
+            'base64_url',
             'gtfs_service_data_key',
             'gtfs_dataset_key',
             'schedule_feed_key']) }} AS key,


### PR DESCRIPTION
# Description

Issue #2320 [reappeared](https://sentry.calitp.org/organizations/sentry/issues/40764/) and brought a friend [`test.calitp_warehouse.dbt_utils_unique_combination_of_columns_int_gtfs_quality__guideline_checks_index_key__date__check.efe3dcfe09 - Got 222 results, configured to fail if != 0`](https://sentry.calitp.org/organizations/sentry/issues/69731/). This fixes it by adding `base64_url` to the key which I thought I had done in #2321 but I guess I missed it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Both tables' tests now pass with this change. Also confirmed no downstream incremental tables.
