### PR TITLE
remove reports check feature filter

### DIFF
--- a/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_monthly_reports_site_organization_guideline_checks.sql
@@ -14,8 +14,6 @@ checks AS (
            is_manual,
            reports_order,
     FROM {{ ref('fct_daily_organization_combined_guideline_checks') }}
-    -- This filtering is temporary, and could also be done further downstream:
-    WHERE feature = {{ compliance_schedule() }}
 ),
 
 generate_biweekly_dates AS (


### PR DESCRIPTION
# Description
This is a followup to https://github.com/cal-itp/reports/pull/265. By moving the feature-level filter from the data infra side to the reports side, I will limit future modifications on the data-infra side.

My next step for reports is to add RT Compliance checks to the site - by making this change, I won't have to manually add that as a filter.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
I tested this in testing https://github.com/cal-itp/reports/pull/265, by confirming that the feature-level filter continues to return the Schedule Compliance checks. As an extra sanity check, I'll rerun everything after this is merged, to ensure everything looks good before the July reports are created.


## Post-merge follow-ups
- [x] Actions required (specified below)

Generate sample reports, to double check that no extra checks are listed.
