### PR TITLE
New column names for quality tables

### DIFF
--- a/docs/analytics_tools/rt_analysis.md
+++ b/docs/analytics_tools/rt_analysis.md
@@ -28,7 +28,7 @@ This section includes detailed information about the data model and processing s
 
 All of the above are sourced from the v2 warehouse. Note that all components must be present and consistently keyed in order to successfully analyze. This module works at the organization level in order to match the reports site and maintain the structure of the speedmap site.
 
-For each organization, this module will combine and analyze all related GTFS Schedule and GTFS Realtime datasets that are `reports_site_assessed` in [`dim_provider_gtfs_data`](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_provider_gtfs_data). Some organizations share GTFS datasets (Sacramento RT and City of Rancho Cordova, San Diego Airport and San Diego MTS...), in those cases the module can generate seperate analysis for each organization but they might duplicate each other. These are based on the underlying organization/dataset relationships in the Transit Database (Airtable).
+For each organization, this module will combine and analyze all related GTFS Schedule and GTFS Realtime datasets that are `public_customer_facing_or_regional_subfeed` in [`dim_provider_gtfs_data`](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_provider_gtfs_data). Some organizations share GTFS datasets (Sacramento RT and City of Rancho Cordova, San Diego Airport and San Diego MTS...), in those cases the module can generate seperate analysis for each organization but they might duplicate each other. These are based on the underlying organization/dataset relationships in the Transit Database (Airtable).
 
 ### How is it structured?
 

--- a/docs/analytics_tools/rt_analysis.md
+++ b/docs/analytics_tools/rt_analysis.md
@@ -28,7 +28,7 @@ This section includes detailed information about the data model and processing s
 
 All of the above are sourced from the v2 warehouse. Note that all components must be present and consistently keyed in order to successfully analyze. This module works at the organization level in order to match the reports site and maintain the structure of the speedmap site.
 
-For each organization, this module will combine and analyze all related GTFS Schedule and GTFS Realtime datasets that are `public_customer_facing_or_regional_subfeed` in [`dim_provider_gtfs_data`](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_provider_gtfs_data). Some organizations share GTFS datasets (Sacramento RT and City of Rancho Cordova, San Diego Airport and San Diego MTS...), in those cases the module can generate seperate analysis for each organization but they might duplicate each other. These are based on the underlying organization/dataset relationships in the Transit Database (Airtable).
+For each organization, this module will combine and analyze all related GTFS Schedule and GTFS Realtime datasets that are `public_customer_facing_or_regional_subfeed_fixed_route` in [`dim_provider_gtfs_data`](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_provider_gtfs_data). Some organizations share GTFS datasets (Sacramento RT and City of Rancho Cordova, San Diego Airport and San Diego MTS...), in those cases the module can generate seperate analysis for each organization but they might duplicate each other. These are based on the underlying organization/dataset relationships in the Transit Database (Airtable).
 
 ### How is it structured?
 

--- a/warehouse/models/intermediate/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs_quality/_int_gtfs_quality.yml
@@ -269,14 +269,14 @@ models:
       - name: service_name
       - name: gtfs_dataset_name
       - name: gtfs_dataset_type
-      - name: public_customer_facing
+      - name: public_customer_facing_fixed_route
         description: |
           Boolean indicator for whether this combined entity met the criteria to be "assessed"
           against the GTFS guidelines on the given date. Applies "and" logic to `organization_assessed`, `service_assessed`,
           and `gtfs_service_data_assessed`.
-      - name: public_customer_facing_or_regional_subfeed
+      - name: public_customer_facing_or_regional_subfeed_fixed_route
         description: |
-          Similar to `public_customer_facing` except:
+          Similar to `public_customer_facing_fixed_route` except:
           * For entities associated with MTC 511, use the regional subfeed instead of the combined regional feed;
             i.e., for organization/services where the MTC combined regional feed is the customer-facing feed and
             "assessed" for guideline purposes, this feed will mark the associated regional subfeed (rather than the combined feed)

