### PR TITLE
add missing column to components external table

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
@@ -48,3 +48,6 @@ schema_fields:
   - name: example_stacks
     type: STRING
     mode: REPEATED
+  - name: id
+    type: STRING
+    mode: NULLABLE


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

In #2708 I missed `id` when defining the external table schema for `components`, causing #2714.

Resolves #2714

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Ran the new external table locally and then:

```
laurie ~/git/data-infra/warehouse [fix-components-id] $ poetry run dbt run -s stg_transit_database__components --vars "{'SOURCE_DATABASE':'cal-itp-data-infra-staging'}"
14:13:44  Running with dbt=1.4.5
14:13:45  Unable to do partial parsing because config vars, config profile, or config target have changed
14:13:45  Unable to do partial parsing because profile has changed
14:14:17  Found 343 models, 939 tests, 0 snapshots, 0 analyses, 820 macros, 0 operations, 6 seed files, 155 sources, 5 exposures, 0 metrics
14:14:22  Concurrency: 4 threads (target='dev')
14:14:22  1 of 1 START sql view model laurie_staging.stg_transit_database__components .... [RUN]
14:14:23  1 of 1 OK created sql view model laurie_staging.stg_transit_database__components  [CREATE VIEW (0 processed) in 1.65s]
14:14:23  Finished running 1 view model in 0 hours 0 minutes and 6.19 seconds (6.19s).
14:14:24  Completed successfully
14:14:24  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
