### PR TITLE
change fct_payments_rides_v2 join to include missing transactions

### DIFF
--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -330,7 +330,7 @@ join_table AS (
     FROM debited_micropayments AS m
     LEFT JOIN refunded_micropayments AS mr
         ON m.micropayment_id = mr.micropayment_id
-    INNER JOIN int_littlepay__customers AS c
+    LEFT JOIN int_littlepay__customers AS c
         ON m.customer_id = c.customer_id
     LEFT JOIN int_littlepay__customer_funding_source_vaults AS v
         ON m.funding_source_vault_id = v.funding_source_vault_id


### PR DESCRIPTION
# Description

After comparing HTA's July littlepay statement to the Metabase dashboard we realized that transactions were missing. After investigating, we realized that it was a result of an inner join on the `customer_id`field in `fct_payments_rides_v2`. This Pr changes that inner join to a left join, which causes the transaction values to match much more closely.

Resolves #\[issue\]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
locally in Bigquery and dbt