### PR TITLE
add more rt validation information to sentry and outcomes

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_service_alerts_validation_outcomes.yml
@@ -14,6 +14,9 @@ schema_fields:
   - name: exception
     type: STRING
     mode: NULLABLE
+  - name: process_stderr
+    type: STRING
+    mode: NULLABLE
   - name: extract
     type: RECORD
     fields:

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_trip_updates_validation_outcomes.yml
@@ -14,6 +14,9 @@ schema_fields:
   - name: exception
     type: STRING
     mode: NULLABLE
+  - name: process_stderr
+    type: STRING
+    mode: NULLABLE
   - name: extract
     type: RECORD
     fields:

--- a/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_rt_v2/rt_v2_vehicle_positions_validation_outcomes.yml
@@ -14,6 +14,9 @@ schema_fields:
   - name: exception
     type: STRING
     mode: NULLABLE
+  - name: process_stderr
+    type: STRING
+    mode: NULLABLE
   - name: extract
     type: RECORD
     fields:

--- a/jobs/gtfs-rt-parser-v2/Dockerfile
+++ b/jobs/gtfs-rt-parser-v2/Dockerfile
@@ -8,7 +8,7 @@ ENV GTFS_RT_VALIDATOR_VERSION=v1.0.0
 RUN apt-get update -y \
     && apt-get install -y python3 python3-pip python3-venv
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:${PATH}"
 
 # from https://github.com/MobilityData/gtfs-realtime-validator/packages/1268973

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -686,6 +686,10 @@ def parse_and_validate(
                         "Process", {"stderr": e.stderr.decode("utf-8")[-2000:]}
                     )
 
+                    # we could also use a custom exception for this
+                    if "Unexpected end of ZLIB input stream" in stderr:
+                        fingerprint.append("Unexpected end of ZLIB input stream")
+
                 scope.fingerprint = fingerprint
                 sentry_sdk.capture_exception(e, scope=scope)
             if verbose:

--- a/jobs/gtfs-rt-parser-v2/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/test_gtfs_rt_parser.py
@@ -5,12 +5,13 @@ from calitp_data_infra.storage import (  # type: ignore
     GTFSFeedType,
     GTFSRTFeedExtract,
 )
+from pydantic import ValidationError
+
 from gtfs_rt_parser import (
     RTFileProcessingOutcome,
     RTHourlyAggregation,
     RTProcessingStep,
 )
-from pydantic import ValidationError
 
 
 def test_rt_file_processing_outcome_construction() -> None:
@@ -31,9 +32,7 @@ def test_rt_file_processing_outcome_construction() -> None:
         aggregation=RTHourlyAggregation(
             filename="vehicle_positions.jsonl.gz",
             step=RTProcessingStep.parse,
-            feed_type=GTFSFeedType.vehicle_positions,
-            hour=extract.ts.replace(minute=0, second=0, microsecond=0),
-            base64_url=extract.base64_url,
+            first_extract=extract,
             extracts=[
                 extract,
             ],

--- a/jobs/gtfs-rt-parser-v2/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/test_gtfs_rt_parser.py
@@ -7,7 +7,9 @@ from calitp_data_infra.storage import (  # type: ignore
 )
 from pydantic import ValidationError
 
-from gtfs_rt_parser import (
+# isort doesn't realize this is a local file when run from the top of the project
+# the actual fix would be to make gtfs_rt_parser a proper module that is executed with -m
+from gtfs_rt_parser import (  # isort:skip
     RTFileProcessingOutcome,
     RTHourlyAggregation,
     RTProcessingStep,

--- a/warehouse/macros/gtfs_rt_stg_outcomes.sql
+++ b/warehouse/macros/gtfs_rt_stg_outcomes.sql
@@ -30,6 +30,8 @@ stg_gtfs_rt__agg_outcomes AS (
              -- 1/28/2020 6:29:01 PM
              WHEN JSON_VALUE(`extract`.response_headers, '$."last_modified"') like '%PM' THEN PARSE_TIMESTAMP("%m/%d/%Y %I:%M:%S %p", JSON_VALUE(`extract`.response_headers, '$."last_modified"'))
         END AS last_modified_timestamp,
+        {% else %}
+        process_stderr,
         {% endif %}
         `extract`.ts AS extract_ts
     FROM raw_outcomes


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves https://github.com/cal-itp/data-infra/issues/2643
Resolves https://github.com/cal-itp/data-infra/issues/2609

Adds stderr to outcomes and Sentry; adds tags to Sentry; and changes fingerprint for Sentry to distinguish ZLIB errors from others.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

pytest passes, and tested via local run.

Here's an example [Sentry event](https://sentry.calitp.org/organizations/sentry/issues/71961/?environment=local&project=2&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h) and I've verified that outcomes contain the stderr.

```sql
select *
from cal-itp-data-infra-staging.external_gtfs_rt_v2.trip_updates_validation_outcomes
where dt = '2023-02-27'
and process_stderr is not null;
```

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
