### PR TITLE
add more keying to underlying rt messages models

### DIFF
--- a/warehouse/macros/gtfs_rt_messages_keying.sql
+++ b/warehouse/macros/gtfs_rt_messages_keying.sql
@@ -22,7 +22,7 @@ WITH
     -- if we ever backfill v1 RT data, the reliance on _config_extract_ts for joins in this table may become problematic
     SELECT
         urls_to_gtfs_datasets.gtfs_dataset_key AS gtfs_dataset_key,
-        rt_datasets.name as name,
+        rt_datasets.name as _gtfs_dataset_name,
         schedule_datasets.key AS schedule_gtfs_dataset_key,
         schedule_datasets.base64_url AS schedule_base64_url,
         schedule_datasets.name AS schedule_name,

--- a/warehouse/macros/gtfs_rt_messages_keying.sql
+++ b/warehouse/macros/gtfs_rt_messages_keying.sql
@@ -1,0 +1,51 @@
+{% macro gtfs_rt_messages_keying(raw_messages) %}
+WITH
+    urls_to_gtfs_datasets AS (
+    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
+    ),
+
+    dim_gtfs_datasets AS (
+        SELECT *
+        FROM {{ ref('dim_gtfs_datasets') }}
+    ),
+
+    validation_bridge AS (
+        SELECT *
+        FROM {{ ref('bridge_schedule_dataset_for_validation') }}
+    ),
+
+    dim_schedule_feeds AS (
+        SELECT *
+        FROM {{ ref('dim_schedule_feeds') }}
+    )
+
+    -- if we ever backfill v1 RT data, the reliance on _config_extract_ts for joins in this table may become problematic
+    SELECT
+        urls_to_gtfs_datasets.gtfs_dataset_key AS gtfs_dataset_key,
+        rt_datasets.name as name,
+        schedule_datasets.key AS schedule_gtfs_dataset_key,
+        schedule_datasets.base64_url AS schedule_base64_url,
+        schedule_datasets.name AS schedule_name,
+        dim_schedule_feeds.key AS schedule_feed_key,
+        dim_schedule_feeds.feed_timezone AS schedule_feed_timezone,
+        rt.* EXCEPT(_name)
+    FROM {{ raw_messages }} AS rt
+    LEFT JOIN urls_to_gtfs_datasets
+        ON rt.base64_url = urls_to_gtfs_datasets.base64_url
+        AND rt._config_extract_ts BETWEEN urls_to_gtfs_datasets._valid_from AND urls_to_gtfs_datasets._valid_to
+    LEFT JOIN dim_gtfs_datasets AS rt_datasets
+        ON urls_to_gtfs_datasets.gtfs_dataset_key = rt_datasets.key
+    LEFT JOIN validation_bridge
+        ON rt_datasets.key = validation_bridge.gtfs_dataset_key
+        AND rt._config_extract_ts BETWEEN validation_bridge._valid_from AND validation_bridge._valid_to
+    -- this would need to be changed if we needed to do joins before September 15, 2022 to go via urls_to_gtfs_datasets
+    LEFT JOIN dim_gtfs_datasets AS schedule_datasets
+        ON validation_bridge.schedule_to_use_for_rt_validation_gtfs_dataset_key = schedule_datasets.key
+        AND rt._config_extract_ts BETWEEN schedule_datasets._valid_from AND schedule_datasets._valid_to
+    -- use _extract_ts for this join because now we're looking at the actual data
+    -- we want the schedule feed that was in effect when this RT data was actually scraped
+    LEFT JOIN dim_schedule_feeds
+        ON schedule_datasets.base64_url = dim_schedule_feeds.base64_url
+        AND rt._extract_ts BETWEEN dim_schedule_feeds._valid_from AND dim_schedule_feeds._valid_to
+
+    {% endmacro %}

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -142,12 +142,73 @@ models:
                 # this threshold may need to increase if the backfill occurs prior to that
                 error_if: ">20"
                 where: '__rt_sampled__'
