### PR TITLE
CI tweaks, use new dbt 1.5.1 release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,10 @@ jobs:
       # - uses: docker://avtodev/markdown-lint:v1
       #   with:
       #     args: '**/*.md'
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: crate-ci/typos@master
+      with:
+        files: ./docs/**

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ main ]
 
-# TODO: bring me back when not flaky anymore
-env:
-  SKIP: sqlfluff-lint
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: ["-ll", "--skip=B108,B608,B310,B303,B324,B113"]
         files: .py$
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 2.0.2
+    rev: 2.1.1
     hooks:
       - id: sqlfluff-lint
         additional_dependencies: ['dbt-bigquery', 'sqlfluff-templater-dbt']

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+BA = "BA"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,4 @@
 [default.extend-words]
 BA = "BA"
+homogenous = "homogenous"
+Unparseable = "Unparseable"

--- a/docs/airflow/dags-maintenance.md
+++ b/docs/airflow/dags-maintenance.md
@@ -60,7 +60,7 @@ Some tasks have unique considerations, beyond the requirements of their overall 
 
 From time-to-time some DAGs may need to be re-ran in order to populate new data.
 
-Subject to the considerations outlined abov, backfilling can be performed by clearing historical runs in the web interface, or via the CLI:
+Subject to the considerations outlined above, backfilling can be performed by clearing historical runs in the web interface, or via the CLI:
 ```shell
 gcloud composer environments run calitp-airflow-prod --location=us-west2 backfill -- --start_date 2021-04-18 --end_date 2021-11-03 -x --reset_dagruns -y -t "gtfs_schedule_history_load" -i gtfs_loader
 ```

--- a/docs/analytics_new_analysts/07-spatial-analysis-intermediate.md
+++ b/docs/analytics_new_analysts/07-spatial-analysis-intermediate.md
@@ -91,15 +91,15 @@ new = df.Coord.str.split(", ", expand = True)
 Then, extract our X, Y components. Put lat, lon into a Shapely object as demonstrated [in the prior section.](#create-geometry-column-from-latitude-and-longitude-coordinates)
 
 ```
-# Make sure only numbers, not parantheses, are captured. Cast it as float.
+# Make sure only numbers, not parentheses, are captured. Cast it as float.
 
 # 0 corresponds to the portion before the comma. [1:] means starting from
-# the 2nd character, right after the opening paranthesis, to the comma.
+# the 2nd character, right after the opening parenthesis, to the comma.
 df['lat'] = new[0].str[1:].astype(float)
 
 # 1 corresponds to the portion after the comma. [:-1] means starting from
 # right after the comma to the 2nd to last character from the end, which
-# is right before the closing paranthesis.
+# is right before the closing parenthesis.
 df['lon'] = new[1].str[:-1].astype(float)
 ```
 

--- a/docs/analytics_tools/overview.md
+++ b/docs/analytics_tools/overview.md
@@ -3,7 +3,7 @@
 Welcome to the Analytics Tools section! If you're here, you're ready to begin conducting analyses.
 
 **What you should know after reading**:
-* [Where to easily acccess links to team tools](tools-quick-links)
+* [Where to easily access links to team tools](tools-quick-links)
 * [How to use our BI & dashboarding tool](metabase)
 * [How to use our cloud notebook](jupyterhub-intro)
 * [How to query the warehouse with SQL](querying-sql-jupyterhub)

--- a/docs/analytics_tools/rt_analysis.md
+++ b/docs/analytics_tools/rt_analysis.md
@@ -28,7 +28,7 @@ This section includes detailed information about the data model and processing s
 
 All of the above are sourced from the v2 warehouse. Note that all components must be present and consistently keyed in order to successfully analyze. This module works at the organization level in order to match the reports site and maintain the structure of the speedmap site.
 
-For each organization, this module will combine and analyze all related GTFS Schedule and GTFS Realtime datasets that are `public_customer_facing_or_regional_subfeed_fixed_route` in [`dim_provider_gtfs_data`](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_provider_gtfs_data). Some organizations share GTFS datasets (Sacramento RT and City of Rancho Cordova, San Diego Airport and San Diego MTS...), in those cases the module can generate seperate analysis for each organization but they might duplicate each other. These are based on the underlying organization/dataset relationships in the Transit Database (Airtable).
+For each organization, this module will combine and analyze all related GTFS Schedule and GTFS Realtime datasets that are `public_customer_facing_or_regional_subfeed_fixed_route` in [`dim_provider_gtfs_data`](https://dbt-docs.calitp.org/#!/model/model.calitp_warehouse.dim_provider_gtfs_data). Some organizations share GTFS datasets (Sacramento RT and City of Rancho Cordova, San Diego Airport and San Diego MTS...), in those cases the module can generate separate analysis for each organization but they might duplicate each other. These are based on the underlying organization/dataset relationships in the Transit Database (Airtable).
 
 ### How is it structured?
 
@@ -332,7 +332,7 @@ The `describe_slow_routes` method lists out the routes in the current filter exp
 
 It's often useful to measure transit delay on a specific corridor to support technical metric generation for the Solutions for Congested Corridors Program, Local Partnership Program, and other analyses.
 
-If you've recieved a corridor from an SCCP/LPP applicant or elsewhere, load it as a geodataframe and add it using the `add_corridor` method. If you're already looking at a speed map and want to measure delay for a portion of the map, you can use the `autocorridor` method to specify a corridor using a shape_id and two stop_sequences. This saves time by avoiding the need to generate the polygon elsewhere.
+If you've received a corridor from an SCCP/LPP applicant or elsewhere, load it as a geodataframe and add it using the `add_corridor` method. If you're already looking at a speed map and want to measure delay for a portion of the map, you can use the `autocorridor` method to specify a corridor using a shape_id and two stop_sequences. This saves time by avoiding the need to generate the polygon elsewhere.
 
 The corridor must be a single polygon, and in order to generate metrics it must include at least one transit stop.
 
@@ -356,7 +356,7 @@ See [`data_analyses/ca_transit_speed_maps/technical_notes.md`](https://github.co
 
 ```{mermaid}
 flowchart TD
-    rcv_corr[/recieve corridor from applicant/] -->
+    rcv_corr[/receive corridor from applicant/] -->
     ver_corr[/verify corridor is polygon/] -->
     gen_data[generate analysis data for timeframe*]
     subgraph fm[RtFilterMapper]

--- a/docs/backups/metabase.md
+++ b/docs/backups/metabase.md
@@ -20,7 +20,7 @@ Within the kubernetes engine on GCE, go to the sidebar of `Secrets and Config Ma
 
 The preferred method is to use the Lens Kubernetes IDE https://k8slens.dev/. Once Lens desktop is set up, sync the following cluster `gke_cal-itp-data-infra_us-west1_data-infra-apps`. Within the configuration sidebar, navigate to `Secrets`. Select the `database-backup` secret where you will see the `RESTIC_PASSWORD`. Click the eye icon to unencrypt the password.
 
-Navigate to the Workloads parent folder and select `CronJobs`. Select the cronjob `postgressql-backup`. If you click the edit button you can look at it in YAML form. There you will obtain the Restic repository info.
+Navigate to the Workloads parent folder and select `CronJobs`. Select the cronjob `postgresql-backup`. If you click the edit button you can look at it in YAML form. There you will obtain the Restic repository info.
 
 ```shell
 name: RESTIC_REPOSITORY

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -192,6 +192,6 @@ Pipeline variables may be changed/redeclared in between steps, but evaluation of
 logic between steps is generally discouraged. E.g., conditional execution should
 be avoidable in most cases where steps are properly idempotent and explicitly
 listing multiple instances of a step should be preferred in cases where a step
-will be re-executed a determinitic number of times. Where there is good reason
+will be re-executed a deterministic number of times. Where there is good reason
 to do so however, the full power of bash logic and evaluation may be employed to
 wrap step execution.

--- a/docs/contribute/content_types.md
+++ b/docs/contribute/content_types.md
@@ -23,7 +23,7 @@ Below we've provided some examples of commons types of content for quick use. To
 4. [Internal References and Cross References](internal-refs)
 (executing-code)=
 ### Executing Code
-Place the following sytax at the top of a `.md` document to include code that will execute.
+Place the following syntax at the top of a `.md` document to include code that will execute.
 ```
 ---
 jupytext:

--- a/docs/datasets_and_tables/transitdatabase.md
+++ b/docs/datasets_and_tables/transitdatabase.md
@@ -69,7 +69,7 @@ Relevant Fields:
 
 #### Update a GTFS Dataset's URL
 
-Navigate to the record for ths dataset in `California Transit.gtfs datasets` and update the field `URI`.  If there is an interesting story or issue behind the update, you can add a comment to the record by [expanding the record](https://support.airtable.com/hc/en-us/articles/202576579-Expanding-records).
+Navigate to the record for the dataset in `California Transit.gtfs datasets` and update the field `URI`.  If there is an interesting story or issue behind the update, you can add a comment to the record by [expanding the record](https://support.airtable.com/hc/en-us/articles/202576579-Expanding-records).
 
 #### Add an additional GTFS Dataset
 

--- a/docs/datasets_and_tables/transitdatabase.md
+++ b/docs/datasets_and_tables/transitdatabase.md
@@ -22,7 +22,7 @@ For the sake of this documentation, we've noted the [`Primary Field`](https://su
 
 ### Full Documentation of Fields
 
-AirTable does not currently have an effective mechanism to programmaticaly download your data schema (they have currently paused issuing keys to their metadata API). Rather than manually type-out and export each individual field definition from AirTable, please see the [AirTable-based documentation of fields](https://airtable.com/appPnJWrQ7ui4UmIl/api/docs) which is produced as a part of their API documentation. Note that you must be authenticated with access to the base to reach this link.
+AirTable does not currently have an effective mechanism to programmatically download your data schema (they have currently paused issuing keys to their metadata API). Rather than manually type-out and export each individual field definition from AirTable, please see the [AirTable-based documentation of fields](https://airtable.com/appPnJWrQ7ui4UmIl/api/docs) which is produced as a part of their API documentation. Note that you must be authenticated with access to the base to reach this link.
 
 ## California Transit
 

--- a/docs/kubernetes/architecture.md
+++ b/docs/kubernetes/architecture.md
@@ -1,6 +1,6 @@
 # architecture
 
-This page displays the architecture of our kubernetes enviornment.
+This page displays the architecture of our kubernetes environment.
 
 ##
 

--- a/docs/publishing/overview.md
+++ b/docs/publishing/overview.md
@@ -17,7 +17,7 @@ listed in increasing order of complexity and therefore capability.
 * HTML visualizations can be rendered in [GitHub Pages](publishing-github-pages)
   and embedded as a URL into slide deck
 * More advanced HTML-based reports can be hosted in the [analytics portfolio](publishing-analytics-portfolio-site)
-  which supports interactivity and notebook paramterization.
+  which supports interactivity and notebook parameterization.
 * Interactive dashboards should be hosted in [Metabase](publishing-metabase) to
   share with external stakeholders.
 * Structured tabular data may be published to [CKAN](publishing-ckan) to facilitate usage by analysts, researchers, or other stakeholders. These will be hosted at [https://data.ca.gov](https://data.ca.gov).

--- a/docs/publishing/sections/4_analytics_portfolio_site.md
+++ b/docs/publishing/sections/4_analytics_portfolio_site.md
@@ -58,7 +58,7 @@ Before executing the build, there are a few prior steps you need to do.
             - chapters:
               - caption: County Name
                 params:
-                  paramter1_county_name
+                  parameter1_county_name
                 sections:
                 - city: parameter2_city_name
                 - city: parameter2_city_name

--- a/docs/publishing/sections/5_notebooks_styling.md
+++ b/docs/publishing/sections/5_notebooks_styling.md
@@ -5,7 +5,7 @@
 ### Parameterized Titles
 * If you're parameterizing the notebook, the first Markdown cell must include parameters to inject.
     * Ex: If `district` is one of the parameters in your `sites/my_report.yml`, a header Markdown cell could be `# District {district} Analysis`.
-    * Note: The site URL is constructed from the original notebok name and the parameter in the JupyterBook build: `0_notebook_name__district_x_analysis.html`
+    * Note: The site URL is constructed from the original notebook name and the parameter in the JupyterBook build: `0_notebook_name__district_x_analysis.html`
 
 ### Consecutive Headers
 

--- a/warehouse/models/payments_views_staging/stg_cleaned_customer_funding_source_vaults.sql
+++ b/warehouse/models/payments_views_staging/stg_cleaned_customer_funding_source_vaults.sql
@@ -31,7 +31,7 @@ WITH stg_cleaned_customer_funding_source_vaults AS (
     WINDOW unique_ids AS (
         PARTITION BY funding_source_vault_id
         ORDER BY calitp_customer_id_rank, calitp_funding_source_vault_id_rank)
-ORDER BY funding_source_vault_id, calitp_valid_at DESC
+    ORDER BY funding_source_vault_id ASC, calitp_valid_at DESC
 )
 
 SELECT * FROM stg_cleaned_customer_funding_source_vaults

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -1,3 +1,4 @@
+-- noqa: disable=AL03
 {{ config(materialized='ephemeral') }}
 
 WITH stg_gtfs_quality__intended_checks AS (

--- a/warehouse/poetry.lock
+++ b/warehouse/poetry.lock
@@ -710,33 +710,33 @@ pyarrow = ">=3.0.0"
 
 [[package]]
 name = "dbt-bigquery"
-version = "1.6.0b1"
+version = "1.5.1"
 description = "The Bigquery adapter plugin for dbt"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "dbt-bigquery-1.6.0b1.tar.gz", hash = "sha256:1481fc4489cb068ac9f021c5b4be7599272c82c64597d5f5d5b2a872dd8beaec"},
-    {file = "dbt_bigquery-1.6.0b1-py3-none-any.whl", hash = "sha256:ded7abdd617b46f6e81f50227c50e8e09a18ca01af655ac7c88e60680421c519"},
+    {file = "dbt-bigquery-1.5.1.tar.gz", hash = "sha256:93fe836a77d08738edf6d11c4446cc851767bfc3a2ecdf72cb31a600876d9150"},
+    {file = "dbt_bigquery-1.5.1-py3-none-any.whl", hash = "sha256:1e93a084fa8631966076381b7b8261c0d4fdae4619cd0452f87b09c9c2ba98f3"},
 ]
 
 [package.dependencies]
 agate = ">=1.6.3,<1.7.0"
-dbt-core = ">=1.6.0b1,<1.7.0"
+dbt-core = ">=1.5.0,<1.6.0"
 google-cloud-bigquery = ">=3.0,<4.0"
 google-cloud-dataproc = ">=5.0,<6.0"
 google-cloud-storage = ">=2.4,<3.0"
 
 [[package]]
 name = "dbt-core"
-version = "1.6.0b2"
+version = "1.5.1"
 description = "With dbt, data analysts and engineers can build analytics the way engineers build applications."
 category = "main"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "dbt-core-1.6.0b2.tar.gz", hash = "sha256:aaea395897aaf0aeea4d39a4d937dc5fa864171c6717ac003d1ae02f972ed8cb"},
-    {file = "dbt_core-1.6.0b2-py3-none-any.whl", hash = "sha256:bb81190a184b159417e937c15a0b927f14daa4c941fb11737a0c68e7178b68a0"},
+    {file = "dbt-core-1.5.1.tar.gz", hash = "sha256:d645ebdc1098ad0fad19f0871022d16ce77bec6b00d2b6b078db792c8917b8be"},
+    {file = "dbt_core-1.5.1-py3-none-any.whl", hash = "sha256:abc685e4149d523e719b3a687705c2885f986e1ba0f984c048fb696c39ea8958"},
 ]
 
 [package.dependencies]
@@ -757,12 +757,26 @@ packaging = ">20.9"
 pathspec = ">=0.9,<0.12"
 protobuf = ">=4.0.0"
 pytz = ">=2015.7"
-pyyaml = ">=5.3"
+pyyaml = ">=6.0"
 requests = "<3.0.0"
 sqlparse = ">=0.2.3,<0.4.4"
 typing-extensions = ">=3.7.4"
-urllib3 = ">=1.0,<2.0"
 werkzeug = ">=1,<3"
+
+[[package]]
+name = "dbt-coverage"
+version = "0.3.4"
+description = "One-stop-shop for docs and test coverage of dbt projects"
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+files = [
+    {file = "dbt_coverage-0.3.4-py3-none-any.whl", hash = "sha256:bfb0a064978149e666406c98a1683d390846c8c1ba756626a01013c45a32311d"},
+    {file = "dbt_coverage-0.3.4.tar.gz", hash = "sha256:4f550965a552bc485d255a3027da1d787d38ab6e408aef3f571f3fb876fff3b7"},
+]
+
+[package.dependencies]
+typer = ">=0.4.0,<0.5.0"
 
 [[package]]
 name = "dbt-extractor"
@@ -4237,24 +4251,24 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.7.0"
+version = "0.4.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d"},
-    {file = "typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"},
+    {file = "typer-0.4.2-py3-none-any.whl", hash = "sha256:023bae00d1baf358a6cc7cea45851639360bb716de687b42b0a4641cd99173f1"},
+    {file = "typer-0.4.2.tar.gz", hash = "sha256:b8261c6c0152dd73478b5ba96ba677e5d6948c715c310f7c91079f311f62ec03"},
 ]
 
 [package.dependencies]
 click = ">=7.1.1,<9.0.0"
 
 [package.extras]
-all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
-doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
-test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+doc = ["mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=5.2,<6.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "types-python-slugify"
@@ -4497,4 +4511,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "e54048011983894c4fb723e8e68e956e4d707a8d1f8e3fbb75f14f778369fa81"
+content-hash = "156d6d8c40ef9ffb8b43c91fb2f1b77d7c97a6f2482d29580713b4efead529bc"

--- a/warehouse/pyproject.toml
+++ b/warehouse/pyproject.toml
@@ -20,7 +20,6 @@ geopandas = "^0.10.2"
 python-slugify = "^6.1.2"
 sentry-sdk = "^1.9.8"
 backoff = "^2.2.1"
-typer = "^0.7.0"
 gcsfs = "^2023.1.0"
 dbt-metabase = "^0.9.14"
 networkx = {version = "<3", extras = ["default"]}
@@ -30,11 +29,12 @@ networkx = {version = "<3", extras = ["default"]}
 # export LDFLAGS="-L $(brew --prefix graphviz)/lib"
 pygraphviz = "^1.10"
 palettable = "^3.3.0"
-dbt-bigquery = "1.6.0b1"
 metabase-api = "^0.3.0"
 # fiona 1.9 requires gdal 3 which ubuntu does not install yet
 # from https://gis.stackexchange.com/questions/375685/how-to-install-or-build-gdal-3-on-debian-buster
 fiona = "~1.8"
+typer = "^0.4.0"
+dbt-bigquery = "1.5.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
@@ -52,6 +52,7 @@ ipdb = "^0.13.13"
 mypy = "^1.2.0"
 pyspark = "~3.0" # pin this low because of stubs
 pyspark-stubs = "^3.0.0.post3"
+dbt-coverage = "^0.3.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -45,7 +45,7 @@ DBT_ARTIFACTS_BUCKET = os.environ["CALITP_BUCKET__DBT_ARTIFACTS"]
 MANIFEST_DEFAULT = f"{DBT_ARTIFACTS_BUCKET}/latest/manifest.json"
 PUBLISH_BUCKET = os.environ["CALITP_BUCKET__PUBLISH"]
 
-app = typer.Typer(pretty_exceptions_enable=False)
+app = typer.Typer()
 
 WGS84 = "EPSG:4326"  # "standard" lat/lon coordinate system
 CHUNK_SIZE = (

--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -22,7 +22,7 @@ artifacts = map(
 
 sentry_sdk.init()
 
-app = typer.Typer(pretty_exceptions_enable=False)
+app = typer.Typer()
 
 
 class DbtException(Exception):

--- a/warehouse/scripts/visualize.py
+++ b/warehouse/scripts/visualize.py
@@ -24,7 +24,7 @@ from dbt_artifacts import (
 )
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-app = typer.Typer(pretty_exceptions_enable=False)
+app = typer.Typer()
 
 
 class ArtifactType(str, Enum):


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Adds a couple new CI checks and brings back sqlfluff; tighter typos scope than https://github.com/cal-itp/data-infra/pull/2515.

Also, now that dbt 1.5.1 is out with a necessary bugfix, we can use it instead of the 1.6 pre-release.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

CI must pass except for check dbt; unfortunately since this downgrades dbt to a version that uses the v9 manifest, we can't compare state with production artifacts with the v10 manifest.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
