### PR TITLE
Change GTFS RT / schedule mapping to handle schedule download failures

### DIFF
--- a/warehouse/macros/gtfs_rt_messages_keying.sql
+++ b/warehouse/macros/gtfs_rt_messages_keying.sql
@@ -22,6 +22,42 @@ WITH
     fct_daily_schedule_feeds AS (
         SELECT *
         FROM {{ ref('fct_daily_schedule_feeds') }}
+    ),
+
+    -- follow int_transit_database__urls_to_gtfs_datasets example
+    -- to handle cases where a feed fails to download on a given day
+    -- schedule models fill in gaps if download later succeeds, but RT data does not
+    -- because RT models are incremental
+    -- we want to map RT data to most recent download
+    -- especially for schedule feed timezone
+
+    appearance_duration AS (
+        SELECT
+            base64_url,
+            MAX(_valid_to) AS latest_app,
+            MIN(_valid_from) AS first_app
+        FROM dim_schedule_feeds
+        GROUP BY base64_url
+    ),
+
+    extend_schedule_dates AS (
+        SELECT
+            dim_schedule_feeds.base64_url,
+            dim_schedule_feeds.key AS schedule_feed_key,
+            dim_schedule_feeds.feed_timezone,
+            -- backdate start of first URL/record relationship so data scraped before record can be mapped
+            CASE
+                WHEN dim_schedule_feeds._valid_from = appearance_duration.first_app THEN CAST('1900-01-01' AS TIMESTAMP)
+                ELSE dim_schedule_feeds._valid_from
+            END AS _valid_from,
+            -- forward date end of last URL/record relationship to allow for mapping if schedule feed fails to download while RT still online
+            CASE
+                WHEN dim_schedule_feeds._valid_to = appearance_duration.latest_app THEN {{ make_end_of_valid_range('CAST("2099-01-01" AS TIMESTAMP)') }}
+                ELSE dim_schedule_feeds._valid_to
+            END AS _valid_to,
+        FROM dim_schedule_feeds
+        LEFT JOIN appearance_duration
+            USING (base64_url)
     )
 
     -- if we ever backfill v1 RT data, the reliance on _config_extract_ts for joins in this table may become problematic
@@ -31,11 +67,11 @@ WITH
         schedule_datasets.key AS schedule_gtfs_dataset_key,
         schedule_datasets.base64_url AS schedule_base64_url,
         schedule_datasets.name AS schedule_name,
-        COALESCE(dim_schedule_feeds.key, fct_daily_schedule_feeds.feed_key) AS schedule_feed_key,
+        COALESCE(extend_schedule_dates.schedule_feed_key, fct_daily_schedule_feeds.feed_key) AS schedule_feed_key,
         -- TODO: coalescing to America/Los_Angeles at the end here is a bit of a blunt instrument to ensure the field is populated
         -- America/Los_Angeles is the most common time zone by a huge margin, so we assume it's a good guess
         -- we could do more advanced imputation eventually; the issue here is cases where RT data was downloaded but schedule wasn't available for some reason
-        COALESCE(dim_schedule_feeds.feed_timezone, fct_daily_schedule_feeds.feed_timezone, "America/Los_Angeles") AS schedule_feed_timezone,
+        COALESCE(extend_schedule_dates.feed_timezone, fct_daily_schedule_feeds.feed_timezone, "America/Los_Angeles") AS schedule_feed_timezone,
         rt.* EXCEPT(_name)
     FROM {{ raw_messages }} AS rt
     LEFT JOIN urls_to_gtfs_datasets
@@ -52,9 +88,9 @@ WITH
         AND rt._config_extract_ts BETWEEN schedule_datasets._valid_from AND schedule_datasets._valid_to
     -- use _extract_ts for this join because now we're looking at the actual data
     -- we want the schedule feed that was in effect when this RT data was actually scraped
-    LEFT JOIN dim_schedule_feeds
-        ON schedule_datasets.base64_url = dim_schedule_feeds.base64_url
-        AND rt._extract_ts BETWEEN dim_schedule_feeds._valid_from AND dim_schedule_feeds._valid_to
+    LEFT JOIN extend_schedule_dates
+        ON schedule_datasets.base64_url = extend_schedule_dates.base64_url
+        AND rt._extract_ts BETWEEN extend_schedule_dates._valid_from AND extend_schedule_dates._valid_to
     -- use this as a fallback for cases where the above join fails because the schedule URL changed
     -- and RT data was downloaded that references a new URL that hasn't had data downloaded yet
     LEFT JOIN fct_daily_schedule_feeds

--- a/warehouse/macros/gtfs_rt_messages_keying.sql
+++ b/warehouse/macros/gtfs_rt_messages_keying.sql
@@ -68,9 +68,10 @@ WITH
         schedule_datasets.base64_url AS schedule_base64_url,
         schedule_datasets.name AS schedule_name,
         COALESCE(extend_schedule_dates.schedule_feed_key, fct_daily_schedule_feeds.feed_key) AS schedule_feed_key,
-        -- TODO: coalescing to America/Los_Angeles at the end here is a bit of a blunt instrument to ensure the field is populated
+        -- extend_schedule_dates + fallback to daily feed should ensure that timezone is populated
+        -- but just in case...
+        -- coalescing to America/Los_Angeles at the end here is a bit of a blunt instrument to ensure the field is populated
         -- America/Los_Angeles is the most common time zone by a huge margin, so we assume it's a good guess
-        -- we could do more advanced imputation eventually; the issue here is cases where RT data was downloaded but schedule wasn't available for some reason
         COALESCE(extend_schedule_dates.feed_timezone, fct_daily_schedule_feeds.feed_timezone, "America/Los_Angeles") AS schedule_feed_timezone,
         rt.* EXCEPT(_name)
     FROM {{ raw_messages }} AS rt


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

This morning, the AC Transit schedule feed failed to download. As a result, we got a bunch of errors on the RT side, because the RT data had no schedule data to map to. The specific symptom that caused the alerting was that the AC Transit feed uses timezone `US/Pacific` and our default fallback is `America/Los_Angeles` so we got some fanout where the same trip was mapping to two time zones across the 3am UTC boundary when the schedule feed download failure registered.

Fixes CAL-ITP-DATA-INFRA-2682 ([x](https://sentry.calitp.org/organizations/sentry/issues/72301/))
Fixes CAL-ITP-DATA-INFRA-2695 ([x](https://sentry.calitp.org/organizations/sentry/issues/72337/))
Fixes CAL-ITP-DATA-INFRA-2697 ([x](https://sentry.calitp.org/organizations/sentry/issues/72339/))
Resolves #[issue]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

Tests now pass on the two models that were failing (int vehicle positions and trip updates trip day mapping). 
Fact vehicle locations now builds and tests pass.

Also tested that the equivalent service alerts model still works and passes tests. 

## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Re-run the dbt job with selector: `fct_vehicle_positions messages+ fct_service_alerts_messages+ fct_trip_updates_messages+`. **Does not have to be a full refresh if we get this merged and run today August 17.**
