### PR TITLE
use specific pool for gtfs schedule parsing

### DIFF
--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/agency_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/agency_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 input_table_name: agency.txt

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/areas_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/areas_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/attributions_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/attributions_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/calendar_dates_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/calendar_dates_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/calendar_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/calendar_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_attributes_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_attributes_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_leg_rules_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_leg_rules_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_media_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_media_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_products_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_products_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_rules_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_rules_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_transfer_rules_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/fare_transfer_rules_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/feed_info_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/feed_info_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/frequencies_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/frequencies_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/levels_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/levels_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/pathways_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/pathways_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/routes_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/routes_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/shapes_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/shapes_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/stop_areas_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/stop_areas_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/stop_times_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/stop_times_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/stops_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/stops_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/transfers_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/transfers_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/translations_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/translations_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/trips_txt.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/convert_to_json/trips_txt.yml
@@ -1,4 +1,5 @@
 operator: operators.GtfsGcsToJsonlOperatorHourly
+pool: schedule_parse_pool
 dependencies:
   - unzip_gtfs_schedule
 


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

The new hourly backfill is running far ahead with unzip/validate but not parsing. We should use a separate pool so we can ensure that the parse is keeping up with the unzip, as well as control it separately from the legacy DAG.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Tested locally.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [ ] Actions required (specified below)
