### PR TITLE
Move failing payments common fields tests to models

### DIFF
--- a/warehouse/models/payments_views_staging/_payments_views_staging.yml
+++ b/warehouse/models/payments_views_staging/_payments_views_staging.yml
@@ -24,6 +24,54 @@ enrichment_field_declarations:
     description: A ranking of the records using a unique key, ordered by decreasing priority
 
 models:
+  - name: int_cleaned_device_transaction_pairs_common_fields
+    columns:
+      - name: participant_id
+      - name: micropayment_id
+        description: '{{ doc("micropayment_adjustments_micropayment_id") }}'
+      - name: littlepay_transaction_id_1
+        description: Unique tap ID generated for the "on" transaction by Littlepay upon receipt of a tap to the Device API.
+      - name: littlepay_transaction_id_2
+        description: Unique tap ID generated for the "off" transaction by Littlepay upon receipt of a tap to the Device API.
+      - name: customer_id_1
+        description: Unique identifier representing the customer that belongs to the "on" transaction's customer funding source.
+      - name: customer_id_2
+        description: Unique identifier representing the customer that belongs to the "off" transaction's customer funding source.
+      - name: device_id_1
+        description: The unique identifier of the device that was tapped for the "on" transaction.
+      - name: device_id_2
+        description: The unique identifier of the device that was tapped for the "off" transaction.
+      - name: device_id_issuer_1
+        description: The entity that issued the device ID for the "on" transaction.
+      - name: device_id_issuer_2
+        description: The entity that issued the device ID for the "off" transaction.
+      - name: route_id_1
+        description: The route identifier provided by the device for the "on" transaction.
+      - name: route_id_2
+        description: The route identifier provided by the device for the "off" transaction.
+      - name: mode_1
+        description: |
+          The mode of transport for the "on transaction.
+
+          Possible values are `bus` and `train`.
+      - name: mode_2
+        description: |
+          The mode of transport for the "off" transaction.
+
+          Possible values are `bus` and `train`.
+      - name: direction_1
+      - name: direction_2
+      - name: vehicle_id_1
+        description: An identifier for the vehicle the "on" transaction took place on. This ID is unique to the participant.
+      - name: vehicle_id_2
+        description: An identifier for the vehicle the "off" transaction took place on. This ID is unique to the participant.
+      - name: has_mismatched_customer_id
+      - name: has_mismatched_device_id
+      - name: has_mismatched_device_id_issuer
+      - name: has_mismatched_route_id
+      - name: has_mismatched_mode
+      - name: has_mismatched_direction
+      - name: has_mismatched_vehicle_id
   - name: stg_enriched_authorisations
     columns:
       - &authorisations_participant_id

