### PR TITLE
Up memory request on open data publication DAG

### DIFF
--- a/airflow/dags/publish_open_data/publish_california_open_data.yml
+++ b/airflow/dags/publish_open_data/publish_california_open_data.yml
@@ -33,7 +33,7 @@ secrets:
     key: calitp-ckan-gtfs-schedule-key
 
 k8s_resources:
-  request_memory: 10.0Gi
+  request_memory: 20.0Gi
   request_cpu: 1
 
 tolerations:


### PR DESCRIPTION
# Description
After adding several new tables to open data publishing, we are seeing failures similar to those reported in #2596. This PR ups the memory provided to the open data publishing job in order to accommodate what we assume is a memory limitation. In the future, we may want to take a closer look at table-by-table memory management in this job.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

We likely want to investigate other strategies for breaking up memory use on this job in the future.