### PR TITLE
Changed `fixed_route` to boolean in external table

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -271,7 +271,7 @@ schema_fields:
     type: STRING
     mode: REPEATED
   - name: fixed_route
-    type: STRING
+    type: BOOLEAN
     mode: NULLABLE
   - name: is_public
     type: STRING


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Noticed while working on GTFS quality dashboard updates that this field should have been a boolean in the external table for consistency. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Ran the Airflow DAG locally, ` poetry run dbt run -s +stg_transit_database__services+2 --vars "{'SOURCE_DATABASE':'cal-itp-data-infra-staging'}"`, ` poetry run dbt test -s +stg_transit_database__services+2 --vars "{'SOURCE_DATABASE':'cal-itp-data-infra-staging'}"`

Confirmed no issues.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

* Run the create external tables DAG manually in Airflow
* Once it's run, run a full refresh with the selector `+stg_transit_database__services+`
