### PR TITLE
RT fingerprint adjustments

### DIFF
--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '2023.4.3'
+  newTag: '2023.4.28'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -14,4 +14,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver'
-  newTag: '2023.4.3'
+  newTag: '2023.4.28'

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -25,11 +25,14 @@ def set_exception_fingerprint(event, hint):
 
     exception = hint["exc_info"][1]
     if isinstance(exception, RTFetchException):
+        # strip out 511 agency ids, since the same outage often affects all of them
         cleaned_url = re.sub(
-            r"agency=\w+$", str(exception.url), "agency=XYZ"
-        )  # strip out 511 agency ids, since the same outage often affects all of them
+            pattern=r"agency=\w+$",
+            repl="agency=XYZ",
+            string=str(exception.url),
+        )
+        # use just the type to avoid differentiating based on underlying exceptions as well as object hashes in exception strings
         event["fingerprint"] = [
-            # use just the type to avoid differentiating based on underlying exceptions as well as object hashes in exception strings
             type(exception.cause).__name__,
             cleaned_url,
         ]

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -29,9 +29,8 @@ def set_exception_fingerprint(event, hint):
             r"agency=\w+$", str(exception.url), "agency=XYZ"
         )  # strip out 511 agency ids, since the same outage often affects all of them
         event["fingerprint"] = [
-            type(
-                exception
-            ),  # use just the type to avoid differentiating based on underlying exceptions as well as object hashes in exception strings
+            # use just the type to avoid differentiating based on underlying exceptions as well as object hashes in exception strings
+            type(exception.cause).__name__,
             cleaned_url,
         ]
         if exception.status_code:

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -28,7 +28,7 @@ def set_exception_fingerprint(event, hint):
         # strip out 511 agency ids, since the same outage often affects all of them
         cleaned_url = re.sub(
             pattern=r"agency=\w+$",
-            repl="agency=XYZ",
+            repl="agency=<hidden from fingerprint>",
             string=str(exception.url),
         )
         # use just the type to avoid differentiating based on underlying exceptions as well as object hashes in exception strings

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -25,12 +25,14 @@ def set_exception_fingerprint(event, hint):
 
     exception = hint["exc_info"][1]
     if isinstance(exception, RTFetchException):
+        cleaned_url = re.sub(
+            r"agency=\w+$", str(exception.url), "agency=XYZ"
+        )  # strip out 511 agency ids, since the same outage often affects all of them
         event["fingerprint"] = [
-            # this is ugly but it's the easiest way to quickly remove the object location hex from the fingerprint
-            # without actually messing with the exception chain;
-            # safety net for exceptions that contain a default object str()
-            compiled_regex.sub("0x...", str(exception)),
-            str(exception.url),
+            type(
+                exception
+            ),  # use just the type to avoid differentiating based on underlying exceptions as well as object hashes in exception strings
+            cleaned_url,
         ]
         if exception.status_code:
             event["fingerprint"].append(str(exception.status_code))

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py
@@ -14,6 +14,7 @@ from calitp_data_infra.storage import GTFSDownloadConfig, download_feed  # type:
 from google.cloud import storage  # type: ignore
 from huey import RedisHuey  # type: ignore
 from huey.api import Task  # type: ignore
+from pydantic.networks import HttpUrl
 from requests import HTTPError, RequestException
 
 from .metrics import (
@@ -54,14 +55,22 @@ base_logger = structlog.get_logger()
 
 
 class RTFetchException(Exception):
-    def __init__(self, url, cause, status_code=None):
+    def __init__(
+        self, url: HttpUrl, cause: Exception, status_code: Optional[int] = None
+    ):
         self.url = url
         self.cause = cause
         self.status_code = status_code
         super().__init__(str(self.cause))
 
-    def __str__(self):
-        return f"{self.cause} ({self.url})"
+    def __str__(self) -> str:
+        return " ".join(
+            [
+                type(self.cause).__name__,
+                f"({self.status_code})" if self.status_code else "",
+                f"{self.url}",
+            ]
+        )
 
 
 @huey.signal()

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "2023.4.3"
+version = "2023.4.28"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/2478

1. Get the top-level exception type for the fingerprint; avoids object hashes in (potentially very nested) exception bodies
2. Strips agency query params from end of URL (to combine 511 issues)

I've also added masking in the [Sentry UI](https://sentry.calitp.org/settings/sentry/security-and-privacy/) but it doesn't seem to be entirely working yet.

fixes CAL-ITP-DATA-INFRA-24S9

(testing that)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
Deployed to test now.

See [this issue](https://sentry.calitp.org/organizations/sentry/issues/70957/?environment=development&project=2&query=is%3Aunresolved&referrer=issue-stream) as an example of a new issue with the updated exception body and the 511 change.

## Screenshots (optional)
