### PR TITLE
point external Schedule tables at new hourly buckets with new hive schema

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/agency.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/agency.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "agency/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.agency"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/areas.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/areas.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "areas/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.areas"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/attributions.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/attributions.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "attributions/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.attributions"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "calendar/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.calendar"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar_dates.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/calendar_dates.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "calendar_dates/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.calendar_dates"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_attributes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_attributes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_attributes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.fare_attributes"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_leg_rules.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_leg_rules.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_leg_rules/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.fare_leg_rules"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_media.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_media.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_media/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.fare_media"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_products.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_products.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_products/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.fare_products"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_rules.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_rules.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_rules/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.fare_rules"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_transfer_rules.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_transfer_rules.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_transfer_rules/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.fare_transfer_rules"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/feed_info.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/feed_info.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "feed_info/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.feed_info"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/frequencies.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/frequencies.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "frequencies/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.frequencies"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_agency_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_agency_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "agency.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.agency_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "agency.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "agency.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_areas_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_areas_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "areas.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.areas_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "areas.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "areas.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_attributions_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_attributions_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "attributions.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.attributions_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "attributions.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "attributions.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_dates_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_dates_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "calendar_dates.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.calendar_dates_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "calendar_dates.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "calendar_dates.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_calendar_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "calendar.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.calendar_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "calendar.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "calendar.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_attributes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_attributes_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_attributes.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.fare_attributes_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "fare_attributes.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "fare_attributes.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_feed_info_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_feed_info_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "feed_info.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.feed_info_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "feed_info.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "feed_info.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_leg_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_leg_rules_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_leg_rules.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.fare_leg_rules_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "fare_leg_rules.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "fare_leg_rules.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_media.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.fare_media_txt_parse_outcomes"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_products_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_products_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_products.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.fare_products_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "fare_products.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "fare_products.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_rules_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_rules.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.fare_rules_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "fare_rules.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "fare_rules.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_transfer_rules_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_transfer_rules_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "fare_transfer_rules.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.fare_transfer_rules_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "fare_transfer_rules.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "fare_transfer_rules.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_frequencies_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_frequencies_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "frequencies.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.frequencies_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "frequencies.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "frequencies.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_levels_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_levels_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "levels.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.levels_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "levels.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "levels.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_pathways_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_pathways_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "pathways.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.pathways_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "pathways.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "pathways.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_routes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_routes_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "routes.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.routes_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "routes.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "routes.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_shapes_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_shapes_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "shapes.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.shapes_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "shapes.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "shapes.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_areas_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_areas_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "stop_areas.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.stop_areas_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "stop_areas.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "stop_areas.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_times_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stop_times_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "stop_times.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.stop_times_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "stop_times.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "stop_times.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stops_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_stops_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "stops.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.stops_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "stops.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "stops.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_transfers_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_transfers_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "transfers.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.transfers_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "transfers.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "transfers.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_translations_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_translations_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "translations.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.translations_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "translations.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "translations.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_trips_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_trips_txt_json_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "trips.txt_parsing_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.trips_txt_parse_outcomes"
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "trips.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "trips.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_unzip_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_unzip_outcomes.yml
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "unzipping_results/{dt:DATE}/"
+  source_uri_prefix: "unzipping_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_unzip_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_unzip_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED_HOURLY') }}"
 source_objects:
   - "unzipping_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.unzip_outcomes"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_validations_outcomes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY') }}"
 source_objects:
   - "validation_job_results/*.jsonl"
 destination_project_dataset_table: "external_gtfs_schedule.validations_outcomes"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_validations_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_validations_outcomes.yml
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "validation_job_results/{dt:DATE}/"
+  source_uri_prefix: "validation_job_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/levels.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/levels.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "levels/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.levels"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/pathways.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/pathways.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "pathways/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.pathways"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/routes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/routes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "routes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.routes"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/shapes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/shapes.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "shapes/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.shapes"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_areas.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_areas.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "stop_areas/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.stop_areas"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_times.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/stop_times.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "stop_times/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.stop_times"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/stops.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/stops.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "stops/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.stops"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/transfers.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/transfers.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "transfers/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.transfers"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/translations.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/translations.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "translations/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.translations"

--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/trips.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/trips.yml
@@ -1,5 +1,5 @@
 operator: operators.ExternalTable
-bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED') }}"
+bucket: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY') }}"
 source_objects:
   - "trips/*.jsonl.gz"
 destination_project_dataset_table: "external_gtfs_schedule.trips"

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -26,7 +26,7 @@ vars:
   GTFS_SCHEDULE_START: '2021-04-16'
   PROD_GTFS_RT_START: '2022-09-15'
   'dbt_date:time_zone': 'America/Los_Angeles'
-  SOURCE_DATABASE: cal-itp-data-infra
+  SOURCE_DATABASE: cal-itp-data-infra # you can override with exported DBT_SOURCE_DATABASE rather than constantly using --vars
 
 models:
   calitp_warehouse:

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -26,7 +26,7 @@ vars:
   GTFS_SCHEDULE_START: '2021-04-16'
   PROD_GTFS_RT_START: '2022-09-15'
   'dbt_date:time_zone': 'America/Los_Angeles'
-  SOURCE_DATABASE: cal-itp-data-infra # you can override with exported DBT_SOURCE_DATABASE rather than constantly using --vars
+  SOURCE_DATABASE: cal-itp-data-infra # you can override with DBT_SOURCE_DATABASE env var rather than constantly using --vars
 
 models:
   calitp_warehouse:

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -26,7 +26,7 @@ vars:
   GTFS_SCHEDULE_START: '2021-04-16'
   PROD_GTFS_RT_START: '2022-09-15'
   'dbt_date:time_zone': 'America/Los_Angeles'
