### PR TITLE
bug fix: missing `mart_gtfs.fct_daily_scheduled_stops`

### DIFF
--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
@@ -19,10 +19,6 @@ WITH fct_scheduled_trips AS (
 dim_stop_times AS (
     SELECT *
     FROM {{ ref('dim_stop_times') }}
-    WHERE {{ incremental_where(default_start_var='GTFS_SCHEDULE_START',
-                               this_dt_column='_feed_valid_from',
-                               filter_dt_column='_feed_valid_from',
-                               dev_lookback_days = None) }}
 ),
 
 dim_stops AS (

--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
@@ -65,14 +65,14 @@ stops_by_day_by_route AS (
             trips.contains_warning_missing_foreign_key_stop_id
         ) AS contains_warning_missing_foreign_key_stop_id
 
-    FROM dim_stop_times AS stop_times
+    FROM fct_scheduled_trips AS trips
+    LEFT JOIN dim_stop_times AS stop_times
+        ON trips.feed_key = stop_times.feed_key
+            AND trips.trip_id = stop_times.trip_id
     LEFT JOIN int_gtfs_schedule__frequencies_stop_times freq
         ON stop_times.feed_key = freq.feed_key
         AND stop_times.trip_id = freq.trip_id
         AND stop_times.stop_id = freq.stop_id
-    LEFT JOIN fct_scheduled_trips AS trips
-        ON trips.feed_key = stop_times.feed_key
-            AND trips.trip_id = stop_times.trip_id
     GROUP BY 1, 2, 3, 4, 5, 6
 
 ),

--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
@@ -10,12 +10,19 @@ WITH fct_scheduled_trips AS (
 
     SELECT *
     FROM {{ ref('fct_scheduled_trips') }}
+    WHERE {{ incremental_where(default_start_var='GTFS_SCHEDULE_START',
+                               this_dt_column='service_date',
+                               filter_dt_column='service_date',
+                               dev_lookback_days = None) }}
 ),
 
 dim_stop_times AS (
     SELECT *
     FROM {{ ref('dim_stop_times') }}
-    WHERE {{ incremental_where(default_start_var='GTFS_SCHEDULE_START', this_dt_column='_feed_valid_from', filter_dt_column='_feed_valid_from', dev_lookback_days = None) }}
+    WHERE {{ incremental_where(default_start_var='GTFS_SCHEDULE_START',
+                               this_dt_column='_feed_valid_from',
+                               filter_dt_column='_feed_valid_from',
+                               dev_lookback_days = None) }}
 ),
 
 dim_stops AS (

--- a/warehouse/tests/mart/gtfs/validate_fct_daily_tables.sql
+++ b/warehouse/tests/mart/gtfs/validate_fct_daily_tables.sql
@@ -1,0 +1,21 @@
+WITH trip_check_cts AS (
+    SELECT service_date, COUNT(DISTINCT feed_key) AS trip_n_feeds
+    FROM {{ ref('fct_scheduled_trips') }}
+    GROUP BY 1
+),
+
+-- check that number of feeds that appear in stops is same as trips
+stop_check_cts AS (
+    SELECT service_date, COUNT(DISTINCT feed_key) AS stop_n_feeds
+    FROM {{ ref('fct_daily_scheduled_stops') }}
+    GROUP BY 1
+)
+
+SELECT
+    trip_check_cts.service_date,
+    trip_n_feeds,
+    stop_n_feeds
+FROM trip_check_cts
+LEFT JOIN stop_check_cts
+    ON trip_check_cts.service_date = stop_check_cts.service_date
+WHERE trip_n_feeds > stop_n_feeds

--- a/warehouse/tests/mart/gtfs/validate_fct_daily_tables.sql
+++ b/warehouse/tests/mart/gtfs/validate_fct_daily_tables.sql
@@ -9,13 +9,20 @@ stop_check_cts AS (
     SELECT service_date, COUNT(DISTINCT feed_key) AS stop_n_feeds
     FROM {{ ref('fct_daily_scheduled_stops') }}
     GROUP BY 1
+),
+
+check_cts AS (
+    SELECT
+        trip_check_cts.service_date,
+        trip_n_feeds,
+        stop_n_feeds,
+        stop_n_feeds / trip_n_feeds AS ratio
+    FROM trip_check_cts
+    LEFT JOIN stop_check_cts
+        ON trip_check_cts.service_date = stop_check_cts.service_date
+    ORDER BY service_date DESC
 )
 
-SELECT
-    trip_check_cts.service_date,
-    trip_n_feeds,
-    stop_n_feeds
-FROM trip_check_cts
-LEFT JOIN stop_check_cts
-    ON trip_check_cts.service_date = stop_check_cts.service_date
-WHERE trip_n_feeds > stop_n_feeds
+SELECT *
+FROM check_cts
+WHERE ratio < 0.75


### PR DESCRIPTION
# Description
_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Since we want `fct_daily_scheduled_stops` to show stops for all days available, move `fct_scheduled_trips` to use as base table on which `dim_stop_times` is joined.


Resolves #2900 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
_Include commands/logs/screenshots as relevant._

`poetry run dbt run --select fct_daily_scheduled_stops`
`poetry run dbt test --select fct_daily_scheduled_stops`

Also, checked Big Query to make sure there are more feeds available in Aug. 
<img width="446" alt="bq" src="https://github.com/cal-itp/data-infra/assets/49657200/5b31df42-33c3-4aeb-8edc-61bfdcca6c81">


## Post-merge follow-ups
_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
full refresh for `mart_gtfs.fct_daily_scheduled_stops`