### PR TITLE
create new table to track weekly unlabeled routes for payments

### DIFF
--- a/warehouse/models/mart/payments/reliability/_payments_views_tests.yml
+++ b/warehouse/models/mart/payments/reliability/_payments_views_tests.yml
@@ -31,7 +31,7 @@ models:
         description: A participant's total ridership on a particular day
       - name: relative_difference
         description: The relative change in a participant's ridership count as compared to the previous day
-  - name: v2_payments_reliability_unlabeled_routes
+  - name: v2_payments_reliability_monthly_unlabeled_routes
     tests:
       - dbt_utils.expression_is_true:
           expression: "n_all_rides >= (n_route_z_rides + n_null_rides)"
@@ -40,6 +40,27 @@ models:
         description: Littlepay-assigned Participant ID
       - name: month_start
         description: The first day of the month for which the count aggregation is being caclulated
+      - name: n_route_z_rides
+        description: The total number of rides labeled as `Route Z` for the given month
+      - name: n_null_rides
+        description: The total number of rides labeled as `Null` for the given month
+      - name: total_unlabeled_rides
+        description: The total number of rides labeled as either `Route Z` or `Null` for the given month
+      - name: n_all_rides
+        description: The total number of rides for the given month
+      - name: pct_unlabeled_rides_to_total_rides
+        description: The percentage of unlabeled rides compared to the total number of rides for the given month
+      - name: recency_rank
+        description: Used to identify a month's recency (for help with filtering)
+  - name: v2_payments_reliability_weekly_unlabeled_routes
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "n_all_rides >= (n_route_z_rides + n_null_rides)"
+    columns:
+      - name: participant_id
+        description: Littlepay-assigned Participant ID
+      - name: week_start
+        description: The first day of the week for which the count aggregation is being caclulated
       - name: n_route_z_rides
         description: The total number of rides labeled as `Route Z` for the given month
       - name: n_null_rides

--- a/warehouse/models/mart/payments/reliability/v2_payments_reliability_monthly_unlabeled_routes.sql
+++ b/warehouse/models/mart/payments/reliability/v2_payments_reliability_monthly_unlabeled_routes.sql
@@ -1,0 +1,60 @@
+WITH payments_rides AS (
+    SELECT * FROM {{ ref('fct_payments_rides_v2') }}
+),
+
+payments_tests_monthly_date_spine AS (
+    SELECT * FROM {{ ref('payments_tests_monthly_date_spine') }}
+),
+
+count_rides AS (
+    SELECT
+
+        spine.participant_id,
+        spine.month_start,
+        COUNTIF(route_id = 'Route Z') AS n_route_z_rides,
+        COUNTIF(route_id IS NULL) AS n_null_rides,
+        COUNTIF(route_id = '') AS n_empty_string_rides,
+        COUNT(*) AS n_all_rides
+
+    FROM payments_tests_monthly_date_spine AS spine
+    INNER JOIN payments_rides
+        ON (spine.participant_id = payments_rides.participant_id) AND transaction_date_pacific >= month_start AND transaction_date_pacific <= month_end
+    GROUP BY month_start, participant_id
+),
+
+aggregations_and_date_spine AS (
+    SELECT
+
+        date_spine.participant_id,
+        date_spine.month_start,
+        count_rides.n_route_z_rides,
+        count_rides.n_null_rides,
+        count_rides.n_empty_string_rides,
+        count_rides.n_all_rides,
+
+        (count_rides.n_route_z_rides + count_rides.n_null_rides + count_rides.n_empty_string_rides) AS total_unlabeled_rides,
+
+        SAFE_DIVIDE((count_rides.n_route_z_rides + count_rides.n_null_rides + count_rides.n_empty_string_rides), count_rides.n_all_rides) * 100 AS pct_unlabeled_rides_to_total_rides
+
+    FROM payments_tests_monthly_date_spine AS date_spine
+    LEFT JOIN count_rides
+        USING (participant_id, month_start)
+),
+
+v2_payments_reliability_monthly_unlabeled_routes AS (
+    SELECT
+
+        participant_id,
+        month_start,
+        n_route_z_rides,
+        n_null_rides,
+        total_unlabeled_rides,
+        n_empty_string_rides,
+        n_all_rides,
+        pct_unlabeled_rides_to_total_rides,
+        RANK() OVER (PARTITION BY participant_id ORDER BY month_start DESC) AS recency_rank
+
+    FROM aggregations_and_date_spine
+)
+
+SELECT * FROM v2_payments_reliability_monthly_unlabeled_routes