-  DEFAULT_SOURCE_DATABASE: cal-itp-data-infra
+  SOURCE_DATABASE: cal-itp-data-infra
 
 models:
   calitp_warehouse:

--- a/warehouse/models/_source_gtfs_schedule_history.yml
+++ b/warehouse/models/_source_gtfs_schedule_history.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: gtfs_schedule_history
     description: Data in the gtfs_schedule_history dataset in BigQuery
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: gtfs_schedule_history
     tables:
       - name: calitp_feed_parse_result

--- a/warehouse/models/benefits/_amplitude.yml
+++ b/warehouse/models/benefits/_amplitude.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: legacy_amplitude
     description: Data exported from Amplitude, using an Airflow DAG.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: amplitude
     tables:
       - name: benefits_events

--- a/warehouse/models/gtfs_views_staging/_gtfs_views_staging.yml
+++ b/warehouse/models/gtfs_views_staging/_gtfs_views_staging.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: gtfs_type2
     description: Data in the gtfs_schedule_type2 dataset in BigQuery
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: gtfs_schedule_type2
     loaded_at_field: CAST(calitp_extracted_at AS TIMESTAMP)
     freshness:

--- a/warehouse/models/payments_views_staging/_payments_source.yml
+++ b/warehouse/models/payments_views_staging/_payments_source.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: payments
     description: Source data from Littlepay data feeds
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: payments
     tables:
       - name: authorisations

--- a/warehouse/models/rt_views/_rt_views.yml
+++ b/warehouse/models/rt_views/_rt_views.yml
@@ -4,7 +4,7 @@ sources:
     # note: these tables should probably be moved at some point
   - name: gtfs_rt_raw
     description: Data in the gtfs_rt dataset in BigQuery, generally produced by the rt_loader and rt_loader_files Airflow DAGs.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: gtfs_rt
     tables:
       - name: calitp_files
@@ -18,7 +18,7 @@ sources:
 
   - name: gtfs_rt_logs
     description: Data in the gtfs_rt_logs dataset in BigQuery, from logs sink.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: gtfs_rt_logs
     tables:
       - name: stdout

--- a/warehouse/models/staging/amplitude/_amplitude.yml
+++ b/warehouse/models/staging/amplitude/_amplitude.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: amplitude
     description: Data exported from Amplitude's Data Destination.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_amplitude
     tables:
       - name: benefits_events

--- a/warehouse/models/staging/audit/_src_audit.yml
+++ b/warehouse/models/staging/audit/_src_audit.yml
@@ -5,11 +5,11 @@ version: 2
 
 sources:
   - name: cloudaudit
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: audit
 
   - name: information_schema
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     # this schema is queried as `region-us`.information_schema
     schema: information_schema
     tables:

--- a/warehouse/models/staging/gtfs/_src_gtfs_rt_external_tables.yml
+++ b/warehouse/models/staging/gtfs/_src_gtfs_rt_external_tables.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_gtfs_rt
     description: Hive-partitioned external tables reading GTFS RT data and validation errors from GCS.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_gtfs_rt_v2
     tables:
       - name: service_alerts

--- a/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
+++ b/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
@@ -4,14 +4,14 @@ sources:
   - name: feed_aggregator_scrapes
     description: |
       URLs scraped at moments in time from various feed aggregators.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_feed_aggregator
     tables:
       - name: scraped_urls
 
   - name: external_gtfs_schedule
     description: Hive-partitioned external tables reading GTFS schedule data and validation errors from GCS.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_gtfs_schedule
     tables:
       - name: download_outcomes

--- a/warehouse/models/staging/hqta/_hqta.yml
+++ b/warehouse/models/staging/hqta/_hqta.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: hqta_external_tables
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_hqta
     tables:
       - name: areas

--- a/warehouse/models/staging/ntd/_src.yml
+++ b/warehouse/models/staging/ntd/_src.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: ntd_data_products
     description: Data sets loaded from NTD Data Reports https://www.transit.dot.gov/ntd/ntd-data.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_ntd_data_products
     tables:
       - name: annual_database_agency_information

--- a/warehouse/models/staging/payments/elavon/_elavon.yml
+++ b/warehouse/models/staging/payments/elavon/_elavon.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: elavon_external_tables
     description: Hive-partitioned external tables reading Elavon transactions from GCS.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_elavon
     tables:
       - name: transactions

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_littlepay
     description: Hive-partitioned external tables reading Littlepay payments data.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_littlepay
     tables:
       - name: authorisations

--- a/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
+++ b/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: gtfs_rt_external_tables
     description: Hive-partitioned external tables reading GTFS RT data and validation errors from GCS.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_gtfs_rt
     tables:
       - name: service_alerts
@@ -23,7 +23,7 @@ sources:
       - name: vehicle_positions_validations_outcomes
   - name: sentry_external_tables
     description: Hive-partitioned external tables reading Sentry events from GCS.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_sentry
     tables:
       - name: events

--- a/warehouse/models/staging/transit_database/_src_airtable.yml
+++ b/warehouse/models/staging/transit_database/_src_airtable.yml
@@ -4,7 +4,7 @@ sources:
   - name: airtable
     description: |
       Data from Airtable.
-    database: "{{ env_var('CALITP_DBT_SOURCE_DATABASE', var('DEFAULT_SOURCE_DATABASE')) }}"
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
     schema: external_airtable
     tables:
       - name: california_transit__county_geography


### PR DESCRIPTION
# Description

Should only merge after https://github.com/cal-itp/data-infra/pull/2523 is merged and the backfill is done.

This will address some Sentry issues (dbt errors / failures) that are caused by timing issues:
Fixes CAL-ITP-DATA-INFRA-24AT
Fixes CAL-ITP-DATA-INFRA-25CC

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
