### PR TITLE
explicitly del lines and jsonl_content after use

### DIFF
--- a/airflow/plugins/operators/gtfs_csv_to_jsonl.py
+++ b/airflow/plugins/operators/gtfs_csv_to_jsonl.py
@@ -96,6 +96,8 @@ def parse_individual_file(
             "\n".join(json.dumps(line) for line in lines).encode()
         )
 
+        del lines
+
         jsonl_file = GTFSScheduleFeedJSONL(
             ts=input_file.ts,
             extract_config=input_file.extract_config,
@@ -104,6 +106,8 @@ def parse_individual_file(
         )
 
         jsonl_file.save_content(content=jsonl_content, fs=fs)
+
+        del jsonl_content
 
     except Exception as e:
         logging.warn(f"Can't process {input_file.path}: {e}")


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves https://github.com/cal-itp/data-infra/issues/2652

It hasn't been occurring much recently (and we now have the tools to deal with the warehouse impact), but it's easy to just explicitly delete the potentially-large strings/bytes since a memory issue is the most likely culprit.

An alternative would be moving this parsing to a PodOperator but I think it's overkill right now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Running locally.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
