### PR TITLE
Batch 4: Guideline check reindexing

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -49,8 +49,8 @@
 'service'
 {% endmacro %}
 
-{% macro gtfs_service_data() -%}
-'gtfs_service_data'
+{% macro gtfs_service_data_schedule() -%}
+'gtfs_service_data_schedule'
 {% endmacro %}
 
 {% macro gtfs_dataset() -%}
@@ -341,11 +341,11 @@
 {% endmacro %}
 
 {% macro fixed_routes_match() %}
-"Static and RT feeds are representative of all fixed-route transit services under the transit providers’ purview"
+"Static feeds are representative of all fixed-route transit services under the transit providers’ purview"
 {% endmacro %}
 
 {% macro demand_responsive_routes_match() %}
-"Static and RT feeds are representative of all demand-responsive transit services under the transit providers’ purview"
+"Static feeds are representative of all demand-responsive transit services under the transit providers’ purview"
 {% endmacro %}
 
 {% macro scheduled_trips_in_tu_feed() %}

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_no_stop_times.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_no_stop_times.sql
@@ -8,6 +8,7 @@
             'granularity': 'day',
         },
         cluster_by='base64_url',
+        on_schema_change='append_new_columns'
     )
 }}
 

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__unioned_parse_outcomes.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__unioned_parse_outcomes.sql
@@ -1,16 +1,46 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by = {
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
+
+{% if is_incremental() %}
+    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set max_ts = timestamps[0] %}
+{% endif %}
+
 WITH service_alerts AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__service_alerts_outcomes') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >=  {{ var('GTFS_RT_START') }}
+    {% endif %}
 ),
 
 vehicle_positions AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__vehicle_positions_outcomes') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >=  {{ var('GTFS_RT_START') }}
+    {% endif %}
 ),
 
 trip_updates AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__trip_updates_outcomes') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >=  {{ var('GTFS_RT_START') }}
+    {% endif %}
 ),
 
 int_gtfs_rt__unioned_parse_outcomes AS (

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -29,6 +29,7 @@ models:
   - name: int_gtfs_quality__no_rt_validation_errors
   - name: int_gtfs_quality__no_stale_vehicle_positions
   - name: int_gtfs_quality__rt_20sec_tu
+  - name: int_gtfs_quality__no_stale_trip_updates
 
 # Service checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -47,3 +47,8 @@ models:
 # organization checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__contact_on_website
+
+# GTFS service data (schedule only) checks reindexed
+# TODO: what kind of yaml do we want for these? specifically what tests
+  - name: int_gtfs_quality__fixed_routes_match
+  - name: int_gtfs_quality__demand_responsive_routes_match

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -43,3 +43,7 @@ models:
   - name: int_gtfs_quality__rt_feeds_present
   - name: int_gtfs_quality__rt_https
   - name: int_gtfs_quality__rt_protobuf_error
+
+# organization checks reindexed
+# TODO: what kind of yaml do we want for these? specifically what tests
+  - name: int_gtfs_quality__contact_on_website

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -31,6 +31,7 @@ models:
   - name: int_gtfs_quality__rt_20sec_tu
   - name: int_gtfs_quality__no_stale_trip_updates
   - name: int_gtfs_quality__no_stale_service_alerts
+  - name: int_gtfs_quality__modification_date_present_rt
 
 # Service checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -30,6 +30,7 @@ models:
   - name: int_gtfs_quality__no_stale_vehicle_positions
   - name: int_gtfs_quality__rt_20sec_tu
   - name: int_gtfs_quality__no_stale_trip_updates
+  - name: int_gtfs_quality__no_stale_service_alerts
 
 # Service checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -28,6 +28,7 @@ models:
   - name: int_gtfs_quality__rt_20sec_vp
   - name: int_gtfs_quality__no_rt_validation_errors
   - name: int_gtfs_quality__no_stale_vehicle_positions
+  - name: int_gtfs_quality__rt_20sec_tu
 
 # Service checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -57,3 +57,4 @@ models:
 # GTFS dataset checks reindexed
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__data_license
+  - name: int_gtfs_quality__authentication_acceptable

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/_int_gtfs_quality_guidelines_checks.yaml
@@ -52,3 +52,8 @@ models:
 # TODO: what kind of yaml do we want for these? specifically what tests
   - name: int_gtfs_quality__fixed_routes_match
   - name: int_gtfs_quality__demand_responsive_routes_match
+
+
+# GTFS dataset checks reindexed
+# TODO: what kind of yaml do we want for these? specifically what tests
+  - name: int_gtfs_quality__data_license

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__authentication_acceptable.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__authentication_acceptable.sql
@@ -1,32 +1,48 @@
-WITH
-
-idx AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__gtfs_dataset_guideline_index') }}
+WITH guideline_index AS (
+    SELECT
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check IN ({{ authentication_acceptable_schedule() }},
+        {{ authentication_acceptable_vp() }},
+        {{ authentication_acceptable_tu() }},
+        {{ authentication_acceptable_sa() }}
+        )
 ),
 
 gtfs_datasets AS (
     SELECT * FROM {{ ref('dim_gtfs_datasets') }}
 ),
 
+check_start AS (
+    SELECT MIN(_valid_from) AS first_check_date
+    FROM gtfs_datasets
+    WHERE manual_check__authentication_acceptable IS NOT NULL AND manual_check__authentication_acceptable != "Unknown"
+),
+
 int_gtfs_quality__authentication_acceptable AS (
     SELECT
-        idx.date,
-        idx.gtfs_dataset_key,
+        idx.* EXCEPT(status),
+        first_check_date,
+        manual_check__authentication_acceptable,
         CASE
-            WHEN gtfs_datasets.type = "schedule" THEN {{ authentication_acceptable_schedule() }}
-            WHEN gtfs_datasets.type = "vehicle_positions" THEN {{ authentication_acceptable_vp() }}
-            WHEN gtfs_datasets.type = "trip_updates" THEN {{ authentication_acceptable_tu() }}
-            WHEN gtfs_datasets.type = "service_alerts" THEN {{ authentication_acceptable_sa() }}
-        END AS check,
-        {{ availability_on_website() }} AS feature,
-        CASE manual_check__authentication_acceptable
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
-            WHEN 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
-            ELSE {{ guidelines_manual_check_needed_status() }}
-        END AS status
-    FROM idx
-    LEFT JOIN gtfs_datasets
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN (idx.has_gtfs_dataset_schedule AND check = {{ authentication_acceptable_schedule() }})
+                OR (idx.has_gtfs_dataset_vp AND check = {{ authentication_acceptable_vp() }})
+                OR (idx.has_gtfs_dataset_tu AND check = {{ authentication_acceptable_tu() }})
+                OR (idx.has_gtfs_dataset_sa AND check = {{ authentication_acceptable_sa() }})
+                   THEN
+                    CASE
+                        WHEN manual_check__authentication_acceptable = 'Yes' THEN {{ guidelines_pass_status() }}
+                        WHEN CAST(idx.date AS TIMESTAMP) < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN manual_check__authentication_acceptable = 'Unknown' OR manual_check__authentication_acceptable IS NULL THEN {{ guidelines_manual_check_needed_status() }}
+                        WHEN manual_check__authentication_acceptable = 'No' THEN {{ guidelines_fail_status() }}
+                        WHEN manual_check__authentication_acceptable = 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN gtfs_datasets
         ON idx.gtfs_dataset_key = gtfs_datasets.key
 )
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__contact_on_website.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__contact_on_website.sql
@@ -1,27 +1,40 @@
-WITH
-
-idx AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__organization_guideline_index') }}
+WITH guideline_index AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ organization_has_contact_info() }}
 ),
 
 organizations AS (
     SELECT * FROM {{ ref('dim_organizations') }}
 ),
 