-      - name: dt
-      - name: hour
-      - name: base64_url
-      - name: _extract_ts
-      - name: _config_extract_ts
-      - name: _gtfs_dataset_name
+      - &gtfs_rt_dt
+        name: dt
+        description: |
+          Date (UTC) on which this data was scraped. A value for this field must be provided when querying this model due
+          to data size.
+      - &gtfs_rt_hour
+        name: hour
+        description: |
+          The starting timestamp for the hour (UTC) in which this data was scraped.
+          Example value: '2023-06-14T15:00:00+00:00'. Adding a filter on this can further improve performance.
+      - *base64_url
+      - &gtfs_rt_extract_ts
+        name: _extract_ts
+        description: |
+            Timestamp at which this message was scraped. More specifically, this identifies the individual "tick" for
+            which this data was collected.
+            These value are pinned to `:00`, `:20`, `:40` second values (to ensure consistency), but there can be some slippage
+            between the `_extract_ts` and the time that the data was actually requested.
+      - &gtfs_rt_config_extract_ts
+        name: _config_extract_ts
+        description: |
+          The timestamp at which the GTFS data config for this download was extracted. This will correspond to the
+          `ts` value for the associated Airtable data extract.
+          Note that there may not be a corresponding value in `dim_gtfs_datasets` with this value in `_valid_from`, because this
+          value updates every time that the Airtable data extract runs, whereas `dim_gtfs_datasets` has versioning applied
+          and `_valid_from` only updates when an attribute within the record actually changes.
+      - &gtfs_rt_name
+        name: name
+        description: |
+          Name from the associated GTFS dataset record.
+      - &gtfs_rt_schedule_dataset_key
+        name: schedule_dataset_key
+        description: |
+          The foreign key to `dim_gtfs_datasets` for the GTFS schedule dataset record associated with this GTFS RT dataset for validation purposes.
+        tests:
+          - relationships:
+              to: ref('dim_gtfs_datasets')
+              field: key
+              config:
+                where: '__rt_sampled__'
+      - &gtfs_rt_schedule_dataset_name
+        name: schedule_name
+        description: |
+          Name of the GTFS schedule dataset used to validate this GTFS RT dataset.
+      - &gtfs_rt_schedule_feed_key
+        name: schedule_feed_key
+        description: |
+          Foreign key to `dim_schedule_feeds` for the GTFS schedule feed associated with the
+          GTFS schedule dataset that is used to validate this GTFS RT data.
+          This is the schedule feed version that was in effect at the time the GTFS RT data
+          was scraped.
+          If this is null, we did not download GTFS schedule data associated with the dataset used
+          to validate this GTFS RT data. This could happen because of download failures (for example, a temporary technical issue) or
+          because of issues with the GTFS dataset associations upstream.
+        tests:
+          - relationships:
+              to: ref('dim_schedule_feeds')
+              field: key
+              config:
+                where: '__rt_sampled__'
+      - &gtfs_rt_schedule_feed_timezone
+        name: schedule_feed_timezone
+        description: |
+          The `feed_timezone` of the feed referenced by `schedule_feed_key`.
+          This information is required to match trips from GTFS RT to
+          their scheduled counterparts, so that the date/time data from the RT feed
+          can be interpreted within the appropriate time zone to align with its schedule.
       - name: header_timestamp
       - name: header_incrementality
       - name: header_version
@@ -222,20 +283,16 @@ models:
           entity `id`, `vehicle_id`, and `trip_id`.
         tests: *almost_unique_rt_key_tests
       - *gtfs_rt_dataset_key
-      - name: dt
-        description: |
-          Date on which we scraped this message.
-          A date filter *must* be provided when querying this table, because of the size of the data.
-      - name: hour
-        description: |
-          Timestamp of the beginning of the hour in which this message was scraped,
-          ex. "2022-09-01T00:00:00+00".
-      - name: base64_url
-        description: |
-          URL-safe base64 encoding of the URL from which this message was scraped.
-      - name: _extract_ts
-        description: |
-          Time at which this message was scraped.
+      - *gtfs_rt_dt
+      - *gtfs_rt_hour
+      - *base64_url
+      - *gtfs_rt_extract_ts
+      - *gtfs_rt_config_extract_ts
+      - *gtfs_rt_name
+      - *gtfs_rt_schedule_dataset_key
+      - *gtfs_rt_schedule_dataset_name
+      - *gtfs_rt_schedule_feed_key
+      - *gtfs_rt_schedule_feed_timezone
       - *_header_message_age
       - name: _vehicle_message_age
         description: |
@@ -907,31 +964,17 @@ models:
               where: '__rt_sampled__'
           - not_null:
               where: '__rt_sampled__'
