### PR TITLE
Payments documentation: Adding new agencies to Metabase

### DIFF
--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -108,7 +108,7 @@ Relevant Metabase Concepts:
 
 Creation of collections and permissions groups are explained in the previous documentation section.
 
-### Duplicating an existing dashboard
+1. Duplicate an existing dashboard
 
 The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`. By duplicating the dashboard into the permission-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
 
@@ -131,7 +131,7 @@ To duplicate a dashboard, navigate to the collection of one of the source dashbo
 
 Like mentioned previously, Metabase Dashboards are comprised of `Questions` which serve as the visualizations in the dashboards. By not selecting the `Only duplicate the dashboard` box, the Questions will also be copied into the Collection along with the Dashboard during the duplication process.
 
-### Re-configuring the copied questions to use the correct `Database`
+1. Re-configuring the copied questions to use the correct `Database`
 
 Duplicating an existing dashboard preserves much of the text, formatting, and settings of the dashboard -- and saves a lot of work as compared to creating a new dashboard from scratch. Unfortunately, within the duplicated questions there is a lot of re-configuring that must be done when switching the question to use the new agency's `Database` within Metabase, created in the previous documentation section.
 
@@ -153,7 +153,7 @@ However, you will need to change the settings of the field being used as the tim
 
 Once you've re-configured the question, you can press save, selecting `Replace original question` when prompted (the default).
 
-### Configure the dashboard `Time Window` filter widget
+1. Configure the dashboard `Time Window` filter widget
 
 Once the questions are updated, the remaining step is to configure them to be filtered by the dashboard filter widget.
 

--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -7,7 +7,7 @@ This documentation is broken out into two sections:
 
 ## Add a New Agency Data Source to Metabase and Create Permissions
 
-As new agencies are introduced to the contactless payments program we will need to access their data within Metabase for use in their payments dashboard and other analysis. Because we use a [row access policy](https://cloud.google.com/bigquery/docs/row-level-security-intro#how_row-level_security_works) ([configured here](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql)) in the warehouse code to limit access to data to authorized parties this is a multi-step process.
+As new agencies are introduced to the contactless payments program, we will need to access their data within Metabase for use in their payments dashboard and other analysis. Because we use a [row access policy](https://cloud.google.com/bigquery/docs/row-level-security-intro#how_row-level_security_works) ([configured here](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql)) in the warehouse code to limit access to data to authorized parties, this is a multi-step process.
 
 ### Create a new service account and row access policy
 
@@ -48,13 +48,13 @@ Substitute the following fields with the appropriate information for the agency 
 - `filter_value` which is the Littlepay `participant_id` for the agency
 - `principals` which is the email address for the service account that was created in step #1. You can simply subsitute the agency name as used in that step as opposed to updating the whole string.
 
-Open a PR in Github and merge these changes. If you'd like access to the results of this policy before the next time the `transform_warehouse` DAG is run, you will need to run it manually. To do this, you should trigger the DAG with a selector [as described in the README for the DAG task](https://github.com/cal-itp/data-infra/tree/main/airflow/dags/transform_warehouse). Use selector: `{"dbt_select": "models/mart/payments"}`.
+Open a PR in Github to merge these changes. If you'd like access to the results of this policy before the next time the `transform_warehouse` DAG is run, you will need to run it manually. To do this, you should trigger the DAG with a selector [as described in the README for the DAG task](https://github.com/cal-itp/data-infra/tree/main/airflow/dags/transform_warehouse). Use selector: `{"dbt_select": "models/mart/payments"}`.
 
 ### Add a new `Database` in Metabase for the agency
 
 **Permissions needed**: Member of the Metabase `Administrators` user group
 
-This creates the limited-access connection to the BigQuery warehouse.
+This creates the limited-access connection to the BigQuery warehouse which allows Metabase to access the agency's payments data tables. In order to properly implement the previously-created row access policy within Metabase, each agency must have their own Metabase `Database`.
 
 1. Navigate to Metabase, then `Settings`
 
@@ -93,7 +93,7 @@ To begin, navigate to `People` in the top menu bar while within the `Admin setti
 
 3. Create a new `Collection` for the agency
 
-This is a folder for the agency within Metabase where we will store their payments dashboard and the questions that comprise it
+This is a folder for the agency within Metabase. We will store their payments dashboard and the questions that comprise it in this folder.
 
 - From the previous step, select `Exit Admin` in the top right-hand corner to return to the Metabase homepage
   - Select `+ New` in the top right-hand corner
@@ -110,7 +110,7 @@ This is a folder for the agency within Metabase where we will store their paymen
   - In the dropdown to the right of `Payments Group - [agency name]`, select `View`. This will allow the agency's users to view the dashboard and questions without breaking anything.
   - In the dropdown to the right of  `Payments Team`, select `Curate`. This will allow the internal team to manage the dashboard and questions.
 
-Now, any questions or dashboards that you create within the collection will only be able to be viewed by the agency representatives that you added to the group that was created, and managed by the larger payments team within Cal-ITP.
+Now, any questions or dashboards that you create within the collection will only be able to be viewed by the agency representatives that you added to the `Group`, and managed by the larger payments team within Cal-ITP.
 
 ## Create a New Agency Dashboard and the Comprising Questions
 
@@ -124,14 +124,20 @@ Creation of collections and permissions groups are explained in the previous doc
 
 1. Duplicate an existing dashboard
 
-The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`. By duplicating the dashboard into the permission-protected collection you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
+The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`. By duplicating the dashboard into the permission-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
 