+check_start AS (
+    SELECT MIN(_valid_from) AS first_check_date
+    FROM organizations
+    WHERE manual_check__contact_on_website IS NOT NULL AND manual_check__contact_on_website != "Unknown"
+),
+
 int_gtfs_quality__contact_on_website AS (
     SELECT
-        idx.date,
-        idx.organization_key,
-        {{ organization_has_contact_info() }} AS check,
-        {{ technical_contact_availability() }} AS feature,
-        CASE manual_check__contact_on_website
-            WHEN 'Yes' THEN {{ guidelines_pass_status() }}
-            WHEN 'No' THEN {{ guidelines_fail_status() }}
-            ELSE {{ guidelines_manual_check_needed_status() }}
+        idx.* EXCEPT(status),
+        orgs.manual_check__contact_on_website,
+        first_check_date,
+        CASE
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_organization
+                   THEN
+                    CASE
+                        WHEN manual_check__contact_on_website = "Yes" THEN {{ guidelines_pass_status() }}
+                        WHEN CAST(idx.date AS TIMESTAMP) < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN manual_check__contact_on_website = "Unknown" OR manual_check__contact_on_website IS NULL THEN {{ guidelines_manual_check_needed_status() }}
+                        WHEN manual_check__contact_on_website = "No" THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
         END AS status,
-    FROM idx
-    LEFT JOIN organizations
-        ON idx.organization_key = organizations.key
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN organizations AS orgs
+        ON idx.organization_key = orgs.key
 )
 
 SELECT * FROM int_gtfs_quality__contact_on_website

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__data_license.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__data_license.sql
@@ -1,40 +1,53 @@
-WITH
-
-idx AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__gtfs_dataset_guideline_index') }}
+WITH guideline_index AS (
+    SELECT
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check IN ({{ data_license_schedule() }},
+        {{ data_license_vp() }},
+        {{ data_license_tu() }},
+        {{ data_license_sa() }}
+        )
 ),
 
 gtfs_datasets AS (
     SELECT * FROM {{ ref('dim_gtfs_datasets') }}
 ),
 
