### PR TITLE
sniff csv dialects and save as metadata

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_agency_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_agency_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_areas_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_areas_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_attributions_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_attributions_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_dates_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_dates_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_attributes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_attributes_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_feed_info_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_feed_info_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_leg_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_leg_rules_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_products_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_products_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_rules_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_transfer_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_transfer_rules_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_frequencies_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_frequencies_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_levels_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_levels_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_pathways_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_pathways_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_routes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_routes_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_shapes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_shapes_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_areas_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_areas_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_times_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_times_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stops_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stops_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_transfers_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_transfers_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_translations_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_translations_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_trips_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_trips_txt_json_outcomes.yml
@@ -57,3 +57,28 @@ schema_fields:
       - *extract_config
       - name: gtfs_filename
         type: STRING
+      - name: dialect
+        type: RECORD
+        mode: NULLABLE
+        fields:
+          - name: delimiter
+            type: STRING
+            mode: NULLABLE
+          - name: doublequote
+            type: STRING
+            mode: NULLABLE
+          - name: escapechar
+            type: STRING
+            mode: NULLABLE
+          - name: lineterminator
+            type: STRING
+            mode: NULLABLE
+          - name: quotechar
+            type: STRING
+            mode: NULLABLE
+          - name: quoting
+            type: STRING
+            mode: NULLABLE
+          - name: skipinitialspace
+            type: STRING
+            mode: NULLABLE


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/2484

We'll have to run the full Schedule backfill after merging.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I copied the tab-delimited feed into test and confirmed that the file is parsed properly and we see the new dialect in the outcomes.

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/4305366/234617855-241e57ed-b311-432e-a4bc-3e84d82ce838.png)

