### PR TITLE
Add Anaheim Transportation Network to LittlePay pipeline

### DIFF
--- a/airflow/dags/parse_littlepay/atn.yml
+++ b/airflow/dags/parse_littlepay/atn.yml
@@ -1,0 +1,2 @@
+operator: operators.LittlepayToJSONL
+instance: atn

--- a/airflow/dags/sync_littlepay/atn.yml
+++ b/airflow/dags/sync_littlepay/atn.yml
@@ -1,0 +1,3 @@
+operator: operators.LittlepayRawSync
+instance: atn
+access_key_secret_name: LITTLEPAY_AWS_IAM_ANAHEIM_TRANSPORTATION_NETWORK_ACCESS_KEY

--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -46,6 +46,11 @@
     principals = ['serviceAccount:redwood-coast-transit@cal-itp-data-infra.iam.gserviceaccount.com']
 ) }}",
 " {{ create_row_access_policy(
+    filter_column = 'participant_id',
+    filter_value = 'atn',
+    principals = ['serviceAccount:atn@cal-itp-data-infra.iam.gserviceaccount.com']
+) }}",
+" {{ create_row_access_policy(
     principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',

--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -48,7 +48,7 @@
 " {{ create_row_access_policy(
     filter_column = 'participant_id',
     filter_value = 'atn',
-    principals = ['serviceAccount:atn@cal-itp-data-infra.iam.gserviceaccount.com']
+    principals = ['serviceAccount:atn-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
 ) }}",
 " {{ create_row_access_policy(
     principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',

--- a/warehouse/seeds/payments_gtfs_datasets.csv
+++ b/warehouse/seeds/payments_gtfs_datasets.csv
@@ -8,3 +8,4 @@ recGTiyx7VcxcUkRu,humboldt-transit-authority
 rec7FygKkATPJZtFR,lake-transit-authority
 recxvrgxNkScGIidy,mendocino-transit-authority
 recWJJ4dRk4lHXaWX,redwood-coast-transit
+recrxmzfLImgBGwUH,atn


### PR DESCRIPTION
# Description

Adds code to bring Anaheim Transportation Network LittlePay data (already available in a vendor-controlled S3 bucket) into the warehouse. The agency is referred to here as `atn` for consistency with the name of the vendor data at the source (the bucket is `littlepay-prod-atn-datafeed`, rather than using an expanded form of the agency's name). That can be changed if we prefer to use the full name - I see there's a mixture of names and acronyms among the current LittlePay syncs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on local Airflow from raw data ingestion to external table creation

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
