### PR TITLE
remove not null test from littlepay_participant_id in payments seed

### DIFF
--- a/warehouse/seeds/_seeds.yml
+++ b/warehouse/seeds/_seeds.yml
@@ -8,7 +8,6 @@ seeds:
       - name: littlepay_participant_id
         description: Littlepay-assigned Participant ID.
         tests:
-          - not_null
           - unique
       - name: elavon_customer_name
         description: Elavon-assigned Customer Name.


### PR DESCRIPTION
# Description

In #3024, we intentionally add rows to the seed `payments_gtfs_datasets` without `littlepay_participant_id` to include all Elavon `customer_name`s. However, we we didn't remove the `not null` test. This PR removes the test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

locally with `dbt test`