### PR TITLE
Document the existence of _feed_valid_from in schedule_latest models

### DIFF
--- a/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
+++ b/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
@@ -154,6 +154,7 @@ models:
         description: '{{ doc("gtfs_attributions__attribution_phone") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
       - &warning_duplicate_gtfs_key
         name: warning_duplicate_gtfs_key
@@ -161,6 +162,7 @@ models:
           Rows with `true` in this column have a duplicate primary key; i.e., the attribute(s) that is meant to
           uniquely identify a row are duplicated within an individual feed instance and `key` will
           also be duplicated as a result. Treat these rows with caution. They will cause fanout in joins.
+
   - name: dim_calendar_latest
     description: |
       This table is a latest-only cut of the cleaned GTFS data.
@@ -217,6 +219,7 @@ models:
         description: '{{ doc("gtfs_calendar__end_date") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_calendar_dates_latest
@@ -247,6 +250,7 @@ models:
         description: '{{ doc("gtfs_calendar_dates__exception_type") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_fare_attributes_latest
@@ -294,6 +298,7 @@ models:
         meta:
           ckan.units: SECONDS
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_fare_leg_rules_latest
@@ -432,6 +437,7 @@ models:
         description: '{{ doc("gtfs_fare_rules__contains_id") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
       - *warning_duplicate_gtfs_key
 
@@ -531,6 +537,7 @@ models:
         description: '{{ doc("gtfs_feed_info__feed_contact_url") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
       - *warning_duplicate_gtfs_key
 
@@ -571,6 +578,7 @@ models:
         description: '{{ doc("gtfs_frequencies__exact_times") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
       - name: start_time_interval
       - name: end_time_interval
@@ -605,6 +613,7 @@ models:
         description: '{{ doc("gtfs_levels__level_name") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_pathways_latest
@@ -674,6 +683,7 @@ models:
         description: '{{ doc("gtfs_pathways__reversed_signposted_as") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_routes_latest
@@ -744,6 +754,7 @@ models:
         description: '{{ doc("gtfs_routes__network_id") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_shapes_latest
@@ -790,6 +801,7 @@ models:
         description: '{{ doc("gtfs_shapes__shape_dist_traveled") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_stop_areas_latest
@@ -908,6 +920,7 @@ models:
         meta:
           ckan.units: SECONDS
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
       - name: arrival_time_interval
       - name: departure_time_interval
@@ -1062,6 +1075,7 @@ models:
         description: '{{ doc("gtfs_stops__platform_code") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
         # TODO: would be good to actually publish this, with appropriate documentation, next time we are ready to make a round of updates
       - name: warning_missing_schedule_dim_pk
@@ -1117,6 +1131,7 @@ models:
         description: '{{ doc("gtfs_transfers__to_trip_id") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
       - *warning_duplicate_gtfs_key
 
@@ -1164,6 +1179,7 @@ models:
         description: '{{ doc("gtfs_translations__field_value") }}'
         meta:
           publish.include: true
+      - *_feed_valid_from
       - *feed_timezone
 
   - name: dim_trips_latest
@@ -1223,6 +1239,7 @@ models:
         meta:
           publish.include: true
       - *warning_duplicate_gtfs_key
+      - *_feed_valid_from
       - *feed_timezone
 
 exposures:


### PR DESCRIPTION
# Description
We are experiencing an issue with our publication script wherein fields on our models that don't have associated YAML entries are ending up in publication. I am investigating the underlying logic and will create an issue and submit a fix for that later, but in the meantime, this corrects the YAML for several published tables that were missing the `_feed_valid_from` column and tripping up the issue as a result.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Models recreated in staging - full publication can't be tested without an updated manifest, which will be done after merge.

## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)

Run the `run_and_upload` and `publish` scripts in prod to create new open data tables and determine whether there are other remaining mismatches.