### PR TITLE
Payments: Remove over-aggressive file deduping

### DIFF
--- a/warehouse/macros/littlepay_staging_transforms.sql
+++ b/warehouse/macros/littlepay_staging_transforms.sql
@@ -32,17 +32,7 @@ CASE
 END
 {% endmacro %}
 
-{% macro qualify_dedupe_lp_files(instance_col = 'instance', file_dt_col = 'littlepay_export_date', file_ts_col = 'littlepay_export_ts', ts_col = 'ts') %}
-
--- remove duplicate instances of the same file (file defined as date-level update from LP)
--- partition by file date, order by LP-defined timestamp (most recent first), and then order by our extract timestamp (most recent first)
--- use dense rank instead of row number because we need to allow all rows from a given file to be included (allow ties)
-QUALIFY DENSE_RANK()
-    OVER (PARTITION BY {{ instance_col }}, {{ file_dt_col }} ORDER BY {{ file_ts_col }} DESC, {{ ts_col }} DESC) = 1
-
-{% endmacro %}
-
-{% macro qualify_dedupe_full_duplicate_lp_rows(content_hash_col = 'content_hash', file_ts_col = 'littlepay_export_ts', line_number_col = '_line_number') %}
+{% macro qualify_dedupe_full_duplicate_lp_rows(content_hash_col = '_content_hash', file_ts_col = 'littlepay_export_ts', line_number_col = '_line_number') %}
 
 -- remove full duplicate rows where *all* content is the same
 -- get most recent instance across files and then highest-line-number instance within most recent file

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -181,13 +181,19 @@ models:
         tests:
           - not_null
           - unique
-      - name: _payments_key
+      - &payments_key_fuzzy_uniqueness
+        name: _payments_key
         description: |
           Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
         tests:
           - not_null
           - unique_proportion:
               at_least: 0.999
+      - &_content_hash
+        name: _content_hash
+        description: |
+          Hash of all data columns to uniquely identify row's content, mostly for debugging purposes.
+          Should ideally be handled by uniqueness of _payments_key but surfaced for troubleshooting.
 
   - name: stg_littlepay__customer_funding_source
     tests:


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Per feedback from @SorenSpicknall, removes the overly aggressive file-deduping from authorisations staging model and refactors `_key` column accordingly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

Compared against prod table to confirm that this restores legitimate unique rows.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [ ] Actions required (specified below)
