### PR TITLE
Update PR template to include post-merge actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,7 @@
 # Description
+_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._
 
-Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies.
-
-Resolves # [issue]
+Resolves #[issue]
 
 ## Type of change
 
@@ -10,8 +9,8 @@ Resolves # [issue]
 - [ ] New feature
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation
-- [ ] agencies.yml
 
 ## How has this been tested?
 
-## Screenshots (optional)
+## Post-merge follow-ups
+_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR. If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@ Resolves #[issue]
 - [ ] Documentation
 
 ## How has this been tested?
+_Include commands/logs/screenshots as relevant._
 
 ## Post-merge follow-ups
 _Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,7 @@ Resolves #[issue]
 ## How has this been tested?
 
 ## Post-merge follow-ups
-_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR. If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._
+_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._
+
+- [ ] No action required
+- [ ] Actions required (specified below)


### PR DESCRIPTION
# Description

I've noticed an increasing number of PRs that require some kind of additional post-merge action (for example, running a full refresh of a given model, or running a backfill of some kind, or perhaps merging another PR in a related repo). I wanted to create a place to record such requirements in a standardized way.

Also, I am removing the `screenshots` section since it is not regularly used and deprecating the `agencies.yml` PR type since we no longer regularly update agencies.yml. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] agencies.yml

## How has this been tested?
N/A
