### PR TITLE
make payments dags run hourly

### DIFF
--- a/airflow/dags/parse_littlepay/METADATA.yml
+++ b/airflow/dags/parse_littlepay/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Parse Littlepay files into JSONL"
-schedule_interval: "0 2 * * *"
+schedule_interval: "30 * * * *"
 tags:
   - all_gusty_features
 default_args:

--- a/airflow/dags/sync_littlepay/METADATA.yml
+++ b/airflow/dags/sync_littlepay/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Syncs Littlepay data from S3 bucket to our buckets"
-schedule_interval: "0 0 * * *"
+schedule_interval: "0 * * * *"
 tags:
   - all_gusty_features
 default_args:

--- a/airflow/dags/transform_warehouse/METADATA.yml
+++ b/airflow/dags/transform_warehouse/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Builds and tests the warehouse, and uploads artifacts"
-schedule_interval: "0 12 * * *"
+schedule_interval: "0 10 * * *"
 tags:
   - all_gusty_features
 default_args:


### PR DESCRIPTION
# Description
The freshness issues we've observed in payments data appear to be correctable with more frequent payments dag runs. This PR changes dag runs to hourly. 

TODO: run transaform_warehouse dag on `--select +fct_payments_rides_v2` hourly at the 45 minute mark ?

## Type of change

- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation