### PR TITLE
CODEOWNERS: remove @lottspot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,10 @@
 *                                       @atvaccaro
 
 # infra components
-/.github/workflows                      @atvaccaro @lottspot @SorenSpicknall
-/ci                                     @atvaccaro @lottspot @SorenSpicknall
-/iac                                    @atvaccaro @lottspot
-/kubernetes                             @atvaccaro @lottspot
+/.github/workflows                      @atvaccaro @SorenSpicknall
+/ci                                     @atvaccaro @SorenSpicknall
+/iac                                    @atvaccaro
+/kubernetes                             @atvaccaro
 
 # jupyter service, e.g. updating the image
 /kubernetes/apps/charts/jupyterhub      @atvaccaro @charlie-costanzo @SorenSpicknall


### PR DESCRIPTION
As a no-longer defacto code owner, being listed makes it unclear when a review is actually needed from me vs when it is a routine change which may proceed with or without my review. Making all review requests explicit removes this ambiguity.