### PR TITLE
address failing tests in long_calendar

### DIFF
--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -53,6 +53,8 @@ models:
       This table transforms the raw GTFS calendar.txt format (where each row corresponds to a `service_id` and
       each day of the week is a column and service indicators are entered in a "wide" fashion)
       into a long format, where a row is identified by `feed_key`, `service_id`, and `date`.
+      Rows are dropped if they have start_date > end_date (which is not valid) or if they have
+      start_date more than a year in the future relative to the date the table is run.
     columns:
       - &schedule_key
         name: key

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
@@ -4,6 +4,9 @@
 WITH dim_calendar AS (
     SELECT *
     FROM {{ ref('dim_calendar') }}
+    -- in May 2023 we got a feed where there were some rows with start_date < end_date
+    -- this breaks generate_date_array below
+    WHERE start_date <= end_date
 ),
 
 int_gtfs_schedule__long_calendar AS (
@@ -29,6 +32,9 @@ int_gtfs_schedule__long_calendar AS (
     -- one row per day between calendar service start and end date
     -- https://stackoverflow.com/questions/38694040/how-to-generate-date-series-to-occupy-absent-dates-in-google-biqquery/58169269#58169269
     LEFT JOIN UNNEST(GENERATE_DATE_ARRAY(start_date, LEAST(end_date, DATE_ADD(CURRENT_DATE(), INTERVAL 1 YEAR)))) AS dt
+    -- in May 2023 we got a feed that was publishing service through 2025 / 2026
+    -- drop service that is more than a year away
+    WHERE start_date < DATE_ADD(CURRENT_DATE(), INTERVAL 1 YEAR)
 )
 
 SELECT *

--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__long_calendar.sql
@@ -1,4 +1,6 @@
 {{ config(materialized='table') }}
+-- NOTE: we cannot make this table incremental without adding a mechanism to pick up all future service
+-- current logic excludes service more than a year out and if we make this incremental we'd need to account for that
 
 -- TODO: make an intermediate calendar and use that instead of the dimension
 WITH dim_calendar AS (


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

[This issue](https://sentry.calitp.org/organizations/sentry/issues/69998/) regressed over the weekend. TLDR (details below): Amtrak uploaded a feed with some date issues in `dim_calendar` this weekend, this PR fixes the resulting issues in `int_gtfs_schedule__long_calendar`.

```
test.calitp_warehouse.not_null_int_gtfs_schedule__long_calendar_service_bool.f3d95d17e2 - Got 917 results, configured to fail if != 0
```

Cause was two distinct issues in the weekend's Amtrak feed: 

1. Some start/end dates in 2025 and 2026, which were breaking in `GENERATE_DATE_ARRAY(start_date, LEAST(end_date, DATE_ADD(CURRENT_DATE(), INTERVAL 1 YEAR)))`. Fix: Truncate to service where `start_date <= current_date() plus one year` (I feel like this makes sense anyway? We don't really expect that service more than a year out is going to be reliable, and because this table is not incremental we are not at risk for never picking up the service; added a comment to flag this in case we eventually do try to make the table incremental)
2. Some start/end dates where start_date > end_date (and these dates were from 2003-2002? 🤔 ). This also broke in the generate date array call. Fix: Drop rows where start_date is not <= end_date. 

Fixes CAL-ITP-DATA-INFRA-244N 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Test now passes locally.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)

No downstream incremental models. 