### PR TITLE
Fix broken elavon/ littlepay transaction history comparison table

### DIFF
--- a/warehouse/models/mart/payments/elavon_littlepay__daily_history_transactions_deposits_billing.sql
+++ b/warehouse/models/mart/payments/elavon_littlepay__daily_history_transactions_deposits_billing.sql
@@ -40,7 +40,7 @@ littlepay_deposits_agg AS (
     GROUP BY transaction_date_pacific, participant_id
 ),
 
-elavon_littlepay__daily_history_transactions_deposits_billing.sql AS (
+elavon_littlepay__daily_history_transactions_deposits_billing AS (
 
     SELECT
 
@@ -57,4 +57,4 @@ elavon_littlepay__daily_history_transactions_deposits_billing.sql AS (
         ON (t1.day_history = t3.payment_date) AND (t1.participant_id = t3.participant_id)
 )
 
-SELECT *  FROM elavon_littlepay__daily_history_transactions_deposits_billing.sql
+SELECT *  FROM elavon_littlepay__daily_history_transactions_deposits_billing


### PR DESCRIPTION
# Description
In #2482 the table `elavon_littlepay__daily_history_transactions_deposits_billing` had a breaking character causing the dbt run to fail

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Locally with `dbt run`