### PR TITLE
Convert array/struct to JSON strings in reports index

### DIFF
--- a/warehouse/models/mart/gtfs_quality/idx_monthly_reports_site.sql
+++ b/warehouse/models/mart/gtfs_quality/idx_monthly_reports_site.sql
@@ -119,7 +119,7 @@ FROM dataset_map
 ),
 
 month_reports_urls AS (
-    SELECT date_start, organization_itp_id, ARRAY_AGG(STRUCT(gtfs_dataset_name, string_url)) AS feeds
+    SELECT date_start, organization_itp_id, TO_JSON_STRING(ARRAY_AGG(STRUCT(gtfs_dataset_name, string_url))) AS feeds
     FROM make_distinct
     GROUP BY 1, 2
 ),


### PR DESCRIPTION
# Description

#2338 added dataset URL information to `idx_monthly_reports_site` for the reports site as array structs, which was causing problems when generating the index with `generate_index_report.py`.

To address this, this PR changes the structs in `idx_monthly_reports_site` to JSON strings, which will then be turned into JSON in generate_index_report.py`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature

## How has this been tested?
In a notebook