### PR TITLE
remove networkx_viewer, add palettable and use it

### DIFF
--- a/warehouse/poetry.lock
+++ b/warehouse/poetry.lock
@@ -2521,21 +2521,6 @@ extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.9)", "sympy (>=1.10
 test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
-name = "networkx-viewer"
-version = "0.3.0"
-description = "Interactive viewer for networkx graphs."
-category = "main"
-optional = false
-python-versions = ">3.5"
-files = [
-    {file = "networkx_viewer-0.3.0-py3-none-any.whl", hash = "sha256:0964de7cf1e9135ae64cef3a74ab6c0c59c3e471a3c612afb6530854a3feb4bc"},
-    {file = "networkx_viewer-0.3.0.tar.gz", hash = "sha256:519d11aebfc29a66cb143429fff44b7e3107b99d1411a719338cda57b8387fc8"},
-]
-
-[package.dependencies]
-networkx = ">=2.2"
-
-[[package]]
 name = "numpy"
 version = "1.24.2"
 description = "Fundamental package for array computing in Python"
@@ -2641,6 +2626,18 @@ python-versions = ">=3.7"
 files = [
     {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
     {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+]
+
+[[package]]
+name = "palettable"
+version = "3.3.0"
+description = "Color palettes for Python"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "palettable-3.3.0-py2.py3-none-any.whl", hash = "sha256:c3bf3f548fc228e86bd3d16928bbf8d621c1d1098791ceab446d0e3a5e1298d1"},
+    {file = "palettable-3.3.0.tar.gz", hash = "sha256:72feca71cf7d79830cd6d9181b02edf227b867d503bec953cf9fa91bf44896bd"},
 ]
 
 [[package]]
@@ -4468,4 +4465,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "073a5bfb56435f421c666081d427b6c7d04c702c559128ea589dfdf8613f754a"
+content-hash = "36177951daad9a87cde34c0ee0eebd2ee5efe59b59c477b2d170246257e7ad8b"

--- a/warehouse/pyproject.toml
+++ b/warehouse/pyproject.toml
@@ -24,13 +24,13 @@ typer = "^0.7.0"
 gcsfs = "^2023.1.0"
 dbt-metabase = "^0.9.14"
 networkx = {version = "<3", extras = ["default"]}
-networkx-viewer = "^0.3.0"
 # from https://github.com/pygraphviz/pygraphviz/issues/398#issuecomment-1450367670
 # May need to run these after `brew install graphviz` when installing on macOS
 # export CFLAGS="-I $(brew --prefix graphviz)/include"
 # export LDFLAGS="-L $(brew --prefix graphviz)/lib"
 pygraphviz = "^1.10"
 dbt-bigquery = "^1.4.3"
+palettable = "^3.3.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"

--- a/warehouse/scripts/dbt_artifacts.py
+++ b/warehouse/scripts/dbt_artifacts.py
@@ -13,7 +13,7 @@ import humanize
 import pendulum
 import yaml
 from catalog import Catalog, CatalogTable
-from palettable.scientific.sequential import LaJolla_6
+from palettable.scientific.sequential import LaJolla_6  # type: ignore
 from pydantic import BaseModel, Field, constr, validator
 from slugify import slugify
 from sqlalchemy import MetaData, Table, create_engine, select

--- a/warehouse/scripts/dbt_artifacts.py
+++ b/warehouse/scripts/dbt_artifacts.py
@@ -13,6 +13,7 @@ import humanize
 import pendulum
 import yaml
 from catalog import Catalog, CatalogTable
+from palettable.scientific.sequential import LaJolla_6
 from pydantic import BaseModel, Field, constr, validator
 from slugify import slugify
 from sqlalchemy import MetaData, Table, create_engine, select
@@ -491,12 +492,17 @@ class RunResult(BaseModel):
         """
         Returns a string representation intended for graphviz labels
         """
-        if self.bytes_processed > 300_000_000_000:
-            color = "red"
+        # TODO: do an actual linear transform on this
+        # the top colors are too dark to use as a background
+        white, yellow, orange, red, _, _ = LaJolla_6.hex_colors
+        if self.bytes_processed > 500_000_000_000:
+            color = red
+        elif self.bytes_processed > 300_000_000_000:
+            color = orange
         elif self.bytes_processed > 100_000_000_000:
-            color = "yellow"
+            color = yellow
         else:
-            color = "white"
+            color = white
 
         return {
             **self.node.gvattrs,

--- a/warehouse/scripts/visualize.py
+++ b/warehouse/scripts/visualize.py
@@ -11,7 +11,6 @@ import networkx as nx  # type: ignore
 import typer
 from catalog import Catalog
 from dbt_artifacts import BaseNode, Manifest, RunResult, RunResults, Seed, Source, Test
-from networkx_viewer import Viewer  # type: ignore
 
 app = typer.Typer(pretty_exceptions_enable=False)
 
@@ -207,15 +206,6 @@ def viz(
     if display:
         url = f"file://{output.resolve()}"
         webbrowser.open(url, new=2)  # open in new tab
-
-
-@app.command()
-def guiviz(
-    graph_path: Path = Path("./target/graph.gpickle"),
-):
-    G = nx.read_gpickle(graph_path)
-    app = Viewer(G)
-    app.mainloop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Removing unuseful dependency on networkx_viewer and improve color palette for run_results.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
locally

## Screenshots (optional)
