### PR TITLE
Align benefits YAML with external table form to fix Metabase sync errors

### DIFF
--- a/warehouse/models/mart/benefits/_mart_benefits.yml
+++ b/warehouse/models/mart/benefits/_mart_benefits.yml
@@ -5,99 +5,101 @@ models:
     description: |
       Events from the Benefits application, from Amplitude. Parsed.
     columns:
-      - name: server_received_time
-        description: UTC ISO-8601 timestamp
       - name: app
         description: int
-      - name: device_carrier
-        description: string
-      - name: $schema
-        description: int
-      - name: city
+      - name: device_id
         description: string
       - name: user_id
         description: string
-      - name: uuid
-        description: UUID
-      - name: event_time
+      - name: client_event_time
         description: UTC ISO-8601 timestamp
+      - name: event_id
+        description: int
+      - name: session_id
+        description: long
+      - name: event_type
+        description: string
+      - name: amplitude_event_type
+        description: string
+      - name: version_name
+        description: string
       - name: platform
+        description: string
+      - name: os_name
         description: string
       - name: os_version
         description: string
-      - name: amplitude_id
-        description: long
-      - name: processed_time
-        description: UTC ISO-8601 timestamp
-      - name: user_creation_time
-        description: UTC ISO-8601 timestamp
-      - name: version_name
+      - name: device_brand
         description: string
+      - name: device_manufacturer
+        description: string
+      - name: device_model
+        description: string
+      - name: device_family
+        description: string
+      - name: device_type
+        description: string
+      - name: device_carrier
+        description: string
+      - name: location_lat
+        description: float
+      - name: location_lng
+        description: float
       - name: ip_address
         description: string
-      - name: paying
-        description: boolean
+      - name: country
+        description: string
+      - name: language
+        description: string
+      - name: library
+        description: string
+      - name: city
+        description: string
+      - name: region
+        description: string
       - name: dma
         description: string
       - name: group_properties
         description: dict
-      - name: user_properties
-        description: dict
-      - name: client_upload_time
-        description: UTC ISO-8601 timestamp
-      - name: $insert_id
-        description: string
-      - name: event_type
-        description: string
-      - name: library
-        description: string
-      - name: amplitude_attribution_ids
-        description: string
-      - name: device_type
-        description: string
-      - name: device_manufacturer
-        description: string
-      - name: start_version
-        description: string
-      - name: location_lng
-        description: float
-      - name: server_upload_time
-        description: UTC ISO-8601 timestamp
-      - name: event_id
-        description: int
-      - name: location_lat
-        description: float
-      - name: os_name
-        description: string
-      - name: amplitude_event_type
-        description: string
-      - name: device_brand
-        description: string
       - name: event_properties
         description: dict
-      - name: data
+      - name: user_properties
         description: dict
-      - name: device_id
+      - name: event_time
+        description: UTC ISO-8601 timestamp
+      - name: client_upload_time
+        description: UTC ISO-8601 timestamp
+      - name: server_upload_time
+        description: UTC ISO-8601 timestamp
+      - name: server_received_time
+        description: UTC ISO-8601 timestamp
+      - name: amplitude_id
+        description: long
+      - name: idfa
         description: string
-      - name: language
+      - name: adid
         description: string
-      - name: device_model
+      - name: paying
+        description: boolean
+      - name: start_version
         description: string
-      - name: country
+      - name: user_creation_time
+        description: UTC ISO-8601 timestamp
+      - name: uuid
+        description: UUID
+      - name: sample_rate
+        description: ""
+      - name: $insert_id
         description: string
-      - name: region
+      - name: insert_key
         description: string
       - name: is_attribution_event
         description: bool
-      - name: adid
+      - name: amplitude_attribution_ids
         description: string
-      - name: session_id
-        description: long
-      - name: device_family
+      - name: partner_id
         description: string
-      - name: sample_rate
-        description: ""
-      - name: idfa
-        description: string
-      - name: client_event_time
+      - name: $schema
+        description: int
+      - name: processed_time
         description: UTC ISO-8601 timestamp

