### PR TITLE
Adjust trip updates materializations

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -24,7 +24,7 @@ clean-targets:         # directories to be removed by `dbt clean`
 vars:
   surrogate_key_treat_nulls_as_empty_strings: true # enable legacy behavior for dbt_utils surrogate keys, i.e. coalesce nulls to empty strings
   GTFS_SCHEDULE_START: '2021-04-16'
-  GTFS_RT_START: "{% if target.name.startswith('prod') %}'2022-09-15'{% else %}{{ dbt_date.n_days_ago(7) }}{% endif %}"
+  PROD_GTFS_RT_START: '2022-09-15'
   'dbt_date:time_zone': 'America/Los_Angeles'
   DEFAULT_SOURCE_DATABASE: cal-itp-data-infra
 

--- a/warehouse/macros/gtfs_rt_dt_where.sql
+++ b/warehouse/macros/gtfs_rt_dt_where.sql
@@ -1,0 +1,20 @@
+{% macro gtfs_rt_dt_where() -%}
+
+{%- if is_incremental() -%}
+    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set max_dt = dates[0] %}
+    {%- if target.name.startswith('prod') -%}
+        {% set start_dt = max_dt %}
+    {%- else -%}
+        {# Never look back more than 7 days #}
+        {% set start_dt = [max_dt, (modules.datetime.date.today() - modules.datetime.timedelta(days=7))] | max %}
+    {%- endif -%}
+{%- else -%}
+    {%- if target.name.startswith('prod') -%}
+        {% set start_dt = var('PROD_GTFS_RT_START') %}
+    {%- else -%}
+        {% set start_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=7) %}
+    {%- endif -%}
+{%- endif -%}
+dt >= '{{ start_dt }}'
+{% endmacro %}

--- a/warehouse/macros/gtfs_rt_dt_where.sql
+++ b/warehouse/macros/gtfs_rt_dt_where.sql
@@ -1,7 +1,7 @@
 {% macro gtfs_rt_dt_where(this_dt_column = 'dt', filter_dt_column = 'dt') -%}
 
 {%- if is_incremental() -%}
-    {% set dates = dbt_utils.get_column_values(table=this, column=dt_column, order_by = dt_column + ' DESC', max_records = 1) %}
+    {% set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
     {% set max_dt = dates[0] %}
     {%- if target.name.startswith('prod') -%}
         {% set start_dt = max_dt %}

--- a/warehouse/macros/gtfs_rt_dt_where.sql
+++ b/warehouse/macros/gtfs_rt_dt_where.sql
@@ -1,7 +1,7 @@
-{% macro gtfs_rt_dt_where() -%}
+{% macro gtfs_rt_dt_where(this_dt_column = 'dt', filter_dt_column = 'dt') -%}
 
 {%- if is_incremental() -%}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
+    {% set dates = dbt_utils.get_column_values(table=this, column=dt_column, order_by = dt_column + ' DESC', max_records = 1) %}
     {% set max_dt = dates[0] %}
     {%- if target.name.startswith('prod') -%}
         {% set start_dt = max_dt %}
@@ -16,5 +16,5 @@
         {% set start_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=7) %}
     {%- endif -%}
 {%- endif -%}
-dt >= '{{ start_dt }}'
+{{ filter_dt_column }} >= '{{ start_dt }}'
 {% endmacro %}

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -334,11 +334,3 @@ models:
         description: Service identifier from calendar and/or calendar_dates.
         tests:
           - not_null