--- a/warehouse/models/intermediate/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs_quality/_int_gtfs_quality.yml
@@ -269,14 +269,14 @@ models:
       - name: service_name
       - name: gtfs_dataset_name
       - name: gtfs_dataset_type
-      - name: guidelines_assessed
+      - name: public_customer_facing
         description: |
           Boolean indicator for whether this combined entity met the criteria to be "assessed"
           against the GTFS guidelines on the given date. Applies "and" logic to `organization_assessed`, `service_assessed`,
           and `gtfs_service_data_assessed`.
-      - name: reports_site_assessed
+      - name: public_customer_facing_or_regional_subfeed
         description: |
-          Similar to `guidelines_assessed` except:
+          Similar to `public_customer_facing` except:
           * For entities associated with MTC 511, use the regional subfeed instead of the combined regional feed;
             i.e., for organization/services where the MTC combined regional feed is the customer-facing feed and
             "assessed" for guideline purposes, this feed will mark the associated regional subfeed (rather than the combined feed)

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
@@ -122,7 +122,7 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
         gtfs_service_data_source_record_id,
         gtfs_dataset_source_record_id,
 
-        assessed AS public_customer_facing,
+        assessed AS public_customer_facing_fixed_route,
         CASE
             -- can only generate reports if ITP ID is present
             WHEN organization_itp_id IS NULL THEN FALSE
@@ -139,7 +139,7 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
                 AND assessed
                 AND gtfs_dataset_source_record_id NOT IN
                 ('rec9AyXUSMUHFnLsH', 'recAQiomSPtajnjLy', 'rec2jN0CkL8noOYIr', 'rec2jN0CkL8noOYIr', 'recAfxxeJWxHexo6e')
-        END AS public_customer_facing_or_regional_subfeed,
+        END AS public_customer_facing_or_regional_subfeed_fixed_route,
         organization_assessed,
         service_assessed,
         gtfs_service_data_assessed,

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__daily_assessment_candidate_entities.sql
@@ -122,7 +122,7 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
         gtfs_service_data_source_record_id,
         gtfs_dataset_source_record_id,
 
-        assessed AS guidelines_assessed,
+        assessed AS public_customer_facing,
         CASE
             -- can only generate reports if ITP ID is present
             WHEN organization_itp_id IS NULL THEN FALSE
@@ -139,7 +139,7 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
                 AND assessed
                 AND gtfs_dataset_source_record_id NOT IN
                 ('rec9AyXUSMUHFnLsH', 'recAQiomSPtajnjLy', 'rec2jN0CkL8noOYIr', 'rec2jN0CkL8noOYIr', 'recAfxxeJWxHexo6e')
