### PR TITLE
Fix failing guideline checks tests

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__modification_date_present_rt.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__modification_date_present_rt.sql
@@ -32,9 +32,9 @@ int_gtfs_quality__modification_date_present_rt AS (
         has_last_modified_string,
         CASE
         -- check that the row has the right entity + check combo, then assign statuses
-            WHEN (idx.has_rt_url_tu AND check = {{ modification_date_present_trip_updates() }})
-                OR (idx.has_rt_url_vp AND check = {{ modification_date_present_vehicle_positions() }})
-                OR (idx.has_rt_url_sa AND check = {{ modification_date_present_service_alerts() }})
+            WHEN (idx.has_rt_feed_tu AND check = {{ modification_date_present_trip_updates() }})
+                OR (idx.has_rt_feed_vp AND check = {{ modification_date_present_vehicle_positions() }})
+                OR (idx.has_rt_feed_sa AND check = {{ modification_date_present_service_alerts() }})
                    THEN
                     CASE
                         WHEN has_last_modified_string THEN {{ guidelines_pass_status() }}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
@@ -3,6 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
+    WHERE organization_key IS NOT NULL
 ),
 
 fct_daily_organization_combined_guideline_checks AS (

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
@@ -3,6 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
+    WHERE service_key IS NOT NULL
 ),
 
 fct_daily_service_combined_guideline_checks AS (


### PR DESCRIPTION
# Description

Resolves #2442 - turns out ticket was wrong, the RT entities *do* check for historical feeds but I had the wrong entity type for the one check, it was supposed to be URL rather than feed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

run & test locally confirmed tests now pass

## Screenshots (optional)