-      - name: gtfs_dataset_key
-        description: |
-          The primary key for the record in `dim_gtfs_datasets` associated with this message.
-        columns:
-          - <<: *gtfs_dataset_key
-            config:
-              where: '__rt_sampled__'
-      - name: dt
-        description: |
-          Date on which we scraped this message.
-          A date filter *must* be provided when querying this table, because of the size of the data.
-      - name: hour
-        description: |
-          Timestamp of the beginning of the hour in which this message was scraped,
-          ex. "2022-09-01T00:00:00+00".
-      - name: base64_url
-        description: |
-          URL-safe base64 encoding of the URL from which this message was scraped.
-      - name: _extract_ts
-        description: |
-          Time at which this message was scraped.
-      - name: _gtfs_dataset_name
-        description: |
-          String name of the GTFS dataset of which this message is a part.
-          This field is provided for human readability and should not be used as a join key.
+      - *gtfs_rt_dataset_key
+      - *gtfs_rt_dt
+      - *gtfs_rt_hour
+      - *base64_url
+      - *gtfs_rt_extract_ts
+      - *gtfs_rt_config_extract_ts
+      - *gtfs_rt_name
+      - *gtfs_rt_schedule_dataset_key
+      - *gtfs_rt_schedule_dataset_name
+      - *gtfs_rt_schedule_feed_key
+      - *gtfs_rt_schedule_feed_timezone
       - name: header_timestamp
         description: |
           See: https://gtfs.org/realtime/reference/#message-feedheader.

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -169,7 +169,7 @@ models:
           value updates every time that the Airtable data extract runs, whereas `dim_gtfs_datasets` has versioning applied
           and `_valid_from` only updates when an attribute within the record actually changes.
       - &gtfs_rt_name
-        name: name
+        name: _gtfs_dataset_name
         description: |
           Name from the associated GTFS dataset record.
       - &gtfs_rt_schedule_dataset_key

