### PR TITLE
Fetch latest RT secrets every minute

### DIFF
--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-consumer.yaml
@@ -24,7 +24,7 @@ spec:
         - name: app
           image: gtfs-rt-archiver
           command: ["python"]
-          args: ["-m", "gtfs_rt_archiver_v3.consumer", "--load-env-secrets"]
+          args: ["-m", "gtfs_rt_archiver_v3.consumer"]
           envFrom:
             - configMapRef:
                 name: archiver-app-vars

--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-ticker.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/gtfs-rt-archiver-ticker.yaml
@@ -24,7 +24,7 @@ spec:
         - name: app
           image: gtfs-rt-archiver
           command: ["python"]
-          args: ["-m", "gtfs_rt_archiver_v3.ticker", "--load-env-secrets"]
+          args: ["-m", "gtfs_rt_archiver_v3.ticker"]
           envFrom:
             - configMapRef:
                 name: archiver-app-vars

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver-v3'
-  newTag: '2023.7.20'
+  newTag: '2023.8.9'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-test/kustomization.yaml
@@ -18,4 +18,4 @@ patches:
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver-v3'
-  newTag: '2023.7.20'
+  newTag: '2023.8.9'

--- a/services/gtfs-rt-archiver-v3/README.md
+++ b/services/gtfs-rt-archiver-v3/README.md
@@ -87,7 +87,7 @@ Code changes require building and pushing a new Docker image, as well as applyin
 4. Finally, apply changes using `kubectl` as described above.
    1. Currently, the image is built/pushed on merges to main but the Kubernetes manifests are not applied.
 
-### Fixing download configurations
+### Changing download configurations
 GTFS download configurations (for both Schedule and RT) are sourced from the [GTFS Dataset table](https://airtable.com/appPnJWrQ7ui4UmIl/tbl5V6Vjs4mNQgYbc) in the California Transit Airtable base, and we have [specific documentation](https://docs.google.com/document/d/1IO8x9-31LjwmlBDH0Jri-uWI7Zygi_IPc9nqd7FPEQM/edit#heading=h.b2yta6yeugar) for modifying the table. (Both of these Airtable links require authentication/access to Airtable.) You may need to make URL or authentication adjustments in this table. This data is downloaded daily into our infrastructure and will propagate to the GTFS Schedule and RT downloads; you may execute the [Airtable download job](https://o1d2fa0877cf3fb10p-tp.appspot.com/dags/airtable_loader_v2/grid) manually after making edits to "deploy" the changes more quickly.
 
-Another possible intervention is updating or adding authentication information in [Secret Manager](https://console.cloud.google.com/security/secret-manager). You may create new versions . **As of 2023-04-10 the archiver does not automatically pick up new/modified secrets; you must restart the archiver for changes to take effect.**
+Another possible intervention is updating or adding authentication information in [Secret Manager](https://console.cloud.google.com/security/secret-manager). You may create new versions of existing secrets, or add entirely new secrets. Secrets must be tagged with `gtfs_rt: true` to be loaded as secrets in the archiver; secrets are refreshed every 5 minutes by the ticker.

--- a/services/gtfs-rt-archiver-v3/docker-compose.yml
+++ b/services/gtfs-rt-archiver-v3/docker-compose.yml
@@ -38,8 +38,8 @@ services:
 
   gtfs-rt-archiver-v3-ticker:
     <<: *gtfs-rt-archiver-v3-common
-    command: python -m gtfs_rt_archiver_v3.ticker --load-env-secrets
+    command: python -m gtfs_rt_archiver_v3.ticker
 
   gtfs-rt-archiver-v3-consumer:
     <<: *gtfs-rt-archiver-v3-common
-    command: python -m gtfs_rt_archiver_v3.consumer --load-env-secrets
+    command: python -m gtfs_rt_archiver_v3.consumer

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/consumer.py
@@ -9,7 +9,6 @@ import sys
 
 import sentry_sdk
 import typer
-from calitp_data_infra.auth import get_secrets_by_label  # type: ignore
 from huey.constants import WORKER_THREAD  # type: ignore
 from huey.consumer_options import ConsumerConfig  # type: ignore
 from prometheus_client import start_http_server
@@ -42,16 +41,9 @@ def set_exception_fingerprint(event, hint):
     return event
 
 
-def main(
-    port: int = int(os.getenv("CONSUMER_PROMETHEUS_PORT", 9102)),
-    load_env_secrets: bool = False,
-):
+def main(port: int = int(os.getenv("CONSUMER_PROMETHEUS_PORT", 9102))):
     sentry_sdk.init(before_send=set_exception_fingerprint)
     start_http_server(port)
-
-    if load_env_secrets:
-        for key, value in get_secrets_by_label("gtfs_rt").items():
-            os.environ[key] = value
 
     config = ConsumerConfig(
         workers=int(

--- a/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/ticker.py
+++ b/services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/ticker.py
@@ -72,7 +72,9 @@ def main(
     sentry_sdk.init(environment=os.getenv("AIRFLOW_ENV"))
     start_http_server(port)
     get_configs()
+    assert configs is not None
     get_secrets()
+    assert secrets is not None
     typer.secho("flushing huey")
     huey.flush()
 

--- a/services/gtfs-rt-archiver-v3/pyproject.toml
+++ b/services/gtfs-rt-archiver-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gtfs-rt-archiver"
-version = "2023.7.20"
+version = "2023.8.9"
 description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves https://github.com/cal-itp/data-infra/issues/1938
(see https://cal-itp.slack.com/archives/C01FNDG1ZPA/p1691601423249999)

Note: I'm choosing an easier/simpler implementation that uses the ticker to grab and pass auth keys in task calls. This means secrets are serialized into Redis, but it's not a huge deal since we don't persist/backup Redis.

~Also, fetching secrets when we fetch configs does add to the fetch delay every 5 minutes. The alternative would be a separate scheduled function call, which I am going to experiment with. (We could use this same scheduled call to update the configs and reduce delay even more).~

I implemented this; the same scheduler that calls `tick` now loads configs and secrets at the `XX:45` every minute.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Testing locally and will deploy to test first.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Deploy to prod.