+check_start AS (
+    SELECT MIN(_valid_from) AS first_check_date
+    FROM gtfs_datasets
+    WHERE manual_check__data_license IS NOT NULL AND manual_check__data_license != "Unknown"
+),
+
 int_gtfs_quality__data_license AS (
     SELECT
-        idx.date,
-        idx.gtfs_dataset_key,
+        idx.* EXCEPT(status),
+        first_check_date,
+        manual_check__data_license,
         CASE
-            WHEN gtfs_datasets.type = "schedule" THEN {{ data_license_schedule() }}
-            WHEN gtfs_datasets.type = "vehicle_positions" THEN {{ data_license_vp() }}
-            WHEN gtfs_datasets.type = "trip_updates" THEN {{ data_license_tu() }}
-            WHEN gtfs_datasets.type = "service_alerts" THEN {{ data_license_sa() }}
-        END AS check,
-        CASE
-            WHEN gtfs_datasets.type = "schedule" THEN {{ compliance_schedule() }}
-            WHEN gtfs_datasets.type IN ("vehicle_positions", "trip_updates", "service_alerts") THEN {{ compliance_rt() }}
-        END AS feature,
-        CASE
-            WHEN manual_check__data_license LIKE ('%Permissive%')
-                 OR manual_check__data_license LIKE ('%CC-BY%')
-                 OR manual_check__data_license LIKE ('%ODL-BY%')
-                THEN {{ guidelines_pass_status() }}
-            WHEN manual_check__data_license LIKE ('%Restrictive%')
-                 OR manual_check__data_license = 'Missing'
-                THEN {{ guidelines_fail_status() }}
-            WHEN manual_check__data_license = 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
-            ELSE {{ guidelines_manual_check_needed_status() }}
-        END AS status
-    FROM idx
-    LEFT JOIN gtfs_datasets
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN (idx.has_gtfs_dataset_schedule AND check = {{ data_license_schedule() }})
+                OR (idx.has_gtfs_dataset_vp AND check = {{ data_license_vp() }})
+                OR (idx.has_gtfs_dataset_tu AND check = {{ data_license_tu() }})
+                OR (idx.has_gtfs_dataset_sa AND check = {{ data_license_sa() }})
+                   THEN
+                    CASE
+                        WHEN manual_check__data_license LIKE ('%Permissive%')
+                            OR manual_check__data_license LIKE ('%CC-BY%')
+                            OR manual_check__data_license LIKE ('%ODL-BY%')
+                            THEN {{ guidelines_pass_status() }}
+                        WHEN CAST(idx.date AS TIMESTAMP) < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN manual_check__data_license = 'Unknown' OR manual_check__data_license IS NULL THEN {{ guidelines_manual_check_needed_status() }}
+                        WHEN manual_check__data_license LIKE ('%Restrictive%')
+                            OR manual_check__data_license = 'Missing'
+                            THEN {{ guidelines_fail_status() }}
+                        WHEN manual_check__data_license = 'N/A - dataset is not public-facing' THEN {{ guidelines_na_check_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN gtfs_datasets
         ON idx.gtfs_dataset_key = gtfs_datasets.key
 )
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__demand_responsive_routes_match.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__demand_responsive_routes_match.sql
@@ -1,27 +1,43 @@
-WITH
-
-idx AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__gtfs_service_data_schedule_guideline_index') }}
+WITH guideline_index AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ demand_responsive_routes_match() }}
 ),
 
 gtfs_service_data AS (
-    SELECT * FROM {{ ref('dim_gtfs_service_data') }}
+    SELECT *
+    FROM {{ ref('dim_gtfs_service_data') }}
+),
+
+-- TODO: technically ideally we would check specifically if there is a value available for a schedule-type record
+-- rather than just checking across all records
+check_start AS (
+    SELECT MIN(_valid_from) AS first_check_date
+    FROM gtfs_service_data
+    WHERE manual_check__demand_response_completeness IS NOT NULL AND manual_check__demand_response_completeness != "Unknown"
 ),
 
 int_gtfs_quality__demand_responsive_routes_match AS (
     SELECT
-        idx.date,
-        idx.gtfs_service_data_key,
-        {{ demand_responsive_routes_match() }} AS check,
-        {{ demand_responsive_completeness() }} AS feature,
-        CASE manual_check__demand_response_completeness
-            WHEN 'Complete' THEN {{ guidelines_pass_status() }}
-            WHEN 'Incomplete' THEN {{ guidelines_fail_status() }}
-            WHEN 'N/A' THEN {{ guidelines_na_check_status() }}
-            ELSE {{ guidelines_manual_check_needed_status() }}
+        idx.* EXCEPT(status),
+        manual_check__demand_response_completeness,
+        first_check_date,
+        CASE
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_gtfs_service_data_schedule
+                   THEN
+                    CASE
+                        WHEN manual_check__demand_response_completeness = "Complete" THEN {{ guidelines_pass_status() }}
+                        WHEN CAST(idx.date AS TIMESTAMP) < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN manual_check__demand_response_completeness = "Unknown"
+                            OR manual_check__demand_response_completeness IS NULL THEN {{ guidelines_manual_check_needed_status() }}
+                        WHEN manual_check__demand_response_completeness = "Incomplete" THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
         END AS status,
-    FROM idx
-    LEFT JOIN gtfs_service_data
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN gtfs_service_data
         ON idx.gtfs_service_data_key = gtfs_service_data.key
 )
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__fixed_routes_match.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__fixed_routes_match.sql
@@ -1,27 +1,44 @@
-WITH
-
-idx AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__gtfs_service_data_guideline_index') }}
+WITH guideline_index AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ fixed_routes_match() }}
 ),
 
 gtfs_service_data AS (
-    SELECT * FROM {{ ref('dim_gtfs_service_data') }}
+    SELECT *
+    FROM {{ ref('dim_gtfs_service_data') }}
+),
+
+-- TODO: technically ideally we would check specifically if there is a value available for a schedule-type record
+-- rather than just checking across all records
+check_start AS (
+    SELECT MIN(_valid_from) AS first_check_date
+    FROM gtfs_service_data
+    WHERE manual_check__fixed_route_completeness IS NOT NULL AND manual_check__fixed_route_completeness != "Unknown"
 ),
 
 int_gtfs_quality__fixed_routes_match AS (
     SELECT
-        idx.date,
-        idx.gtfs_service_data_key,
-        {{ fixed_routes_match() }} AS check,
-        {{ fixed_route_completeness() }} AS feature,
-        CASE manual_check__fixed_route_completeness
-            WHEN 'Complete' THEN {{ guidelines_pass_status() }}
-            WHEN 'Incomplete' THEN {{ guidelines_fail_status() }}
-            WHEN 'N/A' THEN {{ guidelines_na_check_status() }}
-            ELSE {{ guidelines_manual_check_needed_status() }}
+        idx.* EXCEPT(status),
+        manual_check__fixed_route_completeness,
+        first_check_date,
+        CASE
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_gtfs_service_data_schedule
+                   THEN
+                    CASE
+                        WHEN manual_check__fixed_route_completeness = "Complete" THEN {{ guidelines_pass_status() }}
+                        WHEN CAST(idx.date AS TIMESTAMP) < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN manual_check__fixed_route_completeness = "Unknown"
+                            OR manual_check__fixed_route_completeness IS NULL
+                            OR manual_check__fixed_route_completeness = "To be checked in warehouse" THEN {{ guidelines_manual_check_needed_status() }}
+                        WHEN manual_check__fixed_route_completeness = "Incomplete" THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
         END AS status,
-    FROM idx
-    LEFT JOIN gtfs_service_data
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN gtfs_service_data
         ON idx.gtfs_service_data_key = gtfs_service_data.key
 )
 

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__modification_date_present_rt.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__modification_date_present_rt.sql
@@ -1,5 +1,10 @@
-WITH feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index') }}
+WITH guideline_index AS (
+    SELECT
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check IN ({{ modification_date_present_trip_updates() }},
+        {{ modification_date_present_vehicle_positions() }},
+        {{ modification_date_present_service_alerts() }})
 ),
 
 unioned_parse_outcomes AS (
@@ -10,30 +15,40 @@ daily_modification_date_status AS (
     SELECT dt AS date,
            base64_url,
            feed_type,
-           MAX(last_modified_string) AS max_last_modified_string
+           LOGICAL_OR(last_modified_string IS NOT NULL) AS has_last_modified_string
       FROM unioned_parse_outcomes
      GROUP BY dt, base64_url, feed_type
 ),
 
+check_start AS (
+    SELECT MIN(date) AS first_check_date
+    FROM daily_modification_date_status
+),
+
 int_gtfs_quality__modification_date_present_rt AS (
     SELECT
-        idx.date,
-        idx.base64_url,
-        idx.feed_type,
-        CASE WHEN idx.feed_type = 'service_alerts' THEN {{ modification_date_present_service_alerts() }}
-             WHEN idx.feed_type = 'trip_updates' THEN {{ modification_date_present_trip_updates() }}
-             WHEN idx.feed_type = 'vehicle_positions' THEN {{ modification_date_present_vehicle_positions() }}
-        END AS check,
-        {{ best_practices_alignment_rt() }} AS feature,
+        idx.* EXCEPT(status),
+        first_check_date,
+        has_last_modified_string,
         CASE
-            WHEN daily_mod_date.max_last_modified_string IS NOT null THEN {{ guidelines_pass_status() }}
-            ELSE {{ guidelines_fail_status() }}
-        END AS status
-    FROM feed_guideline_index AS idx
-    LEFT JOIN daily_modification_date_status AS daily_mod_date
-    ON idx.date = daily_mod_date.date
-   AND idx.base64_url = daily_mod_date.base64_url
-   AND idx.feed_type = daily_mod_date.feed_type
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN (idx.has_rt_url_tu AND check = {{ modification_date_present_trip_updates() }})
+                OR (idx.has_rt_url_vp AND check = {{ modification_date_present_vehicle_positions() }})
+                OR (idx.has_rt_url_sa AND check = {{ modification_date_present_service_alerts() }})
+                   THEN
+                    CASE
+                        WHEN has_last_modified_string THEN {{ guidelines_pass_status() }}
+                        WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN has_last_modified_string IS NULL THEN {{ guidelines_na_check_status() }}
+                        WHEN NOT has_last_modified_string THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN daily_modification_date_status AS has_mod_date
+        ON idx.date = has_mod_date.date
+        AND idx.base64_url = has_mod_date.base64_url
 )
 
 SELECT * FROM int_gtfs_quality__modification_date_present_rt

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_service_alerts.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_service_alerts.sql
@@ -1,70 +1,42 @@
-{{ config(
-    materialized='incremental',
-    incremental_strategy='insert_overwrite',
-    partition_by = {
-        'field': 'date',
-        'data_type': 'date',
-        'granularity': 'day',
-    },
-) }}
-
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='date', order_by = 'date DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
-WITH
-
-feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index_sa') }}
-    {% if is_incremental() %}
-    WHERE date >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE date >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-fct_service_alerts_messages AS (
-    SELECT * FROM {{ ref('fct_service_alerts_messages') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-service_alert_ages AS (
+WITH guideline_index AS (
     SELECT
-        dt,
-        base64_url,
-        COUNT(*) AS num_service_alerts,
-        MIN(TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND)) AS min_service_alert_feed_age,
-        PERCENTILE_CONT(TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND), 0.5) AS median_service_alert_feed_age,
-        MAX(TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND)) AS max_service_alert_feed_age,
-    FROM fct_service_alerts_messages
-    GROUP BY 1, 2
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ no_stale_service_alerts() }}
+),
+
+sa_message_ages AS (
+    SELECT *
+    FROM {{ ref('fct_daily_service_alerts_message_age_summary') }}
+),
+
+check_start AS (
+    SELECT MIN(dt) AS first_check_date
+    FROM sa_message_ages
 ),
 
 int_gtfs_quality__no_stale_service_alerts AS (
     SELECT
-        idx.date,
-        idx.base64_url,
-        idx.feed_type,
-        {{ no_stale_service_alerts() }} AS check,
-        {{ best_practices_alignment_rt() }} AS feature,
-        min_service_alert_feed_age,
-        max_service_alert_feed_age,
+        idx.* EXCEPT(status),
+        first_check_date,
+        p90_header_message_age,
         CASE
-            WHEN max_service_alert_feed_age <= 600 THEN {{ guidelines_pass_status() }}
-            WHEN max_service_alert_feed_age > 600 THEN {{ guidelines_fail_status() }}
-            -- If there are no service_alerts for that feed for that day, result is N/A
-            -- They will fail other checks for having no feed present
-            WHEN max_service_alert_feed_age IS null THEN {{ guidelines_na_check_status() }}
-        END as status
-    FROM feed_guideline_index AS idx
-    LEFT JOIN service_alert_ages AS ages
-    ON idx.date = ages.dt
-        AND idx.base64_url = ages.base64_url
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_rt_feed_sa
+                   THEN
+                    CASE
+                        WHEN p90_header_message_age <= 600 THEN {{ guidelines_pass_status() }}
+                        WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN p90_header_message_age IS NULL THEN {{ guidelines_na_check_status() }}
+                        WHEN p90_header_message_age > 600 THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN sa_message_ages
+        ON idx.date = sa_message_ages.dt
+        AND idx.base64_url = sa_message_ages.base64_url
 )
 
 SELECT * FROM int_gtfs_quality__no_stale_service_alerts

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_trip_updates.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__no_stale_trip_updates.sql
@@ -1,72 +1,43 @@
-{{ config(
-    materialized='incremental',
-    incremental_strategy='insert_overwrite',
-    partition_by = {
-        'field': 'date',
-        'data_type': 'date',
-        'granularity': 'day',
-    },
-) }}
-
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='date', order_by = 'date DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
-WITH
-
-feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index_tu') }}
-    {% if is_incremental() %}
-    WHERE date >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE date >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-fct_trip_updates_messages AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__trip_updates_no_stop_times') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-trip_update_ages AS (
+WITH guideline_index AS (
     SELECT
-        dt,
-        base64_url,
-        COUNT(*) AS num_trip_updates,
-        MIN(TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND)) AS min_trip_update_age,
-        PERCENTILE_CONT(TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND), 0.5) AS median_trip_update_age,
-        MAX(TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND)) AS max_trip_update_age,
-        MAX(TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND)) AS max_trip_update_feed_age,
-    FROM fct_trip_updates_messages
-    GROUP BY 1, 2
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ no_stale_trip_updates() }}
+),
+
+tu_message_ages AS (
+    SELECT *
+    FROM {{ ref('fct_daily_trip_updates_message_age_summary') }}
+),
+
+check_start AS (
+    SELECT MIN(dt) AS first_check_date
+    FROM tu_message_ages
 ),
 
 int_gtfs_quality__no_stale_trip_updates AS (
     SELECT
-        idx.date,
-        idx.base64_url,
-        idx.feed_type,
-        {{ no_stale_trip_updates() }} AS check,
-        {{ best_practices_alignment_rt() }} AS feature,
-        min_trip_update_age,
-        max_trip_update_age,
-        max_trip_update_feed_age,
+        idx.* EXCEPT(status),
+        first_check_date,
+        p90_header_message_age,
+        p90_trip_update_message_age,
         CASE
-            WHEN max_trip_update_age <= 90 AND max_trip_update_feed_age <= 90 THEN {{ guidelines_pass_status() }}
-            WHEN max_trip_update_age > 90 OR max_trip_update_feed_age > 90 THEN {{ guidelines_fail_status() }}
-            -- If there are no trip updates for that feed for that day, result is N/A
-            -- They will fail other checks for having no feed present
-            WHEN max_trip_update_age IS null OR max_trip_update_feed_age IS null THEN {{ guidelines_na_check_status() }}
-        END as status
-    FROM feed_guideline_index AS idx
-    LEFT JOIN trip_update_ages AS ages
-    ON idx.date = ages.dt
-        AND idx.base64_url = ages.base64_url
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_rt_feed_tu
+                   THEN
+                    CASE
+                        WHEN GREATEST(p90_trip_update_message_age, p90_header_message_age) <= 90 THEN {{ guidelines_pass_status() }}
+                        WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN GREATEST(p90_trip_update_message_age, p90_header_message_age) IS NULL THEN {{ guidelines_na_check_status() }}
+                        WHEN GREATEST(p90_trip_update_message_age, p90_header_message_age) > 90 THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN tu_message_ages
+        ON idx.date = tu_message_ages.dt
+        AND idx.base64_url = tu_message_ages.base64_url
 )
 
 SELECT * FROM int_gtfs_quality__no_stale_trip_updates

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_20sec_tu.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__rt_20sec_tu.sql
@@ -1,74 +1,43 @@
-{{ config(
-    materialized='incremental',
-    incremental_strategy='insert_overwrite',
-    partition_by = {
-        'field': 'date',
-        'data_type': 'date',
-        'granularity': 'day',
-    },
-) }}
-
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='date', order_by = 'date DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
-WITH
-
-feed_guideline_index AS (
-    SELECT * FROM {{ ref('int_gtfs_quality__rt_feed_guideline_index_tu') }}
-    {% if is_incremental() %}
-    WHERE date >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE date >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-trip_updates AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__trip_updates_no_stop_times') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
-),
-
-lag_ts AS (
+WITH guideline_index AS (
     SELECT
-        dt AS date,
-        base64_url,
-        header_timestamp,
-        LAG(header_timestamp) OVER(PARTITION BY base64_url ORDER BY header_timestamp) AS prev_header_timestamp
-    FROM trip_updates
+        *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ rt_20sec_tu() }}
 ),
 
