### PR TITLE
fix(benefits): add group_properties column to external table

### DIFF
--- a/airflow/dags/create_external_tables/amplitude/benefits_events.yml
+++ b/airflow/dags/create_external_tables/amplitude/benefits_events.yml
@@ -60,6 +60,8 @@ schema_fields:
     type: STRING
   - name: dma
     type: STRING
+  - name: group_properties
+    type: JSON
   - name: event_properties
     type: JSON
   - name: user_properties


### PR DESCRIPTION
# Description
- Fixes this Sentry issue: https://sentry.calitp.org/organizations/sentry/issues/71166/?project=2&referrer=assigned_activity-email
- Resolves #2597 
- There is a `group_properties` column in the Amplitude data (and the corresponding Mart and Fact Table), but it's not in the External Table. This pull request adds the `group_properties` column as into the External Table.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
_Include commands/logs/screenshots as relevant._



## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [ ] Actions required (specified below)
