### PR TITLE
Payments: fix join on feed_key for agency_name in fct_payments_ride_v2

### DIFF
--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -146,7 +146,7 @@ participants_to_routes_and_agency AS (
         ON f.feed_key = r.feed_key
     LEFT JOIN dim_agency AS a
         ON r.agency_id = a.agency_id
-            AND r.feed_key = r.feed_key
+            AND r.feed_key = a.feed_key
 ),
 
 debited_micropayments AS (


### PR DESCRIPTION
# Description

PR #3008 included an incorrect join on `feed_key` in `fct_payments_rides_v2` when looking to pull in the `agency_name` field, resulting in duplicate rows and failing tests. This PR resolves that.

Resolves: #3015 

Fixes CAL-ITP-DATA-INFRA-26PC

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
locally with `dbt run` and `dbt test`