### PR TITLE
Update `fct_scheduled_service_by_daypart`

### DIFF
--- a/warehouse/models/mart/ad_hoc/_mart_ad_hoc.yml
+++ b/warehouse/models/mart/ad_hoc/_mart_ad_hoc.yml
@@ -35,7 +35,6 @@ models:
       - name: source_record_id
       - name: route_id
       - name: route_short_name
-      - name: shape_id
       - name: time_of_day
         description: |
           Categorized based on the Pacific Time departure of the trip's first departure.
@@ -54,3 +53,4 @@ models:
           This means that overnight service is associated with the calendar date on which it was scheduled,
           even if it was associated with the prior `service_date` by the agency.
       - name: n_trips
+      - name: ttl_service_hours

--- a/warehouse/models/mart/ad_hoc/_mart_ad_hoc.yml
+++ b/warehouse/models/mart/ad_hoc/_mart_ad_hoc.yml
@@ -35,6 +35,7 @@ models:
       - name: source_record_id
       - name: route_id
       - name: route_short_name
+      - name: route_long_name
       - name: time_of_day
         description: |
           Categorized based on the Pacific Time departure of the trip's first departure.

--- a/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
+++ b/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
@@ -7,7 +7,7 @@ WITH dim_gtfs_datasets AS (
 fct_scheduled_trips AS (
     SELECT *
     FROM {{ ref('fct_scheduled_trips') }}
-    WHERE service_date >= '2022-12-01' AND service_date < '2023-01-01'
+    WHERE service_date >= '2023-06-01' AND service_date < '2023-07-01'
 ),
 
 extract_trip_date_types AS (
@@ -25,13 +25,13 @@ extract_trip_date_types AS (
         AS time_of_day,
 
         gtfs_dataset_key,
-        shape_id,
         route_id,
         route_short_name,
         EXTRACT(hour FROM trip_first_departure_datetime_pacific) AS hour,
         EXTRACT(month FROM service_date) AS month,
         EXTRACT(year FROM service_date) AS year,
-        EXTRACT(DAYOFWEEK from service_date) AS day_type
+        EXTRACT(DAYOFWEEK from service_date) AS day_type,
+        service_hours
 
     FROM fct_scheduled_trips
 
@@ -48,9 +48,9 @@ service_with_daypart AS (
         trips.month,
         trips.year,
         trips.day_type,
-        trips.shape_id,
         trips.route_id,
-        trips.route_short_name
+        trips.route_short_name,
+        trips.service_hours,
 
     FROM extract_trip_date_types AS trips
     LEFT JOIN dim_gtfs_datasets
@@ -65,14 +65,14 @@ daypart_aggregations AS (
         source_record_id,
         route_id,
         route_short_name,
-        shape_id,
         time_of_day,
         hour,
         month,
         year,
         day_type,
 
-        COUNT(*) AS n_trips
+        COUNT(*) AS n_trips,
+        SUM(service_hours) AS ttl_service_hours
 
     FROM service_with_daypart
     GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
@@ -85,13 +85,13 @@ fct_scheduled_service_by_daypart AS (
         source_record_id,
         route_id,
         route_short_name,
-        shape_id,
         time_of_day,
         hour,
         month,
         year,
         day_type,
-        n_trips
+        n_trips,
+        ttl_service_hours
 
     FROM daypart_aggregations
 )

--- a/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
+++ b/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
@@ -7,7 +7,6 @@ WITH dim_gtfs_datasets AS (
 fct_scheduled_trips AS (
     SELECT *
     FROM {{ ref('fct_scheduled_trips') }}
-    WHERE service_date >= '2023-06-01' AND service_date < '2023-07-01'
 ),
 
 extract_trip_date_types AS (

--- a/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
+++ b/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
@@ -75,7 +75,7 @@ daypart_aggregations AS (
         SUM(service_hours) AS ttl_service_hours
 
     FROM service_with_daypart
-    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9
 ),
 
 fct_scheduled_service_by_daypart AS (

--- a/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
+++ b/warehouse/models/mart/ad_hoc/fct_scheduled_service_by_daypart.sql
@@ -27,6 +27,7 @@ extract_trip_date_types AS (
         gtfs_dataset_key,
         route_id,
         route_short_name,
+        route_long_name,
         EXTRACT(hour FROM trip_first_departure_datetime_pacific) AS hour,
         EXTRACT(month FROM service_date) AS month,
         EXTRACT(year FROM service_date) AS year,
@@ -50,6 +51,7 @@ service_with_daypart AS (
         trips.day_type,
         trips.route_id,
         trips.route_short_name,
+        trips.route_long_name,
         trips.service_hours,
 
     FROM extract_trip_date_types AS trips
@@ -65,6 +67,7 @@ daypart_aggregations AS (
         source_record_id,
         route_id,
         route_short_name,
+        route_long_name,
         time_of_day,
         hour,
         month,
@@ -75,7 +78,7 @@ daypart_aggregations AS (
         SUM(service_hours) AS ttl_service_hours
 
     FROM service_with_daypart
-    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 ),
 
 fct_scheduled_service_by_daypart AS (
@@ -85,6 +88,7 @@ fct_scheduled_service_by_daypart AS (
         source_record_id,
         route_id,
         route_short_name,
+        route_long_name,
         time_of_day,
         hour,
         month,


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Remove `shape_id` from `fct_scheduled_service_by_daypart` and include the sum of `service_hours` as `ttl_service_hours` from aggregation.

Resolves #2234 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

`poetry run dbt run --select fct_scheduled_service_by_daypart`
<img width="634" alt="fct_scheduled_service_by_daypart" src="https://github.com/cal-itp/data-infra/assets/49657200/0bf22a05-9c26-4751-a99c-77c0de5838fd">

`poetry run dbt docs generate` -- this was successful, but unable to see using `poetry run dbt docs serve`
<img width="630" alt="fct_scheduled_service_by_daypart_docs" src="https://github.com/cal-itp/data-infra/assets/49657200/1efcb91c-fbb1-4d1f-8978-5fb5f316129c">


## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [ ] Actions required (specified below)
