### PR TITLE
only do sentry releases on main

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
-    branches:
-      - 'main'
 
 jobs:
   release:
@@ -29,4 +26,4 @@ jobs:
           SENTRY_PROJECT: cal-itp-data-infra
           SENTRY_URL: https://sentry.calitp.org
         with:
-          environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cal-itp-data-infra' || 'test'  }}
+          environment: cal-itp-data-infra


### PR DESCRIPTION
# Description

Now that the action has been tested, we can only run on main merges (we don't really "deploy" to test anyways).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?

## Screenshots (optional)
