### PR TITLE
Source NTD ID source to Airtable Instead of Seed

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
@@ -34,6 +34,7 @@ int_transit_database__organizations_dim AS (
         assessment_status,
         manual_check__contact_on_website,
         hq_county_geography,
+        raw_ntd_id,
         _is_current,
         _valid_from,
         _valid_to

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -4,18 +4,12 @@ WITH dim AS (
     SELECT * FROM {{ ref('int_transit_database__organizations_dim') }}
 ),
 
-ntd_agency_to_organization AS (
-    SELECT * FROM {{ ref('ntd_agency_to_organization') }}
-),
-
 dim_organizations AS (
     SELECT
 
         -- key
-        dim.key,
-        dim.source_record_id,
-
-        ntd_to_org.ntd_id,
+        key,
+        source_record_id,
 
         -- attributes
         name,
@@ -32,14 +26,13 @@ dim_organizations AS (
         assessment_status,
         manual_check__contact_on_website,
         alias,
+        raw_ntd_id as ntd_id,
 
-        dim._is_current,
-        dim._valid_from,
-        dim._valid_to
+        _is_current,
+        _valid_from,
+        _valid_to
 
     FROM dim
-    LEFT JOIN ntd_agency_to_organization ntd_to_org
-        ON dim.source_record_id = ntd_to_org.organization_record_id
 )
 
 SELECT * FROM dim_organizations

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -38,7 +38,8 @@ stg_transit_database__organizations AS (
         assessment_status = "Yes" AS assessment_status,
         manual_check__contact_on_website,
         dt,
-        hq_county_geography
+        hq_county_geography,
+        raw_ntd_id
     FROM once_daily_organizations
     LEFT JOIN UNNEST(once_daily_organizations.ntd_id) as unnested_ntd_records
 )


### PR DESCRIPTION
# Description
Following the work performed in #2582, we determined that we wanted to deprecate the NTD information seed and rely on a regularly maintained column in Airtable instead. This PR makes that switch, but at the time of creation it leaves several additional pieces alone - for instance, it does not delete the seed, nor does it get rid of the logic that creates the `unnested_ntd_records` field in `stg_transit_database__organizations`. I'd like advice from other stakeholders about how to proceed with those - perhaps they can be cleaved away in a follow-up PR to keep this one focused on the narrow scope of #2584?

Resolves #2584

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
The `dim_organizations` model was run from scratch in a staging environment, available to staging warehouse users at `soren_mart_transit_database.dim_organizations`. The total number of rows with `ntd_id` values differs from the production table, but the total number of rows with `ntd_id` values for which `_is_current` is true does not differ. There may be implications for historic data here - I welcome input.

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

If we take the minimal route on this PR, we will likely need to follow up with some cleanup tasks related to the current seed file and `stg_transit_database__organizations`.