### PR TITLE
fix fare media pk test

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
@@ -234,7 +234,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `feed_key` and `fare_media_id`.
-        tests: *pk_tests_with_dups
+        tests: *primary_key_tests
       - *feed_key
       - *base64_url
       - name: fare_media_id


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Fixes CAL-ITP-DATA-INFRA-24K3 ([link](https://sentry.calitp.org/organizations/sentry/issues/70511/))

```
test.calitp_warehouse.unique_dim_fare_media_key.4f70bd2c4a - Database Error in test unique_dim_fare_media_key (models/mart/gtfs/_mart_gtfs_dims.yml)
  Unrecognized name: warning_duplicate_primary_key
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

![image](https://github.com/cal-itp/data-infra/assets/55149902/ea630d59-11d0-43c6-a942-fd1e1fe7b314)


## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
