### PR TITLE
address full refresh run failures

### DIFF
--- a/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
@@ -51,7 +51,11 @@ deduped AS (
 fct_vehicle_locations AS (
     SELECT deduped.*,
         LEAD(key) OVER (PARTITION BY vehicle_trip_key ORDER BY location_timestamp) AS next_location_key,
-        ST_GEOGPOINT(position_longitude, position_latitude) AS location,
+        -- BQ errors on latitudes outside this range
+        CASE
+            WHEN position_latitude BETWEEN -90 AND 90 THEN ST_GEOGPOINT(position_longitude, position_latitude)
+        END
+        AS location,
         trip_instance_key
     FROM deduped
     LEFT JOIN vp_trips

--- a/warehouse/profiles.yml
+++ b/warehouse/profiles.yml
@@ -12,8 +12,8 @@ calitp_warehouse:
       priority: interactive
       threads: 8
       # currently slowest models are int_gtfs_rt__vehicle_positions_trip_day_map_grouping / int_gtfs_rt__trip_updates_trip_day_map_grouping
-      # 3000 is not enough
-      timeout_seconds: 5400
+      # 5400 is not enough
+      timeout_seconds: 21600
       type: bigquery
       gcs_bucket: calitp-dbt-python-models
       dataproc_region: us-west2


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Second attempt to full-refresh post #2489 [also timed out](https://o1d2fa0877cf3fb10p-tp.appspot.com/log?execution_date=2023-07-13T18%3A12%3A07%2B00%3A00&task_id=dbt_run_and_upload_artifacts&dag_id=transform_warehouse_full_refresh&map_index=-1) so this increases the timeout even more. Also fixes an error: `ST_GeogPoint failed: Latitude must be between -90 and 90 degrees. Actual value was 436.47925` that was raised.

Resolves #[issue]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Ran vehicle locations locally and confirmed that values are still populated when valid. 

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Try to run the full refresh again