### PR TITLE
create an almost-unique test, and use it in currently failing places

### DIFF
--- a/warehouse/macros/test_unique_proportion.sql
+++ b/warehouse/macros/test_unique_proportion.sql
@@ -1,0 +1,31 @@
+{# mostly copied from dbt_utils not_null_proportion #}
+
+{% macro test_unique_proportion(model, group_by_columns = []) %}
+  {{ return(adapter.dispatch('test_unique_proportion', 'dbt_utils')(model, group_by_columns, **kwargs)) }}
+{% endmacro %}
+
+{% macro default__test_unique_proportion(model, group_by_columns) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
+{% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
+
+with validation as (
+  select
+    sum(case when row_number > 1 then 0 else 1 end) / cast(count(*) as numeric) as unique_proportion
+  from (select
+    {{column_name}}
+    , row_number() over (partition by {{column_name}}) as row_number
+  from {{ model }}) row_counts
+),
+validation_errors as (
+  select
+    unique_proportion
+  from validation
+  where unique_proportion < {{ at_least }} or unique_proportion > {{ at_most }}
+)
+select
+  *
+from validation_errors
+
+{% endmacro %}

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -112,7 +112,7 @@ models:
       - name: key
         tests: &almost_unique_rt_key_tests
           - unique_proportion:
-              at_least: 0.99
+              at_least: 0.999
               where: '__rt_sampled__'
           - not_null:
               where: '__rt_sampled__'
@@ -933,7 +933,12 @@ models:
         description: |
           Synthetic primary key constructed from `service_alerts_message_key`,
           `agency_id`, `trip_id`, `route_id`, and `stop_id`.
-        tests: *almost_unique_rt_key_tests
+        tests: &service_alert_key_tests
+          - unique_proportion:
+              at_least: 0.98
+              where: '__rt_sampled__'
+          - not_null:
+              where: '__rt_sampled__'
       - *service_alert_message_key
       - name: dt
       - name: agency_id
@@ -1028,7 +1033,7 @@ models:
         description: |
           Synthetic primary key constructed from `dt`,
           `base64_url`, and entity `id`.
-        tests: *almost_unique_rt_key_tests
+        tests: *service_alert_key_tests
       - name: first_header_timestamp
         description: |
           Earliest header timestamp at which this alert appeared on this date.

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -110,8 +110,9 @@ models:
       Unnested and de-duped stop time updates.
     columns:
       - name: key
-        tests: &rt_key_tests
-          - unique:
+        tests: &almost_unique_rt_key_tests
+          - unique_proportion:
+              at_least: 0.99
               where: '__rt_sampled__'
           - not_null:
               where: '__rt_sampled__'
@@ -128,7 +129,7 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`, `vehicle_id`, and `trip_id`.
-        tests: *rt_key_tests
+        tests: *almost_unique_rt_key_tests
       - &gtfs_rt_dataset_key
         name: gtfs_dataset_key
         description: |
@@ -224,7 +225,7 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`, `vehicle_id`, and `trip_id`.
-        tests: *rt_key_tests
+        tests: *almost_unique_rt_key_tests
       - *gtfs_rt_dataset_key
       - name: dt
         description: |
@@ -931,7 +932,7 @@ models:
         description: |
           Synthetic primary key constructed from `service_alerts_message_key`,
           `agency_id`, `trip_id`, `route_id`, and `stop_id`.
-        tests: *rt_primary_key_tests
+        tests: *almost_unique_rt_key_tests
       - *service_alert_message_key
       - name: dt
       - name: agency_id
@@ -1026,11 +1027,7 @@ models:
         description: |
           Synthetic primary key constructed from `dt`,
           `base64_url`, and entity `id`.
-        tests:
-          - unique:
-              where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
-          - not_null:
-              where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+        tests: *almost_unique_rt_key_tests
       - name: first_header_timestamp
         description: |
           Earliest header timestamp at which this alert appeared on this date.
@@ -1322,13 +1319,7 @@ models:
       Incrementally materialize trip update messages without stop times; this reduces the data size by about 90%.
     columns:
       - name: key
-        tests:
-          - not_null:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
-          - unique:
-              config:
-                where: dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)
+        tests: *almost_unique_rt_key_tests
 
   - name: fct_service_alerts_trip_summaries
     description: |

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -615,7 +615,8 @@ models:
         would be failing to join and making it essentially impossible to label
         historical GTFS data with their associated transit database records).
       tests:
-        - not_null
+        - dbt_utils.not_null_proportion:
+            at_least: 0.999
         - relationships:
             to: ref('dim_gtfs_datasets')
             field: key


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves https://github.com/cal-itp/data-infra/issues/2499

Switches RT tests to be almost unique, as our keys are intended to be unique if the spec is followed (based on our understanding). We want tests to pass, but indicate to users that those keys should _generally_ be unique as 99.9% uniqueness is a pretty high bar.

Unsure if this will mark these as resolved, but trying again.

fixes CAL-ITP-DATA-INFRA-13R8
fixes CAL-ITP-DATA-INFRA-13Q0
fixes CAL-ITP-DATA-INFRA-248R
fixes CAL-ITP-DATA-INFRA-13EG
fixes CAL-ITP-DATA-INFRA-13EH
fixes CAL-ITP-DATA-INFRA-2458
fixes CAL-ITP-DATA-INFRA-H4G

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)

May need to resolve Sentry issues manually if they don't close automatically.