--- Note that since the header_timestamp will repeat when it hasn't been updated, the DATE_DIFF will be 0 seconds for some.
--- This would affect us if we were measuring the AVG(), but it doesn't since we're only looking at MAX()
-daily_max_lag AS (
-    SELECT
-        date,
-        base64_url,
-        MAX(DATE_DIFF(header_timestamp, prev_header_timestamp, SECOND)) AS max_lag
-    FROM lag_ts
-    GROUP BY 1, 2
+
+tu_message_ages AS (
+    SELECT *
+    FROM {{ ref('fct_daily_trip_updates_message_age_summary') }}
+),
+
+check_start AS (
+    SELECT MIN(dt) AS first_check_date
+    FROM tu_message_ages
 ),
 
 int_gtfs_quality__rt_20sec_tu AS (
     SELECT
-        idx.date,
-        idx.base64_url,
-        idx.feed_type,
-        {{ rt_20sec_tu() }} AS check,
-        {{ accurate_service_data() }} AS feature,
-        max_lag,
+        idx.* EXCEPT(status),
+        first_check_date,
+        p90_header_message_age,
         CASE
-            WHEN max_lag > 20 THEN {{ guidelines_fail_status() }}
-            WHEN max_lag <= 20 THEN {{ guidelines_pass_status() }}
+        -- check that the row has the right entity + check combo, then assign statuses
+            WHEN idx.has_rt_feed_tu
+                   THEN
+                    CASE
+                        WHEN p90_header_message_age <= 20 THEN {{ guidelines_pass_status() }}
+                        WHEN idx.date < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        WHEN p90_header_message_age IS NULL THEN {{ guidelines_na_check_status() }}
+                        WHEN p90_header_message_age > 20 THEN {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
         END AS status,
-    FROM feed_guideline_index AS idx
-    LEFT JOIN daily_max_lag AS files
-           ON idx.date = files.date
-          AND idx.base64_url = files.base64_url
+      FROM guideline_index AS idx
+      CROSS JOIN check_start
+      LEFT JOIN tu_message_ages
+        ON idx.date = tu_message_ages.dt
+        AND idx.base64_url = tu_message_ages.base64_url
 )
 
 SELECT * FROM int_gtfs_quality__rt_20sec_tu

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_index.sql
@@ -74,7 +74,7 @@ cross_join AS (
 
         organization_key IS NOT NULL AS has_organization,
         service_key IS NOT NULL AS has_service,
-        gtfs_service_data_key IS NOT NULL AS has_gtfs_service_data
+        COALESCE((gtfs_service_data_key IS NOT NULL AND gtfs_dataset_type = "schedule"), FALSE) AS has_gtfs_service_data_schedule
 
     FROM assessment_candidates
     CROSS JOIN checks
@@ -137,7 +137,7 @@ int_gtfs_quality__guideline_checks_index AS (
 
         has_organization,
         has_service,
-        has_gtfs_service_data,
+        has_gtfs_service_data_schedule,
 
         CASE
             WHEN (entity = {{ gtfs_dataset_schedule() }} AND NOT has_gtfs_dataset_schedule)
@@ -155,7 +155,7 @@ int_gtfs_quality__guideline_checks_index AS (
                 OR (entity = {{ rt_feed() }} AND NOT has_rt_feed)
                 OR (entity = {{ organization() }} AND NOT has_organization)
                 OR (entity = {{ service() }} AND NOT has_service)
-                OR (entity = {{ gtfs_service_data() }} AND NOT has_gtfs_service_data)
+                OR (entity = {{ gtfs_service_data_schedule() }} AND NOT has_gtfs_service_data_schedule)
                 THEN {{ guidelines_na_entity_status() }}
             ELSE {{ guidelines_to_be_assessed_status() }}
         END AS status,

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -30,7 +30,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__no_stale_service_alerts'),
             ref('int_gtfs_quality__modification_date_present_rt'),
             ref('int_gtfs_quality__contact_on_website'),
-            ref('int_gtfs_quality__fixed_routes_match')
+            ref('int_gtfs_quality__fixed_routes_match'),
+            ref('int_gtfs_quality__demand_responsive_routes_match')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -26,7 +26,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__rt_20sec_vp'),
             ref('int_gtfs_quality__no_stale_vehicle_positions'),
             ref('int_gtfs_quality__rt_20sec_tu'),
-            ref('int_gtfs_quality__no_stale_trip_updates')
+            ref('int_gtfs_quality__no_stale_trip_updates'),
+            ref('int_gtfs_quality__no_stale_service_alerts')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -32,7 +32,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__contact_on_website'),
             ref('int_gtfs_quality__fixed_routes_match'),
             ref('int_gtfs_quality__demand_responsive_routes_match'),
-            ref('int_gtfs_quality__data_license')
+            ref('int_gtfs_quality__data_license'),
+            ref('int_gtfs_quality__authentication_acceptable')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -26,6 +26,7 @@ WITH unioned AS (
             ref('int_gtfs_quality__rt_20sec_vp'),
             ref('int_gtfs_quality__no_stale_vehicle_positions'),
             ref('int_gtfs_quality__rt_20sec_tu'),
+            ref('int_gtfs_quality__no_stale_trip_updates')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -28,7 +28,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__rt_20sec_tu'),
             ref('int_gtfs_quality__no_stale_trip_updates'),
             ref('int_gtfs_quality__no_stale_service_alerts'),
-            ref('int_gtfs_quality__modification_date_present_rt')
+            ref('int_gtfs_quality__modification_date_present_rt'),
+            ref('int_gtfs_quality__contact_on_website')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -29,7 +29,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__no_stale_trip_updates'),
             ref('int_gtfs_quality__no_stale_service_alerts'),
             ref('int_gtfs_quality__modification_date_present_rt'),
-            ref('int_gtfs_quality__contact_on_website')
+            ref('int_gtfs_quality__contact_on_website'),
+            ref('int_gtfs_quality__fixed_routes_match')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -24,7 +24,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__no_rt_validation_errors'),
             ref('int_gtfs_quality__rt_protobuf_error'),
             ref('int_gtfs_quality__rt_20sec_vp'),
-            ref('int_gtfs_quality__no_stale_vehicle_positions')
+            ref('int_gtfs_quality__no_stale_vehicle_positions'),
+            ref('int_gtfs_quality__rt_20sec_tu'),
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -31,7 +31,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__modification_date_present_rt'),
             ref('int_gtfs_quality__contact_on_website'),
             ref('int_gtfs_quality__fixed_routes_match'),
-            ref('int_gtfs_quality__demand_responsive_routes_match')
+            ref('int_gtfs_quality__demand_responsive_routes_match'),
+            ref('int_gtfs_quality__data_license')
         ],
     ) }}
 ),

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -35,6 +35,7 @@ WITH unioned AS (
             ref('int_gtfs_quality__data_license'),
             ref('int_gtfs_quality__authentication_acceptable')
         ],
+        include = dbt_utils.get_filtered_columns_in_relation(from=ref('int_gtfs_quality__guideline_checks_index'))
     ) }}
 ),
 

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long_new_index.sql
@@ -27,7 +27,8 @@ WITH unioned AS (
             ref('int_gtfs_quality__no_stale_vehicle_positions'),
             ref('int_gtfs_quality__rt_20sec_tu'),
             ref('int_gtfs_quality__no_stale_trip_updates'),
-            ref('int_gtfs_quality__no_stale_service_alerts')
+            ref('int_gtfs_quality__no_stale_service_alerts'),
+            ref('int_gtfs_quality__modification_date_present_rt')
         ],
     ) }}
 ),

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -164,6 +164,27 @@ models:
       - name: trip_start_date
       - name: trip_schedule_relationship
       - name: stop_time_updates
