### PR TITLE
log dbt-metabase errors and add enrichment/filepaths

### DIFF
--- a/airflow/dags/deploy_dbt_docs/sync_dbt_docs_to_metabase.yml
+++ b/airflow/dags/deploy_dbt_docs/sync_dbt_docs_to_metabase.yml
@@ -28,6 +28,8 @@ env_vars:
   DBT_DATABASE: "{{ get_project_id() }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   MB_HOST: dashboards.calitp.org
+  SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
+  SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
 
 secrets:
   - deploy_type: volume

--- a/warehouse/scripts/dbt_artifacts.py
+++ b/warehouse/scripts/dbt_artifacts.py
@@ -128,6 +128,7 @@ class BaseNode(BaseModel):
     unique_id: str
     fqn: List[str]
     path: Path
+    original_file_path: Path
     database: str
     schema_: str = Field(None, alias="schema")
     name: str

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -58,6 +58,7 @@ class DbtTestWarn(Exception):
 def get_failure_context(failure: RunResult, node: Node) -> Dict[str, Any]:
     context: Dict[str, Any] = {
         "unique_id": failure.unique_id,
+        "path": str(node.original_file_path),
     }
     if failure.unique_id.startswith("test"):
         if node.depends_on:


### PR DESCRIPTION
# Description

~I actually have mixed feelings about https://github.com/cal-itp/data-infra/issues/2362; my worry is that we don't actually know when Metabase has synced a schema. At best, we could trigger a manual sync and wait for a period of time. I don't think we can actually monitor for sync completion.~

~Actually it looks like we can use https://www.metabase.com/docs/latest/api/notify potentially~

Even better, dbt-metabase already triggers a sync and waits before attempting to update metadata.

Resolves https://github.com/cal-itp/data-infra/issues/2362

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
See [Sentry](https://sentry.calitp.org/organizations/sentry/issues/70462/?environment=development&project=2&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h) for examples

## Screenshots (optional)
