### PR TITLE
V2 payments reliability tables

### DIFF
--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -21,6 +21,11 @@
     principals = ['serviceAccount:clean-air-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
 ) }}",
 " {{ create_row_access_policy(
+    filter_column = 'participant_id',
+    filter_value = 'ccjpa',
+    principals = ['serviceAccount:ccjpa-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }}",
+" {{ create_row_access_policy(
     principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',

--- a/warehouse/models/mart/payments/reliability/_payments_views_tests.yml
+++ b/warehouse/models/mart/payments/reliability/_payments_views_tests.yml
@@ -1,0 +1,54 @@
+version: 2
+
+models:
+  - name: v2_payments_monthly_transaction_deltas
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: month_start
+        description: The month and year of the ridership count calculation
+      - name: ridership_count
+        description: A participant's total ridership in a particular month
+      - name: relative_difference
+        description: The relative change in a participant's ridership count as compared to the previous month
+  - name: v2_payments_weekly_transaction_deltas
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: week_start
+        description: The week and year of the ridership count calculation
+      - name: ridership_count
+        description: A participant's total ridership in a particular week
+      - name: relative_difference
+        description: The relative change in a participant's ridership count as compared to the previous week
+  - name: v2_payments_daily_transaction_deltas
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: transaction_date
+        description: The day of the ridership count calculation
+      - name: ridership_count
+        description: A participant's total ridership on a particular day
+      - name: relative_difference
+        description: The relative change in a participant's ridership count as compared to the previous day
+  - name: v2_payments_reliability_unlabeled_routes
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "n_all_rides >= (n_route_z_rides + n_null_rides)"
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: month_start
+        description: The first day of the month for which the count aggregation is being caclulated
+      - name: n_route_z_rides
+        description: The total number of rides labeled as `Route Z` for the given month
+      - name: n_null_rides
+        description: The total number of rides labeled as `Null` for the given month
+      - name: total_unlabeled_rides
+        description: The total number of rides labeled as either `Route Z` or `Null` for the given month
+      - name: n_all_rides
+        description: The total number of rides for the given month
+      - name: pct_unlabeled_rides_to_total_rides
+        description: The percentage of unlabeled rides compared to the total number of rides for the given month
+      - name: recency_rank
+        description: Used to identify a month's recency (for help with filtering)

--- a/warehouse/models/mart/payments/reliability/v2_payments_daily_transaction_deltas.sql
+++ b/warehouse/models/mart/payments/reliability/v2_payments_daily_transaction_deltas.sql
@@ -1,0 +1,65 @@
+WITH payments_rides AS (
+    SELECT * FROM {{ ref('fct_payments_rides_v2') }}
+),
+
+payments_tests_daily_date_spine AS (
+    SELECT * FROM {{ ref('payments_tests_daily_date_spine') }}
+),
+
+extract_count_date AS (
+    SELECT
+
+        participant_id,
+        COUNT(*) AS ridership_count,
+        DATE(
+            EXTRACT(DATE FROM transaction_date_time_pacific)
+        ) AS transaction_date
+
+    FROM payments_rides
+    GROUP BY transaction_date, participant_id
+),
+
+add_date_spine AS (
+    SELECT
+
+        t1.participant_id,
+        t1.day_history AS transaction_date,
+
+        t2.ridership_count
+
+    FROM payments_tests_daily_date_spine AS t1
+    LEFT JOIN extract_count_date AS t2
+        ON (t1.day_history = t2.transaction_date)
+            AND (t1.participant_id = t2.participant_id)
+),
+
+calculate_relative_difference AS (
+    SELECT
+
+        *,
+        (
+            (
+                ridership_count - LAG(
+                    ridership_count, 1
+                ) OVER (PARTITION BY participant_id ORDER BY transaction_date)
+            ) / LAG(ridership_count, 1)
+            OVER (PARTITION BY participant_id ORDER BY transaction_date)) * 100
+        AS relative_difference
+
+    FROM add_date_spine
+),
+
+v2_payments_daily_transaction_deltas AS (
+
+    SELECT
+
+        participant_id,
+        transaction_date,
+        COALESCE(ridership_count, 0) AS ridership_count,
+        relative_difference
+
+    FROM calculate_relative_difference
+
+)
+
+SELECT * FROM v2_payments_daily_transaction_deltas

--- a/warehouse/models/mart/payments/reliability/v2_payments_monthly_transaction_deltas.sql
+++ b/warehouse/models/mart/payments/reliability/v2_payments_monthly_transaction_deltas.sql
@@ -1,0 +1,69 @@
+WITH payments_rides AS (
+    SELECT * FROM {{ ref('fct_payments_rides_v2') }}
+),
+
+payments_tests_monthly_date_spine AS (
+    SELECT * FROM {{ ref('payments_tests_monthly_date_spine') }}
+),
+
+extract_count_month AS (
+    SELECT
+
+        participant_id,
+        month_start,
+        COUNT(*) AS ridership_count
+
+    FROM payments_tests_monthly_date_spine
+    INNER JOIN payments_rides
+        USING (participant_id) WHERE transaction_date_pacific >= month_start AND transaction_date_pacific <= month_end
+    GROUP BY month_start, participant_id
+),
+
+match_date_spine AS (
+    SELECT
+
+        participant_id,
+        month_start,
+        ridership_count
+
+    FROM payments_tests_monthly_date_spine
+    LEFT JOIN extract_count_month
+        USING (participant_id, month_start)
+),
+
+calculate_relative_difference AS (
+    SELECT
+
+        *,
+        (
+            (
+                ridership_count - LAG(
+                    ridership_count, 1
+                ) OVER (PARTITION BY participant_id ORDER BY month_start)
+            ) / LAG(ridership_count, 1) OVER (PARTITION BY participant_id ORDER BY month_start)
+        ) * 100
+        AS relative_difference
+
+    FROM match_date_spine
+),
+
+v2_payments_monthly_transaction_deltas AS (
+    SELECT
+
+        participant_id,
+        month_start,
+        COALESCE(ridership_count, 0) AS ridership_count,
+        relative_difference,
+        recency_rank
+
+    FROM
+        (SELECT
+            participant_id,
+            month_start,
+            ridership_count,
+            relative_difference,
+            RANK() OVER (PARTITION BY participant_id ORDER BY month_start DESC) AS recency_rank
+            FROM calculate_relative_difference)
+)
+
+SELECT * FROM v2_payments_monthly_transaction_deltas

--- a/warehouse/models/mart/payments/reliability/v2_payments_reliability_unlabeled_routes.sql
+++ b/warehouse/models/mart/payments/reliability/v2_payments_reliability_unlabeled_routes.sql
@@ -1,0 +1,57 @@
+WITH payments_rides AS (
+    SELECT * FROM {{ ref('fct_payments_rides_v2') }}
+),
+
+payments_tests_monthly_date_spine AS (
+    SELECT * FROM {{ ref('payments_tests_monthly_date_spine') }}
+),
+
+count_rides AS (
+    SELECT
+
+        spine.participant_id,
+        spine.month_start,
+        COUNTIF(route_id = 'Route Z') AS n_route_z_rides,
+        COUNTIF(route_id IS NULL) AS n_null_rides,
+        COUNT(*) AS n_all_rides
+
+    FROM payments_tests_monthly_date_spine AS spine
+    INNER JOIN payments_rides
+        ON (spine.participant_id = payments_rides.participant_id) AND transaction_date_pacific >= month_start AND transaction_date_pacific <= month_end
+    GROUP BY month_start, participant_id
+),
+
+aggregations_and_date_spine AS (
+    SELECT
+
+        date_spine.participant_id,
+        date_spine.month_start,
+        count_rides.n_route_z_rides,
+        count_rides.n_null_rides,
+        count_rides.n_all_rides,
+
+        (count_rides.n_route_z_rides + count_rides.n_null_rides) AS total_unlabeled_rides,
+
+        SAFE_DIVIDE((count_rides.n_route_z_rides + count_rides.n_null_rides), count_rides.n_all_rides) * 100 AS pct_unlabeled_rides_to_total_rides
+
+    FROM payments_tests_monthly_date_spine AS date_spine
+    LEFT JOIN count_rides
+        USING (participant_id, month_start)
+),
+
+v2_payments_reliability_unlabeled_routes AS (
+    SELECT
+
+        participant_id,
+        month_start,
+        n_route_z_rides,
+        n_null_rides,
+        total_unlabeled_rides,
+        n_all_rides,
+        pct_unlabeled_rides_to_total_rides,
+        RANK() OVER (PARTITION BY participant_id ORDER BY month_start DESC) AS recency_rank
+
+    FROM aggregations_and_date_spine
+)
+
+SELECT * FROM v2_payments_reliability_unlabeled_routes

--- a/warehouse/models/mart/payments/reliability/v2_payments_weekly_transaction_deltas.sql
+++ b/warehouse/models/mart/payments/reliability/v2_payments_weekly_transaction_deltas.sql
@@ -1,0 +1,69 @@
+WITH payments_rides AS (
+    SELECT * FROM {{ ref('fct_payments_rides_v2') }}
+),
+
+payments_tests_weekly_date_spine AS (
+    SELECT * FROM {{ ref('payments_tests_weekly_date_spine') }}
+),
+
+extract_count_week AS (
+    SELECT
+
+        participant_id,
+        week_start,
+        COUNT(*) AS ridership_count
+
+    FROM payments_tests_weekly_date_spine
+    INNER JOIN payments_rides
+        USING (participant_id) WHERE transaction_date_pacific >= week_start AND transaction_date_pacific <= week_end
+    GROUP BY week_start, participant_id
+),
+
+match_date_spine AS (
+    SELECT
+
+        participant_id,
+        week_start,
+        ridership_count
+
+    FROM payments_tests_weekly_date_spine
+    LEFT JOIN extract_count_week
+        USING (participant_id, week_start)
+),
+
+calculate_relative_difference AS (
+    SELECT
+
+        *,
+        (
+            (
+                ridership_count - LAG(
+                    ridership_count, 1
+                ) OVER (PARTITION BY participant_id ORDER BY week_start)
+            ) / LAG(ridership_count, 1) OVER (PARTITION BY participant_id ORDER BY week_start)
+        ) * 100
+        AS relative_difference
+
+    FROM match_date_spine
+),
+
+v2_payments_weekly_transaction_deltas AS (
+    SELECT
+
+        participant_id,
+        week_start,
+        COALESCE(ridership_count, 0) AS ridership_count,
+        relative_difference,
+        recency_rank
+
+    FROM
+        (SELECT
+            participant_id,
+            week_start,
+            ridership_count,
+            relative_difference,
+            RANK() OVER (PARTITION BY participant_id ORDER BY week_start DESC) AS recency_rank
+            FROM calculate_relative_difference)
+)
+
+SELECT * FROM v2_payments_weekly_transaction_deltas


### PR DESCRIPTION
# Description

This PR replicates the tables that power the payments reliability dashboard in the v1 pipeline for the v2 pipeline

Question @atvaccaro - is there a better place that this should live?

## Type of change

- [x] New feature