### PR TITLE
Drop rows from bridge tables where one key is missing 

### DIFF
--- a/warehouse/macros/transit_database_many_to_many.sql
+++ b/warehouse/macros/transit_database_many_to_many.sql
@@ -20,6 +20,8 @@
             , T1.{{ table_a['end_date_col'] }} AS {{ shared_end_date_name }}
             , T1.{{ shared_current_name }} AS {{ shared_current_name }}
         FROM
+        -- this correlated cross join drops rows where table a has no table b records listed
+        -- if we wanted to keep all rows, we could convert this to a left join
             {{ table_a['name'] }} T1
             , UNNEST({{ table_a['unversioned_join_col'] }}) {{ table_a['unversioned_join_col'] }}
     ),
@@ -34,6 +36,8 @@
             , T2.{{ table_b['end_date_col'] }} AS {{ shared_end_date_name }}
             , T2.{{ shared_current_name }} AS {{ shared_current_name }}
         FROM
+        -- this correlated cross join drops rows where table b has no table a records listed
+        -- if we wanted to keep all rows, we could convert this to a left join
             {{ table_b['name'] }} T2
             , UNNEST({{ table_b['unversioned_join_col'] }}) {{ table_b['unversioned_join_col'] }}
     )
@@ -47,11 +51,17 @@
         LEAST(unnested_table_a.{{ shared_end_date_name }}, unnested_table_b.{{ shared_end_date_name }}) AS {{ shared_end_date_name }},
         (unnested_table_a.{{ shared_current_name }} AND unnested_table_b.{{ shared_current_name }}) AS {{ shared_current_name }}
     FROM unnested_table_a
-    FULL OUTER JOIN unnested_table_b
+    -- this inner join drops rows where one of the tables has foreign keys but the other does not
+    -- one example case is if one table is versioned/historical and the other is current-only,
+    -- if a record in the historical table is deleted the current-only table will no longer have the relationships
+    -- and the historical table will have "dangling" references
+    -- this inner join drops such rows
+    -- in future we could consider instead keeping all rows from both tables
+    -- so that every row is guaranteed to be present whether or not it had relationships to the other table
+    INNER JOIN unnested_table_b
         ON unnested_table_a.table_a_unversioned_key = unnested_table_b.table_a_unversioned_key
         AND unnested_table_b.table_b_unversioned_key = unnested_table_a.table_b_unversioned_key
         AND unnested_table_a.{{ shared_start_date_name }} < unnested_table_b.{{ shared_end_date_name }}
         AND unnested_table_a.{{ shared_end_date_name }} > unnested_table_b.{{ shared_start_date_name }}
-    WHERE unnested_table_a.{{ table_a['key_col_name'] }} IS NOT NULL AND unnested_table_b.{{ table_b['key_col_name'] }} IS NOT NULL
 
 {% endmacro %}

--- a/warehouse/macros/transit_database_many_to_many.sql
+++ b/warehouse/macros/transit_database_many_to_many.sql
@@ -52,5 +52,6 @@
         AND unnested_table_b.table_b_unversioned_key = unnested_table_a.table_b_unversioned_key
         AND unnested_table_a.{{ shared_start_date_name }} < unnested_table_b.{{ shared_end_date_name }}
         AND unnested_table_a.{{ shared_end_date_name }} > unnested_table_b.{{ shared_start_date_name }}
+    WHERE unnested_table_a.{{ table_a['key_col_name'] }} IS NOT NULL AND unnested_table_b.{{ table_b['key_col_name'] }} IS NOT NULL
 
 {% endmacro %}

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -670,7 +670,13 @@ models:
     description: |
       Mapping table between fare systems and services.
       Relationship indicates that service utilizes the given fare system.
-      This is a versioned, many-to-many relationship.
+      This is a partially versioned, many-to-many relationship.
+      Because service records are versioned and fare systems records
+      are current-only this represents relationships between versioned service
+      records and unversioned fare systems records.
+
+      Services that have been deleted will not have their fare systems present in
+      this table.
       Joins via this table can result in fanout.
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -649,6 +649,9 @@ models:
       This is a partially versioned, many-to-many relationship.
       Because organization records are versioned and funding programs are current-only this represents relationships between
       versioned organization records and unversioned funding program records.
+
+      Organizations that have been deleted will not have their funding programs present in
+      this table.
       Joins via this table can result in fanout.
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -772,6 +775,10 @@ models:
       Because organization records are versioned and headquarters county geography records
       are current-only this represents relationships between versioned organization
       records and unversioned headquarters county geography records.
+
+      Organizations that have been deleted will not have their headquarters county geographies present in
+      this table.
+
       Joins via this table can result in fanout.
   - name: bridge_services_x_operating_county_geographies
     description: |

--- a/warehouse/models/mart/transit_database/bridge_fare_systems_x_services.sql
+++ b/warehouse/models/mart/transit_database/bridge_fare_systems_x_services.sql
@@ -10,7 +10,7 @@ services AS ( -- noqa
     FROM {{ ref('int_transit_database__services_dim') }}
 ),
 
-naive_bridge AS (
+bridge_fare_systems_x_services AS (
  {{ transit_database_many_to_many_versioned(
     shared_start_date_name = '_valid_from',
     shared_end_date_name = '_valid_to',
@@ -35,14 +35,6 @@ naive_bridge AS (
         'start_date_col': '_valid_from',
         'end_date_col': '_valid_to'}
     ) }}
-),
-
--- TODO: can remove this once fare systems is made historical
-bridge_fare_systems_x_services AS (
-    SELECT *
-    FROM naive_bridge
-    WHERE fare_system_key IS NOT NULL
 )
-
 
 SELECT * FROM bridge_fare_systems_x_services

--- a/warehouse/models/mart/transit_database/bridge_fare_systems_x_services.sql
+++ b/warehouse/models/mart/transit_database/bridge_fare_systems_x_services.sql
@@ -10,7 +10,7 @@ services AS ( -- noqa
     FROM {{ ref('int_transit_database__services_dim') }}
 ),
 
-bridge_fare_systems_x_services AS (
+naive_bridge AS (
  {{ transit_database_many_to_many_versioned(
     shared_start_date_name = '_valid_from',
     shared_end_date_name = '_valid_to',
@@ -35,6 +35,14 @@ bridge_fare_systems_x_services AS (
         'start_date_col': '_valid_from',
         'end_date_col': '_valid_to'}
     ) }}
+),
+
+-- TODO: can remove this once fare systems is made historical
+bridge_fare_systems_x_services AS (
+    SELECT *
+    FROM naive_bridge
+    WHERE fare_system_key IS NOT NULL
 )
+
 
 SELECT * FROM bridge_fare_systems_x_services


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Fixes #2658 by dropping rows from bridge tables where one table's key is not present (i.e., dangling references). #2658 was caused by deleted services being present in a bridge table with a current-only table, so there were two rows with the same `service_key` and null `fare_systems_key`. 

I also updated the relevant table descriptions to explicitly describe the most confusing case here. 

Resolves #2658

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

`dbt run -s +models/mart/transit_database` & `dbt test -s +models/mart/transit_database`

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
