### PR TITLE
Payments: Intermediate settlements model

### DIFF
--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -1,0 +1,5 @@
+Documentation related to Littlepay data schema
+
+{% docs lp_participant_id %}
+Littlepay identifier for the participant (transit agency) associated with this entity or event.
+{% enddocs %}

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -81,6 +81,10 @@ models:
               inclusive: true
         description: |
           Total dollar amount associated with debit settlements in this aggregation.
+          Numbers in this column are positive because they represent amounts debited (charged) by the participant to the customer (rider);
+          i.e., these values represent income for the participant (agency).
       - name: credit_amount
         description: |
           Total dollar amount associated with credit (refund) settlements in this aggregation.
+          Numbers in this column are negative because they represent amounts credited (refunded) by the participant (agency) to the customer (rider);
+          i.e., these values represent costs for the participant (agency).

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -79,6 +79,7 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
+      - name: debit_amount
         description: |
           Total dollar amount associated with debit settlements in this aggregation.
           Numbers in this column are positive because they represent amounts debited (charged) by the participant to the customer (rider);

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -30,3 +30,57 @@ models:
         tests:
           - not_null
           - unique
+  - name: int_payments__settlements_summarized
+    description: |
+      This model contains Littlepay settlements aggregated to the `aggregation_id + retrieval_reference_number` level.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - aggregation_id
+            - retrieval_reference_number
+      - dbt_utils.expression_is_true:
+          expression: "debit_amount + credit_amount = net_settled_amount_dollars"
+      - dbt_utils.expression_is_true:
+          expression: "contains_refund = (credit_amount < 0)"
+    columns:
+      - name: aggregation_id
+        description: |
+          ID of the aggregation being settled.
+        tests:
+          - not_null
+          - unique
+      - name: retrieval_reference_number
+        tests:
+          - not_null
+          - unique
+      - name: participant_id
+        description: '{{ doc("lp_participant_id") }}'
+      - name: contains_imputed_type
+        description: |
+          Some settlements are missing `settlement_type` (i.e., `DEBIT` vs. `CREDIT` designation).
+          We impute those missing values on the heuristic that first updates tend to be the debit
+          and any subsequent updates are credits (refunds).
+          Rows with "true" in this column indicate that at least one input row had its settlement type imputed.
+          These rows could potentially (though we believe it is unlikely) be sources of error if the imputation
+          assumptions were incorrect.
+      - name: contains_refund
+        description: |
+          If `true`, this aggregation settlement included at least one row with settlement_type = `CREDIT`.
+      - name: latest_update_timestamp
+        description: |
+          Most recent `settlement_requested_date_time_utc` value for this aggregation settlement.
+          If a credit (refund) was issued after the initial debit, this will be the timestamp of the credit.
+      - name: net_settled_amount_dollars
+        description: |
+          Net dollar amount of this aggregation settlement; if a refund (credit) has been issued,
+          that will be reflected. So for example if $20 was debited and then $8 was credited,
+          the value in this column will be `12` (= 20 - 8).
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+        description: |
+          Total dollar amount associated with debit settlements in this aggregation.
+      - name: credit_amount
+        description: |
+          Total dollar amount associated with credit (refund) settlements in this aggregation.