--- a/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
@@ -16,7 +16,7 @@ fct_service_alerts_messages AS (
         base64_url,
         _extract_ts,
         _config_extract_ts,
-        name,
+        _gtfs_dataset_name,
         schedule_gtfs_dataset_key,
         schedule_base64_url,
         schedule_name,

--- a/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
@@ -3,26 +3,8 @@ WITH stg_gtfs_rt__service_alerts AS (
     FROM {{ ref('stg_gtfs_rt__service_alerts') }}
 ),
 
-urls_to_gtfs_datasets AS (
-    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
-),
-
-dim_gtfs_datasets AS (
-    SELECT *
-    FROM {{ ref('dim_gtfs_datasets') }}
-),
-
 keying AS (
-    SELECT
-        urls_to_gtfs_datasets.gtfs_dataset_key,
-        gd.name as _gtfs_dataset_name,
-        sa.*
-    FROM stg_gtfs_rt__service_alerts AS sa
-    LEFT JOIN urls_to_gtfs_datasets
-        ON sa.base64_url = urls_to_gtfs_datasets.base64_url
-        AND sa._extract_ts BETWEEN urls_to_gtfs_datasets._valid_from AND urls_to_gtfs_datasets._valid_to
-    LEFT JOIN dim_gtfs_datasets AS gd
-        ON urls_to_gtfs_datasets.gtfs_dataset_key = gd.key
+    {{ gtfs_rt_messages_keying('stg_gtfs_rt__service_alerts') }}
 ),
 
 fct_service_alerts_messages AS (
@@ -34,7 +16,12 @@ fct_service_alerts_messages AS (
         base64_url,
         _extract_ts,
         _config_extract_ts,
-        _gtfs_dataset_name,
+        name,
+        schedule_gtfs_dataset_key,
+        schedule_base64_url,
+        schedule_name,
+        schedule_feed_key,
+        schedule_feed_timezone,
         TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND) AS _header_message_age,
         header_timestamp,
         header_version,

--- a/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
@@ -17,7 +17,7 @@ fct_trip_updates_messages AS (
         base64_url,
         _extract_ts,
         _config_extract_ts,
-        name,
+        _gtfs_dataset_name,
         schedule_gtfs_dataset_key,
         schedule_base64_url,
         schedule_name,

--- a/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_messages.sql
@@ -3,26 +3,8 @@ WITH stg_gtfs_rt__trip_updates AS (
     FROM {{ ref('stg_gtfs_rt__trip_updates') }}
 ),
 
-urls_to_gtfs_datasets AS (
-    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
-),
-
-dim_gtfs_datasets AS (
-    SELECT *
-    FROM {{ ref('dim_gtfs_datasets') }}
-),
-
 keying AS (
-    SELECT
-        urls_to_gtfs_datasets.gtfs_dataset_key,
-        gd.name as _gtfs_dataset_name,
-        tu.*
-    FROM stg_gtfs_rt__trip_updates AS tu
-    LEFT JOIN urls_to_gtfs_datasets
-        ON tu.base64_url = urls_to_gtfs_datasets.base64_url
-        AND tu._extract_ts BETWEEN urls_to_gtfs_datasets._valid_from AND urls_to_gtfs_datasets._valid_to
-    LEFT JOIN dim_gtfs_datasets AS gd
-        ON urls_to_gtfs_datasets.gtfs_dataset_key = gd.key
+    {{ gtfs_rt_messages_keying('stg_gtfs_rt__trip_updates') }}
 ),
 
 fct_trip_updates_messages AS (
@@ -35,7 +17,12 @@ fct_trip_updates_messages AS (
         base64_url,
         _extract_ts,
         _config_extract_ts,
-        _gtfs_dataset_name,
+        name,
+        schedule_gtfs_dataset_key,
+        schedule_base64_url,
+        schedule_name,
+        schedule_feed_key,
+        schedule_feed_timezone,
 
         TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND) AS _header_message_age,
         TIMESTAMP_DIFF(_extract_ts, trip_update_timestamp, SECOND) AS _trip_update_message_age,

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -18,7 +18,7 @@ fct_vehicle_positions_messages AS (
         base64_url,
         _extract_ts,
         _config_extract_ts,
-        name,
+        _gtfs_dataset_name,
         schedule_gtfs_dataset_key,
         schedule_base64_url,
         schedule_name,

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -3,26 +3,8 @@ WITH stg_gtfs_rt__vehicle_positions AS (
     FROM {{ ref('stg_gtfs_rt__vehicle_positions') }}
 ),
 
-urls_to_gtfs_datasets AS (
-    SELECT * FROM {{ ref('int_transit_database__urls_to_gtfs_datasets') }}
-),
-
-dim_gtfs_datasets AS (
-    SELECT *
-    FROM {{ ref('dim_gtfs_datasets') }}
-),
-
 keying AS (
-    SELECT
-        urls_to_gtfs_datasets.gtfs_dataset_key,
-        gd.name as _gtfs_dataset_name,
-        vp.*
-    FROM stg_gtfs_rt__vehicle_positions AS vp
-    LEFT JOIN urls_to_gtfs_datasets
-        ON vp.base64_url = urls_to_gtfs_datasets.base64_url
-        AND vp._extract_ts BETWEEN urls_to_gtfs_datasets._valid_from AND urls_to_gtfs_datasets._valid_to
-    LEFT JOIN dim_gtfs_datasets AS gd
-        ON urls_to_gtfs_datasets.gtfs_dataset_key = gd.key
+    {{ gtfs_rt_messages_keying('stg_gtfs_rt__vehicle_positions') }}
 ),
 
 fct_vehicle_positions_messages AS (
@@ -36,7 +18,12 @@ fct_vehicle_positions_messages AS (
         base64_url,
         _extract_ts,
         _config_extract_ts,
-        _gtfs_dataset_name,
+        name,
+        schedule_gtfs_dataset_key,
+        schedule_base64_url,
+        schedule_name,
+        schedule_feed_key,
+        schedule_feed_timezone,
 
         TIMESTAMP_DIFF(_extract_ts, header_timestamp, SECOND) AS _header_message_age,
         TIMESTAMP_DIFF(_extract_ts, vehicle_timestamp, SECOND) AS _vehicle_message_age,


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Pulling this out of #2489 for scope/size. This PR adds a bunch of new keys to RT messages models:

* schedule dataset key
* schedule feed key
* schedule dataset name 
* schedule feed time zone 

These (schedule time zone in particular) facilitate better date/time handling in downstream models, to be implemented in #2489.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

I ran an incremental run on top of models run from `main` (`poetry run dbt run -s source:external_gtfs_rt+,models/mart/gtfs`) and confirmed that this is backwards-compatible on its own, i.e., no full refresh or any special handling required. 


## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
