### PR TITLE
Suppress tests on tab-delimited Auburn feed

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
@@ -73,6 +73,8 @@ models:
         description: '{{ doc("gtfs_agency__agency_timezone") }}'
         tests: &not_null_warn
         - not_null:
+            # TODO: remove this once we deal with Auburn feed that has tab-delimited files
+            where: "feed_key != '6368fe701bdd68c4f521751a9a222a10'"
             config:
               severity: warn
       - name: agency_lang
@@ -104,7 +106,9 @@ models:
       - name: area_id
         description: '{{ doc("gtfs_areas__area_id") }}'
         tests: &not_null_error
-          - not_null
+          - not_null:
+              # TODO: remove this once we deal with Auburn feed that has tab-delimited files
+              where: "feed_key != '6368fe701bdd68c4f521751a9a222a10'"
       - name: area_name
         description: '{{ doc("gtfs_areas__area_name") }}'
       - *_feed_valid_from

--- a/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
+++ b/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
@@ -49,6 +49,8 @@ models:
         description: '{{ doc("gtfs_agency__agency_timezone") }}'
         tests: &not_null_warn
         - not_null:
+            # TODO: remove this once we deal with Auburn feed that has tab-delimited files
+            where: "feed_key != '6368fe701bdd68c4f521751a9a222a10'"
             config:
               severity: warn
       - name: agency_lang
@@ -123,7 +125,9 @@ models:
       - name: service_id
         description: '{{ doc("gtfs_calendar__service_id") }}'
         tests: &not_null_error
-        - not_null
+        - not_null:
+            # TODO: remove this once we deal with Auburn feed that has tab-delimited files
+            where: "feed_key != '6368fe701bdd68c4f521751a9a222a10'"
       - name: monday
         description: '{{ doc("gtfs_calendar__monday") }}'
         tests: *not_null_warn


### PR DESCRIPTION
# Description

We got a ton of failing dbt tests and warnings over the weekend due to an Auburn feed that uses tabs instead of commas to delimit some feeds, leading to all parsed fields being null. This is a temporary workaround to suppress these failing tests just so that we can get alerted if another issue occurs while we figure out a longer term fix for Auburn. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

Ran `dim_calendar` and confirmed tests pass. I also went through all the fails & warns and confirmed they were associated specifically with tab-delimited Auburn files (`calendar`, `calendar_dates`, `fare_attributes`, `fare_products`, and `routes`). 

## Screenshots (optional)
