### PR TITLE
Fix customer funding source valid ranges + tests

### DIFF
--- a/warehouse/models/payments_views_staging/_payments_views_staging.yml
+++ b/warehouse/models/payments_views_staging/_payments_views_staging.yml
@@ -765,6 +765,7 @@ models:
           lower_bound_column: calitp_valid_at
           upper_bound_column: calitp_invalid_at
           partition_by: funding_source_vault_id
+          zero_length_range_allowed: True
     columns:
       - name: customer_id
         description: '{{ doc("customer_funding_source_customer_id") }}'

--- a/warehouse/models/payments_views_staging/stg_cleaned_customer_funding_source_vaults.sql
+++ b/warehouse/models/payments_views_staging/stg_cleaned_customer_funding_source_vaults.sql
@@ -30,7 +30,7 @@ WITH stg_cleaned_customer_funding_source_vaults AS (
     WHERE calitp_dupe_number = 1
     WINDOW unique_ids AS (
         PARTITION BY funding_source_vault_id
-        ORDER BY calitp_customer_id_rank)
+        ORDER BY calitp_customer_id_rank, calitp_funding_source_vault_id_rank)
 ORDER BY funding_source_vault_id, calitp_valid_at DESC
 )
 


### PR DESCRIPTION
# Description
The mutually exclusive ranges test was turning up errors on the `stg_cleaned_customer_funding_source_vaults` - some legitimate, and some a result of the fact that the test doesn't allow zero-length ranges by default. This PR adds another layer of ordering to the window generation used to fill `calitp_valid_at` and `calitp_invalid_at` which resolves incorrect assignments, and loosens the test requirements to allow zero-length ranges to pass. Together, this resolves the issue.

Resolves #2591

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Tested on a full recreation of the `stg_cleaned_customer_funding_source_vaults` model in staging.

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

The `stg_cleaned_customer_funding_source_vaults` table will need a full refresh following merge.