-At this time there are two different types of agency dashboards: those that use flat fare formats and those that use variable fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority of the dashboards are the same. By nature, variable fare format dashboards include some additional questions, some dashboards have custom questions as requested by agencies, and currently one agency excludes certain questions (CCJPA doesn't include any `Form Factor` related questions due to only accepting one type).
+At this time there are two different types of agency dashboards: those that use flat fare formats, and those that use variable fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority of the dashboards are the same.
+
+*Some notable differences*:
+
+- By nature, variable fare format dashboards include some additional questions
+- Some dashboards have custom questions as requested by agencies
+- Currently, one agency excludes certain questions (CCJPA doesn't include any `Form Factor` related questions due to only accepting one type)
 
 Good source dashboards for copying:
 
-- Flat Fare: Humboldt Transit Authority
-- Variable Fare: Redwood Coast Transit
+- **Flat Fare**: Humboldt Transit Authority
+- **Variable Fare**: Redwood Coast Transit
 
 To duplicate a dashboard, navigate to the collection of one of the source dashboards above
 
@@ -186,5 +192,5 @@ Once the questions are updated, the remaining step is to configure them to be fi
     - `Total Revenue by Day`
     - `Number of Settled Refunds, Grouped by Week`
     - `Value of Settled Refunds, Grouped by Week`
-  - `Week Start` for
+  - `Week Start` for:
     - `Journeys with Unlabeled Routes`

--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -14,14 +14,14 @@ As new agencies are introduced to the contactless payments program we will want 
 - Within the `Grant this service account access to the project` section, assign the role `Agency Payments Service Reader`
 - Select `Done`
 
-1. Download the service account key for the service account you've just created
+2. Download the service account key for the service account you've just created
 
 - After selecting `Done` in the previous section, you'll be returned to the list of existing service accounts, where you should click into the service account that you just created
 - Select `Keys` from the top-center of the page, and then select the `Add Key` dropdown and the `Create new key` selection within that
 - Keep the default key type `JSON` and select `Create`
 - This will download a JSON copy of the service accout key to your local environment, which will be used in later steps within Metabase
 
-1. Open a new branch and edit the [create_row_access_policy macro](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql)
+3. Open a new branch and edit the [create_row_access_policy macro](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql)
 
 Duplicate an existing row access policy within the file and append to the bottom of the file, before the `{% endmacro %}` text. The contents of the policy you're duplicating should look like this:
 
@@ -48,7 +48,7 @@ This creates the limited-access connection the the BigQuery warehouse.
 
 In the upper-right hand corner, select the `Settings` wheel icon. Within the dropdown, select `Admin settings`.
 
-1. In the top menu, select the `Databases` section to add a new databse
+2. In the top menu, select the `Databases` section to add a new databse
 
 Select `Add database` in the top-right. Replace the following information:
 
@@ -60,7 +60,7 @@ Select `Add database` in the top-right. Replace the following information:
 
 Then `Save` your changes
 
-1. Add a new user `Group` for the agency
+3. Add a new user `Group` for the agency
 
 This step will limit the users that can access the previously created database.
 
@@ -78,7 +78,7 @@ This step will limit the users that can access the previously created database.
     - Populate `First name`, `Last name`, `Email`
     - In the `Groups` dropdown, select the new agency group that was created in the previous step.
 
-1. Create a new `Collection` for the agency
+4. Create a new `Collection` for the agency
 
 This is the folder for the agency within Metbase where we will store their payments dashboard and the questions that comprise it
 
@@ -87,7 +87,7 @@ This is the folder for the agency within Metbase where we will store their payme
   - Input the name as `Payments Collection - [agency name]`
   - Collection it's saved in --> `Our Analytics` (the default)
 
-1. Limit the access permissions on the new `Collection` by using the `Group` created in step #3
+5. Limit the access permissions on the new `Collection` by using the `Group` created in step #3
 
 - Navigate back to `Settings --> Admin settings` in the upper right-hand corner
   - Select `Permissions` from the top menu
@@ -131,7 +131,7 @@ To duplicate a dashboard, navigate to the collection of one of the source dashbo
 
 Like mentioned previously, Metabase Dashboards are comprised of `Questions` which serve as the visualizations in the dashboards. By not selecting the `Only duplicate the dashboard` box, the Questions will also be copied into the Collection along with the Dashboard during the duplication process.
 
-1. Re-configuring the copied questions to use the correct `Database`
+2. Re-configuring the copied questions to use the correct `Database`
 
 Duplicating an existing dashboard preserves much of the text, formatting, and settings of the dashboard -- and saves a lot of work as compared to creating a new dashboard from scratch. Unfortunately, within the duplicated questions there is a lot of re-configuring that must be done when switching the question to use the new agency's `Database` within Metabase, created in the previous documentation section.
 
@@ -153,7 +153,7 @@ However, you will need to change the settings of the field being used as the tim
 
 Once you've re-configured the question, you can press save, selecting `Replace original question` when prompted (the default).
 
-1. Configure the dashboard `Time Window` filter widget
+3. Configure the dashboard `Time Window` filter widget
 
 Once the questions are updated, the remaining step is to configure them to be filtered by the dashboard filter widget.
 

--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -1,0 +1,92 @@
+# Onboarding New Agencies to Metabase
+
+## Adding a New Agency Data Source to Metabase
+
+As new agencies are introduced to the contactless payments program we will want to be able to access their data in Metabase for use in their payments dashboard. Because we have a \[row access policy\](insert link) in the warehouse to limit the data that is able to be viewed by agencies while within Metabase this is a multi-step process and doesn't happen automatically.
+
+1. To begin, create a new service account for the agency within the Google Cloud Platform console.
+
+- Navigate to: https://console.cloud.google.com/iam-admin/serviceaccounts
+- Select `+ Create Service Account` in the top-center of the page
+- When naming the service account, use the convention: `[agency-name]-payments-user@cal-itp-data-infra.iam.gserviceaccount.com`
+- Download the JSON service account for use later in this process
+
+2. Duplicate an existing row access policy within the \[create_row_access_policy macro\](insert link and make sure file name is correct) and substitute the following with the appropriate information for the agency that you are adding:
+
+- `filter_value` which is the Littlepay `participant_id` for the agency
+
+- `principals` which is the address for the service account that was created in the previous step
+
+- Open a PR and merge these changes
+
+- Navigate to the service account that you created in the Google Cloud Platform console and download the key as a `.json` file and store locally on your computer
+
+3. Add a new `Database` in Metabase for the agency
+   This creates the limit-access connection the the BigQuery warehouse.
+
+- Navigate to Metabase, then from the upper-right hand corner select the `Settings --> Admin settings` section, then the `Databases` section in the top menu
+  - Select `Add database`. Replace the following information:
+    - Database type --> BigQuery
+    - Display name --> `Payments - [agency name]`
+    - Service account JSON file --> upload the file downloaded in the previous step
+    - Datasets --> `Only these...`
+    - Comma separated names of datasets that should appear in Metabase --> `mart_payments`
+  - Then `Save changes`
+
+4. Add a new user `Group` for the agency
+   This limits the people that can access the previously created database.
+
+- Navigate to `People` in the top menu bar
+- Select `Groups` in the left-hand menu
+  - Select `Create a group` and input `Payments Group - [agency name]`
+- Select `People` in the left-hand menu
+  - Select `Invite someone`
+  - Add representatives from the agency that you are adding
+  - Select `Groups`,  and then select the new agency group that was created in the previous step.
+
+5. Create a new `Collection` for the agency
+
+- Select `Exit Admin` in the top right-hand corner, then select `+ New` in the top right-hand corner
+  - Select `Collection` from the drop-down
+  - Input the name as `Payments Collection - [agency name]`
+  - Collection it's saved in --> `Our Analytics` (the default)
+
+6. Limit the access permissions on the new `Collection`
+
+- Navigate back to `Settings --> Admin settings` in the upper right-hand corner
+  - Select `Permissions` from the top menu
+  - Select `Collections` from the top left-hand side
+  - Click on the payments collection that you just created
+  - In the dropdown next to `Payments Collection - [agency name]` that you just created, select `View`
+  - Next to the group `Payments Team`, select `Curate`
+
+Now, any questions or dashboards that you create within the collection that was created will only be able to be viewed by the agency representatives that you added to the new group that was created, as well as the larger payments team within Cal-ITP.
+
+## Creating a New Agency Dashboard and the Comprising Questions
+
+Relevant Metabase Concepts:
+
+- `Collection` - Created for each agency, in the previous section
+
+The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing existing dashboard into the new agency's `Collection`, created in the previous section. By duplicating the dashboard into the privacy-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
+
+At this time there are two different types of agency dashboards: those that use flat-fare fare formats and those that use variable-fare fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority is the same. Some dashboards do have custom questions as requested by agencies.
+
+Good source dashboards for copying:
+
+- Variable Fare: CCJPA
+- Flat Fare: MST
+
+Metabase dashboards are comprised of `Questions`, which serve as the tiles in the dashboard. These will also be copied into the collection along with the dashboard during the copying process.
+
+Most of the work of setting up a new dashboard is configuring the copied questions to use the agency-specific database created in the previous section. You will need to open every question in the new collection and change the source table. Unfortunately, this requires you to reconfigure every question. It would be suggested to open up the agency's questions that you used as a source side-by-side with the copied questions and using that as the template. Using this method (duplicating an existing dashboard, changing the source database, and reconfiguring the question) is still preferable to starting from scratch because once the questions are saved the formatting and layout of the dashboard remains.
+
+How to change source database in normal questions:
+
+How to change source database and filter variables in SQL questions:
+
+How to update the dashboard filter:
+
+Once the questions are updated, the remaining step is to configure them to be filtered by the dashboard filter widget.
+
+Navigate to the dashboard, select edit, and then click on the settings wheel next to the filter widget in the top-left hand side of the dashboard. This will display a dropdown menu within all questions. Within the dropdown, select `Transaction Date Time Pacific`. SQL-based questions have already had the filter added in the step above, and will not have a drop-down menu displayed.

--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -2,101 +2,169 @@
 
 ## Adding a New Agency Data Source to Metabase
 
-As new agencies are introduced to the contactless payments program we will want to be able to access their data in Metabase for use in their payments dashboard. Because we have a \[row access policy\](insert link) in the warehouse to limit the data that is able to be viewed by agencies while within Metabase this is a multi-step process and doesn't happen automatically.
+As new agencies are introduced to the contactless payments program we will want to be able to access their data within Metabase. Because we use a [row access policy](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql) in the warehouse code to limit access to data to authorized parties, this is a multi-step process and doesn't happen automatically.
 
-1. To begin, create a new service account for the agency within the Google Cloud Platform console.
+### Create a new service account and row access policy
 
-- Navigate to: https://console.cloud.google.com/iam-admin/serviceaccounts
+1. To begin, create a new service account for the agency within the Google Cloud Platform console, which will be used to allow Metabase read-access to the agency's payments data.
+
+- Navigate to: <https://console.cloud.google.com/iam-admin/serviceaccounts>
 - Select `+ Create Service Account` in the top-center of the page
-- When naming the service account, use the convention: `[agency-name]-payments-user@cal-itp-data-infra.iam.gserviceaccount.com`
-- Download the JSON service account for use later in this process
+- Populate the `Service account ID` field using the convention: `[agency-name]-payments-user`, then select `Create and Continue`
+- Within the `Grant this service account access to the project` section, assign the role `Agency Payments Service Reader`
+- Select `Done`
 
-2. Duplicate an existing row access policy within the \[create_row_access_policy macro\](insert link and make sure file name is correct) and substitute the following with the appropriate information for the agency that you are adding:
+1. Download the service account key for the service account you've just created
+
+- After selecting `Done` in the previous section, you'll be returned to the list of existing service accounts, where you should click into the service account that you just created
+- Select `Keys` from the top-center of the page, and then select the `Add Key` dropdown and the `Create new key` selection within that
+- Keep the default key type `JSON` and select `Create`
+- This will download a JSON copy of the service accout key to your local environment, which will be used in later steps within Metabase
+
+1. Open a new branch and edit the [create_row_access_policy macro](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql)
+
+Duplicate an existing row access policy within the file and append to the bottom of the file, before the `{% endmacro %}` text. The contents of the policy you're duplicating should look like this:
+
+```
+{{ create_row_access_policy(
+    filter_column = 'participant_id',
+    filter_value = '[agency-name]',
+    principals = ['serviceAccount:`agency-name`-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+```
+
+Substitute the following fields with the appropriate information for the agency that you are adding:
 
 - `filter_value` which is the Littlepay `participant_id` for the agency
+- `principals` which is the email address for the service account that was created in the previous step
 
-- `principals` which is the address for the service account that was created in the previous step
+Open a PR and merge these changes. If you'd like access to the results of this policy before the next time the `transform_warehouse` DAG is run, you will need to run it manually.
 
-- Open a PR and merge these changes
+### Add a new `Database` in Metabase for the agency
 
-- Navigate to the service account that you created in the Google Cloud Platform console and download the key as a `.json` file and store locally on your computer
+This creates the limited-access connection the the BigQuery warehouse.
 
-3. Add a new `Database` in Metabase for the agency
-   This creates the limited-access connection the the BigQuery warehouse.
+1. Navigate to Metabase, then `Settings`
 
-- Navigate to Metabase, then from the upper-right hand corner select the `Settings --> Admin settings` section, then the `Databases` section in the top menu
-  - Select `Add database`. Replace the following information:
-    - Database type --> BigQuery
-    - Display name --> `Payments - [agency name]`
-    - Service account JSON file --> upload the file downloaded in the previous step
-    - Datasets --> `Only these...`
-    - Comma separated names of datasets that should appear in Metabase --> `mart_payments`
-  - Then `Save changes`
+In the upper-right hand corner, select the `Settings` wheel icon. Within the dropdown, select `Admin settings`.
 
-4. Add a new user `Group` for the agency
-   This limits the people that can access the previously created database.
+1. In the top menu, select the `Databases` section to add a new databse
+
+Select `Add database` in the top-right. Replace the following information:
+
+- `Database type` --> BigQuery
+- `Display name` --> `Payments - [agency name]`
+- `Service account JSON file` --> upload the file downloaded in the previous section
+- `Datasets` --> `Only these...`
+- `Comma separated names of datasets that should appear in Metabase` --> `mart_payments`
+
+Then `Save` your changes
+
+1. Add a new user `Group` for the agency
+
+This step will limit the users that can access the previously created database.
 
 - Navigate to `People` in the top menu bar
 - Select `Groups` in the left-hand menu
   - Select `Create a group` and input `Payments Group - [agency name]`
-- Select `People` in the left-hand menu
-  - Select `Invite someone`
-  - Add representatives from the agency that you are adding
-  - Select `Groups`,  and then select the new agency group that was created in the previous step.
+- Add users to this new group
+  - If they have already have Metabase user accounts:
+    - From within the `Groups` section, select the group that was just created
+    - From there, select `Add members` from the top-right of the page
+    - Type their name in the prompt, and once it auto-populates select `Add`
+  - If they don't have Metabase user accounts:
+    - Select `People` in the left-hand menu
+    - Select `Invite someone` from the top-right of the page
+    - Populate `First name`, `Last name`, `Email`
+    - In the `Groups` dropdown, select the new agency group that was created in the previous step.
 
-5. Create a new `Collection` for the agency
+1. Create a new `Collection` for the agency
 
-- Select `Exit Admin` in the top right-hand corner, then select `+ New` in the top right-hand corner
+This is the folder for the agency within Metbase where we will store their payments dashboard and the questions that comprise it
+
+- From the previous step, select `Exit Admin` in the top right-hand corner, then select `+ New` in the top right-hand corner
   - Select `Collection` from the drop-down
   - Input the name as `Payments Collection - [agency name]`
   - Collection it's saved in --> `Our Analytics` (the default)
 
-6. Limit the access permissions on the new `Collection`
+1. Limit the access permissions on the new `Collection` by using the `Group` created in step #3
 
 - Navigate back to `Settings --> Admin settings` in the upper right-hand corner
   - Select `Permissions` from the top menu
   - Select `Collections` from the top left-hand side
   - Click on the payments collection that you just created
-  - In the dropdown next to `Payments Collection - [agency name]` that you just created, select `View`
-  - Next to the group `Payments Team`, select `Curate`
+  - In the dropdown to the right of `Payments Group - [agency name]`, select `View`
+  - In the dropdown to the right of  `Payments Team`, select `Curate`. This will allow the internal team to manage the dashboard and questions.
 
-Now, any questions or dashboards that you create within the collection that was created will only be able to be viewed by the agency representatives that you added to the new group that was created, as well as the larger payments team within Cal-ITP.
+Now, any questions or dashboards that you create within the collection that was created will only be able to be viewed by the agency representatives that you added to the group that was created, and managed by the larger payments team within Cal-ITP.
 
 ## Creating a New Agency Dashboard and the Comprising Questions
 
 Relevant Metabase Concepts:
 
-- `Question` - Visualizations of analysis concepts
-- `Dashboard` - Comprised of `Question`s and text tiles
-- `Collection` - An agency-specific 'folder' within Metabase where agency `Question`s and `Dashboard`s live. Created is explained in the previous documetnation  section. Permission layers are added at the Collection level.
+- `Question` - Individual visualizations
+- `Dashboard` - Made up of `Question` and text tiles
+- `Collection` - An agency-specific 'folder' within Metabase where agency `Dashboards` and `Questions` live.
+
+Creation of collections and permissions groups are explained in the previous documentation section.
 
 ### Duplicating an existing dashboard
 
-The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`, created in the previous documentation section. By duplicating the dashboard into the permission-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
+The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`. By duplicating the dashboard into the permission-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
 
-At this time there are two different types of agency dashboards: those that use flat fare formats and those that use variable fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority of the dashboards is the same. Some dashboards do have custom questions as requested by agencies.
+At this time there are two different types of agency dashboards: those that use flat fare formats and those that use variable fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority of the dashboards is the same. Some dashboards do have custom questions as requested by agencies, and currently one agency excludes certain questions (CCJPA doesn't include any `Form Factor` related questions due to only accepting one type).
 
 Good source dashboards for copying:
 
-- Variable Fare: CCJPA
-- Flat Fare: MST
+- Flat Fare: Humboldt Transit Authority
+- Variable Fare: Redwood Coast Transit
 
-Metabase dashboards are comprised of `Questions`, which serve as the tiles in the dashboard. These will also be copied into the collection along with the dashboard during the copying process.
+To duplicate a dashboard, navigate to the collection of one of the source dashboards above
+
+- The dashboard should be pinned to the top of the collection, when hovering your cursor over the dashboard a menu icon should appear
+- Select the menu icon, and select `Duplicate` in the dropdown
+- In the window that appears:
+  - In the `Name` field, subsitute the name of the new agency in the parentheses and remove ` - Duplicate` which was appended to the end
+  - in the `Which collection should this go in` dropdown, select the Collection of the new agency
+  - **DO NOT** select the `Only duplicate the dashboard` box, which is not selected by default
+  - Select `Duplicate` to create the duplicate dashboard and questions
+
+Like mentioned previously, Metabase Dashboards are comprised of `Questions` which serve as the visualizations in the dashboards. By not selecting the `Only duplicate the dashboard` box, the Questions will also be copied into the Collection along with the Dashboard during the duplication process.
 
 ### Re-configuring the copied questions to use the correct `Database`
 
-Most of the work of setting up a new dashboard is re-configuring the copied questions to use the agency-specific database created in the previous section. You will need to open every question in the new collection and change the source table. The database name will be `Payments - [agency name]`, and the table that you use within the database will be the same as the example question.
+Duplicating an existing dashboard preserves much of the text, formatting, and settings of the dashboard -- and saves a lot of work as compared to creating a new dashboard from scratch. Unfortunately, within the duplicated questions there is a lot of re-configuring that must be done when switching the question to use the new agency's `Database` within Metabase, created in the previous documentation section.
 
-Unfortunately, this requires you to reconfigure every question. It would be suggested to open up the agency's questions that you used as a source side-by-side with the copied questions and using that as the template. Using this method (duplicating an existing dashboard, changing the source database, and reconfiguring the question) is still preferable to starting from scratch because once the questions are saved the formatting and layout of the dashboard remains.
+You will need to open every question in the new dashboard and change the source table used. This will reset all of the components of the `Question` which will need to be replaced.
 
-#### How to change source database in normal questions:
+The easiest way to do this is to pull up the collection of the agency whose dashboard you initially duplicated and the new agency's collection side-by-side. Go down the lists, opening up each question. Change the Database and table name of the new agency's question to use the new agency's version of the Database and table, and then change the question's configuration to match the original question. Thankfully, question visualization configurations like visualization type (bar, line) and axis labels should mostly be preserved.
 
-#### How to change source database and filter variables in SQL questions:
+**For SQL-based questions**
 
-#### How to update the dashboard filter:
+You will only need to change the name of the Database, the table name is explicit in the query.
 
-### Configure the dashboard date `Time Window` filter widget
+However, you will need to change the settings of the field being used as the time filter
+
+- Navigate to edit the SQL-based question, and select the `Variables` icon to the right of the query text.
+- From here, modify the variable settings:
+  - `Variable Type` --> `Field Filter`
+  - `Field to Map to` --> navigate to the table being used in the query (`FCT PAYMENTS RIDES V2`) and select the `On Transaction Date Time Pacific` field
+  - `Filter widget type` --> `Date Filter`
+
+Once you've re-configured the question, you can press save, selecting `Replace original question` when prompted (the default).
+
+### Configure the dashboard `Time Window` filter widget
 
 Once the questions are updated, the remaining step is to configure them to be filtered by the dashboard filter widget.
 
-Navigate to the dashboard, select edit, and then click on the settings wheel next to the filter widget in the top-left hand side of the dashboard. This will display a dropdown menu within all questions. Within the dropdown, select `Transaction Date Time Pacific`. SQL-based questions have already had the filter added in the step above, and will not have a drop-down menu displayed.
+- Navigate to the dashboard, select the `Edit dashboard` icon in the top-right
+- Select the settings wheel that appears next to the `Time Window` widget in the top-left of the dashboard
+- This will cause a dropdown menu to display within all the Question tiles of the dashboard, except for SQL-based questions which have already had the filter applied in the previous step and will not have a drop-down menu displayed.
+- Within the dropdowns, select `On Transaction Date Time Pacific` for all of the questions except the exceptions below
+  - `Settlement Requested Date Time Utc` for:
+    - `Total Revenue`
+    - `Total Revenue by Day`
+    - `Number of Settled Refunds, Grouped by Week`
+    - `Value of Settled Refunds, Grouped by Week`
+  - `Week Start` for
+    - `Journeys with Unlabeled Routes`

--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -22,7 +22,7 @@ As new agencies are introduced to the contactless payments program we will want 
 - Navigate to the service account that you created in the Google Cloud Platform console and download the key as a `.json` file and store locally on your computer
 
 3. Add a new `Database` in Metabase for the agency
-   This creates the limit-access connection the the BigQuery warehouse.
+   This creates the limited-access connection the the BigQuery warehouse.
 
 - Navigate to Metabase, then from the upper-right hand corner select the `Settings --> Admin settings` section, then the `Databases` section in the top menu
   - Select `Add database`. Replace the following information:
@@ -66,11 +66,15 @@ Now, any questions or dashboards that you create within the collection that was 
 
 Relevant Metabase Concepts:
 
-- `Collection` - Created for each agency, in the previous section
+- `Question` - Visualizations of analysis concepts
+- `Dashboard` - Comprised of `Question`s and text tiles
+- `Collection` - An agency-specific 'folder' within Metabase where agency `Question`s and `Dashboard`s live. Created is explained in the previous documetnation  section. Permission layers are added at the Collection level.
 
-The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing existing dashboard into the new agency's `Collection`, created in the previous section. By duplicating the dashboard into the privacy-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
+### Duplicating an existing dashboard
 
-At this time there are two different types of agency dashboards: those that use flat-fare fare formats and those that use variable-fare fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority is the same. Some dashboards do have custom questions as requested by agencies.
+The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`, created in the previous documentation section. By duplicating the dashboard into the permission-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
+
+At this time there are two different types of agency dashboards: those that use flat fare formats and those that use variable fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority of the dashboards is the same. Some dashboards do have custom questions as requested by agencies.
 
 Good source dashboards for copying:
 
@@ -79,13 +83,19 @@ Good source dashboards for copying:
 
 Metabase dashboards are comprised of `Questions`, which serve as the tiles in the dashboard. These will also be copied into the collection along with the dashboard during the copying process.
 
-Most of the work of setting up a new dashboard is configuring the copied questions to use the agency-specific database created in the previous section. You will need to open every question in the new collection and change the source table. Unfortunately, this requires you to reconfigure every question. It would be suggested to open up the agency's questions that you used as a source side-by-side with the copied questions and using that as the template. Using this method (duplicating an existing dashboard, changing the source database, and reconfiguring the question) is still preferable to starting from scratch because once the questions are saved the formatting and layout of the dashboard remains.
+### Re-configuring the copied questions to use the correct `Database`
 
-How to change source database in normal questions:
+Most of the work of setting up a new dashboard is re-configuring the copied questions to use the agency-specific database created in the previous section. You will need to open every question in the new collection and change the source table. The database name will be `Payments - [agency name]`, and the table that you use within the database will be the same as the example question.
 
-How to change source database and filter variables in SQL questions:
+Unfortunately, this requires you to reconfigure every question. It would be suggested to open up the agency's questions that you used as a source side-by-side with the copied questions and using that as the template. Using this method (duplicating an existing dashboard, changing the source database, and reconfiguring the question) is still preferable to starting from scratch because once the questions are saved the formatting and layout of the dashboard remains.
 
-How to update the dashboard filter:
+#### How to change source database in normal questions:
+
+#### How to change source database and filter variables in SQL questions:
+
+#### How to update the dashboard filter:
+
+### Configure the dashboard date `Time Window` filter widget
 
 Once the questions are updated, the remaining step is to configure them to be filtered by the dashboard filter widget.
 

--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -154,7 +154,7 @@ The easiest way to do this is to:
 
 Thankfully, question visualization configurations like visualization type (bar, line) and axis labels should be preserved.
 
-### For SQL-based questions
+**For SQL-based questions**
 
 You will only need to change the name of the Database, but not the table name as it is explicit in the query. There is a dropdown above the query text where you can change the source Database to use the new agency's database.
 

--- a/runbooks/workflow/payments/add_agency_dashboard_data_source.md
+++ b/runbooks/workflow/payments/add_agency_dashboard_data_source.md
@@ -1,14 +1,19 @@
-# Onboarding New Agencies to Metabase
+# Metabase: Configure Agency Payments Data and Generate Dashboards
 
-## Adding a New Agency Data Source to Metabase
+This documentation is broken out into two sections:
 
-As new agencies are introduced to the contactless payments program we will want to be able to access their data within Metabase. Because we use a [row access policy](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql) in the warehouse code to limit access to data to authorized parties, this is a multi-step process and doesn't happen automatically.
+- [Add a New Agency Data Source to Metabase and Create Permissions](#add-a-new-agency-data-source-to-metabase-and-create-permissions)
+- [Create a New Agency Dashboard and the Comprising Questions](#create-a-new-agency-dashboard-and-the-comprising-questions)
+
+## Add a New Agency Data Source to Metabase and Create Permissions
+
+As new agencies are introduced to the contactless payments program we will need to access their data within Metabase for use in their payments dashboard and other analysis. Because we use a [row access policy](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql) in the warehouse code to limit access to data to authorized parties this is a multi-step process.
 
 ### Create a new service account and row access policy
 
 1. To begin, create a new service account for the agency within the Google Cloud Platform console, which will be used to allow Metabase read-access to the agency's payments data.
 
-- Navigate to: <https://console.cloud.google.com/iam-admin/serviceaccounts>
+- Navigate to: <https://console.cloud.google.com/iam-admin/serviceaccounts> in the `cal-itp-data-infra` project
 - Select `+ Create Service Account` in the top-center of the page
 - Populate the `Service account ID` field using the convention: `[agency-name]-payments-user`, then select `Create and Continue`
 - Within the `Grant this service account access to the project` section, assign the role `Agency Payments Service Reader`
@@ -16,14 +21,16 @@ As new agencies are introduced to the contactless payments program we will want 
 
 2. Download the service account key for the service account you've just created
 
-- After selecting `Done` in the previous section, you'll be returned to the list of existing service accounts, where you should click into the service account that you just created
-- Select `Keys` from the top-center of the page, and then select the `Add Key` dropdown and the `Create new key` selection within that
+- After selecting `Done` in the previous section you'll be returned to the list of existing service accounts. Click into the service account that you just created.
+- Select `Keys` from the top-center of the page and then select the `Add Key` dropdown. Choose the `Create new key` selection within that.
 - Keep the default key type `JSON` and select `Create`
 - This will download a JSON copy of the service accout key to your local environment, which will be used in later steps within Metabase
 
 3. Open a new branch and edit the [create_row_access_policy macro](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql)
 
-Duplicate an existing row access policy within the file and append to the bottom of the file, before the `{% endmacro %}` text. The contents of the policy you're duplicating should look like this:
+Duplicate an existing row access policy within the file and append to the bottom , before the `{% endmacro %}` text.
+
+The contents of the policy you're duplicating should look like this:
 
 ```
 {{ create_row_access_policy(
@@ -36,7 +43,7 @@ Duplicate an existing row access policy within the file and append to the bottom
 Substitute the following fields with the appropriate information for the agency that you are adding:
 
 - `filter_value` which is the Littlepay `participant_id` for the agency
-- `principals` which is the email address for the service account that was created in the previous step
+- `principals` which is the email address for the service account that was created in step #1
 
 Open a PR and merge these changes. If you'd like access to the results of this policy before the next time the `transform_warehouse` DAG is run, you will need to run it manually.
 
@@ -46,59 +53,61 @@ This creates the limited-access connection the the BigQuery warehouse.
 
 1. Navigate to Metabase, then `Settings`
 
-In the upper-right hand corner, select the `Settings` wheel icon. Within the dropdown, select `Admin settings`.
+- In the upper-right hand corner, select the `Settings` wheel icon. Within the dropdown, select `Admin settings`.
+- In the top menu, select the `Databases` section to add a new databse
+- Select `Add database` in the top-right. Replace the following information:
+  - `Database type` --> BigQuery
+  - `Display name` --> `Payments - [agency name]`
+  - `Service account JSON file` --> upload the file downloaded in the previous section
+  - `Datasets` --> `Only these...`
+  - `Comma separated names of datasets that should appear in Metabase` --> `mart_payments`
+- `Save` your changes
 
-2. In the top menu, select the `Databases` section to add a new databse
-
-Select `Add database` in the top-right. Replace the following information:
-
-- `Database type` --> BigQuery
-- `Display name` --> `Payments - [agency name]`
-- `Service account JSON file` --> upload the file downloaded in the previous section
-- `Datasets` --> `Only these...`
-- `Comma separated names of datasets that should appear in Metabase` --> `mart_payments`
-
-Then `Save` your changes
-
-3. Add a new user `Group` for the agency
+2. Add a new user `Group` for the agency and add users to the `Group`
 
 This step will limit the users that can access the previously created database.
 
-- Navigate to `People` in the top menu bar
+To begin, navigate to `People` in the top menu bar while within the `Admin settings` section
+
+#### Create a new user `Group`
+
 - Select `Groups` in the left-hand menu
-  - Select `Create a group` and input `Payments Group - [agency name]`
-- Add users to this new group
-  - If they have already have Metabase user accounts:
-    - From within the `Groups` section, select the group that was just created
-    - From there, select `Add members` from the top-right of the page
-    - Type their name in the prompt, and once it auto-populates select `Add`
-  - If they don't have Metabase user accounts:
-    - Select `People` in the left-hand menu
-    - Select `Invite someone` from the top-right of the page
-    - Populate `First name`, `Last name`, `Email`
-    - In the `Groups` dropdown, select the new agency group that was created in the previous step.
+- Select `Create a group` and input `Payments Group - [agency name]`
 
-4. Create a new `Collection` for the agency
+#### Add users to this new group
 
-This is the folder for the agency within Metbase where we will store their payments dashboard and the questions that comprise it
+- **If they have already have Metabase user accounts**:
+  - From within the `Groups` section, select the group that was just created
+  - From there, select `Add members` from the top-right of the page
+  - Type their name in the prompt, and once it auto-populates select `Add`
+- **If they don't have Metabase user accounts**:
+  - Select `People` in the left-hand menu
+  - Select `Invite someone` from the top-right of the page
+  - Populate `First name`, `Last name`, `Email`
+  - In the `Groups` dropdown, select the new agency group that was just created
 
-- From the previous step, select `Exit Admin` in the top right-hand corner, then select `+ New` in the top right-hand corner
+3. Create a new `Collection` for the agency
+
+This is a folder for the agency within Metabase where we will store their payments dashboard and the questions that comprise it
+
+- From the previous step, select `Exit Admin` in the top right-hand corner to return to the Metabase homepage
+  - Select `+ New` in the top right-hand corner
   - Select `Collection` from the drop-down
-  - Input the name as `Payments Collection - [agency name]`
+  - Input the name as `Payments Collection - [Agency Name]`
   - Collection it's saved in --> `Our Analytics` (the default)
 
-5. Limit the access permissions on the new `Collection` by using the `Group` created in step #3
+4. Limit the access permissions on the new `Collection` by using the `Group` created in step #2
 
-- Navigate back to `Settings --> Admin settings` in the upper right-hand corner
+- Navigate back to `Settings --> Admin settings` in the upper right-hand corner of the page
   - Select `Permissions` from the top menu
   - Select `Collections` from the top left-hand side
-  - Click on the payments collection that you just created
-  - In the dropdown to the right of `Payments Group - [agency name]`, select `View`
+  - Click on the payments collection that was just created in step #3
+  - In the dropdown to the right of `Payments Group - [agency name]`, select `View`. This will allow the agency's users to view the dashboard and questions without breaking anything.
   - In the dropdown to the right of  `Payments Team`, select `Curate`. This will allow the internal team to manage the dashboard and questions.
 
-Now, any questions or dashboards that you create within the collection that was created will only be able to be viewed by the agency representatives that you added to the group that was created, and managed by the larger payments team within Cal-ITP.
+Now, any questions or dashboards that you create within the collection will only be able to be viewed by the agency representatives that you added to the group that was created, and managed by the larger payments team within Cal-ITP.
 
-## Creating a New Agency Dashboard and the Comprising Questions
+## Create a New Agency Dashboard and the Comprising Questions
 
 Relevant Metabase Concepts:
 
@@ -110,9 +119,9 @@ Creation of collections and permissions groups are explained in the previous doc
 
 1. Duplicate an existing dashboard
 
-The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`. By duplicating the dashboard into the permission-protected collection, you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
+The easiest way to create a new dashboard for an agency in Metabase is to duplicate an existing dashboard into the new agency's `Collection`. By duplicating the dashboard into the permission-protected collection you are ensuring that only representatives from that agency (and internal staff) are able to view the data.
 
-At this time there are two different types of agency dashboards: those that use flat fare formats and those that use variable fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority of the dashboards is the same. Some dashboards do have custom questions as requested by agencies, and currently one agency excludes certain questions (CCJPA doesn't include any `Form Factor` related questions due to only accepting one type).
+At this time there are two different types of agency dashboards: those that use flat fare formats and those that use variable fare formats. There are currently none that use both. These differences impact a few questions within the dashboards, but the majority of the dashboards are the same. By nature, variable fare format dashboards include some additional questions, some dashboards have custom questions as requested by agencies, and currently one agency excludes certain questions (CCJPA doesn't include any `Form Factor` related questions due to only accepting one type).
 
 Good source dashboards for copying:
 
@@ -122,28 +131,34 @@ Good source dashboards for copying:
 To duplicate a dashboard, navigate to the collection of one of the source dashboards above
 
 - The dashboard should be pinned to the top of the collection, when hovering your cursor over the dashboard a menu icon should appear
-- Select the menu icon, and select `Duplicate` in the dropdown
+- Select the menu icon, and choose `Duplicate` in the dropdown
 - In the window that appears:
-  - In the `Name` field, subsitute the name of the new agency in the parentheses and remove ` - Duplicate` which was appended to the end
-  - in the `Which collection should this go in` dropdown, select the Collection of the new agency
+  - In the `Name` field, subsitute the name of the new agency in the parentheses and remove ` - Duplicate` which was automatically appended to the end
+  - In the `Which collection should this go in` dropdown, select the Collection of the new agency
   - **DO NOT** select the `Only duplicate the dashboard` box, which is not selected by default
   - Select `Duplicate` to create the duplicate dashboard and questions
 
-Like mentioned previously, Metabase Dashboards are comprised of `Questions` which serve as the visualizations in the dashboards. By not selecting the `Only duplicate the dashboard` box, the Questions will also be copied into the Collection along with the Dashboard during the duplication process.
+Like mentioned previously, Metabase Dashboards are comprised of `Questions` which serve as the visualizations in the dashboards. By not selecting the `Only duplicate the dashboard` box, the Questions will also be copied into the new agency's Collection along with the Dashboard during the duplication process.
 
 2. Re-configuring the copied questions to use the correct `Database`
 
-Duplicating an existing dashboard preserves much of the text, formatting, and settings of the dashboard -- and saves a lot of work as compared to creating a new dashboard from scratch. Unfortunately, within the duplicated questions there is a lot of re-configuring that must be done when switching the question to use the new agency's `Database` within Metabase, created in the previous documentation section.
+Duplicating an existing dashboard preserves much of the text, formatting, and settings of the dashboard -- and saves a lot of work as compared to creating a new dashboard from scratch. Unfortunately, within the duplicated questions there is a lot of re-configuring that must be done to switch the Questions to use the new agency's `Database` within Metabase -- created in the previous documentation section.
 
-You will need to open every question in the new dashboard and change the source table used. This will reset all of the components of the `Question` which will need to be replaced.
+You will need to open every question in the new dashboard and change the source table used. This will reset all of the components of the `Question`, which will need to be re-implemented.
 
-The easiest way to do this is to pull up the collection of the agency whose dashboard you initially duplicated and the new agency's collection side-by-side. Go down the lists, opening up each question. Change the Database and table name of the new agency's question to use the new agency's version of the Database and table, and then change the question's configuration to match the original question. Thankfully, question visualization configurations like visualization type (bar, line) and axis labels should mostly be preserved.
+The easiest way to do this is to:
 
-**For SQL-based questions**
+- Pull up the collection of the agency whose dashboard you initially duplicated and the new agency's collection side-by-side
+- Go down the lists, opening up each question
+- Change the Database and table name of the new agency's question to use the new agency's version of the Database and table, and then change the question's configuration to match the original question
 
-You will only need to change the name of the Database, the table name is explicit in the query.
+Thankfully, question visualization configurations like visualization type (bar, line) and axis labels should be preserved.
 
-However, you will need to change the settings of the field being used as the time filter
+### For SQL-based questions
+
+You will only need to change the name of the Database, but not the table name as it is explicit in the query. There is a dropdown above the query text where you can change the source Database to use the new agency's database.
+
+For SQL-based questions you will also need to change the settings of the time filter from within the question:
 
 - Navigate to edit the SQL-based question, and select the `Variables` icon to the right of the query text.
 - From here, modify the variable settings:
@@ -151,9 +166,9 @@ However, you will need to change the settings of the field being used as the tim
   - `Field to Map to` --> navigate to the table being used in the query (`FCT PAYMENTS RIDES V2`) and select the `On Transaction Date Time Pacific` field
   - `Filter widget type` --> `Date Filter`
 
-Once you've re-configured the question, you can press save, selecting `Replace original question` when prompted (the default).
+Once you've re-configured the question you can press `Save`, selecting `Replace original question` when prompted (the default).
 
-3. Configure the dashboard `Time Window` filter widget
+3. Configure the dashboard `Time Window` filter widget for the non-SQL-based questions
 
 Once the questions are updated, the remaining step is to configure them to be filtered by the dashboard filter widget.
 


### PR DESCRIPTION
# Description

This documentation addresses two workflows:

- Add a New Agency Data Source to Metabase and Create Permissions
- Create a New Agency Dashboard and the Comprising Questions

Resolves #2981 and #2982 

## Type of change

- [x] Documentation