### PR TITLE
handle cases where gtfs dims are empty

### DIFF
--- a/warehouse/macros/incremental_where.sql
+++ b/warehouse/macros/incremental_where.sql
@@ -1,11 +1,11 @@
 {% macro incremental_where(default_start_var, this_dt_column = 'dt', filter_dt_column = 'dt', dev_lookback_days = 7) -%}
+{# BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
+{# save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
 
 {%- if is_incremental() -%}
     {% if var('INCREMENTAL_MAX_DT') %}
         {% set max_dt = var('INCREMENTAL_MAX_DT') %}
     {% else %}
-        -- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost
-        -- save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination
         {% set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
         {% set max_dt = dates[0] %}
     {% endif %}
@@ -14,7 +14,10 @@
     {%- else -%}
         {% set start_dt = [max_dt, (modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days))] | max %}
     {%- endif -%}
-{%- else -%}
+{% endif %}
+
+{%- if not start_dt -%}
+    {# full refresh, or the table was empty #}
     {%- if target.name.startswith('prod') or not dev_lookback_days -%}
         {% set start_dt = var(default_start_var) %}
     {%- else -%}


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves the currently failing `dim_translations`; handles situations where the table is empty but exists.

I'm a bit worried this means we could theoretically continue to query upstream data if a bug means that we don't ever _insert_ any queried rows. I just don't know a good way to check whether there's any upstream data without actually querying for upstream data. We don't have rowcounts or anything in the outcomes, unfortunately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._



## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
