### PR TITLE
Payments settlements: add missing columns for Anaheim and all agencies

### DIFF
--- a/airflow/dags/create_external_tables/payments/littlepay/settlements.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/settlements.yml
@@ -28,9 +28,21 @@ schema_fields:
     type: STRING
   - name: external_reference_number
     type: STRING
+  - name: acquirer
+    type: STRING
   - name: settlement_requested_date_time_utc
     type: STRING
-  - name: acquirer
+  - name: record_updated_timestamp_utc
+    type: STRING
+  - name: settlement_type
+    type: STRING
+  - name: acquirer_response_rrn
+    type: STRING
+  - name: settlement_status
+    type: STRING
+  - name: request_created_timestamp_utc
+    type: STRING
+  - name: response_created_timestamp_utc
     type: STRING
   - name: _line_number
     type: STRING


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Adds 6 new columns to the Payments settlements external table to facilitate future work deduping & settlements.

Five of the columns are specific to Anaheim because they have a new data schema from Littlepay:
  - `record_updated_timestamp_utc`
  - `acquirer_response_rrn`
  - `settlement_status`
  - `request_created_timestamp_utc`
  - `response_created_timestamp_utc`

And one is a column that we just missed before:
  - `settlement_type`
  
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Confirmed new columns are available in staging after running the updated DAG task locally:

```sql
SELECT *
FROM `cal-itp-data-infra-staging.external_littlepay.settlements`
WHERE participant_id = 'atn'
```


_Include commands/logs/screenshots as relevant._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Point the staging settlements table back at test bucket; changed it for testing of this PR.