### PR TITLE
Remove tests from _latest models used for open data publishing

### DIFF
--- a/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
+++ b/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
@@ -15,24 +15,14 @@ models:
         name: key
         description: |
           Synthetic primary key constructed from `feed_key` and `_line_number`.
-        tests:
-          - not_null
-          - unique
       - &schedule_dim_gtfs_key
         name: _gtfs_key
         description:
           Synthetic primary natural key constructed from the model's GTFS specification uniqueness.
-        tests:
-          - not_null
-          - unique
       - &schedule_dim_dt
         name: _dt
-        tests:
-          - not_null
       - &schedule_dim_line_number
         name: _line_number
-        tests:
-          - not_null
       - &feed_key
         name: feed_key
         description: |


### PR DESCRIPTION
# Description
In a recent PR, new tests were added to open data publishing tables when new columns were added to those tables. This isn't in line with our recent approach to these tables, where we've chosen to rely on the tests from underlying models instead. This PR removes the tests in question in order to silence a set of active related Sentry issues like [this one](https://sentry.calitp.org/organizations/sentry/issues/71679/?project=2). These models will soon be discontinued altogether via #2701, so this PR is essentially a convenience for the moment to prevent overzealous Sentry alerting.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Publishing models and tests (or lack thereof) run in staging after the YAML changes made in this PR

## Post-merge follow-ups
- [x] No action required
- [ ] Actions required (specified below)
