### PR TITLE
HOTFIX missing parenthesis on dim_organizations

### DIFF
--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -40,5 +40,6 @@ dim_organizations AS (
     FROM dim
     LEFT JOIN ntd_agency_to_organization ntd_to_org
         ON dim.source_record_id = ntd_to_org.organization_record_id
+)
 
 SELECT * FROM dim_organizations


### PR DESCRIPTION
# Description
#2582 introduced a missing parenthesis that broke `dim_organizations`, due to last-minute changes that were merged without additional dbt test runs. This PR solves the problem introduced by those changes.

Resolves #2586

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
dbt test run completed on existing code to verify the same error occurs locally, then run after changes to verify its resolution.

## Post-merge follow-ups
Will mark the Sentry issue generated by this bug as `resolve on next release`.

- [x] No action required
- [ ] Actions required (specified below)
