### PR TITLE
use helm diff plugin vs kustomize workaround

### DIFF
--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -9,15 +9,6 @@ from google.cloud import secretmanager
 from invoke import Exit, Result, task
 from pydantic import BaseModel, validator
 
-KUSTOMIZE_HELM_TEMPLATE = """
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: {namespace}
-resources:
-- manifest.yaml
-"""
-
-
 GENERIC_HELP = {
     "driver": "The k8s driver (kustomize or helm)",
     "app": "The specific app/release (e.g. metabase or archiver)",
@@ -64,6 +55,11 @@ class CalitpConfig(BaseModel):
         if not self.git_repo.working_tree_dir:
             return None
         return Path(self.git_repo.working_tree_dir)
+
+
+@task
+def install_helm_plugins(c):
+    c.run("helm plugin install https://github.com/databus23/helm-diff", warn=True)
 
 
 @task
@@ -149,6 +145,7 @@ def secrets(
 
 @task(
     parse_calitp_config,
+    install_helm_plugins,
     help={
         **GENERIC_HELP,
         "outfile": "File in which to save the combined kubectl diff output",
@@ -178,22 +175,25 @@ def diff(
             chart_path = c.calitp_config.git_root / Path(release.helm_chart)
             c.run(f"helm dependency update {chart_path}")
 
-            with tempfile.TemporaryDirectory() as tmpdir:
-                manifest_path = Path(tmpdir) / Path("manifest.yaml")
-                kustomization_path = Path(tmpdir) / Path("kustomization.yaml")
-                values_str = " ".join(
+            values_str = " ".join(
+                [
+                    f"--values {c.calitp_config.git_root / Path(values_file)}"
+                    for values_file in release.helm_values
+                ]
+            )
+            result = c.run(
+                " ".join(
                     [
-                        f"--values {c.calitp_config.git_root / Path(values_file)}"
-                        for values_file in release.helm_values
+                        "helm",
+                        "diff",
+                        "upgrade",
+                        release.helm_name,
+                        str(chart_path),
+                        f"--namespace={release.namespace}",
+                        values_str,
                     ]
                 )
-                # TODO: consider looking into https://github.com/databus23/helm-diff
-                c.run(
-                    f"helm template {release.helm_name} {chart_path} --namespace {release.namespace} {values_str} > {manifest_path}"
-                )
-                with open(kustomization_path, "w") as f:
-                    f.write(KUSTOMIZE_HELM_TEMPLATE.format(namespace=release.namespace))
-                result = c.run(f"kubectl diff -k {tmpdir}", warn=True)
+            )
         else:
             print(f"Encountered unknown driver: {release.driver}", flush=True)
             raise RuntimeError

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -193,13 +193,14 @@ def diff(
                         values_str,
                         "-C 5",  # only include 5 lines of context
                     ]
-                )
+                ),
+                warn=True,
             )
         else:
             print(f"Encountered unknown driver: {release.driver}", flush=True)
             raise RuntimeError
 
-        if result.exited != 0:
+        if result.stdout:
             full_diff += result.stdout
 
     msg = (

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -191,6 +191,7 @@ def diff(
                         str(chart_path),
                         f"--namespace={release.namespace}",
                         values_str,
+                        "-C 5",  # only include 5 lines of context
                     ]
                 )
             )

--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -36,6 +36,9 @@ sentry:
         hosts:
           - sentry.calitp.org
           - sentry.k8s.calitp.jarv.us
+
+  # mail and slack use the same existingSecret as github but we use the default/only keys
+
   mail:
     backend: smtp
     useTls: true
@@ -49,10 +52,15 @@ sentry:
     existingSecret: sentry-secret
 
   # https://develop.sentry.dev/self-hosted/sso/#update-your-configuration-with-your-github-app-information
+  # namespace these keys since the defaults overlap with slack
   github:
     appId: 288470
     appName: 'cal-itp-sentry'
     existingSecret: sentry-secret
+    existingSecretPrivateKeyKey: "github-private-key"
+    existingSecretWebhookSecretKey: "github-webhook-secret"
+    existingSecretClientIdKey: "github-client-id"
+    existingSecretClientSecretKey: "github-client-secret"
 
   sentry:
     web:


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

https://github.com/cal-itp/data-infra/pull/2850 is failing to show changes to jupyterhub; it looks like the kustomize/kubectl diff workaround isn't working. This PR uses a helm diff plugin instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

We should see proper CI diffs in a candidate PR.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Deploy to prod.