--- a/warehouse/models/intermediate/payments/int_payments__settlements_summarized.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_summarized.sql
@@ -3,12 +3,40 @@
 WITH settlements AS (
     SELECT *
     FROM {{ ref('stg_littlepay__settlements') }}
+),
+
+impute_settlement_type AS (
+    SELECT
+        * EXCEPT(settlement_type),
+        COALESCE(settlement_type,
+            -- when a settlement (aggregation_id / RRN) appears multiple times, it is generally because the subsequent lines are refunds
+            -- vast majority of refunds have exactly one debit line and one credit (refund) line, but there are a few oddities with multiple credit (refund) lines
+            CASE
+                WHEN ROW_NUMBER() OVER(PARTITION BY aggregation_id, retrieval_reference_number ORDER BY settlement_requested_date_time_utc) > 1 THEN "CREDIT"
+                ELSE "DEBIT"
+            END
+        ) AS settlement_type,
+        settlement_type IS NULL AS imputed_type,
+    FROM settlements
+),
+
+summarize_by_type AS (
+    SELECT
+        aggregation_id,
+        retrieval_reference_number,
+        settlement_type,
+        LOGICAL_OR(imputed_type) AS contains_imputed_type,
+        MAX(settlement_requested_date_time_utc) AS latest_update_timestamp,
+        CASE
+            WHEN settlement_type = "CREDIT" THEN -SUM(transaction_amount)
+            WHEN settlement_type = "DEBIT" THEN SUM(transaction_amount)
+        END AS total_amount,
+    FROM impute_settlement_type
+    GROUP BY 1,2,3
+
 )
 
 -- TODO:
--- pair up debit with credit settlements to get final settled amount per aggregation id
--- question is how / whether to actually join with refunds
--- looks like settlements.type (which determines debit vs. credit) is not always populated :/
--- so we may need to join with refunds to determine which are credits
+-- pair up debit with credit settlements (pivot) to get final settled amount per aggregation id
 
-SELECT * FROM settlements
+SELECT * FROM summarize_by_type

--- a/warehouse/models/intermediate/payments/int_payments__settlements_summarized.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_summarized.sql
@@ -5,6 +5,8 @@ WITH settlements AS (
     FROM {{ ref('stg_littlepay__settlements') }}
 ),
 