+      - &_header_message_age
+        name: _header_message_age
+        description: |
+          Difference between `_extract_ts` (time at which we scraped the message) and `header_timestamp` (timestamp
+          of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader).
+          Because of delay in the request process, the actual scrape request may occur up to a few
+          seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
+          this field should only be interpreted as accurate within 3-4 seconds (do not try to do extremely precise
+          measurements below that level.)
+      - name: _trip_update_message_age
+        description: |
+          Difference between `_extract_ts` (time at which we scraped the message) and `trip_update_timestamp` (timestamp
+          of individual trip update message from producer; see https://gtfs.org/realtime/reference/#message-tripupdate).
+          Because of delay in the request process, the actual scrape request may occur up to a few
+          seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
+          this field should only be interpreted as accurate within 3-4 seconds (do not try to do extremely precise
+          measurements below that level.)
+      - name: _trip_update_message_age_vs_header
+        description: |
+          Difference between `header_timestamp` (timestamp of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader)
+          and `trip_update_timestamp` (timestamp of individual trip_update message from producer; see https://gtfs.org/realtime/reference/#message-tripupdate).
 
   - name: fct_vehicle_locations
     description: |
@@ -215,14 +236,7 @@ models:
       - name: _extract_ts
         description: |
           Time at which this message was scraped.
-      - name: _header_message_age
-        description: |
-          Difference in seconds between `_extract_ts` (time at which we scraped the message) and `header_timestamp` (timestamp
-          of overall message from producer; see https://gtfs.org/realtime/reference/#message-feedheader).
-          Because of delay in the request process, the actual scrape request may occur up to a few
-          seconds after `_extract_ts`, and it may take time for the producer to respond to the request, so
-          this field should only be interpreted as accurate within 3-4 seconds (do not try to do extremely precise
-          measurements below that level.)
+      - *_header_message_age
       - name: _vehicle_message_age
         description: |
           Difference in seconds between `_extract_ts` (time at which we scraped the message) and `vehicle_timestamp` (timestamp
@@ -753,6 +767,7 @@ models:
       - name: severity_level
         description: |
           See: https://gtfs.org/realtime/reference/#message-alert.
+      - *_header_message_age
   - name: fct_service_alert_active_periods
     description: |
       Each row is an active period for a service alerts message.

--- a/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
@@ -35,6 +35,7 @@ fct_service_alerts_messages AS (
         _extract_ts,
         _config_extract_ts,
         _gtfs_dataset_name,
+        TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND) AS _header_message_age,
         header_timestamp,
         header_version,
         header_incrementality,

--- a/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
@@ -37,6 +37,10 @@ fct_trip_updates_messages AS (
         _config_extract_ts,
         _gtfs_dataset_name,
 
+        TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND) AS _header_message_age,
+        TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND) AS _trip_update_message_age,
+        TIMESTAMP_DIFF(header_timestamp, trip_update_timestamp, SECOND) AS _trip_update_message_age_vs_header,
+
         header_timestamp,
         header_version,
         header_incrementality,

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -638,18 +638,43 @@ models:
         that the `header_timestamp` was later than `_extract_ts`.
       - `pX` refers to a percentile, so `p25` refers to 25th percentile.
       - `avg` refers to the mean.
-    tests:
+    tests: &message_age_summary_tests
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - dt
             - base64_url
-    columns:
+    columns: &message_age_summary_cols
       - name: dt
         tests:
           - not_null
       - name: base64_url
         tests:
           - not_null
+
+  - name: fct_daily_trip_updates_message_age_summary
+    description: |
+      Table summarizing the age in seconds of various message components by RT URL by date.
+      Terms:
+      - For definitions of the underlying `header_message_age`, `trip_update_message_age`, and `trip_update_message_age_vs_header`
+        values, see `fct_trip_updates_messages`. In particular, note that a negative value indicates that the
+        referenced item happened *after* the item it's being compared to; i.e., a negative `header_message_age` indicates
+        that the `header_timestamp` was later than `_extract_ts`.
+      - `pX` refers to a percentile, so `p25` refers to 25th percentile.
+      - `avg` refers to the mean.
+    tests: *message_age_summary_tests
+    columns: *message_age_summary_cols
+
+  - name: fct_daily_service_alerts_message_age_summary
+    description: |
+      Table summarizing the age in seconds of various message components by RT URL by date.
+      Terms:
+      - For definitions of the underlying `header_message_age` see `fct_service_alerts_messages`. In particular, note that a negative value indicates that the
+        referenced item happened *after* the item it's being compared to; i.e., a negative `header_message_age` indicates
+        that the `header_timestamp` was later than `_extract_ts`.
+      - `pX` refers to a percentile, so `p25` refers to 25th percentile.
+      - `avg` refers to the mean.
+    tests: *message_age_summary_tests
+    columns: *message_age_summary_cols
 
 exposures:
  - name: calitp_reports_site

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_alerts_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_alerts_message_age_summary.sql
@@ -1,0 +1,68 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by = {
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
+
+{% if is_incremental() %}
+    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set max_ts = timestamps[0] %}
+{% endif %}
+
+WITH service_alerts_ages AS (
+    SELECT DISTINCT
+        dt,
+        base64_url,
+        _header_message_age,
+    FROM {{ ref('fct_service_alerts_messages') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >=  {{ var('GTFS_RT_START') }}
+    {% endif %}
+),
+
+-- these values are repeated because one row in the source table is one service_alerts message so the header is identical for all messages on a given request
+-- select distinct to deduplicate these to the overall message level to make summary statistics more meaningful
+distinct_headers AS (
+    SELECT DISTINCT
+        dt,
+        base64_url,
+        _header_message_age,
+    FROM service_alerts_ages
+),
+
+header_age_percentiles AS (
+    SELECT
+        *,
+        -- calculate median: https://stackoverflow.com/a/66213692
+        PERCENTILE_CONT(_header_message_age, .5) OVER(PARTITION BY dt, base64_url) AS median_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .25) OVER(PARTITION BY dt, base64_url) AS p25_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .75) OVER(PARTITION BY dt, base64_url) AS p75_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .90) OVER(PARTITION BY dt, base64_url) AS p90_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_header_message_age
+    FROM distinct_headers
+),
+
+fct_daily_service_alerts_message_age_summary AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['dt', 'base64_url']) }} AS key,
+        dt,
+        base64_url,
+        median_header_message_age,
+        p25_header_message_age,
+        p75_header_message_age,
+        p90_header_message_age,
+        p99_header_message_age,
+        MAX(_header_message_age) AS max_header_message_age,
+        MIN(_header_message_age) AS min_header_message_age,
+        AVG(_header_message_age) AS avg_header_message_age,
+    FROM header_age_percentiles
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8
+)
+
+SELECT * FROM fct_daily_service_alerts_message_age_summary

