### PR TITLE
filter back to only assessed entities

### DIFF
--- a/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
@@ -3,7 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
-    WHERE organization_key IS NOT NULL
+    WHERE organization_key IS NOT NULL AND guidelines_assessed
 ),
 
 fct_daily_organization_combined_guideline_checks AS (

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
@@ -3,7 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
-    WHERE service_key IS NOT NULL
+    WHERE service_key IS NOT NULL AND guidelines_assessed
 ),
 
 fct_daily_service_combined_guideline_checks AS (


### PR DESCRIPTION
# Description

@owades comment made me realize that in the refactor I had accidentally removed the filters that kept only guidelines-assessed feeds in the `_combined` mart tables.

Resolves # [issue]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

dbt run & test locally, both tables pass. Inspected the following query to confirm that in prod you see all the non-assessed feeds but that post-fix you only see the regional feeds:

```
SELECT organization_name, check, status, service_names_included_array, gtfs_dataset_names_included_array
FROM `cal-itp-data-infra.mart_gtfs_quality.fct_daily_organization_combined_guideline_checks`
WHERE organization_name = 'Alameda-Contra Costa Transit District' AND date = '2023-03-29'
ORDER BY date DESC, check
```

## Screenshots (optional)
