### PR TITLE
Suppress duplicate row that is causing settlements test to fail

### DIFF
--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
@@ -70,10 +70,10 @@ stg_littlepay__settlements AS (
         _key,
         _payments_key
     FROM dedupe_and_keys
-    -- we have just one duplicate on settlement id; it's not associated with a refund
-    -- drop this one case so that we can continue testing for absolute uniqueness
+    -- we have just two duplicates on settlement id; they are not associated with a refund
+    -- drop these two cases so that we can continue testing for absolute uniqueness
     -- if we get more cases, we can add a qualify to get latest appearance only
-    WHERE _key != "bc6dd0f735a1087b13b424a3c790fc4d"
+    WHERE _key NOT IN ("bc6dd0f735a1087b13b424a3c790fc4d", "e8c09f593df1c61c9a890da0935d0863")
 
 )
 


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

At midnight UTC on 10/10-10/11, one specific settlement record seems to have had a duplicate created. There are two rows that are totally identical except for `settlement_requested_date_time_utc`, which differ by 12 seconds (one just before midnight, the other just after). It seems clear that these are just accidental duplicates and it seems safe to suppress the earlier update. 

Resolves #3010 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

```
laurie ~/git/data-infra/warehouse [fix-failing-settlements-test] $ poetry run dbt build -s stg_littlepay__settlements
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
20:30:25  Running with dbt=1.5.1
20:30:28  Unable to do partial parsing because profile has changed
20:30:40  Found 326 models, 883 tests, 0 snapshots, 0 analyses, 845 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
20:30:40  
20:30:43  Concurrency: 4 threads (target='dev')
20:30:43  
20:30:43  1 of 6 START sql view model laurie_staging.stg_littlepay__settlements .......... [RUN]
20:30:45  1 of 6 OK created sql view model laurie_staging.stg_littlepay__settlements ..... [CREATE VIEW (0 processed) in 1.76s]
20:30:45  2 of 6 START test dbt_utils_unique_combination_of_columns_stg_littlepay__settlements_instance__extract_filename__ts___line_number  [RUN]
20:30:45  3 of 6 START test not_null_stg_littlepay__settlements__key ..................... [RUN]
20:30:45  4 of 6 START test not_null_stg_littlepay__settlements__payments_key ............ [RUN]
20:30:45  5 of 6 START test unique_stg_littlepay__settlements__key ....................... [RUN]
20:30:48  5 of 6 PASS unique_stg_littlepay__settlements__key ............................. [PASS in 2.67s]
20:30:48  6 of 6 START test unique_stg_littlepay__settlements__payments_key .............. [RUN]
20:30:48  2 of 6 PASS dbt_utils_unique_combination_of_columns_stg_littlepay__settlements_instance__extract_filename__ts___line_number  [PASS in 2.72s]
20:30:48  4 of 6 PASS not_null_stg_littlepay__settlements__payments_key .................. [PASS in 2.74s]
20:30:48  3 of 6 PASS not_null_stg_littlepay__settlements__key ........................... [PASS in 2.76s]
20:30:50  6 of 6 PASS unique_stg_littlepay__settlements__payments_key .................... [PASS in 2.28s]
20:30:50  
20:30:50  Finished running 1 view model, 5 tests in 0 hours 0 minutes and 9.96 seconds (9.96s).
20:30:51  
20:30:51  Completed successfully
20:30:51  
20:30:51  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 TOTAL=6
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
