### PR TITLE
Restrict qualified columns for publishing in node.select

### DIFF
--- a/warehouse/scripts/dbt_artifacts/__init__.py
+++ b/warehouse/scripts/dbt_artifacts/__init__.py
@@ -111,9 +111,7 @@ class NodeModelMixin(BaseModel):
         columns = [
             c
             for c in self.sqlalchemy_table(engine).columns
-            if not self.columns
-            or c.name not in self.columns
-            or self.columns[c.name].publish  # type: ignore[attr-defined]
+            if self.columns[c.name].publish  # type: ignore[attr-defined]
         ]
         return select(columns=columns)
 


### PR DESCRIPTION
# Description
Turns out our publishing issue came from a layered loose definition of columns qualified for publishing within the `NodeModelMixIn` class, outside the publication script itself. This tightens up the column selection to adhere to our current practice of explicit inclusion for publishing, rather than explicit exclusion. This will not immediately impact the columns currently being published, since the initial bug only appeared where there was a mismatch between a model's YAML and its select statement, but it will protect us from future such issues and bring our selection logic within this class in line with the selection logic used by the publication script.

Resolves #2792

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Column selection tested locally

## Post-merge follow-ups
- [x] No action required
- [ ] Actions required (specified below)
