### PR TITLE
Reduce not-null test threshold for fct_daily_rt_feed_files

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -630,7 +630,7 @@ models:
         historical GTFS data with their associated transit database records).
       tests:
         - dbt_utils.not_null_proportion:
-            at_least: 0.999
+            at_least: 0.998
         - relationships:
             to: ref('dim_gtfs_datasets')
             field: key

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -630,6 +630,8 @@ models:
         historical GTFS data with their associated transit database records).
       tests:
         - dbt_utils.not_null_proportion:
+            # TODO: raise back to .999 after some time getting new data - was .998 because
+            # old data pipeline produced more nulls
             at_least: 0.998
         - relationships:
             to: ref('dim_gtfs_datasets')


### PR DESCRIPTION
# Description
Due to missing older data before our ingestion and modeling were evolved, fct_daily_rt_feed_files doesn't currently test a .999-threshold not null test for the `gtfs_dataset_key`. This lowers the threshold to .998 in order to pass, while keeping it high enough that newly introduced issues should still trip up alarms.

Resolves #2571

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
dbt tests run locally, using the production table as a reference.

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

Eventually, as this table grows, we should likely move this back to a .999-threshold test.