### PR TITLE
disable psp in both grafana and loki

### DIFF
--- a/ci/channels/prod.yaml
+++ b/ci/channels/prod.yaml
@@ -35,6 +35,8 @@ calitp:
       namespace: monitoring-loki
       helm_name: loki
       helm_chart: kubernetes/apps/charts/loki
+      helm_values:
+        - kubernetes/apps/values/loki-prod.yaml
     - name: metabase
       driver: helm
       namespace: metabase

--- a/kubernetes/apps/values/grafana-prod.yaml
+++ b/kubernetes/apps/values/grafana-prod.yaml
@@ -1,3 +1,10 @@
+# override things coming from cluster-template; won't be necessary starting with grafana chart version 6.51.3
+rbac:
+  pspEnabled: false
+  pspUserAppArmor: false
+testFramework:
+  enabled: false
+
 ingress:
   enabled: true
   annotations:

--- a/kubernetes/apps/values/loki-prod.yaml
+++ b/kubernetes/apps/values/loki-prod.yaml
@@ -1,0 +1,7 @@
+# override things coming from cluster-template; shouldn't be necessary when migrated off the grafana helm-chart source
+# to the loki repo itself
+rbac:
+  pspEnabled: false
+  pspUserAppArmor: false
+testFramework:
+  enabled: false


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Step towards unblocking GKE automatic upgrade to k8s v1.25.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

I've deployed both of these and confirmed `kubectl get psp` no longer shows anything, and the upgrades themselves do not show the deprecation warnings.

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
I'll have deployed this manually to migrate.