### PR TITLE
Suppress Bad Littlepay Customer Funding Source Row

### DIFF
--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__customer_funding_source.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__customer_funding_source.sql
@@ -75,6 +75,12 @@ stg_littlepay__customer_funding_source AS (
         _payments_key,
         _content_hash,
     FROM add_keys_drop_full_dupes
+    -- We experienced one customer_id in source files that mapped to two different
+    -- principal_customer_id values and instances, but these rows appear to be related to testing.
+    -- Because one of them has associated micropayment records, we keep that one while dropping
+    -- this one that has no associated micropayments. The one that's dropped appears to be genuine
+    -- bad data, mapping to an instance not otherwise associated with this customer_id.
+    WHERE _key != 'bf3d17b734923c2429add3c422e3cfe9'
     -- Some funding sources have incomplete information when first present in data, like missing
     -- values for form_factor or issuer_country that are filled in during later exports.
     -- Additionally, sometimes a filled column value is updated in newer exports for a given entry.

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__device_transaction_purchases.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__device_transaction_purchases.sql
@@ -54,6 +54,9 @@ stg_littlepay__device_transaction_purchases AS (
         _payments_key,
         _content_hash,
     FROM add_keys_drop_full_dupes
+    -- Drops one row associated with the bad customer record, likely used for testing, that's
+    -- dropped in stg_littlepay__customer_funding_source.
+    WHERE _key != '299c8bbfce21157dbab8a724e5831f8b'
     -- Some purchases initially are given a value of 'autoscan' for product_id, and then that
     -- value is later updated. No other partial duplicate conditions exist at implementation time.
     QUALIFY ROW_NUMBER() OVER (

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__device_transactions.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__device_transactions.sql
@@ -96,6 +96,9 @@ stg_littlepay__device_transactions AS (
             _payments_key,
             _content_hash,
     FROM add_keys_drop_full_dupes
+    -- Drops one row associated with the bad customer record, likely used for testing, that's
+    -- dropped in stg_littlepay__customer_funding_source.
+    WHERE _key != 'b926629d7962c80880d6c4af01db94ae'
     -- Some transactions have placeholder information for routes, stops, and directions in their first export,
     -- then a later export contains the canonical version of the transaction with that information corrected
     QUALIFY ROW_NUMBER() OVER (

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayment_device_transactions.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayment_device_transactions.sql
@@ -42,6 +42,9 @@ stg_littlepay__micropayment_device_transactions AS (
         _payments_key,
         _content_hash,
     FROM add_keys_drop_full_dupes
+    -- Drops one row associated with the bad customer record, likely used for testing, that's
+    -- dropped in stg_littlepay__customer_funding_source.
+    WHERE _key != 'f224555905f05b4869475f01a385d2bb'
 )
 
 SELECT * FROM stg_littlepay__micropayment_device_transactions


### PR DESCRIPTION
# Description

Fully resolves Sentry issue [72530](https://sentry.calitp.org/organizations/sentry/issues/72530/), and partially resolves [71485](https://sentry.calitp.org/organizations/sentry/issues/71485/) and [71486](https://sentry.calitp.org/organizations/sentry/issues/71486/). A customer record in `customer_funding_source` data, one with very little activity (appears to have been used for testing), was associated with multiple instances. This PR suppresses rows related to one of those instances, which didn't see any micropayment activity for that customer record and therefore doesn't map to other resources anyways, resolving several dbt test violations.

Since this appears to a be a one-off situation stemming from a data quality or testing issue, I took the single-row suppression approach that we took e.g. [here](https://github.com/cal-itp/data-infra/pull/3011).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

dbt models and tests run locally

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