--- a/warehouse/models/mart/payments/reliability/v2_payments_reliability_weekly_unlabeled_routes.sql
+++ b/warehouse/models/mart/payments/reliability/v2_payments_reliability_weekly_unlabeled_routes.sql
@@ -2,31 +2,31 @@ WITH payments_rides AS (
     SELECT * FROM {{ ref('fct_payments_rides_v2') }}
 ),
 
-payments_tests_monthly_date_spine AS (
-    SELECT * FROM {{ ref('payments_tests_monthly_date_spine') }}
+payments_tests_weekly_date_spine AS (
+    SELECT * FROM {{ ref('payments_tests_weekly_date_spine') }}
 ),
 
 count_rides AS (
     SELECT
 
         spine.participant_id,
-        spine.month_start,
+        spine.week_start,
         COUNTIF(route_id = 'Route Z') AS n_route_z_rides,
         COUNTIF(route_id IS NULL) AS n_null_rides,
         COUNTIF(route_id = '') AS n_empty_string_rides,
         COUNT(*) AS n_all_rides
 
-    FROM payments_tests_monthly_date_spine AS spine
+    FROM payments_tests_weekly_date_spine AS spine
     INNER JOIN payments_rides
-        ON (spine.participant_id = payments_rides.participant_id) AND transaction_date_pacific >= month_start AND transaction_date_pacific <= month_end
-    GROUP BY month_start, participant_id
+        ON (spine.participant_id = payments_rides.participant_id) AND transaction_date_pacific >= week_start AND transaction_date_pacific <= week_end
+    GROUP BY week_start, participant_id
 ),
 
 aggregations_and_date_spine AS (
     SELECT
 
         date_spine.participant_id,
-        date_spine.month_start,
+        date_spine.week_start,
         count_rides.n_route_z_rides,
         count_rides.n_null_rides,
         count_rides.n_empty_string_rides,
@@ -36,25 +36,25 @@ aggregations_and_date_spine AS (
 
         SAFE_DIVIDE((count_rides.n_route_z_rides + count_rides.n_null_rides + count_rides.n_empty_string_rides), count_rides.n_all_rides) * 100 AS pct_unlabeled_rides_to_total_rides
 
-    FROM payments_tests_monthly_date_spine AS date_spine
+    FROM payments_tests_weekly_date_spine AS date_spine
     LEFT JOIN count_rides
-        USING (participant_id, month_start)
+        USING (participant_id, week_start)
 ),
 
-v2_payments_reliability_unlabeled_routes AS (
+v2_payments_reliability_weekly_unlabeled_routes AS (
     SELECT
 
         participant_id,
-        month_start,
+        week_start,
         n_route_z_rides,
         n_null_rides,
         total_unlabeled_rides,
         n_empty_string_rides,
         n_all_rides,
         pct_unlabeled_rides_to_total_rides,
-        RANK() OVER (PARTITION BY participant_id ORDER BY month_start DESC) AS recency_rank
+        RANK() OVER (PARTITION BY participant_id ORDER BY week_start DESC) AS recency_rank
 
     FROM aggregations_and_date_spine
 )
 
-SELECT * FROM v2_payments_reliability_unlabeled_routes
+SELECT * FROM v2_payments_reliability_weekly_unlabeled_routes


### PR DESCRIPTION
# Description
create new weekly unlabeled routes tracking table `v2_payments_reliability_weekly_unlabeled_routes`, rename original title from `v2_payments_reliability_unlabeled_routes` to `v2_payments_reliability_monthly_unlabeled_routes`

Once this is merged, we can create the alert in the SBMTD dashboard as requested in #2619

## Type of change
- [x] New feature

## How has this been tested?
tested locally with dbt

## Post-merge follow-ups
- [x] Actions required (specified below)
Set up alerts in Metabase
