### PR TITLE
WIP: Update publication script so that it doesn't rely on _latest models

### DIFF
--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -437,7 +437,7 @@ def _publish_exposure(
                     )
 
                     schedule_feeds_table = (
-                        node.database + "mart_gtfs.dim_schedule_feeds"
+                        node.database + ".mart_gtfs.dim_schedule_feeds"
                     )
 
                     df = pd.read_gbq(

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -436,8 +436,18 @@ def _publish_exposure(
                         os.path.join(tmpdir, destination.filename(model_name))
                     )
 
+                    schedule_feeds_table = (
+                        node.database + "mart_gtfs.dim_schedule_feeds"
+                    )
+
                     df = pd.read_gbq(
-                        str(node.select),
+                        str(node.select)
+                        + f"""
+                            WHERE EXISTS (
+                                SELECT 1
+                                FROM {schedule_feeds_table} s
+                                    WHERE s._is_current AND t.feed_key = s.key
+                        """,
                         project_id=node.database,
                         progress_bar_type="tqdm",
                     )


### PR DESCRIPTION
# Description
Once ready, this PR will removes the `_latest` models from the path to open data publication, relying instead on dynamic generation of the required CSV files via a recreation of the effect of the `get_latest_schedule_data` macro inside the publication script.

Resolves #2701

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Not thoroughly tested at the time of WIP PR creation

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)
After we merge this and ensure it works as expected in prod, we can deprecate the `_latest` models via our regular stepped-in deprecation process.