### PR TITLE
Create .jupyter directory in Docker image during single-user setup if it doesn't already exist

### DIFF
--- a/images/jupyter-singleuser/docker-compose.yaml
+++ b/images/jupyter-singleuser/docker-compose.yaml
@@ -7,6 +7,6 @@ services:
       - "8888:8888"
     volumes:
       - jovyan_home:/home/jovyan/
-    entrypoint: sh -c 'cp /tmp/jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py && jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --notebook-dir=/home/jovyan --allow-root'
+    entrypoint: sh -c 'mkdir -p -- home/jovyan/.jupyter && cp /tmp/jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py && jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --notebook-dir=/home/jovyan --allow-root'
 volumes:
   jovyan_home:

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -8,7 +8,7 @@ jupyterhub:
     defaultUrl: "/lab"
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
-      tag: 2023.6.6
+      tag: 2023.6.8
     memory:
       # Much more than 10 and we risk bumping up against the actual capacity of e2-highmem-2
       limit: 10G

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -25,6 +25,7 @@ jupyterhub:
             - "-c"
             - >
               cp /tmp/profile.sh /home/jovyan/.profile;
+              mkdir -p -- home/jovyan/.jupyter;
               cp /tmp/jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py;
   scheduling:
     userPods:


### PR DESCRIPTION
# Description
A new Jupyterhub user in the Cal-ITP ecosystem recently ran into setup issues because of a missing folder that short-circuited our sh scripts. This attempts to address the issue by pre-creating the target directory if required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

We'll need to deploy this and confirm with the impacted user that they were able to successfully get up and running without additional errors.