### PR TITLE
Fix failing test on fct monthly routes

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2098,9 +2098,8 @@ models:
         tests: *primary_key_tests
       - name: source_record_id
         description: |
-          Source record ID of the associated `dim_gtfs_datasets` record for this route
+          Source record ID of the associated GTFS dataset record for this route
           as of the last day of this month.
-          If null, the source feed was not present on the last day of this month to facilitate a lookup.
       - name: name
       - name: base64_url
       - name: route_id

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2089,22 +2089,40 @@ models:
       - *rt_trip_num_distinct_updates
   - name: fct_monthly_routes
     description: |
-      An aggregation of GTFS schedule routes, where the shape with the most trips is  associated.
+      An aggregation of GTFS schedule routes with trip activity in a given month,
+      where the shape with the most trips is associated.
     columns:
       - name: key
         description: |
           Synthetic primary key constructed from `base64_url`, `route_id`, `month`, and `year`.
         tests: *primary_key_tests
       - name: source_record_id
+        description: |
+          Source record ID of the associated `dim_gtfs_datasets` record for this route
+          as of the last day of this month.
+          If null, the source feed was not present on the last day of this month to facilitate a lookup.
       - name: name
       - name: base64_url
       - name: route_id
       - name: shape_id
+        description: |
+          If null, this route was mostly missing shapes data.
       - name: month
         description: |
           Service month in which this service was scheduled to occur.
       - name: year
         description: |
           Service year in which this service was scheduled to occur.
+      - name: month_last_day
+        description: |
+          Last day of the month being summarized. This is the date that was used
+          to look up feed and GTFS dataset attributes.
       - name: shape_array_key
+        description: |
+          Key to `dim_shapes_arrays` for this month, route, and shape.
+          If null, it's possible that: this route did not have shapes data; or the most common associated shape may have
+          been deleted in the course of the month being summarized; or the source feed was not
+          present on the last day of this month to facilitate a shape lookup.
       - name: pt_array
+        description: |
+          Array of points describing this shape, looked up from `dim_shapes_arrays` via `shape_array_key`.

--- a/warehouse/models/mart/gtfs/fct_monthly_routes.sql
+++ b/warehouse/models/mart/gtfs/fct_monthly_routes.sql
@@ -13,7 +13,6 @@ fct_daily_schedule_feeds AS (
     SELECT
         feed_key,
         base64_url,
-        gtfs_dataset_key,
         LAST_DAY(date, MONTH) as month_last_day
     FROM {{ ref('fct_daily_schedule_feeds') }}
     WHERE date = LAST_DAY(date, MONTH)


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Fixes failing test by re-keying table and refactoring the join with GTFS datasets. Also adds a bit of documentation.

Fixes CAL-ITP-DATA-INFRA-26BK ([x](https://sentry.calitp.org/organizations/sentry/issues/72428/?project=2))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

``` 
laurie ~/git/data-infra/warehouse [fix-monthly-routes-keying] $ poetry run dbt test -s fct_monthly_routes
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
18:48:02  Running with dbt=1.5.1
18:48:04  Found 324 models, 843 tests, 0 snapshots, 0 analyses, 839 macros, 0 operations, 7 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
18:48:04  
18:48:06  Concurrency: 4 threads (target='dev')
18:48:06  
18:48:06  1 of 2 START test not_null_fct_monthly_routes_key .............................. [RUN]
18:48:06  2 of 2 START test unique_fct_monthly_routes_key ................................ [RUN]
18:48:08  1 of 2 PASS not_null_fct_monthly_routes_key .................................... [PASS in 1.18s]
18:48:08  2 of 2 PASS unique_fct_monthly_routes_key ...................................... [PASS in 1.26s]

```

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
