### PR TITLE
Add agency information to fct_payments_rides_v2

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -69,6 +69,13 @@ models:
         description: The route_long_name of the first tap transaction
       - name: route_short_name
         description: The route_short_name of the first tap transaction
+      - name: agency_id
+        description: |
+          Agency for the specified route.
+
+          This field is required when the dataset provides data for routes from more than one agency in agency.txt, otherwise it is optional.
+      - name: agency_name
+        description: Full name of the transit agency.
       - name: direction
         description: The direction of the first tap transaction
       - name: vehicle_id


### PR DESCRIPTION
# Description
As requested by HTA, an organization that operates multiple transit 'agencies', we are pulling in agency-related columns `agency_id` and `agency_name` to `fct_payments_rides_v2` so that they can distinguish agency information among rides.

Part of #2976 

## Type of change

- [x] New feature

## How has this been tested?
locally in dbt