### PR TITLE
Patch GTFS datasets model for new publication rules

### DIFF
--- a/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
+++ b/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
@@ -14,6 +14,8 @@ models:
         description: |
           An arbitrary human-readable title for the GTFS feed in question, usually
           referencing the corresponding agency transit agency and feed type.
+        meta:
+          publish.include: true
       - name: type
         description: |
           GTFS data type ("schedule", "trip_updates",
@@ -23,6 +25,8 @@ models:
               values: ["trip_updates", "vehicle_positions", "service_alerts"]
               config:
                 where: "schedule_to_use_for_rt_validation_base64_url IS NOT NULL"
+        meta:
+          publish.include: true
       - name: regional_feed_type
         description: |
           Describes whether this feed is a combined regional feed or has a relation
@@ -33,15 +37,21 @@ models:
           inappropriate (even though that is the customer-facing data), this field can
           help you assess other alternative feeds for the same services and organizations.
           Not specified (null) for feeds with no relationship to regional feeds.
+        meta:
+          publish.include: true
       - name: base64_url
         description: |
           Base64-encoded URL of the GTFS feed referenced by the row, using
           URL-safe base64 as described in
           https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#to_base64
+        meta:
+          publish.include: true
       - name: url
         description: |
           Plaintext URL of the GTFS feed referenced by the row, unencoded for
           convenience directly from the value of base64_url.
+        meta:
+          publish.include: true
       - name: schedule_to_use_for_rt_validation_base64_url
         description: |
           Base64-encoded URL of the GTFS schedule feed associated with the row, only
@@ -51,9 +61,13 @@ models:
               values: [NULL]
               config:
                 where: "type = 'schedule'"
+        meta:
+          publish.include: true
       - name: schedule_to_use_for_rt_validation_url
         description: |
           Plaintext URL of the GTFS schedule feed associated with the row, only
           filled with a value for rows representing non-schedule-type feeds,
           unencoded for convenience directly from the value of
           schedule_to_use_for_rt_validation_base64_url.
+        meta:
+          publish.include: true


### PR DESCRIPTION
# Description
The `dim_gtfs_datasets_latest` was inadvertently left out of #2700 because it sits in a different dataset than the other `_latest` models. This setup can likely be revisited when we consider ridding ourselves of the `_latest` models altogether in an upcoming sprint. But for now, this will align the model with the changes we made last week to default to non-publication on new columns.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Table documentation generated and compared to the most recent version we sent to Chad.

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

Rerun open data publishing for this week