### PR TITLE
Add GTFS Schedule fare_media table to mart

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_media.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_media.yml
@@ -1,0 +1,20 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+source_objects:
+  - "fare_media/*.jsonl.gz"
+destination_project_dataset_table: "external_gtfs_schedule.fare_media"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  source_uri_prefix: "fare_media/{dt:DATE}/{ts:TIMESTAMP}/{base64_url:STRING}/"
+schema_fields:
+  - name: _line_number
+    mode: NULLABLE
+    type: INTEGER
+  - name: fare_media_id
+    type: STRING
+  - name: fare_media_name
+    type: STRING
+  - name: fare_media_type
+    type: STRING

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
@@ -1,0 +1,59 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+source_objects:
+  - "fare_media.txt_parsing_results/*.jsonl"
+destination_project_dataset_table: "external_gtfs_schedule.fare_media_txt_parse_outcomes"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "fare_media.txt_parsing_results/{dt:DATE}/"
+schema_fields:
+  - name: success
+    type: BOOLEAN
+  - name: exception
+    type: STRING
+  - name: feed_file
+    type: RECORD
+    fields:
+      - &filename
+        name: filename
+        type: STRING
+      - &ts
+        name: ts
+        type: TIMESTAMP
+      - &extract_config
+        name: extract_config
+        type: RECORD
+        fields:
+          - name: extracted_at
+            type: TIMESTAMP
+          - name: name
+            type: STRING
+          - name: url
+            type: STRING
+          - name: feed_type
+            type: STRING
+          - name: schedule_url_for_validation
+            type: STRING
+          - name: auth_query_params
+            type: JSON
+          - name: auth_headers
+            type: JSON
+          - name: computed
+            type: BOOLEAN
+            mode: NULLABLE
+      - name: original_filename
+        type: STRING
+  - name: fields
+    type: STRING
+    mode: REPEATED
+  - name: parsed_file
+    type: RECORD
+    fields:
+      - *filename
+      - *ts
+      - *extract_config
+      - name: gtfs_filename
+        type: STRING

--- a/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_media_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule/convert_to_json/fare_media_txt.yml
@@ -1,0 +1,5 @@
+operator: operators.GtfsGcsToJsonlOperator
+dependencies:
+  - unzip_gtfs_schedule
+
+input_table_name: fare_media.txt

--- a/warehouse/models/docs/gtfs schedule/fare_media.md
+++ b/warehouse/models/docs/gtfs schedule/fare_media.md
@@ -1,0 +1,20 @@
+Original definitions from https://gtfs.org/reference/static#fare_mediatxt
+
+{% docs gtfs_fare_media__fare_media_id %}
+Identifies a fare media.
+{% enddocs %}
+
+{% docs gtfs_fare_media__fare_media_name %}
+Name of the fare media.
+
+For fare media which are transit cards (fare_media_type =2) or mobile apps (fare_media_type =4), the fare_media_name should be included and should match the rider-facing name used by the organizations delivering them.
+{% enddocs %}
+
+{% docs gtfs_fare_media__fare_media_type %}
+The type of fare media. Valid options are:
+
+0 - None. Used when there is no fare media involved in purchasing or validating a fare product, such as paying cash to a driver or conductor with no physical ticket provided.
+2 - Physical transit card that has stored tickets, passes or monetary value.
+3 - cEMV (contactless Europay, Mastercard and Visa) as an open-loop token container for account-based ticketing.
+4 - Mobile app that have stored virtual transit cards, tickets, passes, or monetary value.
+{% enddocs %}

--- a/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
@@ -231,12 +231,14 @@ models:
       Definitions for the original GTFS fields are available at:
       https://gtfs.org/schedule/reference/#fare_mediatxt.
     columns:
+      - name: key
+        description: |
+          Synthetic primary key constructed from `feed_key` and `fare_media_id`.
+        tests: *pk_tests_with_dups
       - *feed_key
       - *base64_url
       - name: fare_media_id
         description: '{{ doc("gtfs_fare_media__fare_media_id") }}'
-        tests:
-          - unique
       - name: fare_media_name
         description: '{{ doc("gtfs_fare_media__fare_media_name") }}'
       - name: fare_media_type

--- a/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
@@ -225,6 +225,25 @@ models:
       - *_feed_valid_from
       - *feed_timezone_no_tests
 
+  - name: dim_fare_media
+    description: |
+      Each row is a cleaned row from a fare_media.txt file.
+      Definitions for the original GTFS fields are available at:
+      https://gtfs.org/schedule/reference/#fare_mediatxt.
+    columns:
+      - *feed_key
+      - *base64_url
+      - name: fare_media_id
+        description: '{{ doc("gtfs_fare_media__fare_media_id") }}'
+        tests:
+          - unique
+      - name: fare_media_name
+        description: '{{ doc("gtfs_fare_media__fare_media_name") }}'
+      - name: fare_media_type
+        description: '{{ doc("gtfs_fare_media__fare_media_type") }}'
+      - *_feed_valid_from
+      - *feed_timezone_no_tests
+
   - name: dim_fare_products
     description: |
       Each row is a cleaned row from a fare_products.txt file.

--- a/warehouse/models/mart/gtfs/dim_fare_media.sql
+++ b/warehouse/models/mart/gtfs/dim_fare_media.sql
@@ -1,0 +1,21 @@
+WITH make_dim AS (
+    {{ make_schedule_file_dimension_from_dim_schedule_feeds(
+        ref('dim_schedule_feeds'),
+        ref('stg_gtfs_schedule__fare_media'),
+    ) }}
+),
+
+dim_fare_media AS (
+    SELECT
+        {{ dbt_utils.generate_surrogate_key(['feed_key', 'fare_media_id']) }} AS key,
+        feed_key,
+        base64_url,
+        fare_media_id,
+        fare_media_name,
+        fare_media_type,
+        _feed_valid_from,
+        feed_timezone,
+    FROM make_dim
+)
+
+SELECT * FROM dim_fare_media

--- a/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
+++ b/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
@@ -29,6 +29,7 @@ sources:
       - name: fare_attributes
       - name: fare_attributes_txt_parse_outcomes
       - name: fare_leg_rules
+      - name: fare_media
       - name: fare_leg_rules_txt_parse_outcomes
       - name: fare_products
       - name: fare_products_txt_parse_outcomes

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_media.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_media.sql
@@ -1,0 +1,22 @@
+WITH external_fare_media AS (
+    SELECT *
+    FROM {{ source('external_gtfs_schedule', 'fare_media') }}
+),
+
+stg_gtfs_schedule__fare_media AS (
+
+    -- Trim all string fields
+    -- Incoming schema explicitly defined in gtfs_schedule_history external table definition
+
+    SELECT
+        base64_url,
+        ts,
+        dt AS _dt,
+        {{ trim_make_empty_string_null('fare_media_id') }} AS fare_media_id,
+        {{ trim_make_empty_string_null('fare_media_name') }} AS fare_media_name,
+        {{ trim_make_empty_string_null('fare_media_type') }} AS fare_media_type
+
+    FROM external_fare_media
+)
+
+SELECT * FROM stg_gtfs_schedule__fare_media


### PR DESCRIPTION
# Description

This PR adds processing for the GTFS Schedule fare_media table, recently added to the GTFS spec and beginning to show up in a handful of feeds. We are already receiving raw fare_media.txt files, so this takes the steps necessary to bring the received data into the warehouse alongside other GTFS schedule data.

Resolves #2414

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

New Airflow jobs tested locally writing to/from test tables in the staging environment, and all new dbt jobs run locally writing into the staging warehouse.