--- a/warehouse/models/staging/amplitude/_amplitude.yml
+++ b/warehouse/models/staging/amplitude/_amplitude.yml
@@ -12,99 +12,101 @@ models:
   - name: stg_amplitude__benefits_events
     description: Benefits application events data from Amplitude.
     columns:
-      - name: server_received_time
-        description: UTC ISO-8601 timestamp
       - name: app
         description: int
-      - name: device_carrier
-        description: string
-      - name: $schema
-        description: int
-      - name: city
+      - name: device_id
         description: string
       - name: user_id
         description: string
-      - name: uuid
-        description: UUID
-      - name: event_time
+      - name: client_event_time
         description: UTC ISO-8601 timestamp
+      - name: event_id
+        description: int
+      - name: session_id
+        description: long
+      - name: event_type
+        description: string
+      - name: amplitude_event_type
+        description: string
+      - name: version_name
+        description: string
       - name: platform
+        description: string
+      - name: os_name
         description: string
       - name: os_version
         description: string
-      - name: amplitude_id
-        description: long
-      - name: processed_time
-        description: UTC ISO-8601 timestamp
-      - name: user_creation_time
-        description: UTC ISO-8601 timestamp
-      - name: version_name
+      - name: device_brand
         description: string
+      - name: device_manufacturer
+        description: string
+      - name: device_model
+        description: string
+      - name: device_family
+        description: string
+      - name: device_type
+        description: string
+      - name: device_carrier
+        description: string
+      - name: location_lat
+        description: float
+      - name: location_lng
+        description: float
       - name: ip_address
         description: string
-      - name: paying
-        description: boolean
+      - name: country
+        description: string
+      - name: language
+        description: string
+      - name: library
+        description: string
+      - name: city
+        description: string
+      - name: region
+        description: string
       - name: dma
         description: string
       - name: group_properties
         description: dict
-      - name: user_properties
-        description: dict
-      - name: client_upload_time
-        description: UTC ISO-8601 timestamp
-      - name: $insert_id
-        description: string
-      - name: event_type
-        description: string
-      - name: library
-        description: string
-      - name: amplitude_attribution_ids
-        description: string
-      - name: device_type
-        description: string
-      - name: device_manufacturer
-        description: string
-      - name: start_version
-        description: string
-      - name: location_lng
-        description: float
-      - name: server_upload_time
-        description: UTC ISO-8601 timestamp
-      - name: event_id
-        description: int
-      - name: location_lat
-        description: float
-      - name: os_name
-        description: string
-      - name: amplitude_event_type
-        description: string
-      - name: device_brand
-        description: string
       - name: event_properties
         description: dict
-      - name: data
+      - name: user_properties
         description: dict
-      - name: device_id
+      - name: event_time
+        description: UTC ISO-8601 timestamp
+      - name: client_upload_time
+        description: UTC ISO-8601 timestamp
+      - name: server_upload_time
+        description: UTC ISO-8601 timestamp
+      - name: server_received_time
+        description: UTC ISO-8601 timestamp
+      - name: amplitude_id
+        description: long
+      - name: idfa
         description: string
-      - name: language
+      - name: adid
         description: string
-      - name: device_model
+      - name: paying
+        description: boolean
+      - name: start_version
         description: string
-      - name: country
+      - name: user_creation_time
+        description: UTC ISO-8601 timestamp
+      - name: uuid
+        description: UUID
+      - name: sample_rate
+        description: ""
+      - name: $insert_id
         description: string
-      - name: region
+      - name: insert_key
         description: string
       - name: is_attribution_event
         description: bool
-      - name: adid
+      - name: amplitude_attribution_ids
         description: string
-      - name: session_id
-        description: long
-      - name: device_family
+      - name: partner_id
         description: string
-      - name: sample_rate
-        description: ""
-      - name: idfa
-        description: string
-      - name: client_event_time
+      - name: $schema
+        description: int
+      - name: processed_time
         description: UTC ISO-8601 timestamp


### PR DESCRIPTION
# Description
This PR is a continuation of #2614 after inspecting for other issues with the column lists in benefits-related YAML. This should resolve remaining Metabase sync errors on the benefits events tables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Column lists inspected by hand and compared to production tables in the warehouse.

## Post-merge follow-ups
- [x] No action required
- [ ] Actions required (specified below)
