### PR TITLE
Remove Caltrans District from transit data quality issues table

### DIFF
--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -892,7 +892,6 @@ models:
       - name: qc__num_issue_types
       - name: qc_checks
       - name: waiting_on_someone_other_than_transit_data_quality_
-      - name: caltrans_district__from_operating_county_geographies___from_services_
       - name: is_open
       - name: last_update
       - name: last_update_month


### PR DESCRIPTION
# Description

This column is not included in the SQL and should be looked up via a bridge table anyways. This is resulting in an error when synching metabase.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

It was not. See https://github.com/cal-itp/data-infra/issues/3004

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
