### PR TITLE
Switch GitHub comment action

### DIFF
--- a/.github/workflows/build-dbt.yml
+++ b/.github/workflows/build-dbt.yml
@@ -65,12 +65,8 @@ jobs:
         id: changed-files-warehouse
         with:
           files: 'warehouse/models/**/*.sql'
-      - uses: iterative/setup-cml@v1
+      - name: Create report.md
         if: steps.changed-files-warehouse.outputs.any_changed == 'true'
-      - name: Create GitHub comment
-        if: steps.changed-files-warehouse.outputs.any_changed == 'true'
-        env:
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd warehouse
           gsutil cp -r gs://calitp-dbt-artifacts/latest/ .
@@ -83,7 +79,20 @@ jobs:
           poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | grep "^calitp_warehouse\." | sed 's/^/--include /g' | xargs poetry run python scripts/visualize.py man --output=target/dag.png
           echo "" >> report.md
           echo '![](./target/dag.png "Changed models")' >> report.md
-          cml comment update report.md
+      - uses: peter-evans/find-comment@v2
+        if: steps.changed-files-warehouse.outputs.any_changed == 'true'
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Warehouse report
+      - uses: peter-evans/create-or-update-comment@v3
+        if: steps.changed-files-warehouse.outputs.any_changed == 'true'
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: warehouse/report.md
+          edit-mode: replace
 
   build_push:
     name: package warehouse image

--- a/.github/workflows/build-dbt.yml
+++ b/.github/workflows/build-dbt.yml
@@ -77,8 +77,9 @@ jobs:
           poetry run dbt --no-use-colors ls --resource-type model --select state:modified --exclude state:new --state ./latest | grep "^calitp_warehouse\." | sed "s/calitp_warehouse\.//g" >> report.md
           echo "### DAG" >> report.md
           poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | grep "^calitp_warehouse\." | sed 's/^/--include /g' | xargs poetry run python scripts/visualize.py man --output=target/dag.png
-          echo "" >> report.md
-          echo '![](./target/dag.png "Changed models")' >> report.md
+# TODO: add these back
+#          echo "" >> report.md
+#          echo '![](./target/dag.png "Changed models")' >> report.md
       - uses: peter-evans/find-comment@v2
         if: steps.changed-files-warehouse.outputs.any_changed == 'true'
         id: fc

--- a/.github/workflows/build-dbt.yml
+++ b/.github/workflows/build-dbt.yml
@@ -75,8 +75,8 @@ jobs:
           poetry run dbt --no-use-colors ls --resource-type model --select state:new --state ./latest | grep "^calitp_warehouse\." | sed "s/calitp_warehouse\.//g" >> report.md
           echo "### Changed models 🔀" >> report.md
           poetry run dbt --no-use-colors ls --resource-type model --select state:modified --exclude state:new --state ./latest | grep "^calitp_warehouse\." | sed "s/calitp_warehouse\.//g" >> report.md
-          echo "### DAG" >> report.md
-          poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | grep "^calitp_warehouse\." | sed 's/^/--include /g' | xargs poetry run python scripts/visualize.py man --output=target/dag.png
+#          echo "### DAG" >> report.md
+#          poetry run dbt --no-use-colors ls --resource-type model --select state:modified --state ./latest | grep "^calitp_warehouse\." | sed 's/^/--include /g' | xargs poetry run python scripts/visualize.py man --output=target/dag.png
 # TODO: add these back
 #          echo "" >> report.md
 #          echo '![](./target/dag.png "Changed models")' >> report.md


### PR DESCRIPTION
# Description

Stop using CML since it's erroring and overkill anyways; use a specific action for creating/updating comments.

Brings in `max-ts-override` commits for testing.

I've temporarily disabled the actual DAG image; it's addition work to render it without CML, but I want to stop all the Action failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
CI should pass, then I'll strip out the test commits and merge.

## Screenshots (optional)
