### PR TITLE
update sentry search link

### DIFF
--- a/runbooks/pipeline/sentry-triage.md
+++ b/runbooks/pipeline/sentry-triage.md
@@ -6,7 +6,7 @@
 
 Once a day, we should check Sentry issues created since the prior day, using the following query.
 
-`is:unresolved firstSeen:-24h ` ([saved search link](https://sentry.calitp.org/organizations/sentry/issues/?environment=cal-itp-data-infra&project=2&query=is%3Aunresolved+firstSeen%3A-24h))
+`is:unresolved firstSeen:-24h ` ([saved search link](https://sentry.calitp.org/organizations/sentry/issues/searches/5/?environment=cal-itp-data-infra&project=2))
 
 Categorize those issues and perform relevant steps if the issue is not already assigned.
 

--- a/runbooks/pipeline/sentry-triage.md
+++ b/runbooks/pipeline/sentry-triage.md
@@ -6,7 +6,7 @@
 
 Once a day, we should check Sentry issues created since the prior day, using the following query.
 
-`is:unresolved firstSeen:-24h ` ([saved search link](https://sentry.calitp.org/organizations/sentry/issues/searches/3/?environment=cal-itp-data-infra&project=2&referrer=issue-list&sort=date&statsPeriod=24h))
+`is:unresolved firstSeen:-24h ` ([saved search link](https://sentry.calitp.org/organizations/sentry/issues/?environment=cal-itp-data-infra&project=2&query=is%3Aunresolved+firstSeen%3A-24h))
 
 Categorize those issues and perform relevant steps if the issue is not already assigned.
 


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Updates the default search link in the Sentry runbook to actually filter to only new issues from last 24 hours (old link was not actually filtering to `firstSeen:-24hr`). When I clicked the existing link this morning for triage I got 144 issues; updated link yields only 9 (which I think is more what we would expect?)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Confirmed the link works.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
