### PR TITLE
Remove erroneous "groups" column reference from benefits YAML

### DIFF
--- a/warehouse/models/mart/benefits/_mart_benefits.yml
+++ b/warehouse/models/mart/benefits/_mart_benefits.yml
@@ -73,8 +73,6 @@ models:
         description: string
       - name: device_brand
         description: string
-      - name: groups
-        description: dict
       - name: event_properties
         description: dict
       - name: data

--- a/warehouse/models/staging/amplitude/_amplitude.yml
+++ b/warehouse/models/staging/amplitude/_amplitude.yml
@@ -80,8 +80,6 @@ models:
         description: string
       - name: device_brand
         description: string
-      - name: groups
-        description: dict
       - name: event_properties
         description: dict
       - name: data


### PR DESCRIPTION
# Description
An incorrect reference to a nonexistent `groups` column in benefits events tables was causing errors when writing table metadata to Metabase. This resolves the issue by removing the erroneous column reference from the two YAML files in which it appeared.

Resolves #2597 (previously marked as resolved due to shared fingerprinting with another issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?
Column lists inspected by hand and compared to production tables in the warehouse.

## Post-merge follow-ups
- [x] No action required
- [ ] Actions required (specified below)