-
-  - name: int_gtfs_rt__trip_updates_no_stop_times
-    description: |
-      This is really intended to be a temporary table until
-      this work is done at the Airflow level, most likely.
-      Incrementally materialized trip updates data for use
-      downstream to minimize amount of raw data read from
-      GCS.

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__distinct_download_configs.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__distinct_download_configs.sql
@@ -8,11 +8,6 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_dt = dates[0] %}
-{% endif %}
-
 WITH
 
 int_gtfs_rt__distinct_download_configs AS (
@@ -21,11 +16,7 @@ int_gtfs_rt__distinct_download_configs AS (
         dt,
         _config_extract_ts
     FROM {{ ref('stg_gtfs_rt__service_alerts_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= '{{ max_dt }}'
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 )
 
 SELECT * FROM int_gtfs_rt__distinct_download_configs

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__unioned_parse_outcomes.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__unioned_parse_outcomes.sql
@@ -8,39 +8,22 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH service_alerts AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__service_alerts_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >=  {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 vehicle_positions AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__vehicle_positions_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >=  {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 trip_updates AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__trip_updates_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >=  {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 int_gtfs_rt__unioned_parse_outcomes AS (

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__rt_validation_notices.sql
@@ -8,39 +8,22 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='ts', order_by = 'ts DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH
 
 int_gtfs_quality__rt_validation_notices AS (
     -- predicate pushdown does not seem to work through UNIONs so list these all out
     SELECT * FROM {{ ref('stg_gtfs_rt__service_alerts_validation_notices') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 
     UNION ALL
 
     SELECT * FROM {{ ref('stg_gtfs_rt__trip_updates_validation_notices') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 
     UNION ALL
 
     SELECT * FROM {{ ref('stg_gtfs_rt__vehicle_positions_validation_notices') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 )
 
 SELECT * FROM int_gtfs_quality__rt_validation_notices

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__rt_validation_outcomes.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__rt_validation_outcomes.sql
@@ -8,39 +8,22 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_dt = timestamps[0] %}
-{% endif %}
-
 WITH
 
 int_gtfs_quality__rt_validation_outcomes AS (
     -- predicate pushdown does not seem to work through UNIONs so list these all out
     SELECT * FROM {{ ref('stg_gtfs_rt__service_alerts_validation_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 
     UNION ALL
 
     SELECT * FROM {{ ref('stg_gtfs_rt__trip_updates_validation_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 
     UNION ALL
 
     SELECT * FROM {{ ref('stg_gtfs_rt__vehicle_positions_validation_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 )
 
 SELECT * FROM int_gtfs_quality__rt_validation_outcomes

--- a/warehouse/models/mart/ad_hoc/fct_daily_trip_update_status_counts.sql
+++ b/warehouse/models/mart/ad_hoc/fct_daily_trip_update_status_counts.sql
@@ -14,7 +14,7 @@
 {% endif %}
 
 WITH fct_stop_time_updates AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__trip_updates_no_stop_times') }}
+    SELECT * FROM {{ ref('fct_trip_updates_no_stop_times') }}
     {% if is_incremental() %}
     WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
     {% else %}

--- a/warehouse/models/mart/ad_hoc/fct_daily_trip_update_status_counts.sql
+++ b/warehouse/models/mart/ad_hoc/fct_daily_trip_update_status_counts.sql
@@ -8,18 +8,9 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_dt = dates[0] %}
-{% endif %}
-
 WITH fct_stop_time_updates AS (
     SELECT * FROM {{ ref('fct_trip_updates_no_stop_times') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 fct_daily_trip_update_status_counts AS (

--- a/warehouse/models/mart/ad_hoc/fct_daily_vehicle_location_feed_trip_counts.sql
+++ b/warehouse/models/mart/ad_hoc/fct_daily_vehicle_location_feed_trip_counts.sql
@@ -8,18 +8,9 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_dt = dates[0] %}
-{% endif %}
-
 WITH fct_vehicle_locations AS (
     SELECT * FROM {{ ref('fct_vehicle_locations') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 fct_daily_vehicle_location_trip_counts AS (

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1164,12 +1164,26 @@ models:
       - name: sa_max_header_timestamp
         description: Timestamp of last service alert header referencing this trip.
 
+  - name: fct_trip_updates_no_stop_times
+    description: |
+      Incrementally materialize trip update messages without stop times; this reduces the data size by about 90%.
+    columns:
+      - name: key
+        tests:
+          - not_null:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+          - unique:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
 
   - name: fct_service_alerts_trip_summaries
     description: |
       Summarizes trips observed in service alert messages.
     columns:
-      - name: key
+      - &rt_trip_summary_key
+        name: key
+        description: Date, URL, and trip_descriptor.
         tests:
           - not_null:
               config:
@@ -1177,42 +1191,37 @@ models:
           - unique:
               config:
                 where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
-
-  - name: fct_trip_updates_no_stop_times
-    description: |
-      Incrementally trip update messages without stop times; this reduces the data size by about 90%.
-    columns:
-      - name: key
-        tests:
-          - not_null:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
-          - unique:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+      - &num_distinct_message_ids
+        name: num_distinct_message_ids
+        description: Distinct count of top-level ids.
+      - &num_distinct_header_timestamps
+        name: num_distinct_header_timestamps
+        description: Distinct count of header timestamps.
+      - &min_extract_ts
+        name: min_extract_ts
+        description: Distinct count of header timestamps.
+      - &max_extract_ts
+        name: max_extract_ts
+        description: Distinct count of header timestamps.
+      - &min_header_timestamp
+        name: min_header_timestamp
+        description: Distinct count of header timestamps.
+      - &max_header_timestamp
+        name: max_header_timestamp
+        description: Distinct count of header timestamps.
 
   - name: fct_trip_updates_summaries
     description: |
       Summarizes trips observed in trip update messages.
     columns:
-      - name: key
-        tests:
-          - not_null:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
-          - unique:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+      - *rt_trip_summary_key
+      - *num_distinct_message_ids
+      - *num_distinct_header_timestamps
 
   - name: fct_vehicle_positions_trip_summaries
     description: |
       Summarizes trips observed in vehicle position messages.
     columns:
-      - name: key
-        tests:
-          - not_null:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
-          - unique:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+      - *rt_trip_summary_key
+      - *num_distinct_message_ids
+      - *num_distinct_header_timestamps

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1183,7 +1183,7 @@ models:
     columns:
       - &rt_trip_summary_key
         name: key
-        description: Date, URL, and trip_descriptor.
+        description: Date, URL, and trip descriptor (https://gtfs.org/realtime/reference/#message-tripdescriptor).
         tests:
           - not_null:
               config:
@@ -1199,16 +1199,22 @@ models:
         description: Distinct count of header timestamps.
       - &min_extract_ts
         name: min_extract_ts
-        description: Distinct count of header timestamps.
+        description: Timestamp of the first extract on this day referencing this trip.
       - &max_extract_ts
         name: max_extract_ts
-        description: Distinct count of header timestamps.
+        description: Timestamp of the last extract on this day referencing this trip.
       - &min_header_timestamp
         name: min_header_timestamp
-        description: Distinct count of header timestamps.
+        description: Earliest header timestamp of a message referencing this trip.
       - &max_header_timestamp
         name: max_header_timestamp
-        description: Distinct count of header timestamps.
+        description: Latest header timestamp of a message referencing this trip.
+      - name: service_alert_message_keys
+        description: Keys of the service alert messages that referenced this trip.
+        tests:
+          - relationships:
+              to: ref('fct_service_alerts_messages')
+              field: key
 
   - name: fct_trip_updates_summaries
     description: |
@@ -1217,6 +1223,20 @@ models:
       - *rt_trip_summary_key
       - *num_distinct_message_ids
       - *num_distinct_header_timestamps
+      - *min_extract_ts
+      - *max_extract_ts
+      - *min_header_timestamp
+      - *max_header_timestamp
+      - name: min_trip_update_timestamp
+        description: Earliest trip update timestamp of a message referencing this trip.
+      - name: max_trip_update_timestamp
+        description: Latest trip update timestamp of a message referencing this trip.
+      - name: max_delay
+        description: Maximium observed delay for this trip during this day.
+      - name: num_skipped_stops
+        description: Distinct count of stop_ids in messages where schedule_relationship was SKIPPED.
+      - name: num_scheduled_canceled_added_stops
+        description: Distinct count of stop_ids in messages where schedule_relationship was SCHEDULED, CANCELED, or ADDED.
 
   - name: fct_vehicle_positions_trip_summaries
     description: |
@@ -1225,3 +1245,19 @@ models:
       - *rt_trip_summary_key
       - *num_distinct_message_ids
       - *num_distinct_header_timestamps
+      - *min_extract_ts
+      - *max_extract_ts
+      - *min_header_timestamp
+      - *max_header_timestamp
+      - name: min_vehicle_timestamp
+        description: Earliest vehicle timestamp of a message referencing this trip.
+      - name: max_vehicle_timestamp
+        description: Latest vehicle timestamp of a message referencing this trip.
+      - name: first_position_latitude
+        description: Position latitude of the first extract referencing this trip.
+      - name: first_position_longitude
+        description: Position longitude of the first extract referencing this trip.
+      - name: last_position_latitude
+        description: Position latitude of the last extract referencing this trip.
+      - name: last_position_longitude
+        description: Position longitude of the last extract referencing this trip.

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1193,16 +1193,22 @@ models:
                 where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
       - &num_distinct_message_ids
         name: num_distinct_message_ids
-        description: Distinct count of top-level ids.
+        description: Distinct count of top-level ids (https://gtfs.org/realtime/reference/#message-feedentity).
       - &num_distinct_header_timestamps
         name: num_distinct_header_timestamps
-        description: Distinct count of header timestamps.
+        description: Distinct count of header timestamps from the feed (https://gtfs.org/realtime/reference/#message-feedheader).
       - &min_extract_ts
         name: min_extract_ts
-        description: Timestamp of the first extract on this day referencing this trip.
+        description: |
+          Timestamp of the first extract (i.e. the time at which
+          we downloaded this feed extract) on this day referencing this trip.
+          For RT, our extracts are pinned to 20 second intervals, i.e. :00, :20, :40.
       - &max_extract_ts
         name: max_extract_ts
-        description: Timestamp of the last extract on this day referencing this trip.
+        description: |
+          Timestamp of the last extract (i.e. the time at which
+          we downloaded this feed extract) on this day referencing this trip.
+          For RT, our extracts are pinned to 20 second intervals, i.e. :00, :20, :40.
       - &min_header_timestamp
         name: min_header_timestamp
         description: Earliest header timestamp of a message referencing this trip.
@@ -1223,6 +1229,8 @@ models:
       - *rt_trip_summary_key
       - *num_distinct_message_ids
       - *num_distinct_header_timestamps
+      - name: num_distinct_trip_update_timestamps
+        description: Distinct count of trip update timestamps from the feed (https://gtfs.org/realtime/reference/#message-tripupdate).
       - *min_extract_ts
       - *max_extract_ts
       - *min_header_timestamp
@@ -1245,6 +1253,8 @@ models:
       - *rt_trip_summary_key
       - *num_distinct_message_ids
       - *num_distinct_header_timestamps
+      - name: num_distinct_vehicle_timestamps
+        description: Distinct count of vehicle timestamps from the feed (https://gtfs.org/realtime/reference/#message-vehicleposition).
       - *min_extract_ts
       - *max_extract_ts
       - *min_header_timestamp

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1163,3 +1163,21 @@ models:
         description: Timestamp of first service alert header referencing this trip.
       - name: sa_max_header_timestamp
         description: Timestamp of last service alert header referencing this trip.
+
+
+  - name: fct_trip_updates_no_stop_times
+    description: |
+      This is really intended to be a temporary table until
+      this work is done at the Airflow level, most likely.
+      Incrementally materialized trip updates data for use
+      downstream to minimize amount of raw data read from
+      GCS.
+    columns:
+      - name: key
+        tests:
+          - not_null:
+              config:
+                where: '__rt_sampled__'
+          - unique:
+              config:
+                where: '__rt_sampled__'

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1165,19 +1165,54 @@ models:
         description: Timestamp of last service alert header referencing this trip.
 
 
-  - name: fct_trip_updates_no_stop_times
+  - name: fct_service_alerts_trip_summaries
     description: |
-      This is really intended to be a temporary table until
-      this work is done at the Airflow level, most likely.
-      Incrementally materialized trip updates data for use
-      downstream to minimize amount of raw data read from
-      GCS.
+      Summarizes trips observed in service alert messages.
     columns:
       - name: key
         tests:
           - not_null:
               config:
-                where: '__rt_sampled__'
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
           - unique:
               config:
-                where: '__rt_sampled__'
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+
+  - name: fct_trip_updates_no_stop_times
+    description: |
+      Incrementally trip update messages without stop times; this reduces the data size by about 90%.
+    columns:
+      - name: key
+        tests:
+          - not_null:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+          - unique:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+
+  - name: fct_trip_updates_summaries
+    description: |
+      Summarizes trips observed in trip update messages.
+    columns:
+      - name: key
+        tests:
+          - not_null:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+          - unique:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+
+  - name: fct_vehicle_positions_trip_summaries
+    description: |
+      Summarizes trips observed in vehicle position messages.
+    columns:
+      - name: key
+        tests:
+          - not_null:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+          - unique:
+              config:
+                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)

--- a/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
@@ -23,7 +23,7 @@ validation_map AS (
 parse_outcomes AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__unioned_parse_outcomes') }}
-    WHERE {{ gtfs_rt_dt_where() }}
+    WHERE {{ gtfs_rt_dt_where(this_dt_column = 'date') }}
 ),
 
 grouped_parse_outcomes AS (

--- a/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_rt_feed_files.sql
@@ -1,12 +1,5 @@
 {{ config(materialized='incremental', unique_key = 'key') }}
 
--- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost
--- save max date in a variable instead so it can be referenced in incremental logic and still use partition elimination
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='date', order_by = 'date DESC', max_records = 1) %}
-    {% set max_date = dates[0] %}
-{% endif %}
-
 WITH int_transit_database__urls_to_gtfs_datasets AS (
     SELECT *
     FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
@@ -30,11 +23,7 @@ validation_map AS (
 parse_outcomes AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__unioned_parse_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= DATE '{{ max_date }}'
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 grouped_parse_outcomes AS (

--- a/warehouse/models/mart/gtfs/fct_daily_service_alerts.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_service_alerts.sql
@@ -8,18 +8,9 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_dt = dates[0] %}
-{% endif %}
-
 WITH fct_service_alert_translations AS (
     SELECT * FROM {{ ref('fct_service_alert_translations') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_dt }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 select_english AS (

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files.sql
@@ -1,23 +1,12 @@
 {{ config(materialized='incremental', unique_key = 'key') }}
 
--- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost
--- save max date in a variable instead so it can be referenced in incremental logic and still use partition elimination
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_date = dates[0] %}
-{% endif %}
-
 WITH
 
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
     WHERE data_quality_pipeline
-    {% if is_incremental() %}
-    AND dt >= DATE '{{ max_date }}'
-    {% else %}
-    AND dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    AND {{ gtfs_rt_dt_where() }}
 ),
 
 fct_daily_rt_feed_files AS (
@@ -28,11 +17,7 @@ fct_daily_rt_feed_files AS (
 parse_outcomes AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__unioned_parse_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= DATE '{{ max_date }}'
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 daily_totals AS (

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
@@ -1,23 +1,12 @@
 {{ config(materialized='incremental', unique_key = 'key') }}
 
--- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost
--- save max date in a variable instead so it can be referenced in incremental logic and still use partition elimination
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_date = dates[0] %}
-{% endif %}
-
 WITH
 
 int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
     WHERE data_quality_pipeline
-    {% if is_incremental() %}
-    AND dt >= DATE '{{ max_date }}'
-    {% else %}
-    AND dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 fct_daily_rt_feed_files AS (
@@ -28,11 +17,7 @@ fct_daily_rt_feed_files AS (
 parse_outcomes AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__unioned_parse_outcomes') }}
-    {% if is_incremental() %}
-    WHERE dt >= DATE '{{ max_date }}'
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 daily_totals AS (

--- a/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
+++ b/warehouse/models/mart/gtfs/fct_hourly_rt_feed_files_success.sql
@@ -6,7 +6,7 @@ int_gtfs_rt__daily_url_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__daily_url_index') }}
     WHERE data_quality_pipeline
-    WHERE {{ gtfs_rt_dt_where() }}
+        AND {{ gtfs_rt_dt_where() }}
 ),
 
 fct_daily_rt_feed_files AS (

--- a/warehouse/models/mart/gtfs/fct_observed_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_observed_trips.sql
@@ -13,13 +13,13 @@ assessment_entities AS (
     SELECT * FROM {{ ref('int_gtfs_quality__daily_assessment_candidate_entities') }}
 ),
 trip_updates AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__trip_updates_summaries') }}
+    SELECT * FROM {{ ref('fct_trip_updates_summaries') }}
 ),
 vehicle_positions AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__vehicle_positions_trip_summaries') }}
+    SELECT * FROM {{ ref('fct_vehicle_positions_trip_summaries') }}
 ),
 service_alerts AS (
-    SELECT * FROM {{ ref('int_gtfs_rt__service_alerts_trip_summaries') }}
+    SELECT * FROM {{ ref('fct_service_alerts_trip_summaries') }}
 ),
 
 -- get each of these distinct

--- a/warehouse/models/mart/gtfs/fct_service_alerts_trip_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_trip_summaries.sql
@@ -16,8 +16,8 @@
     {% set max_ts = timestamps[0] %}
 {% endif %}
 
-WITH vehicle_positions AS (
-    SELECT * FROM {{ ref('fct_vehicle_positions_messages') }}
+WITH service_alerts AS (
+    SELECT * FROM {{ ref('fct_service_alert_informed_entities') }}
     {% if is_incremental() %}
     WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}
@@ -25,7 +25,7 @@ WITH vehicle_positions AS (
     {% endif %}
 ),
 
-int_gtfs_rt__vehicle_positions_trip_summaries AS (
+fct_service_alerts_trip_summaries AS (
     SELECT
         -- https://gtfs.org/realtime/reference/#message-tripdescriptor
         {{ dbt_utils.generate_surrogate_key([
@@ -45,18 +45,13 @@ int_gtfs_rt__vehicle_positions_trip_summaries AS (
         trip_start_time,
         trip_start_date,
         COUNT(DISTINCT id) AS num_distinct_message_ids,
+        ARRAY_AGG(DISTINCT service_alert_message_key) AS service_alert_message_keys,
         MIN(_extract_ts) AS min_extract_ts,
         MAX(_extract_ts) AS max_extract_ts,
         MIN(header_timestamp) AS min_header_timestamp,
         MAX(header_timestamp) AS max_header_timestamp,
-        MIN(vehicle_timestamp) AS min_vehicle_timestamp,
-        MAX(vehicle_timestamp) AS max_vehicle_timestamp,
-        ARRAY_AGG(position_latitude ORDER BY _extract_ts)[OFFSET(0)] AS first_position_latitude,
-        ARRAY_AGG(position_longitude ORDER BY _extract_ts)[OFFSET(0)] AS first_position_longitude,
-        ARRAY_AGG(position_latitude ORDER BY _extract_ts DESC)[OFFSET(0)] AS last_position_latitude,
-        ARRAY_AGG(position_longitude ORDER BY _extract_ts DESC)[OFFSET(0)] AS last_position_longitude,
-    FROM vehicle_positions
-    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8 --noqa: L054
+    FROM service_alerts
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8
 )
 
-SELECT * FROM int_gtfs_rt__vehicle_positions_trip_summaries
+SELECT * FROM fct_service_alerts_trip_summaries

--- a/warehouse/models/mart/gtfs/fct_service_alerts_trip_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_trip_summaries.sql
@@ -11,18 +11,9 @@
     )
 }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH service_alerts AS (
     SELECT * FROM {{ ref('fct_service_alert_informed_entities') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 fct_service_alerts_trip_summaries AS (

--- a/warehouse/models/mart/gtfs/fct_service_alerts_trip_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_trip_summaries.sql
@@ -36,6 +36,7 @@ fct_service_alerts_trip_summaries AS (
         trip_start_time,
         trip_start_date,
         COUNT(DISTINCT id) AS num_distinct_message_ids,
+        COUNT(DISTINCT header_timestamp) AS num_distinct_header_timestamps,
         ARRAY_AGG(DISTINCT service_alert_message_key) AS service_alert_message_keys,
         MIN(_extract_ts) AS min_extract_ts,
         MAX(_extract_ts) AS max_extract_ts,

--- a/warehouse/models/mart/gtfs/fct_trip_updates_no_stop_times.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_no_stop_times.sql
@@ -28,9 +28,9 @@ trip_updates AS (
     {% endif %}
 ),
 
-int_gtfs_rt__trip_updates_no_stop_times AS (
+fct_trip_updates_no_stop_times AS (
     SELECT * EXCEPT (stop_time_updates)
     FROM trip_updates
 )
 
-SELECT * FROM int_gtfs_rt__trip_updates_no_stop_times
+SELECT * FROM fct_trip_updates_no_stop_times

--- a/warehouse/models/mart/gtfs/fct_trip_updates_no_stop_times.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_no_stop_times.sql
@@ -12,20 +12,11 @@
     )
 }}
 
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_dt = dates[0] %}
-{% endif %}
-
 WITH
 
 trip_updates AS (
     SELECT * FROM {{ ref('fct_trip_updates_messages') }}
-    {% if is_incremental() %}
-    WHERE dt >= '{{ max_dt }}'
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 fct_trip_updates_no_stop_times AS (

--- a/warehouse/models/mart/gtfs/fct_trip_updates_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_summaries.sql
@@ -11,18 +11,9 @@
     )
 }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH stop_time_updates AS (
     SELECT * FROM {{ ref('fct_stop_time_updates') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 fct_trip_updates_summaries AS (

--- a/warehouse/models/mart/gtfs/fct_trip_updates_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_summaries.sql
@@ -25,7 +25,7 @@ WITH stop_time_updates AS (
     {% endif %}
 ),
 
-int_gtfs_rt__trip_updates_summaries AS (
+fct_trip_updates_summaries AS (
     SELECT
         -- https://gtfs.org/realtime/reference/#message-tripdescriptor
         {{ dbt_utils.generate_surrogate_key([
@@ -58,4 +58,4 @@ int_gtfs_rt__trip_updates_summaries AS (
     GROUP BY 1, 2, 3, 4, 5, 6, 7, 8
 )
 
-SELECT * FROM int_gtfs_rt__trip_updates_summaries
+SELECT * FROM fct_trip_updates_summaries

--- a/warehouse/models/mart/gtfs/fct_trip_updates_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_summaries.sql
@@ -36,6 +36,8 @@ fct_trip_updates_summaries AS (
         trip_start_time,
         trip_start_date,
         COUNT(DISTINCT id) AS num_distinct_message_ids,
+        COUNT(DISTINCT header_timestamp) AS num_distinct_header_timestamps,
+        COUNT(DISTINCT trip_update_timestamp) AS num_distinct_trip_update_timestamps,
         MIN(_extract_ts) AS min_extract_ts,
         MAX(_extract_ts) AS max_extract_ts,
         MIN(header_timestamp) AS min_header_timestamp,

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_summaries.sql
@@ -11,18 +11,9 @@
     )
 }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH vehicle_positions AS (
     SELECT * FROM {{ ref('fct_vehicle_positions_messages') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 fct_vehicle_positions_trip_summaries AS (

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_summaries.sql
@@ -36,6 +36,8 @@ fct_vehicle_positions_trip_summaries AS (
         trip_start_time,
         trip_start_date,
         COUNT(DISTINCT id) AS num_distinct_message_ids,
+        COUNT(DISTINCT header_timestamp) AS num_distinct_header_timestamps,
+        COUNT(DISTINCT vehicle_timestamp) AS num_distinct_vehicle_timestamps,
         MIN(_extract_ts) AS min_extract_ts,
         MAX(_extract_ts) AS max_extract_ts,
         MIN(header_timestamp) AS min_header_timestamp,

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_alerts_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_alerts_message_age_summary.sql
@@ -8,22 +8,13 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH service_alerts_ages AS (
     SELECT DISTINCT
         dt,
         base64_url,
         _header_message_age,
     FROM {{ ref('fct_service_alerts_messages') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >=  {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 -- these values are repeated because one row in the source table is one service_alerts message so the header is identical for all messages on a given request

--- a/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
@@ -20,7 +20,7 @@ WITH trip_updates_ages AS (
         _header_message_age,
         _trip_update_message_age,
         _trip_update_message_age_vs_header,
-    FROM {{ ref('int_gtfs_rt__trip_updates_no_stop_times') }}
+    FROM {{ ref('fct_trip_updates_no_stop_times') }}
     {% if is_incremental() %}
     WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
     {% else %}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
@@ -8,11 +8,6 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH trip_updates_ages AS (
     SELECT DISTINCT
         dt,
@@ -21,11 +16,7 @@ WITH trip_updates_ages AS (
         _trip_update_message_age,
         _trip_update_message_age_vs_header,
     FROM {{ ref('fct_trip_updates_no_stop_times') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >=  {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 -- these values are repeated because one row in the source table is one trip_updates message so the header is identical for all messages on a given request

--- a/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_vehicle_positions_message_age_summary.sql
@@ -8,11 +8,6 @@
     },
 ) }}
 
-{% if is_incremental() %}
-    {% set timestamps = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_ts = timestamps[0] %}
-{% endif %}
-
 WITH vehicle_positions_ages AS (
     SELECT DISTINCT
         dt,
@@ -21,11 +16,7 @@ WITH vehicle_positions_ages AS (
         _vehicle_message_age,
         _vehicle_message_age_vs_header,
     FROM {{ ref('fct_vehicle_positions_messages') }}
-    {% if is_incremental() %}
-    WHERE dt >= EXTRACT(DATE FROM TIMESTAMP('{{ max_ts }}'))
-    {% else %}
-    WHERE dt >=  {{ var('GTFS_RT_START') }}
-    {% endif %}
+    WHERE {{ gtfs_rt_dt_where() }}
 ),
 
 -- these values are repeated because one row in the source table is one vehicle message so the header is identical for all messages on a given request

--- a/warehouse/models/mart/gtfs_quality/fct_rt_feed_fetch_errors.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_rt_feed_fetch_errors.sql
@@ -72,7 +72,7 @@ WITH fct_rt_feed_fetch_errors AS (
         dt,
         execution_ts
     FROM {{ ref('stg_rt__feed_fetch_errors') }}
-    {{ gtfs_rt_dt_where() }}
+    WHERE {{ gtfs_rt_dt_where() }}
     AND message LIKE '%RTFetchException%'
 )
 

--- a/warehouse/models/mart/gtfs_quality/fct_rt_feed_fetch_errors.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_rt_feed_fetch_errors.sql
@@ -10,11 +10,6 @@
     )
 }}
 
-{% if is_incremental() %}
-    {% set dates = dbt_utils.get_column_values(table=this, column='dt', order_by = 'dt DESC', max_records = 1) %}
-    {% set max_dt = dates[0] %}
-{% endif %}
-
 WITH fct_rt_feed_fetch_errors AS (
     SELECT
         project_id,
@@ -77,12 +72,8 @@ WITH fct_rt_feed_fetch_errors AS (
         dt,
         execution_ts
     FROM {{ ref('stg_rt__feed_fetch_errors') }}
-    WHERE message LIKE '%RTFetchException%'
-    {% if is_incremental() %}
-    AND dt >= '{{ max_dt }}'
-    {% else %}
-    AND dt >= {{ var('GTFS_RT_START') }}
-    {% endif %}
+    {{ gtfs_rt_dt_where() }}
+    AND message LIKE '%RTFetchException%'
 )
 
 SELECT * FROM fct_rt_feed_fetch_errors


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/2401 once backfill runs

Moves 4 of our incremental tables to be mart-level facts, to encourage usage. Will also be backfilling new columns required for guideline checks models downstream.

I will be performing the following manual steps:
- [ ] Copy the 3 tables without schema changes to their new locations
- [ ] ~Running a full-refresh on `int_gtfs_rt__trip_updates_no_stop_times` and downstream~ we are going to wait on https://github.com/cal-itp/data-infra/pull/2457 and run a single full refresh once that is merged

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Testing locally.

## Screenshots (optional)
Dev full refresh:
```
19:44:20  20 of 36 OK created sql incremental model andrew_mart_ad_hoc.fct_daily_vehicle_location_feed_trip_counts  [CREATE TABLE (713.0 rows, 162.8 GB processed) in 77.23s]
19:44:34  15 of 36 OK created sql incremental model andrew_mart_gtfs.fct_vehicle_positions_trip_summaries  [CREATE TABLE (819.2k rows, 162.8 GB processed) in 91.75s]
19:44:49  13 of 36 OK created sql incremental model andrew_mart_gtfs_quality.fct_daily_vehicle_positions_message_age_summary  [CREATE TABLE (735.0 rows, 325.7 GB processed) in 107.34s]
19:46:49  17 of 36 OK created sql incremental model andrew_mart_gtfs.fct_trip_updates_no_stop_times  [CREATE TABLE (368.4m rows, 1022.8 GB processed) in 226.86s]
```

Dev run:
```
19:53:09  1 of 4 OK created sql incremental model andrew_mart_ad_hoc.fct_daily_vehicle_location_feed_trip_counts  [SCRIPT (16.6 GB processed) in 48.41s]
19:53:12  2 of 4 OK created sql incremental model andrew_mart_gtfs_quality.fct_daily_vehicle_positions_message_age_summary  [SCRIPT (33.2 GB processed) in 50.88s]
19:53:22  4 of 4 OK created sql incremental model andrew_mart_gtfs.fct_vehicle_positions_trip_summaries  [SCRIPT (16.7 GB processed) in 60.86s]
19:54:29  3 of 4 OK created sql incremental model andrew_mart_gtfs.fct_trip_updates_no_stop_times  [SCRIPT (23.6 GB processed) in 128.01s]
```