### PR TITLE
assert mb_host is not empty for mypy, ignore library that lacks stubs

### DIFF
--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -16,7 +16,7 @@ import pendulum
 import sentry_sdk
 import typer
 from dbt_artifacts import Manifest, RunResults, RunResultStatus
-from dbtmetabase.models.interface import DbtInterface, MetabaseInterface
+from dbtmetabase.models.interface import DbtInterface, MetabaseInterface  # type: ignore
 from metabase_api import Metabase_API  # type: ignore
 
 CALITP_BUCKET__DBT_ARTIFACTS = os.getenv("CALITP_BUCKET__DBT_ARTIFACTS")
@@ -316,6 +316,7 @@ def run(
             )
 
             # initialize session
+            assert mb_host, "mb_host is empty."
             mb = Metabase_API(mb_host, mb_user, mb_pass)
 
             # get database ids (does this need prod / staging handling?)


### PR DESCRIPTION
# Description
assert `mb_host` is not empty for mypy, ignore library `dbtmetabase.models.interface` that lacks stubs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
locally

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
