### PR TITLE
Add incomplete variable fares to device transaction types so they willl appear in payments rides

### DIFF
--- a/warehouse/models/staging/payments/littlepay/int_littlepay__device_transaction_types.sql
+++ b/warehouse/models/staging/payments/littlepay/int_littlepay__device_transaction_types.sql
@@ -32,6 +32,17 @@ pending_device_transaction_ids AS (
     WHERE m.charge_type = 'pending_charge_fare'
 ),
 
+incomplete_variable_fare_micropayment_device_transaction_ids AS (
+    SELECT
+        micropayment_id,
+        littlepay_transaction_id,
+        transaction_date_time_utc
+    FROM stg_littlepay__micropayments AS m
+    INNER JOIN int_littlepay__cleaned_micropayment_device_transactions USING (micropayment_id)
+    INNER JOIN stg_littlepay__device_transactions USING (littlepay_transaction_id)
+    WHERE m.charge_type = 'incomplete_variable_fare'
+),
+
 potential_tap_on_or_off_micropayment_device_transaction_ids AS (
     SELECT
         micropayment_id,
@@ -83,6 +94,14 @@ int_littlepay__device_transaction_types AS (
         'off' AS transaction_type,
         False AS pending
     FROM paired_device_transaction_ids
+
+    UNION ALL
+
+    SELECT
+        littlepay_transaction_id,
+        'on' AS transaction_type,
+        False AS pending
+    FROM incomplete_variable_fare_micropayment_device_transaction_ids
 )
 
 SELECT * FROM int_littlepay__device_transaction_types


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Adds incomplete variable fares to device transaction types so they will appear in fct payments rides. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

Confirmed `littlepay_transaction_id` is populated for all but one incomplete variable fare rows with this change (342/343 rows):

```sql
SELECT  
  charge_type,
  littlepay_transaction_id IS NULL AS missing_id,
  COUNT(*)
FROM `cal-itp-data-infra-staging.laurie_mart_payments.fct_payments_rides_v2`
GROUP BY 1,2
ORDER BY 1,2 
```

We can do further investigation on the one row where it's still missing. Also confirmed that no new tests fail on models downstream of this change.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
