### PR TITLE
remove @charlie-costanzo from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,11 +10,11 @@
 /kubernetes                             @atvaccaro
 
 # jupyter service, e.g. updating the image
-/kubernetes/apps/charts/jupyterhub      @atvaccaro @charlie-costanzo @SorenSpicknall
-/images                                 @atvaccaro @charlie-costanzo @SorenSpicknall
+/kubernetes/apps/charts/jupyterhub      @atvaccaro @SorenSpicknall
+/images                                 @atvaccaro @SorenSpicknall
 
 # project documentation
-/docs                                   @charlie-costanzo @lauriemerrell
+/docs                                   @lauriemerrell
 
 # actual pipeline code
 /airflow                                @atvaccaro @lauriemerrell @SorenSpicknall


### PR DESCRIPTION
# Description

With the data services contract winding down it seems timely to remove `@charlie-costanzo` from `codeowners`.