### PR TITLE
renaming missing form_factor values to 'Unidentified'

### DIFF
--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -354,7 +354,12 @@ join_table AS (
 fct_payments_rides_v2 AS (
     SELECT
 
-        *,
+        * EXCEPT(form_factor),
+        CASE
+            WHEN form_factor IS NULL THEN 'Unidentified'
+            WHEN form_factor = '' THEN 'Unidentified'
+            ELSE form_factor
+            END AS form_factor,
         DATETIME_DIFF(
             off_transaction_date_time_pacific,
             transaction_date_time_pacific,


### PR DESCRIPTION
# Description
In our Metabase dashboards, missing `form_factor` values appear as several different values including `Null`s and empty strings. This PR converts them all to 'Unidentified'

## Type of change

- [x] New feature

## How has this been tested?
bigquery/ local dbt
