### PR TITLE
Fix data type in transit funding programs schema

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
@@ -42,6 +42,3 @@ schema_fields:
   - name: drmt_data
     type: STRING
     mode: NULLABLE
-  - name: dt
-    type: STRING
-    mode: NULLABLE

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
@@ -33,6 +33,9 @@ schema_fields:
   - name: services
     type: STRING
     mode: REPEATED
+  - name: organization
+    type: STRING
+    mode: REPEATED
   - name: category
     type: STRING
     mode: NULLABLE

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
@@ -32,13 +32,10 @@ schema_fields:
     mode: NULLABLE
   - name: services
     type: STRING
-    mode: NULLABLE
-  - name: organization
-    type: STRING
-    mode: NULLABLE
+    mode: REPEATED
   - name: category
     type: STRING
     mode: NULLABLE
   - name: drmt_data
     type: STRING
-    mode: NULLABLE
+    mode: REPEATED


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Fixes #3003 and fixes the data type issues that were still present in  `external_airtable_california_transit_funding_programs`. Arrays need to use the `mode: REPEATED`, so use this for all array columns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Evan tested on local Airflow and it succeeded 

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