--- a/warehouse/models/payments_views_staging/int_cleaned_device_transaction_pairs_common_fields.sql
+++ b/warehouse/models/payments_views_staging/int_cleaned_device_transaction_pairs_common_fields.sql
@@ -1,11 +1,3 @@
-{{ config(store_failures = true) }}
-
--- dst_table_name: "payments.invalid_cleaned_device_transaction_common_fields"
--- Ensure that fields that are expected to be consistent across tap on/off
--- transactions are actually consistent. Invalid records are any that differ on
--- the device_id, device_id_issuer, route_id, mode, direction, of vehicle_id
--- fields.
-
 WITH initial_transactions AS (
     SELECT *
     FROM {{ ref('stg_cleaned_micropayment_device_transactions') }}
@@ -55,7 +47,7 @@ joined_transactions AS (
     INNER JOIN second_transactions AS t2 USING (participant_id, micropayment_id)
 ),
 
-validate_cleaned_device_transaction_pairs_common_fields AS (
+int_cleaned_device_transaction_pairs_common_fields AS (
 
     SELECT *
     FROM joined_transactions
@@ -68,4 +60,4 @@ validate_cleaned_device_transaction_pairs_common_fields AS (
         OR has_mismatched_vehicle_id
 )
 
-SELECT * FROM validate_cleaned_device_transaction_pairs_common_fields
+SELECT * FROM int_cleaned_device_transaction_pairs_common_fields

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -18,6 +18,55 @@ sources:
       - name: settlements
 
 models:
+  - name: int_device_transaction_pairs_common_fields
+    columns:
+      - name: participant_id
+      - name: micropayment_id
+        description: '{{ doc("micropayment_adjustments_micropayment_id") }}'
+      - name: littlepay_transaction_id_1
+        description: Unique tap ID generated for the "on" transaction by Littlepay upon receipt of a tap to the Device API.
+      - name: littlepay_transaction_id_2
+        description: Unique tap ID generated for the "off" transaction by Littlepay upon receipt of a tap to the Device API.
+      - name: customer_id_1
+        description: Unique identifier representing the customer that belongs to the "on" transaction's customer funding source.
+      - name: customer_id_2
+        description: Unique identifier representing the customer that belongs to the "off" transaction's customer funding source.
+      - name: device_id_1
+        description: The unique identifier of the device that was tapped for the "on" transaction.
+      - name: device_id_2
+        description: The unique identifier of the device that was tapped for the "off" transaction.
+      - name: device_id_issuer_1
+        description: The entity that issued the device ID for the "on" transaction.
+      - name: device_id_issuer_2
+        description: The entity that issued the device ID for the "off" transaction.
+      - name: route_id_1
+        description: The route identifier provided by the device for the "on" transaction.
+      - name: route_id_2
+        description: The route identifier provided by the device for the "off" transaction.
+      - name: mode_1
+        description: |
+          The mode of transport for the "on transaction.
+
+          Possible values are `bus` and `train`.
+      - name: mode_2
+        description: |
+          The mode of transport for the "off" transaction.
+
+          Possible values are `bus` and `train`.
+      - name: direction_1
+      - name: direction_2
+      - name: vehicle_id_1
+        description: An identifier for the vehicle the "on" transaction took place on. This ID is unique to the participant.
+      - name: vehicle_id_2
+        description: An identifier for the vehicle the "off" transaction took place on. This ID is unique to the participant.
+      - name: has_mismatched_customer_id
+      - name: has_mismatched_device_id
+      - name: has_mismatched_device_id_issuer
+      - name: has_mismatched_route_id
+      - name: has_mismatched_mode
+      - name: has_mismatched_direction
+      - name: has_mismatched_vehicle_id
+
   - name: int_littlepay__cleaned_micropayment_device_transactions
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/warehouse/models/staging/payments/littlepay/int_device_transaction_pairs_common_fields.sql
+++ b/warehouse/models/staging/payments/littlepay/int_device_transaction_pairs_common_fields.sql
@@ -1,11 +1,3 @@
-{{ config(store_failures = true) }}
-
--- dst_table_name: "payments.invalid_cleaned_device_transaction_common_fields"
--- Ensure that fields that are expected to be consistent across tap on/off
--- transactions are actually consistent. Invalid records are any that differ on
--- the device_id, device_id_issuer, route_id, mode, direction, of vehicle_id
--- fields.
-
 WITH initial_transactions AS (
     SELECT *
     FROM {{ ref('int_littlepay__cleaned_micropayment_device_transactions') }}
@@ -55,7 +47,7 @@ joined_transactions AS (
     INNER JOIN second_transactions AS t2 USING (participant_id, micropayment_id)
 ),
 
-validate_cleaned_device_transaction_pairs_common_fields AS (
+int_device_transaction_pairs_common_fields AS (
 
     SELECT *
     FROM joined_transactions
@@ -68,4 +60,4 @@ validate_cleaned_device_transaction_pairs_common_fields AS (
         OR has_mismatched_vehicle_id
 )
 
-SELECT * FROM validate_cleaned_device_transaction_pairs_common_fields
+SELECT * FROM int_device_transaction_pairs_common_fields


### PR DESCRIPTION
# Description
As described in the discussion around #2592, there were a couple payments tests that weren't serving our needs well - they began failing on new data not because something was wrong with the pipeline, but because we don't know enough about the constraints on the data to begin with. We decided to move these to models so that somebody could feasibly build dashboards off of them if desired.

Resolves #2592

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
New models built via dbt runs in staging

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

If we want to actually have a dashboard in place to monitor the phenomena previously measured by the tests, we'll need to create some non-staging models after this PR and base the dashboard on those, since staging datasets aren't meant to underpin prod dashboards.