### PR TITLE
update syvt url, per vendor's instructions

### DIFF
--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1167,7 +1167,7 @@ santa-maria-area-transit:
 santa-ynez-valley-transit:
   agency_name: Santa Ynez Valley Transit
   feeds:
-    - gtfs_schedule_url: https://mjcaction.com/MJC_GTFS_Public/syvt_google_transit.zip
+    - gtfs_schedule_url: http://app.mecatran.com/urb/ws/feed/c2l0ZT1zeXZ0O2NsaWVudD1zZWxmO2V4cGlyZT07dHlwZT1ndGZzO2tleT00MjcwNzQ0ZTY4NTAzOTMyMDIxMDdjNzI0MDRkMzYyNTM4MzI0YzI0
       gtfs_rt_vehicle_positions_url: https://lat-long-prototype.wl.r.appspot.com/vehicle-positions.pb?agency=santa-ynez-valley-transit
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null

--- a/airflow/data/agencies.yml
+++ b/airflow/data/agencies.yml
@@ -1167,7 +1167,7 @@ santa-maria-area-transit:
 santa-ynez-valley-transit:
   agency_name: Santa Ynez Valley Transit
   feeds:
-    - gtfs_schedule_url: http://app.mecatran.com/urb/ws/feed/c2l0ZT1zeXZ0O2NsaWVudD1zZWxmO2V4cGlyZT07dHlwZT1ndGZzO2tleT00MjcwNzQ0ZTY4NTAzOTMyMDIxMDdjNzI0MDRkMzYyNTM4MzI0YzI0
+    - gtfs_schedule_url: https://app.mecatran.com/urb/ws/feed/c2l0ZT1zeXZ0O2NsaWVudD1zZWxmO2V4cGlyZT07dHlwZT1ndGZzO2tleT00MjcwNzQ0ZTY4NTAzOTMyMDIxMDdjNzI0MDRkMzYyNTM4MzI0YzI0
       gtfs_rt_vehicle_positions_url: https://lat-long-prototype.wl.r.appspot.com/vehicle-positions.pb?agency=santa-ynez-valley-transit
       gtfs_rt_service_alerts_url: null
       gtfs_rt_trip_updates_url: null


### PR DESCRIPTION
their vendor, Transnovation, says this is the new URL (as per Ali Attari).

As a reminder, GRaaS still uses agencies.yml as a source of truth, which is why I'm updating it here. 

I believe @evansiroky is making the corresponding update in Airtable, and will look for his confirmation.