### PR TITLE
Update rt_analysis.md (typo)

### DIFF
--- a/docs/analytics_tools/rt_analysis.md
+++ b/docs/analytics_tools/rt_analysis.md
@@ -294,12 +294,12 @@ After generating a speed map, the underlying data is available at RtFilterMapper
 |--- |--- |--- |
 |Column|Source|Type|
 |shape_meters|Projection of GTFS Stop along GTFS Shape (with 0 being start of shape), additionally 1km segments generated where stops are infrequent|float64|
-|stop_id|GTFS Schedule|string*|
-|stop_name|GTFS Schedule|string*|
+|stop_id|GTFS Schedule|string|
+|stop_name|GTFS Schedule|string|
 |geometry|GTFS Schedule|geometry|
 |shape_id|GTFS Schedule|string|
 |trip_id|GTFS Schedule|string|
-|stop_sequence|GTFS Schedule|float64**|
+|stop_sequence|GTFS Schedule|float64|
 |route_id|GTFS Schedule|string|
 |route_short_name|GTFS Schedule|string|
 |direction_id|GTFS Schedule|float64|


### PR DESCRIPTION
- fix typo in rt_analysis table desciption

# Description

copy/pasted a few extra asterisks into the `stop_segment_speed_view` description that should be removed for clarity


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
