### PR TITLE
Modified littlepay/elavon transaction comparison table to include ccjpa

### DIFF
--- a/warehouse/models/mart/payments/elavon_littlepay__daily_history_transactions_deposits_billing.sql
+++ b/warehouse/models/mart/payments/elavon_littlepay__daily_history_transactions_deposits_billing.sql
@@ -2,9 +2,15 @@
 
 WITH fct_elavon__transactions AS (
     SELECT
+
         *,
         -- this same treatment for the other customers in the future when we expand dashboard for other customers?
-        IF(customer_name = 'MST TAP TO RIDE', 'mst', customer_name) AS participant_id
+        CASE
+          WHEN customer_name = 'MST TAP TO RIDE' THEN 'mst'
+          WHEN customer_name = 'CAPITOL CORRIDOR TAP2RIDE' THEN 'ccjpa'
+        ELSE customer_name
+        END AS participant_id
+
     FROM  {{ ref('fct_elavon__transactions') }}
 ),
 


### PR DESCRIPTION
# Description
Based on feedback, we're adding an MVP dashboard for CCJPA so as to compare Littlepay and Elavon revenue data. This PR makes that data available for CCJPA.

## Type of change

- [x] New feature

## How has this been tested?
locally with dbt run and in Metabase

## Post-merge follow-ups

- [x] Actions required (specified below)
This data should automatically be available in the CCJPA metabase dashboard but we may need to modify filters and do some QC etc