### PR TITLE
revise payments date spine to exclude null values

### DIFF
--- a/warehouse/models/mart/payments/indexes/payments_tests_daily_date_spine.sql
+++ b/warehouse/models/mart/payments/indexes/payments_tests_daily_date_spine.sql
@@ -1,10 +1,10 @@
 {{ config(materialized='ephemeral') }}
 
-{% set min_date_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', order_by = 'transaction_date_pacific', max_records = 1) %}
+{% set min_date_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific', max_records = 1) %}
 
 {% set min_date = min_date_list[0] %}
 
-{% set max_date_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', order_by = 'transaction_date_pacific DESC', max_records = 1) %}
+{% set max_date_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific DESC', max_records = 1) %}
 
 {% set max_date = max_date_list[0] %}
 

--- a/warehouse/models/mart/payments/indexes/payments_tests_monthly_date_spine.sql
+++ b/warehouse/models/mart/payments/indexes/payments_tests_monthly_date_spine.sql
@@ -1,10 +1,10 @@
 {{ config(materialized='ephemeral') }}
 
-{% set min_month_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', order_by = 'transaction_date_pacific', max_records = 1) %}
+{% set min_month_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific', max_records = 1) %}
 
 {% set min_month = min_month_list[0] %}
 
-{% set max_month_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', order_by = 'transaction_date_pacific DESC', max_records = 1) %}
+{% set max_month_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific DESC', max_records = 1) %}
 
 {% set max_month = max_month_list[0] %}
 

--- a/warehouse/models/mart/payments/indexes/payments_tests_weekly_date_spine.sql
+++ b/warehouse/models/mart/payments/indexes/payments_tests_weekly_date_spine.sql
@@ -1,10 +1,10 @@
 {{ config(materialized='ephemeral') }}
 
-{% set min_week_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', order_by = 'transaction_date_pacific', max_records = 1) %}
+{% set min_week_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific', max_records = 1) %}
 
 {% set min_week = min_week_list[0] %}
 
-{% set max_week_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', order_by = 'transaction_date_pacific DESC', max_records = 1) %}
+{% set max_week_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific DESC', max_records = 1) %}
 
 {% set max_week = max_week_list[0] %}
 


### PR DESCRIPTION
# Description

Since merging the PR which includes payments rides that have `off` taps but don't have `on` taps, we introduced rides with no transaction date which is interfering with the date spine we created. This PR excludes null values for transaction dates in the date spine.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

locally with dbt