-        END AS reports_site_assessed,
+        END AS public_customer_facing_or_regional_subfeed,
         organization_assessed,
         service_assessed,
         gtfs_service_data_assessed,

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_index.sql
@@ -27,8 +27,8 @@ cross_join AS (
         gtfs_service_data_source_record_id,
         gtfs_dataset_source_record_id,
 
-        guidelines_assessed,
-        reports_site_assessed,
+        public_customer_facing,
+        public_customer_facing_or_regional_subfeed,
         organization_assessed,
         service_assessed,
         gtfs_service_data_assessed,
@@ -97,8 +97,8 @@ int_gtfs_quality__guideline_checks_index AS (
         gtfs_service_data_source_record_id,
         gtfs_dataset_source_record_id,
 
-        guidelines_assessed,
-        reports_site_assessed,
+        public_customer_facing,
+        public_customer_facing_or_regional_subfeed,
         organization_assessed,
         service_assessed,
         gtfs_service_data_assessed,

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_index.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_index.sql
@@ -27,8 +27,8 @@ cross_join AS (
         gtfs_service_data_source_record_id,
         gtfs_dataset_source_record_id,
 
-        public_customer_facing,
-        public_customer_facing_or_regional_subfeed,
+        public_customer_facing_fixed_route,
+        public_customer_facing_or_regional_subfeed_fixed_route,
         organization_assessed,
         service_assessed,
         gtfs_service_data_assessed,
@@ -97,8 +97,8 @@ int_gtfs_quality__guideline_checks_index AS (
         gtfs_service_data_source_record_id,
         gtfs_dataset_source_record_id,
 
-        public_customer_facing,
-        public_customer_facing_or_regional_subfeed,
+        public_customer_facing_fixed_route,
+        public_customer_facing_or_regional_subfeed_fixed_route,
         organization_assessed,
         service_assessed,
         gtfs_service_data_assessed,

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__organization_dataset_map.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__organization_dataset_map.sql
@@ -21,8 +21,8 @@ int_gtfs_quality__organization_dataset_map AS (
         base64_url,
         schedule_feed_key,
         LOGICAL_OR(gtfs_service_data_customer_facing) AS gtfs_service_data_customer_facing,
-        LOGICAL_OR(public_customer_facing) AS public_customer_facing,
-        LOGICAL_OR(public_customer_facing_or_regional_subfeed) AS public_customer_facing_or_regional_subfeed
+        LOGICAL_OR(public_customer_facing_fixed_route) AS public_customer_facing_fixed_route,
+        LOGICAL_OR(public_customer_facing_or_regional_subfeed_fixed_route) AS public_customer_facing_or_regional_subfeed_fixed_route
     FROM int_gtfs_quality__daily_assessment_candidate_entities
     -- TODO: maybe we can/should make this an AND? not sure if having rows where one is null is useful
     WHERE COALESCE(organization_key, gtfs_dataset_key) IS NOT NULL

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__organization_dataset_map.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__organization_dataset_map.sql
@@ -21,8 +21,8 @@ int_gtfs_quality__organization_dataset_map AS (
         base64_url,
         schedule_feed_key,
         LOGICAL_OR(gtfs_service_data_customer_facing) AS gtfs_service_data_customer_facing,
-        LOGICAL_OR(guidelines_assessed) AS guidelines_assessed,
-        LOGICAL_OR(reports_site_assessed) AS reports_site_assessed
+        LOGICAL_OR(public_customer_facing) AS public_customer_facing,
+        LOGICAL_OR(public_customer_facing_or_regional_subfeed) AS public_customer_facing_or_regional_subfeed
     FROM int_gtfs_quality__daily_assessment_candidate_entities
     -- TODO: maybe we can/should make this an AND? not sure if having rows where one is null is useful
     WHERE COALESCE(organization_key, gtfs_dataset_key) IS NOT NULL

--- a/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
@@ -3,7 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
-    WHERE organization_key IS NOT NULL AND guidelines_assessed
+    WHERE organization_key IS NOT NULL AND public_customer_facing
 ),
 
 fct_daily_organization_combined_guideline_checks AS (

--- a/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
@@ -3,7 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
-    WHERE organization_key IS NOT NULL AND public_customer_facing
+    WHERE organization_key IS NOT NULL AND public_customer_facing_fixed_route
 ),
 
 fct_daily_organization_combined_guideline_checks AS (

--- a/warehouse/models/mart/gtfs_quality/fct_daily_reports_site_organization_scheduled_service_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_reports_site_organization_scheduled_service_summary.sql
@@ -11,7 +11,7 @@ int_gtfs__organization_dataset_map AS (
 
     SELECT *
     FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE reports_site_assessed
+    WHERE public_customer_facing_or_regional_subfeed
 
 ),
 

--- a/warehouse/models/mart/gtfs_quality/fct_daily_reports_site_organization_scheduled_service_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_reports_site_organization_scheduled_service_summary.sql
@@ -11,7 +11,7 @@ int_gtfs__organization_dataset_map AS (
 
     SELECT *
     FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE public_customer_facing_or_regional_subfeed
+    WHERE public_customer_facing_or_regional_subfeed_fixed_route
 
 ),
 

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
@@ -3,7 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
-    WHERE service_key IS NOT NULL AND guidelines_assessed
+    WHERE service_key IS NOT NULL AND public_customer_facing
 ),
 
 fct_daily_service_combined_guideline_checks AS (

--- a/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_service_combined_guideline_checks.sql
@@ -3,7 +3,7 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
-    WHERE service_key IS NOT NULL AND public_customer_facing
+    WHERE service_key IS NOT NULL AND public_customer_facing_fixed_route
 ),
 
 fct_daily_service_combined_guideline_checks AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_gtfs_vendors.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_gtfs_vendors.sql
@@ -4,7 +4,7 @@ WITH assessed_entities AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__daily_assessment_candidate_entities') }}
     -- filter to only organizations that are supposed to be assessed
-    WHERE reports_site_assessed
+    WHERE public_customer_facing_or_regional_subfeed
 ),
 
 gtfs_generation_components AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_gtfs_vendors.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_gtfs_vendors.sql
@@ -4,7 +4,7 @@ WITH assessed_entities AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__daily_assessment_candidate_entities') }}
     -- filter to only organizations that are supposed to be assessed
-    WHERE public_customer_facing_or_regional_subfeed
+    WHERE public_customer_facing_or_regional_subfeed_fixed_route
 ),
 
 gtfs_generation_components AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_validation_codes.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_validation_codes.sql
@@ -12,7 +12,7 @@ idx_monthly_reports_site AS (
 int_gtfs__organization_dataset_map AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE public_customer_facing_or_regional_subfeed
+    WHERE public_customer_facing_or_regional_subfeed_fixed_route
 ),
 
 validator_details AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_validation_codes.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_validation_codes.sql
@@ -12,7 +12,7 @@ idx_monthly_reports_site AS (
 int_gtfs__organization_dataset_map AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE reports_site_assessed
+    WHERE public_customer_facing_or_regional_subfeed
 ),
 
 validator_details AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_route_id_changes.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_route_id_changes.sql
@@ -4,7 +4,7 @@ WITH reports_index AS (
 
 organization_dataset_map AS (
     SELECT * FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE reports_site_assessed
+    WHERE public_customer_facing_or_regional_subfeed
 ),
 
 dim_routes AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_route_id_changes.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_route_id_changes.sql
@@ -4,7 +4,7 @@ WITH reports_index AS (
 
 organization_dataset_map AS (
     SELECT * FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE public_customer_facing_or_regional_subfeed
+    WHERE public_customer_facing_or_regional_subfeed_fixed_route
 ),
 
 dim_routes AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_stop_id_changes.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_stop_id_changes.sql
@@ -4,7 +4,7 @@ WITH reports_index AS (
 
 organization_dataset_map AS (
     SELECT * FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE public_customer_facing_or_regional_subfeed
+    WHERE public_customer_facing_or_regional_subfeed_fixed_route
 ),
 
 dim_stops AS (

--- a/warehouse/models/mart/gtfs_quality/fct_monthly_stop_id_changes.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_stop_id_changes.sql
@@ -4,7 +4,7 @@ WITH reports_index AS (
 
 organization_dataset_map AS (
     SELECT * FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
-    WHERE reports_site_assessed
+    WHERE public_customer_facing_or_regional_subfeed
 ),
 
 dim_stops AS (

--- a/warehouse/models/mart/gtfs_quality/idx_monthly_reports_site.sql
+++ b/warehouse/models/mart/gtfs_quality/idx_monthly_reports_site.sql
@@ -5,7 +5,7 @@ WITH dataset_map AS (
     DATE_TRUNC(date, MONTH) AS date_start
     FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
     -- filter to only organizations that are supposed to be assessed
-    WHERE reports_site_assessed
+    WHERE public_customer_facing_or_regional_subfeed
 ),
 
 assessed_entities AS (

--- a/warehouse/models/mart/gtfs_quality/idx_monthly_reports_site.sql
+++ b/warehouse/models/mart/gtfs_quality/idx_monthly_reports_site.sql
@@ -5,7 +5,7 @@ WITH dataset_map AS (
     DATE_TRUNC(date, MONTH) AS date_start
     FROM {{ ref('int_gtfs_quality__organization_dataset_map') }}
     -- filter to only organizations that are supposed to be assessed
-    WHERE public_customer_facing_or_regional_subfeed
+    WHERE public_customer_facing_or_regional_subfeed_fixed_route
 ),
 
 assessed_entities AS (

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -411,10 +411,10 @@ models:
             relationships:
               to: ref('dim_gtfs_datasets')
               field: key
-      - name: public_customer_facing
+      - name: public_customer_facing_fixed_route
         description: |
           If "Yes", this service should be considered "assessed" by Cal-ITP for guideline/quality purposes.
-      - name: public_customer_facing_or_regional_subfeed
+      - name: public_customer_facing_or_regional_subfeed_fixed_route
         description: |
           If "Yes", this service should be considered "assessed" by Cal-ITP for the reports site.
       - name: service_alerts_gtfs_dataset_key

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -411,10 +411,10 @@ models:
             relationships:
               to: ref('dim_gtfs_datasets')
               field: key
-      - name: guidelines_assessed
+      - name: public_customer_facing
         description: |
           If "Yes", this service should be considered "assessed" by Cal-ITP for guideline/quality purposes.
-      - name: reports_site_assessed
+      - name: public_customer_facing_or_regional_subfeed
         description: |
           If "Yes", this service should be considered "assessed" by Cal-ITP for the reports site.
       - name: service_alerts_gtfs_dataset_key

--- a/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
+++ b/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
@@ -10,8 +10,8 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
     -- which sometimes exist
     SELECT DISTINCT
         date,
-        guidelines_assessed,
-        reports_site_assessed,
+        public_customer_facing,
+        public_customer_facing_or_regional_subfeed,
         organization_key,
         organization_name,
         organization_itp_id,
@@ -39,8 +39,8 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
 disambiguate_dups AS (
     SELECT
         date,
-        guidelines_assessed,
-        reports_site_assessed,
+        public_customer_facing,
+        public_customer_facing_or_regional_subfeed,
         organization_key,
         organization_name,
         organization_itp_id,
@@ -153,8 +153,8 @@ dim_provider_gtfs_data AS (
             'gtfs_dataset_key_trip_updates',
             'gtfs_service_data_customer_facing'
             ]) }} AS key,
-        guidelines_assessed,
-        reports_site_assessed,
+        public_customer_facing,
+        public_customer_facing_or_regional_subfeed,
         organization_key,
         organization_name,
         organization_itp_id,

--- a/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
+++ b/warehouse/models/mart/transit_database/dim_provider_gtfs_data.sql
@@ -10,8 +10,8 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
     -- which sometimes exist
     SELECT DISTINCT
         date,
-        public_customer_facing,
-        public_customer_facing_or_regional_subfeed,
+        public_customer_facing_fixed_route,
+        public_customer_facing_or_regional_subfeed_fixed_route,
         organization_key,
         organization_name,
         organization_itp_id,
@@ -39,8 +39,8 @@ int_gtfs_quality__daily_assessment_candidate_entities AS (
 disambiguate_dups AS (
     SELECT
         date,
-        public_customer_facing,
-        public_customer_facing_or_regional_subfeed,
+        public_customer_facing_fixed_route,
+        public_customer_facing_or_regional_subfeed_fixed_route,
         organization_key,
         organization_name,
         organization_itp_id,
@@ -153,8 +153,8 @@ dim_provider_gtfs_data AS (
             'gtfs_dataset_key_trip_updates',
             'gtfs_service_data_customer_facing'
             ]) }} AS key,
-        public_customer_facing,
-        public_customer_facing_or_regional_subfeed,
+        public_customer_facing_fixed_route,
+        public_customer_facing_or_regional_subfeed_fixed_route,
         organization_key,
         organization_name,
         organization_itp_id,


### PR DESCRIPTION
# Description
Responsive to #2464, renames two columns used in quality tables to reflect a more commonsense understanding of those columns' meanings.

Resolves #2464

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Working through dbt tests at the time of PR creation.

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

Downstream references to the old columns (e.g. in Metabase) will need to be switched out.