### PR TITLE
try sentry upgrade again; change backup frequency

### DIFF
--- a/kubernetes/apps/charts/sentry/Chart.yaml
+++ b/kubernetes/apps/charts/sentry/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 appVersion: "1.4.2"
 dependencies:
   - name: sentry
-    version: 18.0.0
+    version: 20.0.0
     repository: https://sentry-kubernetes.github.io/charts

--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -7,7 +7,10 @@ sentry:
   postgresql:
     global:
       postgresql:
-        existingSecret: sentry-sentry-postgresql
+        auth:
+          existingSecret: sentry-sentry-postgresql
+          adminPasswordKey: postgresql-password
+          userPasswordKey: postgresql-password
     resources:
       requests:
         memory: 3Gi
@@ -95,3 +98,7 @@ sentry:
   kafka:
     logRetentionHours: 72 # 3 days, the default is 7
     numPartitions: 12
+    kraft:
+      enabled: false
+    zookeeper:
+      enabled: true

--- a/kubernetes/apps/values/postgresql-backup-sentry.yaml
+++ b/kubernetes/apps/values/postgresql-backup-sentry.yaml
@@ -1,4 +1,5 @@
 cronjob:
+  schedule: "15 0,12 * * *"
   image: ghcr.io/jarvusinnovations/restic-toolkit:1.3.0
 
 secretMounts:


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves the post-upgrade sentry issues. The upgrade changed a couple defaults that I failed to override before now. Also, the postgres backup takes ~1.5 hours to run, so with the cron default of hourly, it was running constantly and stopping long-running database migrations from being able to run. I've changed it to run 2x a day.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Sentry is up and running.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Release to prod.