### PR TITLE
Update YAML for several models to align with warehouse

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -1466,6 +1466,13 @@ models:
       Summarizes trips observed in trip update messages.
     columns:
       - *rt_trip_summary_key
+      - name: dt
+      - name: base64_url
+      - name: trip_id
+      - name: trip_route_id
+      - name: trip_direction_id
+      - name: trip_start_time
+      - name: trip_start_date
       - *num_distinct_message_ids
       - *num_distinct_header_timestamps
       - name: num_distinct_trip_update_timestamps
@@ -1490,6 +1497,13 @@ models:
       Summarizes trips observed in vehicle position messages.
     columns:
       - *rt_trip_summary_key
+      - name: dt
+      - name: base64_url
+      - name: trip_id
+      - name: trip_route_id
+      - name: trip_direction_id
+      - name: trip_start_time
+      - name: trip_start_date
       - *num_distinct_message_ids
       - *num_distinct_header_timestamps
       - name: num_distinct_vehicle_timestamps

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -406,7 +406,7 @@ models:
       - name: last_arrival_sec
         description: |
           Time of last trip arrival on date across all reports-assessed feeds for this organization
-      - name: num_stop_times
+      - name: n_stop_times
         description: |
           Count of scheduled stop events on date across all reports-assessed feeds for this organization
       - name: n_routes


### PR DESCRIPTION
# Description
We were seeing Metabase failures on each of the models touched here, due to mismatches between observed columns and expected columns. Only one of the three sets of errors will be resolved entirely by this PR, since we need to backfill `fct_trip_updates_summaries` and `fct_vehicle_positions_trip_summaries` to bring in new columns on each of those models before their respective Metabase errors will go away, but they needed YAML adjustments nonetheless.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?
Alignment between tables in warehouse and YAML confirmed by hand inspection (except in the case of the two column additions to `fct_trip_updates_summaries` and `fct_vehicle_positions_trip_summaries`, which are expected to differ).

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

We will need to resolve [this Sentry issue](https://sentry.calitp.org/organizations/sentry/issues/71495/events/56ce8235aaf04d04984b954379c180b3/?project=2), then resolve [this one](https://sentry.calitp.org/organizations/sentry/issues/70509/events/bd2d792e60d3471d82a8af0296f25e47/?project=2) and [this one](https://sentry.calitp.org/organizations/sentry/issues/70508/events/d72fe01bc55644ad8afba7b069a4148b/?project=2) after `fct_trip_updates_summaries` and `fct_vehicle_positions_trip_summaries` have been fully refreshed down the line, a process that Laurie is holding.