### PR TITLE
Update NTD scraper with new calitp-data-infra import

### DIFF
--- a/script/requirements.txt
+++ b/script/requirements.txt
@@ -3,7 +3,7 @@ async-timeout==3.0.1; python_version >= "3.8" and python_version < "3.11" and py
 attrs==22.2.0; python_version >= "3.8" and python_version < "3.11"
 backoff==2.2.1; python_version >= "3.8" and python_version < "3.11"
 cachetools==5.3.0; python_version >= "3.7" and python_version < "4.0" and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "3.11" or python_version >= "3.8" and python_version < "3.11" and python_full_version >= "3.6.0")
-calitp==2023.1.3; python_version >= "3.8" and python_version < "3.11"
+calitp-data-infra==2023.2.16.1; python_version >= "3.8" and python_version < "3.11"
 certifi==2022.12.7; python_version >= "3.8" and python_version < "3.11"
 chardet==4.0.0; python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "3.11" or python_version >= "3.8" and python_version < "3.11" and python_full_version >= "3.5.0"
 charset-normalizer==3.0.1; python_version >= "3.8" and python_version < "3.11"

--- a/script/scrape_ntd.py
+++ b/script/scrape_ntd.py
@@ -18,7 +18,7 @@ import pandas as pd  # type: ignore
 import pendulum
 import requests
 import typer
-from calitp.storage import (  # type: ignore
+from calitp_data_infra.storage import (  # type: ignore
     PartitionedGCSArtifact,
     get_fs,
     make_name_bq_safe,


### PR DESCRIPTION
# Description
While working through old import references in our docs, I found this old import still active in our NTD scraper. Best to patch it up before we need to run it next.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Requirements.txt imports checked with new calitp-data-infra version reference, and a modified version of the NTD import (with no real effect) was tested to ensure the import made it in okay.

## Post-merge follow-ups
- [x] No action required
- [ ] Actions required (specified below)
