### PR TITLE
dockerfile update to get dbt running on m1

### DIFF
--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update \
-  && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
+  && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev libunwind-dev liblz4-dev
 
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 


### PR DESCRIPTION
# Description
Worked through my open issues with @atvaccaro, got it running with this tiny change.

If you're experiencing this issue too (memray install issues), merge this change and then:

1. `build -t local-dbt -f Dockerfile.local --no-cache .`
2. Delete warehouse/dbt_packages dir
3. run `dbt deps`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
I was able to run dbt build



## Post-merge follow-ups
- [x] No action required
- [ ] Actions required (specified below)
