### PR TITLE
Add fare_media_id to fare_products table + update related docs

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_products.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/fare_products.yml
@@ -16,6 +16,8 @@ schema_fields:
     type: STRING
   - name: fare_product_name
     type: STRING
+  - name: fare_media_id
+    type: STRING
   - name: amount
     type: STRING
   - name: currency

--- a/warehouse/models/docs/gtfs schedule/fare_products.md
+++ b/warehouse/models/docs/gtfs schedule/fare_products.md
@@ -8,6 +8,10 @@ Identifies a fare product.
 The name of the fare product as displayed to riders.
 {% enddocs %}
 
+{% docs gtfs_fare_products__fare_media_id %}
+Identifies a fare media that can be employed to use the fare product during the trip. When fare_media_id is empty, it is considered that the fare media is unknown.
+{% enddocs %}
+
 {% docs gtfs_fare_products__amount %}
 The cost of the fare product. May be negative to represent transfer discounts. May be zero to represent a fare product that is free.
 {% enddocs %}

--- a/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
@@ -263,6 +263,8 @@ models:
         tests: *not_null_error
       - name: fare_product_name
         description: '{{ doc("gtfs_fare_products__fare_product_name") }}'
+      - name: fare_media_id
+        description: '{{ doc("gtfs_fare_products__fare_media_id") }}'
       - name: amount
         description: '{{ doc("gtfs_fare_products__amount") }}'
         tests: *not_null_warn_99_threshold

--- a/warehouse/models/mart/gtfs/dim_fare_products.sql
+++ b/warehouse/models/mart/gtfs/dim_fare_products.sql
@@ -23,6 +23,7 @@ dim_fare_products AS (
         feed_key,
         fare_product_id,
         fare_product_name,
+        fare_media_id,
         amount,
         currency,
         COALESCE(warning_duplicate_primary_key, FALSE) AS warning_duplicate_primary_key,

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -236,6 +236,19 @@ models:
         description: '{{ doc("gtfs_fare_leg_rules__to_area_id") }}'
       - name: fare_product_id
         description: '{{ doc("gtfs_fare_leg_rules__fare_product_id") }}'
+  - name: stg_gtfs_schedule_fare_media
+    description: |
+      Cleaned GTFS schedule fare media data.
+      See https://gtfs.org/schedule/reference/#fare_mediatxt for specification.
+    columns:
+      - name: base64_url
+      - name: ts
+      - name: fare_media_id
+        description: '{{ doc("gtfs_fare_media__fare_media_id") }}'
+      - name: fare_media_name
+        description: '{{ doc("gtfs_fare_media__fare_media_name") }}'
+      - name: fare_media_type
+        description: '{{ doc("gtfs_fare_media__fare_media_type") }}'
   - name: stg_gtfs_schedule__fare_products
     description: |
       Cleaned GTFS schedule fare products data.
@@ -247,6 +260,8 @@ models:
         description: '{{ doc("gtfs_fare_products__fare_product_id") }}'
       - name: fare_product_name
         description: '{{ doc("gtfs_fare_products__fare_product_name") }}'
+      - name: fare_media_id
+        description: '{{ doc("gtfs_fare_products__fare_media_id") }}'
       - name: amount
         description: '{{ doc("gtfs_fare_products__amount") }}'
       - name: currency

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_products.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_products.sql
@@ -14,6 +14,7 @@ stg_gtfs_schedule__fare_products AS (
         dt AS _dt,
         {{ trim_make_empty_string_null('fare_product_id') }} AS fare_product_id,
         {{ trim_make_empty_string_null('fare_product_name') }} AS fare_product_name,
+        {{ trim_make_empty_string_null('fare_media_id') }} AS fare_media_id,
         SAFE_CAST({{ trim_make_empty_string_null('amount') }} AS NUMERIC) AS amount,
         {{ trim_make_empty_string_null('currency') }} AS currency
     FROM external_fare_products


### PR DESCRIPTION
# Description

We recently added the new `fare_media` table to the warehouse `mart_` tables in #2509. This PR adds the newly implemented `fare_media_id` field in the preexisting `fare_products` table, and updates the YAML for GTFS schedule staging tables to include information about `stg_gtfs_schedule__fare_products`, documentation which was missed in the previous PR.

Resolves #2432

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?

External table successfully updated in staging, and dbt tests run on the staging external table