### PR TITLE
add active period start/end timestamp columns and cleanup yaml

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -900,19 +900,6 @@ models:
         description: |
           See: https://gtfs.org/realtime/reference/#message-alert.
       - *_header_message_age
-  - name: fct_service_alert_active_periods
-    description: |
-      Each row is an active period for a service alerts message.
-      See https://gtfs.org/realtime/reference/#message-alert for information
-      about message structure.
-      Due to data size, this table **must** be queried with a date filter (like `WHERE dt = 'YYYY-MM-DD'`).
-      Hour filters will also further improve performance.
-    columns:
-      - name: key
-        description: |
-          Synthetic primary key constructed from `service_alerts_message_key`,
-          `active_period_start`, and `active_period_end`.
-        tests: *rt_primary_key_tests
   - name: fct_service_alerts_messages_unnested
     description: |
       This table contains GTFS RT service alerts messages with all elements (informed entities,
@@ -922,6 +909,10 @@ models:
       Therefore one row here should correspond to one actual "alert" (counting alerts
       that apply to different entities or different time periods as distinct.)
       See: https://gtfs.org/realtime/reference/#message-alert for field definitions.
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "active_period_start <= active_period_end"
+          where: '__rt_sampled__'
     columns:
       - name: key
         description: |
@@ -1036,6 +1027,14 @@ models:
       - name: active_period_end
         description: |
           See: https://gtfs.org/realtime/reference/#message-timerange.
+      - name: active_period_start_ts
+        description: |
+          `active_period_start` converted to a TIMESTAMP data type.
+          If `active_period_start` is null, will be midnight on January 1, 1900.
+      - name: active_period_end_ts
+        description: |
+          `active_period_end` converted to a TIMESTAMP data type.
+          If `active_period_end` is null, will be midnight on January 1, 2099.
       - *_header_message_age
   - name: fct_daily_service_alerts
     description: |

--- a/warehouse/models/mart/gtfs/fct_service_alerts_messages_unnested.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_messages_unnested.sql
@@ -65,6 +65,10 @@ fct_service_alerts_messages_unnested AS (
         -- active periods
         active_period_start,
         active_period_end,
+        -- per spec, start/end is +/- infinity if null: https://gtfs.org/realtime/reference/#message-timerange
+        -- use placeholders instead
+        COALESCE(TIMESTAMP_SECONDS(active_period_start), TIMESTAMP(DATE(1900,1,1))) AS active_period_start_ts,
+        COALESCE(TIMESTAMP_SECONDS(active_period_end), TIMESTAMP(DATE(2099,1,1))) AS active_period_end_ts,
 
         -- informed entities
         agency_id,


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

* Was adding `active_period_start_ts` in #2489 and realized it should just go on the main fct table 
* Cleaning up some YAML I missed before in #2583 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Full refreshed `fct_service_alerts_messages_unnested` and confirmed new columns appear and seem reasonable. New test passes and I looked at the executed SQL and confirmed that `__rt_sampled__` is compiling as expected. 

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required (well, I have to rebase #2489)
- [ ] Actions required (specified below)
