### PR TITLE
Drop a few dupe micropayments

### DIFF
--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayment_adjustments.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayment_adjustments.sql
@@ -40,6 +40,15 @@ add_keys_drop_full_dupes AS (
     {{ qualify_dedupe_full_duplicate_lp_rows() }}
 ),
 
+drop_additional_dupes AS (
+    SELECT
+        *
+    FROM add_keys_drop_full_dupes
+    -- drops four true duplicates from two micropayments that generated multiple IDs seemingly
+    -- unintentionally (those micropayments are themselves dropped in the micropayments model)
+    WHERE _key not in ('3d78961ec137c0a16e7e3b888d81c024', '748f95a050d6f45598d1571381b17fad', 'af41f1341756c8feea02d4b8aa9de973', '61fccf1b84e7e3f0afddaae426f29f36')
+),
+
 stg_littlepay__micropayment_adjustments AS (
     SELECT
         micropayment_id,
@@ -63,7 +72,7 @@ stg_littlepay__micropayment_adjustments AS (
         _key,
         _payments_key,
         _content_hash,
-    FROM add_keys_drop_full_dupes
+    FROM drop_additional_dupes
 )
 
 SELECT * FROM stg_littlepay__micropayment_adjustments

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayment_device_transactions.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayment_device_transactions.sql
@@ -45,6 +45,9 @@ stg_littlepay__micropayment_device_transactions AS (
     -- Drops one row associated with the bad customer record, likely used for testing, that's
     -- dropped in stg_littlepay__customer_funding_source.
     WHERE _key != 'f224555905f05b4869475f01a385d2bb'
+    -- drops two true duplicates from two micropayments that generated multiple IDs seemingly
+    -- unintentionally (those micropayments are themselves dropped in the micropayments model)
+    AND _key not in ('b9578c8e1ffa81a1c5b452cfbee0d8ea', '2a286598030d7037ef4425854b54382b')
 )
 
 SELECT * FROM stg_littlepay__micropayment_device_transactions


### PR DESCRIPTION
# Description

Responsive to Sentry issue [#69798](https://sentry.calitp.org/organizations/sentry/issues/69798/), and in keeping with recent changes in which we've identified and dropped rows that clearly represent duplicate information sending or corrupt/testing data from Littlepay, this PR proposes to rid us of two micropayments that are identical to other micropayments but for their `micropayment_id`. Each rolls up into a `transaction_id` that maps to another micropayment with exactly the same metadata and activity. They seem to be the result of the system erroneously creating two identical micropayment entries. If we kept them, we'd likely be double-counting the associated payment activities.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

All dbt models run in staging, and table row counts and shapes compared to prod.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Mark the corresponding Sentry issue as resolved after ensuring that it doesn't repeat.