+-- some rows have null settlement type (debit vs. credit)
+-- so we try to impute based on settlement order
 impute_settlement_type AS (
     SELECT
         * EXCEPT(settlement_type),
@@ -22,21 +24,52 @@ impute_settlement_type AS (
 
 summarize_by_type AS (
     SELECT
+        participant_id,
         aggregation_id,
         retrieval_reference_number,
         settlement_type,
-        LOGICAL_OR(imputed_type) AS contains_imputed_type,
-        MAX(settlement_requested_date_time_utc) AS latest_update_timestamp,
+        LOGICAL_OR(imputed_type) AS type_contains_imputed_type,
+        MAX(settlement_requested_date_time_utc) AS type_latest_update_timestamp,
         CASE
-            WHEN settlement_type = "CREDIT" THEN -SUM(transaction_amount)
+            WHEN settlement_type = "CREDIT" THEN -1*SUM(transaction_amount)
             WHEN settlement_type = "DEBIT" THEN SUM(transaction_amount)
         END AS total_amount,
     FROM impute_settlement_type
-    GROUP BY 1,2,3
+    GROUP BY 1, 2, 3, 4
+),
 
+-- group again to get overall summary across types
+summarize_overall AS (
+    SELECT
+        participant_id,
+        aggregation_id,
+        retrieval_reference_number,
+        LOGICAL_OR(type_contains_imputed_type) AS contains_imputed_type,
+        MAX(type_latest_update_timestamp) AS latest_update_timestamp,
+        SUM(total_amount) AS net_amount,
+    FROM summarize_by_type
+    GROUP BY 1, 2, 3
+),
+
+int_payments__settlements_summarized AS (
+    SELECT
+        summary.participant_id,
+        summary.aggregation_id,
+        summary.retrieval_reference_number,
+        contains_imputed_type,
+        latest_update_timestamp,
+        net_amount AS net_settled_amount_dollars,
+        COALESCE(debit.total_amount,0) AS debit_amount,
+        COALESCE(credit.total_amount,0) AS credit_amount
+    FROM summarize_overall AS summary
+    LEFT JOIN summarize_by_type AS debit
+        ON summary.aggregation_id = debit.aggregation_id
+        AND summary.retrieval_reference_number = debit.retrieval_reference_number
+        AND debit.settlement_type = "DEBIT"
+    LEFT JOIN summarize_by_type AS credit
+        ON summary.aggregation_id = credit.aggregation_id
+        AND summary.retrieval_reference_number = credit.retrieval_reference_number
+        AND credit.settlement_type = "CREDIT"
 )
 
--- TODO:
--- pair up debit with credit settlements (pivot) to get final settled amount per aggregation id
-
-SELECT * FROM summarize_by_type
+SELECT * FROM int_payments__settlements_summarized

--- a/warehouse/models/intermediate/payments/int_payments__settlements_summarized.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_summarized.sql
@@ -1,0 +1,14 @@
+{{ config(materialized = 'table',) }}
+
+WITH settlements AS (
+    SELECT *
+    FROM {{ ref('stg_littlepay__settlements') }}
+)
+
+-- TODO:
+-- pair up debit with credit settlements to get final settled amount per aggregation id
+-- question is how / whether to actually join with refunds
+-- looks like settlements.type (which determines debit vs. credit) is not always populated :/
+-- so we may need to join with refunds to determine which are credits
+
+SELECT * FROM settlements

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -753,7 +753,7 @@ models:
         tests:
             - relationships:
                 to: ref('int_payments__settlements_summarized')
-                field: _aggregation_id
+                field: aggregation_id
       - name: customer_id
         description: Identifies the customer that the micropayment belongs to.
       - name: funding_source_id

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -20,7 +20,9 @@ sources:
 models:
   - name: int_device_transaction_pairs_common_fields
     columns:
-      - name: participant_id
+      - &participant_id
+        name: participant_id
+        description: '{{ doc("lp_participant_id") }}'
       - name: micropayment_id
         description: '{{ doc("micropayment_adjustments_micropayment_id") }}'
       - name: littlepay_transaction_id_1
@@ -139,8 +141,7 @@ models:
 
   - name: stg_littlepay__authorisations
     columns:
-      - name: participant_id
-        description: Identifies the participant that the authorisation belongs to.
+      - *participant_id
       - name: aggregation_id
         description: The aggregation that is being authorised. A single aggregation can have multiple authorisations. The authorisations that are submitted depend on the scheme and the result of the initial authorisation (if declined, debt recovery authorisations may be performed).
       - name: acquirer_id
@@ -223,8 +224,7 @@ models:
         description: Form factor describing the contactless EMV device of the funding source.
       - name: principal_customer_id
         description: '{{ doc("customer_funding_source_principal_customer_id") }}'
-      - name: participant_id
-        description: The participant ID that uniquely identifies each participant.
+      - *participant_id
       - name: calitp_funding_source_id_ranking_size
         description: The number of records on which the `funding_source_id` shows up in the table
       - name: calitp_funding_source_id_rank
@@ -333,8 +333,7 @@ models:
 
           The difference between this field and transaction_date_time_utc can be sizeable when data
           is sent by the customer via the Back Office API
-      - name: participant_id
-        description: The unique identifier of the participant that the device belongs to.
+      - *participant_id
       - name: route_id
         description: The route identifier provided by the device.
       - name: transaction_date_time_utc
@@ -399,8 +398,7 @@ models:
         tests:
           - unique:
               where: applied
-      - name: participant_id
-        description: Identifies the participant that the adjustment belongs to.
+      - *participant_id
       - name: customer_id
         description: Identifies the customer that the adjustment belongs to.
       - name: product_id
@@ -470,8 +468,7 @@ models:
           - unique
       - name: aggregation_id
         description: Identifies the aggregation that the micropayment belongs to.
-      - name: participant_id
-        description: Identifies the participant that the micropayment belongs to.
+      - *participant_id
       - name: customer_id
         description: Identifies the customer that the micropayment belongs to.
       - name: funding_source_vault_id
@@ -517,8 +514,7 @@ models:
 
   - name: stg_littlepay__product_data
     columns:
-      - name: participant_id
-        description: Identifies the participant that the micropayment belongs to.
+      - *participant_id
       - name: product_id
         description: '{{ doc("product_data_product_id") }}'
         tests:
@@ -671,8 +667,7 @@ models:
           authorisations that are submitted depend on the scheme and the result
           of the initial authorisation. For example, if an authorisation is declined,
           then a debt recovery authorisation may be performed.
-      - name: participant_id
-        description: Identifies the participant that the micropayment belongs to.
+      - *participant_id
       - name: customer_id
         description: Identifies the customer that the micropayment belongs to.
       - name: micropayment_id
@@ -752,10 +747,13 @@ models:
     columns:
       - name: settlement_id
         description: A unique identifier for each settlement.
-      - name: participant_id
-        description: The unique identifier of the participant that the device belongs to.
+      - *participant_id
       - name: aggregation_id
         description: Identifies the aggregation that the micropayment belongs to.
+        tests:
+            - relationships:
+                to: ref('int_payments__settlements_summarized')
+                field: _aggregation_id
       - name: customer_id
         description: Identifies the customer that the micropayment belongs to.
       - name: funding_source_id
@@ -777,6 +775,10 @@ models:
           Uniquely identifies a card transaction, based on the ISO 8583 standard.
 
           If the acquirer is Elavon, this value will be split between `littlepay_reference_number` and `external_reference_number`.
+        tests:
+            - relationships:
+                to: ref('int_payments__settlements_summarized')
+                field: retrieval_reference_number
       - name: littlepay_reference_number
         description: |
           Uniquely identifies a card transaction.

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
@@ -74,7 +74,9 @@ stg_littlepay__settlements AS (
     -- drop these two cases so that we can continue testing for absolute uniqueness
     -- if we get more cases, we can add a qualify to get latest appearance only
     WHERE _key NOT IN ("bc6dd0f735a1087b13b424a3c790fc4d", "e8c09f593df1c61c9a890da0935d0863")
-
+    -- this second drop is a separate issue: we have one single case of a duplicate aggregation_id with separate RRNs
+    -- dropping the first of these two settlements based on cross-referencing with authorisations
+        AND _key != "e8c25be12ecf1f0ec610771422c6efc8"
 )
 
 SELECT * FROM stg_littlepay__settlements


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

More progress towards #2958 by summarizing settlements data to the aggregation/retrieval reference number level. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

```
laurie ~/git/data-infra/warehouse [intermediate-settlements] $ poetry run dbt build -s +int_payments__settlements_summarized 
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
19:17:15  Running with dbt=1.5.1
19:17:16  Unable to do partial parsing because profile has changed
19:17:30  Found 329 models, 898 tests, 0 snapshots, 0 analyses, 846 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
19:17:30  
19:17:32  Concurrency: 4 threads (target='dev')
19:17:32  
19:17:32  1 of 17 START sql view model laurie_staging.stg_littlepay__settlements ......... [RUN]
19:17:34  1 of 17 OK created sql view model laurie_staging.stg_littlepay__settlements .... [CREATE VIEW (0 processed) in 1.85s]
19:17:34  2 of 17 START test dbt_utils_unique_combination_of_columns_stg_littlepay__settlements_instance__extract_filename__ts___line_number  [RUN]
19:17:34  3 of 17 START test not_null_stg_littlepay__settlements__key .................... [RUN]
19:17:34  4 of 17 START test not_null_stg_littlepay__settlements__payments_key ........... [RUN]
19:17:34  5 of 17 START test unique_stg_littlepay__settlements__key ...................... [RUN]
19:17:36  2 of 17 PASS dbt_utils_unique_combination_of_columns_stg_littlepay__settlements_instance__extract_filename__ts___line_number  [PASS in 2.33s]
19:17:36  6 of 17 START test unique_stg_littlepay__settlements__payments_key ............. [RUN]
19:17:37  5 of 17 PASS unique_stg_littlepay__settlements__key ............................ [PASS in 2.35s]
19:17:37  3 of 17 PASS not_null_stg_littlepay__settlements__key .......................... [PASS in 2.54s]
19:17:37  4 of 17 PASS not_null_stg_littlepay__settlements__payments_key ................. [PASS in 2.57s]
19:17:39  6 of 17 PASS unique_stg_littlepay__settlements__payments_key ................... [PASS in 2.66s]
19:17:39  7 of 17 START sql table model laurie_staging.int_payments__settlements_summarized  [RUN]
19:17:45  7 of 17 OK created sql table model laurie_staging.int_payments__settlements_summarized  [CREATE TABLE (155.8k rows, 233.4 MiB processed) in 5.96s]
19:17:45  8 of 17 START test dbt_utils_accepted_range_int_payments__settlements_summarized_net_settled_amount_dollars__True__0  [RUN]
19:17:45  9 of 17 START test dbt_utils_expression_is_true_int_payments__settlements_summarized_contains_refund_credit_amount_0_  [RUN]
19:17:45  10 of 17 START test dbt_utils_expression_is_true_int_payments__settlements_summarized_debit_amount_credit_amount_net_settled_amount_dollars  [RUN]
19:17:45  11 of 17 START test dbt_utils_unique_combination_of_columns_int_payments__settlements_summarized_aggregation_id__retrieval_reference_number  [RUN]
19:17:46  8 of 17 PASS dbt_utils_accepted_range_int_payments__settlements_summarized_net_settled_amount_dollars__True__0  [PASS in 1.14s]
19:17:46  12 of 17 START test not_null_int_payments__settlements_summarized_aggregation_id  [RUN]
19:17:46  10 of 17 PASS dbt_utils_expression_is_true_int_payments__settlements_summarized_debit_amount_credit_amount_net_settled_amount_dollars  [PASS in 1.20s]
19:17:46  13 of 17 START test not_null_int_payments__settlements_summarized_retrieval_reference_number  [RUN]
19:17:46  9 of 17 PASS dbt_utils_expression_is_true_int_payments__settlements_summarized_contains_refund_credit_amount_0_  [PASS in 1.21s]
19:17:46  14 of 17 START test relationships_stg_littlepay__settlements_aggregation_id__aggregation_id__ref_int_payments__settlements_summarized_  [RUN]
19:17:47  11 of 17 PASS dbt_utils_unique_combination_of_columns_int_payments__settlements_summarized_aggregation_id__retrieval_reference_number  [PASS in 1.43s]
19:17:47  15 of 17 START test relationships_stg_littlepay__settlements_retrieval_reference_number__retrieval_reference_number__ref_int_payments__settlements_summarized_  [RUN]
19:17:47  12 of 17 PASS not_null_int_payments__settlements_summarized_aggregation_id ..... [PASS in 1.04s]
19:17:47  16 of 17 START test unique_int_payments__settlements_summarized_aggregation_id . [RUN]
19:17:47  13 of 17 PASS not_null_int_payments__settlements_summarized_retrieval_reference_number  [PASS in 1.05s]
19:17:47  17 of 17 START test unique_int_payments__settlements_summarized_retrieval_reference_number  [RUN]
19:17:49  16 of 17 PASS unique_int_payments__settlements_summarized_aggregation_id ....... [PASS in 1.37s]
19:17:49  17 of 17 PASS unique_int_payments__settlements_summarized_retrieval_reference_number  [PASS in 1.37s]
19:17:49  14 of 17 PASS relationships_stg_littlepay__settlements_aggregation_id__aggregation_id__ref_int_payments__settlements_summarized_  [PASS in 2.51s]
19:17:49  15 of 17 PASS relationships_stg_littlepay__settlements_retrieval_reference_number__retrieval_reference_number__ref_int_payments__settlements_summarized_  [PASS in 2.46s]
19:17:49  
19:17:49  Finished running 1 view model, 15 tests, 1 table model in 0 hours 0 minutes and 19.26 seconds (19.26s).
19:17:49  
19:17:49  Completed successfully
19:17:49  
19:17:49  Done. PASS=17 WARN=0 ERROR=0 SKIP=0 TOTAL=17
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
