### PR TITLE
Allow RT Validation to Use Most Recent Available Schedule Feeds (Up to 7 Days)

### DIFF
--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -368,12 +368,11 @@ def validate_and_upload(
     pbar=None,
 ) -> List[RTFileProcessingOutcome]:
     first_extract = hour.extracts[0]
-    fallback_days = 0
-    for fallback_days in range(
-        0, 8
+    today = pendulum.today()
+    for target_date in reversed(
+        list(today - today.subtract(days=7))
     ):  # Fall back to most recent available schedule within 7 days
         try:
-            target_date = first_extract.dt - datetime.timedelta(days=fallback_days)
             schedule_extract = get_schedule_extracts_for_day(target_date)[
                 first_extract.config.base64_validation_url
             ]

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -368,10 +368,9 @@ def validate_and_upload(
     pbar=None,
 ) -> List[RTFileProcessingOutcome]:
     first_extract = hour.extracts[0]
-    gtfs_zip = None
     fallback_days = 0
-    while (
-        fallback_days < 7
+    for fallback_days in range(
+        0, 8
     ):  # Fall back to most recent available schedule within 7 days
         try:
             target_date = first_extract.dt - datetime.timedelta(days=fallback_days)
@@ -391,9 +390,7 @@ def validate_and_upload(
             print(
                 f"no schedule data found for {first_extract.path} and day {target_date}"
             )
-            fallback_days += 1
-
-    if gtfs_zip is None:
+    else:
         raise ScheduleDataNotFound(
             f"no recent schedule data found for {first_extract.path}"
         )

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -368,9 +368,9 @@ def validate_and_upload(
     pbar=None,
 ) -> List[RTFileProcessingOutcome]:
     first_extract = hour.extracts[0]
-    today = first_extract.dt
+    extract_day = first_extract.dt
     for target_date in reversed(
-        list(today - today.subtract(days=7))
+        list(extract_day - extract_day.subtract(days=7))
     ):  # Fall back to most recent available schedule within 7 days
         try:
             schedule_extract = get_schedule_extracts_for_day(target_date)[

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -365,10 +365,18 @@ def validate_and_upload(
 ) -> List[RTFileProcessingOutcome]:
     first_extract = hour.extracts[0]
     try:
-        # TODO: this does not work if we didn't download a schedule zip for that day
-        schedule_extract = get_schedule_extracts_for_day(first_extract.dt)[
-            first_extract.config.base64_validation_url
-        ]
+        # two levels of tries - the inner catches unavailability of current-day schedule during early
+        # morning hours UTC, and the outer catches a broader set of errors for the one-day fallback
+        try:
+            schedule_extract = get_schedule_extracts_for_day(first_extract.dt)[
+                first_extract.config.base64_validation_url
+            ]
+        except (
+            KeyError
+        ):  # Attempt a one-day fallback in case of delayed schedule processing
+            schedule_extract = get_schedule_extracts_for_day(
+                first_extract.dt - datetime.timedelta(days=1)
+            )[first_extract.config.base64_validation_url]
         gtfs_zip = download_gtfs_schedule_zip(
             fs,
             schedule_extract=schedule_extract,

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -368,7 +368,7 @@ def validate_and_upload(
     pbar=None,
 ) -> List[RTFileProcessingOutcome]:
     first_extract = hour.extracts[0]
-    today = pendulum.today()
+    today = first_extract.dt
     for target_date in reversed(
         list(today - today.subtract(days=7))
     ):  # Fall back to most recent available schedule within 7 days

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -374,7 +374,7 @@ def validate_and_upload(
         fallback_days < 7
     ):  # Fall back to most recent available schedule within 7 days
         try:
-            target_date = first_extract.dt - datetime.timedelta(days=1)
+            target_date = first_extract.dt - datetime.timedelta(days=fallback_days)
             schedule_extract = get_schedule_extracts_for_day(target_date)[
                 first_extract.config.base64_validation_url
             ]


### PR DESCRIPTION
# Description

We currently have a gap in RT validation caused by missing schedule extracts during times of day before the current day's schedule extracts have been processed. This PR allows RT validation to look back on the previously extracted version of the schedule, with a delay of up to seven days, before failing.

Resolves #2306

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Various pieces of the changed code have been tested locally, but at the time of PR creation the whole GTFS RT Parser job has not yet been run in local Airflow.