### PR TITLE
Add performance dashboard/spreadsheet check to triage runbook

### DIFF
--- a/runbooks/pipeline/sentry-triage.md
+++ b/runbooks/pipeline/sentry-triage.md
@@ -54,3 +54,7 @@ This category primarily includes unhandled data processing exceptions (e.g. RTFe
     1. Create a GitHub issue to update the fingerprint, usually adding additional values to the fingerprint to distinguish between different errors.
     2. For example, you may want to split up an issue by feed URL, which would mean adding the feed URL to the fingerprint.
     3. When the new fingerprint has been deployed, _resolve_ the existing issue since it should no longer appear.
+
+## Additional Triage Task: Monday Performance Check
+
+Each Monday, the person assigned to Sentry triage should use the [Cal-ITP System Performance and Outcomes Monitoring dashboard](https://dashboards.calitp.org/dashboard/138-cal-itp-system-performance-and-outcomes-monitoring?single_date=2023-06-22) to fill out the spreadsheet linked within the dashboard with metrics from the previous week.


### PR DESCRIPTION
# Description
Reflecting an additional duty for the person on triage for a given sprint, this adds a reference to Monday morning checks of the performance dashboard and fillout of the associated spreadsheet to the triage runbook.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?
README markdown validated

## Post-merge follow-ups
- [x] No action required
- [ ] Actions required (specified below)
