### PR TITLE
Revert "upgrade sentry helm chart"

### DIFF
--- a/kubernetes/apps/charts/sentry/Chart.yaml
+++ b/kubernetes/apps/charts/sentry/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 appVersion: "1.4.2"
 dependencies:
   - name: sentry
-    version: 20.0.0
+    version: 18.0.0
     repository: https://sentry-kubernetes.github.io/charts


### PR DESCRIPTION
Reverts cal-itp/data-infra#2871

I'm hitting an issue around existingSecret for the underlying postgres chart. Going to see if I can revert.