--- a/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
@@ -1,0 +1,144 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by = {
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
+
+{% if is_incremental() %}
+    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set max_ts = timestamps[0] %}
+{% endif %}
+
+WITH trip_updates_ages AS (
+    SELECT DISTINCT
+        dt,
+        base64_url,
+        _header_message_age,
+        _trip_update_message_age,
+        _trip_update_message_age_vs_header,
+    FROM {{ ref('int_gtfs_rt__trip_updates_no_stop_times') }}
+    {% if is_incremental() %}
+    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
+    {% else %}
+    WHERE dt >=  {{ var('GTFS_RT_START') }}
+    {% endif %}
+),
+
+-- these values are repeated because one row in the source table is one trip_updates message so the header is identical for all messages on a given request
+-- select distinct to deduplicate these to the overall message level to make summary statistics more meaningful
+distinct_headers AS (
+    SELECT DISTINCT
+        dt,
+        base64_url,
+        _header_message_age,
+    FROM trip_updates_ages
+),
+
+header_age_percentiles AS (
+    SELECT
+        *,
+        -- calculate median: https://stackoverflow.com/a/66213692
+        PERCENTILE_CONT(_header_message_age, .5) OVER(PARTITION BY dt, base64_url) AS median_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .25) OVER(PARTITION BY dt, base64_url) AS p25_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .75) OVER(PARTITION BY dt, base64_url) AS p75_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .90) OVER(PARTITION BY dt, base64_url) AS p90_header_message_age,
+        PERCENTILE_CONT(_header_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_header_message_age
+    FROM distinct_headers
+),
+
+summarize_header_ages AS (
+    SELECT
+        dt,
+        base64_url,
+        median_header_message_age,
+        p25_header_message_age,
+        p75_header_message_age,
+        p90_header_message_age,
+        p99_header_message_age,
+        MAX(_header_message_age) AS max_header_message_age,
+        MIN(_header_message_age) AS min_header_message_age,
+        AVG(_header_message_age) AS avg_header_message_age,
+    FROM header_age_percentiles
+    GROUP BY 1, 2, 3, 4, 5, 6, 7
+),
+
+trip_updates_age_percentiles AS (
+    SELECT
+        *,
+        -- calculate median: https://stackoverflow.com/a/66213692
+        PERCENTILE_CONT(_trip_update_message_age, .5) OVER(PARTITION BY dt, base64_url) AS median_trip_update_message_age,
+        PERCENTILE_CONT(_trip_update_message_age, .25) OVER(PARTITION BY dt, base64_url) AS p25_trip_update_message_age,
+        PERCENTILE_CONT(_trip_update_message_age, .75) OVER(PARTITION BY dt, base64_url) AS p75_trip_update_message_age,
+        PERCENTILE_CONT(_trip_update_message_age, .90) OVER(PARTITION BY dt, base64_url) AS p90_trip_update_message_age,
+        PERCENTILE_CONT(_trip_update_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_trip_update_message_age,
+        PERCENTILE_CONT(_trip_update_message_age_vs_header, .5) OVER(PARTITION BY dt, base64_url) AS median_trip_update_message_age_vs_header,
+        PERCENTILE_CONT(_trip_update_message_age_vs_header, .25) OVER(PARTITION BY dt, base64_url) AS p25_trip_update_message_age_vs_header,
+        PERCENTILE_CONT(_trip_update_message_age_vs_header, .75) OVER(PARTITION BY dt, base64_url) AS p75_trip_update_message_age_vs_header,
+        PERCENTILE_CONT(_trip_update_message_age_vs_header, .90) OVER(PARTITION BY dt, base64_url) AS p90_trip_update_message_age_vs_header,
+        PERCENTILE_CONT(_trip_update_message_age_vs_header, .99) OVER(PARTITION BY dt, base64_url) AS p99_trip_update_message_age_vs_header
+    FROM trip_updates_ages
+),
+
+summarize_trip_updates_ages AS (
+    SELECT
+        dt,
+        base64_url,
+        median_trip_update_message_age,
+        p25_trip_update_message_age,
+        p75_trip_update_message_age,
+        p90_trip_update_message_age,
+        p99_trip_update_message_age,
+        median_trip_update_message_age_vs_header,
+        p25_trip_update_message_age_vs_header,
+        p75_trip_update_message_age_vs_header,
+        p90_trip_update_message_age_vs_header,
+        p99_trip_update_message_age_vs_header,
+        MAX(_trip_update_message_age) AS max_trip_update_message_age,
+        MIN(_trip_update_message_age) AS min_trip_update_message_age,
+        AVG(_trip_update_message_age) AS avg_trip_update_message_age,
+        MAX(_trip_update_message_age_vs_header) AS max_trip_update_message_age_vs_header,
+        MIN(_trip_update_message_age_vs_header) AS min_trip_update_message_age_vs_header,
+        AVG(_trip_update_message_age_vs_header) AS avg_trip_update_message_age_vs_header,
+    FROM trip_updates_age_percentiles
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+),
+
+fct_daily_trip_update_message_age_summary AS (
+    SELECT
+        {{ dbt_utils.surrogate_key(['dt', 'base64_url']) }} AS key,
+        dt,
+        base64_url,
+        median_header_message_age,
+        p25_header_message_age,
+        p75_header_message_age,
+        p90_header_message_age,
+        p99_header_message_age,
+        max_header_message_age,
+        min_header_message_age,
+        avg_header_message_age,
+        median_trip_update_message_age,
+        p25_trip_update_message_age,
+        p75_trip_update_message_age,
+        p90_trip_update_message_age,
+        p99_trip_update_message_age,
+        max_trip_update_message_age,
+        min_trip_update_message_age,
+        avg_trip_update_message_age,
+        median_trip_update_message_age_vs_header,
+        p25_trip_update_message_age_vs_header,
+        p75_trip_update_message_age_vs_header,
+        p90_trip_update_message_age_vs_header,
+        p99_trip_update_message_age_vs_header,
+        max_trip_update_message_age_vs_header,
+        min_trip_update_message_age_vs_header,
+        avg_trip_update_message_age_vs_header
+    FROM summarize_header_ages
+    LEFT JOIN summarize_trip_updates_ages
+        USING (dt, base64_url)
+)
+
+SELECT * FROM fct_daily_trip_update_message_age_summary

--- a/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
@@ -46,7 +46,7 @@ header_age_percentiles AS (
         PERCENTILE_CONT(_header_message_age, .25) OVER(PARTITION BY dt, base64_url) AS p25_header_message_age,
         PERCENTILE_CONT(_header_message_age, .75) OVER(PARTITION BY dt, base64_url) AS p75_header_message_age,
         PERCENTILE_CONT(_header_message_age, .90) OVER(PARTITION BY dt, base64_url) AS p90_header_message_age,
-        PERCENTILE_CONT(_header_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_header_message_age
+        PERCENTILE_CONT(_header_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_header_message_age
     FROM distinct_headers
 ),
 
@@ -58,7 +58,7 @@ summarize_header_ages AS (
         p25_header_message_age,
         p75_header_message_age,
         p90_header_message_age,
-        p99_quartile_header_message_age,
+        p99_header_message_age,
         MAX(_header_message_age) AS max_header_message_age,
         MIN(_header_message_age) AS min_header_message_age,
         AVG(_header_message_age) AS avg_header_message_age,
@@ -74,12 +74,12 @@ vehicle_age_percentiles AS (
         PERCENTILE_CONT(_vehicle_message_age, .25) OVER(PARTITION BY dt, base64_url) AS p25_vehicle_message_age,
         PERCENTILE_CONT(_vehicle_message_age, .75) OVER(PARTITION BY dt, base64_url) AS p75_vehicle_message_age,
         PERCENTILE_CONT(_vehicle_message_age, .90) OVER(PARTITION BY dt, base64_url) AS p90_vehicle_message_age,
-        PERCENTILE_CONT(_vehicle_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, .99) OVER(PARTITION BY dt, base64_url) AS p99_vehicle_message_age,
         PERCENTILE_CONT(_vehicle_message_age_vs_header, .5) OVER(PARTITION BY dt, base64_url) AS median_vehicle_message_age_vs_header,
         PERCENTILE_CONT(_vehicle_message_age_vs_header, .25) OVER(PARTITION BY dt, base64_url) AS p25_vehicle_message_age_vs_header,
         PERCENTILE_CONT(_vehicle_message_age_vs_header, .75) OVER(PARTITION BY dt, base64_url) AS p75_vehicle_message_age_vs_header,
         PERCENTILE_CONT(_vehicle_message_age_vs_header, .90) OVER(PARTITION BY dt, base64_url) AS p90_vehicle_message_age_vs_header,
-        PERCENTILE_CONT(_vehicle_message_age_vs_header, .99) OVER(PARTITION BY dt, base64_url) AS p99_quartile_vehicle_message_age_vs_header
+        PERCENTILE_CONT(_vehicle_message_age_vs_header, .99) OVER(PARTITION BY dt, base64_url) AS p99_vehicle_message_age_vs_header
     FROM vehicle_positions_ages
 ),
 
@@ -91,12 +91,12 @@ summarize_vehicle_ages AS (
         p25_vehicle_message_age,
         p75_vehicle_message_age,
         p90_vehicle_message_age,
-        p99_quartile_vehicle_message_age,
+        p99_vehicle_message_age,
         median_vehicle_message_age_vs_header,
         p25_vehicle_message_age_vs_header,
         p75_vehicle_message_age_vs_header,
         p90_vehicle_message_age_vs_header,
-        p99_quartile_vehicle_message_age_vs_header,
+        p99_vehicle_message_age_vs_header,
         MAX(_vehicle_message_age) AS max_vehicle_message_age,
         MIN(_vehicle_message_age) AS min_vehicle_message_age,
         AVG(_vehicle_message_age) AS avg_vehicle_message_age,
@@ -116,7 +116,7 @@ fct_daily_vehicle_positions_message_age_summary AS (
         p25_header_message_age,
         p75_header_message_age,
         p90_header_message_age,
-        p99_quartile_header_message_age,
+        p99_header_message_age,
         max_header_message_age,
         min_header_message_age,
         avg_header_message_age,
@@ -124,7 +124,7 @@ fct_daily_vehicle_positions_message_age_summary AS (
         p25_vehicle_message_age,
         p75_vehicle_message_age,
         p90_vehicle_message_age,
-        p99_quartile_vehicle_message_age,
+        p99_vehicle_message_age,
         max_vehicle_message_age,
         min_vehicle_message_age,
         avg_vehicle_message_age,
@@ -132,7 +132,7 @@ fct_daily_vehicle_positions_message_age_summary AS (
         p25_vehicle_message_age_vs_header,
         p75_vehicle_message_age_vs_header,
         p90_vehicle_message_age_vs_header,
-        p99_quartile_vehicle_message_age_vs_header,
+        p99_vehicle_message_age_vs_header,
         max_vehicle_message_age_vs_header,
         min_vehicle_message_age_vs_header,
         avg_vehicle_message_age_vs_header

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -85,11 +85,11 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ service_alerts_feed_on_mobility_database() }}, {{ feed_aggregator_availability_rt() }}, {{ rt_url_sa() }}
     UNION ALL
-    SELECT {{ modification_date_present_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ modification_date_present_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_sa() }}
     UNION ALL
-    SELECT {{ modification_date_present_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ modification_date_present_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_vp() }}
     UNION ALL
-    SELECT {{ modification_date_present_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ modification_date_present_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_tu() }}
     UNION ALL
     SELECT {{ scheduled_trips_in_tu_feed() }}, {{ fixed_route_completeness() }}, {{ service() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -63,9 +63,9 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ no_stale_vehicle_positions() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_vp() }}
     UNION ALL
-    SELECT {{ no_stale_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_stale_trip_updates() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_tu() }}
     UNION ALL
-    SELECT {{ no_stale_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed() }}
+    SELECT {{ no_stale_service_alerts() }}, {{ best_practices_alignment_rt() }}, {{ rt_feed_sa() }}
     UNION ALL
     SELECT {{ modification_date_present() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -55,7 +55,7 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ rt_20sec_vp() }}, {{ accurate_service_data() }}, {{ rt_feed_vp() }}
     UNION ALL
-    SELECT {{ rt_20sec_tu() }}, {{ accurate_service_data() }}, {{ rt_feed() }}
+    SELECT {{ rt_20sec_tu() }}, {{ accurate_service_data() }}, {{ rt_feed_tu() }}
     UNION ALL
     SELECT {{ persistent_ids_schedule() }}, {{ best_practices_alignment_schedule() }}, {{ schedule_feed() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -108,13 +108,13 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ shapes_accurate() }}, {{ accurate_service_data() }}, {{ gtfs_dataset() }}
     UNION ALL
-    SELECT {{ data_license_schedule() }}, {{ compliance_schedule() }}, {{ gtfs_dataset() }}
+    SELECT {{ data_license_schedule() }}, {{ compliance_schedule() }}, {{ gtfs_dataset_schedule() }}
     UNION ALL
-    SELECT {{ data_license_vp() }}, {{ compliance_rt() }}, {{ gtfs_dataset() }}
+    SELECT {{ data_license_vp() }}, {{ compliance_rt() }}, {{ gtfs_dataset_vp() }}
     UNION ALL
-    SELECT {{ data_license_tu() }}, {{ compliance_rt() }}, {{ gtfs_dataset() }}
+    SELECT {{ data_license_tu() }}, {{ compliance_rt() }}, {{ gtfs_dataset_tu() }}
     UNION ALL
-    SELECT {{ data_license_sa() }}, {{ compliance_rt() }}, {{ gtfs_dataset() }}
+    SELECT {{ data_license_sa() }}, {{ compliance_rt() }}, {{ gtfs_dataset_sa() }}
     UNION ALL
     SELECT {{ authentication_acceptable_schedule() }}, {{ availability_on_website() }}, {{ gtfs_dataset() }}
     UNION ALL

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -146,9 +146,9 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ trip_planner_rt() }}, {{ compliance_rt() }}, {{ service() }}
     UNION ALL
-    SELECT {{ fixed_routes_match() }}, {{ fixed_route_completeness() }}, {{ gtfs_service_data() }}
+    SELECT {{ fixed_routes_match() }}, {{ fixed_route_completeness() }}, {{ gtfs_service_data_schedule() }}
     UNION ALL
-    SELECT {{ demand_responsive_routes_match() }}, {{ demand_responsive_completeness() }}, {{ gtfs_service_data() }}
+    SELECT {{ demand_responsive_routes_match() }}, {{ demand_responsive_completeness() }}, {{ gtfs_service_data_schedule() }}
 )
 
 SELECT * FROM stg_gtfs_quality__intended_checks

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -116,13 +116,13 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ data_license_sa() }}, {{ compliance_rt() }}, {{ gtfs_dataset_sa() }}
     UNION ALL
-    SELECT {{ authentication_acceptable_schedule() }}, {{ availability_on_website() }}, {{ gtfs_dataset() }}
+    SELECT {{ authentication_acceptable_schedule() }}, {{ availability_on_website() }}, {{ gtfs_dataset_schedule() }}
     UNION ALL
-    SELECT {{ authentication_acceptable_vp() }}, {{ availability_on_website() }}, {{ gtfs_dataset() }}
+    SELECT {{ authentication_acceptable_vp() }}, {{ availability_on_website() }}, {{ gtfs_dataset_vp() }}
     UNION ALL
-    SELECT {{ authentication_acceptable_tu() }}, {{ availability_on_website() }}, {{ gtfs_dataset() }}
+    SELECT {{ authentication_acceptable_tu() }}, {{ availability_on_website() }}, {{ gtfs_dataset_tu() }}
     UNION ALL
-    SELECT {{ authentication_acceptable_sa() }}, {{ availability_on_website() }}, {{ gtfs_dataset() }}
+    SELECT {{ authentication_acceptable_sa() }}, {{ availability_on_website() }}, {{ gtfs_dataset_sa() }}
     UNION ALL
     SELECT {{ stable_url_schedule() }}, {{ compliance_schedule() }}, {{ gtfs_dataset() }}
     UNION ALL


### PR DESCRIPTION
# Description

Merging into staging branch, will merge to main in #2371 with the rest. 

Continue migrating guideline checks to shared index, see [Google Sheet](https://docs.google.com/spreadsheets/d/15eYntYFoYyHuXYyp4dmqM3g5N18tw2r8dU2S7wDDM4E/edit) for progress.

As in #2379, creates some new fact tables summarizing RT message ages. 

Biggest new functional change here is formally restricting the fixed route and demand responsive checks to only apply to *schedule* GTFS service data records. 

Also restricts columns in the final table (adds columns to include). 

Some follow up will be required in #2401 

Progress towards #2263 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Checked each check individually as it was migrated to ensure reasonable parity with old version. 

Also ran:

```
SELECT check, COUNT(*)
FROM `cal-itp-data-infra-staging.laurie_staging.int_gtfs_quality__guideline_checks_long_new_index`
GROUP BY check
```
to ensure no changes in row count by check. 

## Screenshots (optional)
