### PR TITLE
increase timeout in dbt profile

### DIFF
--- a/warehouse/profiles.yml
+++ b/warehouse/profiles.yml
@@ -11,9 +11,9 @@ calitp_warehouse:
       method: oauth
       priority: interactive
       threads: 8
-      # currently slowest model is int_gtfs_rt__trip_updates_no_stop_times
-      # which takes ~2700 seconds to full refresh
-      timeout_seconds: 3000
+      # currently slowest models are int_gtfs_rt__vehicle_positions_trip_day_map_grouping / int_gtfs_rt__trip_updates_trip_day_map_grouping
+      # 3000 is not enough
+      timeout_seconds: 5400
       type: bigquery
       gcs_bucket: calitp-dbt-python-models
       dataproc_region: us-west2


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Full refresh from #2489 [timed out](https://o1d2fa0877cf3fb10p-tp.appspot.com/dags/transform_warehouse_full_refresh/grid?dag_run_id=manual__2023-07-13T16%3A27%3A51.422835%2B00%3A00&task_id=dbt_run_and_upload_artifacts) on the new trip day map grouping models. Increasing timeout to hope they can complete. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Hasn't, no great way to test locally (local dev env caps history at 7 days; seems wasteful to try to calibrate too closely in test vs. try to get it to work in prod.)

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Re-run full refresh for tables that failed. 