### PR TITLE
Payments: Add end of month date columns

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -155,6 +155,8 @@ models:
           The last day of the month of the aggregation_datetime.
           This column is primarily for use in BI tooling to support consistent dates across activity types.
           Aggregation activity happens throughout the month.
+        tests:
+          - not_null
       - name: aggregation_id
         description: |
           Aggregation ID that uniquely identifies this aggregation.
@@ -245,6 +247,8 @@ models:
           This column is primarily for use in BI tooling to support consistent dates across activity types.
           Billing activity generally occurs only once per month, at the end of the month, while deposit
           activity happens throughout the month.
+        tests:
+          - not_null
       - name: payment_reference
         description: |
           Unique number assigned to every "Fund Event" (ACH Payment/Withdrawal, Wire Transfer, Invoice)

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -150,6 +150,11 @@ models:
         description: |
           `source_record_id` of the Cal-ITP defined organization (from `dim_organizations`) associated with this payments activity.
           The mapping of organization records to payments entities is manually maintained in a seed file.
+      - name: end_of_month_date
+        description: |
+          The last day of the month of the aggregation_datetime.
+          This column is primarily for use in BI tooling to support consistent dates across activity types.
+          Aggregation activity happens throughout the month.
       - name: aggregation_id
         description: |
           Aggregation ID that uniquely identifies this aggregation.
@@ -232,6 +237,14 @@ models:
     columns:
       - *organization_name
       - *organization_source_record_id
+      - name: end_of_month_date
+        description: |
+          The last day of the month associated with this activity.
+          For deposit activity, this is the last day of the month of the settlement date.
+          For billing activity, this is the last day of the month of the payment date.
+          This column is primarily for use in BI tooling to support consistent dates across activity types.
+          Billing activity generally occurs only once per month, at the end of the month, while deposit
+          activity happens throughout the month.
       - name: payment_reference
         description: |
           Unique number assigned to every "Fund Event" (ACH Payment/Withdrawal, Wire Transfer, Invoice)

--- a/warehouse/models/mart/payments/fct_elavon__transactions.sql
+++ b/warehouse/models/mart/payments/fct_elavon__transactions.sql
@@ -50,6 +50,8 @@ fct_elavon__transactions AS (
     SELECT
         organization_name,
         organization_source_record_id,
+        -- settlement date is populated for deposits but not for billing
+        LAST_DAY(COALESCE(settlement_date, payment_date), MONTH) AS end_of_month_date,
         payment_reference,
         payment_date,
         account_number,

--- a/warehouse/models/mart/payments/fct_payments_aggregations.sql
+++ b/warehouse/models/mart/payments/fct_payments_aggregations.sql
@@ -68,6 +68,7 @@ fct_payments_aggregations AS (
         participant_id,
         organization_name,
         organization_source_record_id,
+        LAST_DAY(EXTRACT(DATE FROM aggregation_datetime), MONTH) AS end_of_month_date,
         aggregation_id,
         has_micropayment,
         has_authorisation,


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Working with the Elavon & LP aggregations data in Metabase, it seems like having a common date column would be helpful to standardize. This PR just extracts a common "end of month" date that can be used across data types.  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

```
laurie ~/git/data-infra/warehouse [add-elavon-eom-date] $ poetry run dbt build -s fct_payments_aggregations fct_elavon__transactions
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
14:02:55  Running with dbt=1.5.1
14:02:56  Unable to do partial parsing because profile has changed
14:03:09  Found 331 models, 907 tests, 0 snapshots, 0 analyses, 846 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
14:03:09  
14:03:12  Concurrency: 4 threads (target='dev')
14:03:12  
14:03:12  1 of 7 START sql table model laurie_mart_payments.fct_elavon__transactions ..... [RUN]
14:03:12  2 of 7 START sql table model laurie_mart_payments.fct_payments_aggregations .... [RUN]
14:03:16  1 of 7 OK created sql table model laurie_mart_payments.fct_elavon__transactions  [CREATE TABLE (76.4k rows, 31.3 MiB processed) in 4.46s]
14:03:16  3 of 7 START test not_null_fct_elavon__transactions_end_of_month_date .......... [RUN]
14:03:16  4 of 7 START test unique_fct_elavon__transactions_trn_ref_num .................. [RUN]
14:03:17  3 of 7 PASS not_null_fct_elavon__transactions_end_of_month_date ................ [PASS in 1.30s]
14:03:17  4 of 7 PASS unique_fct_elavon__transactions_trn_ref_num ........................ [PASS in 1.37s]
14:03:22  2 of 7 OK created sql table model laurie_mart_payments.fct_payments_aggregations  [CREATE TABLE (169.1k rows, 54.2 MiB processed) in 10.64s]
14:03:22  5 of 7 START test not_null_fct_payments_aggregations_aggregation_id ............ [RUN]
14:03:22  6 of 7 START test not_null_fct_payments_aggregations_end_of_month_date ......... [RUN]
14:03:22  7 of 7 START test unique_fct_payments_aggregations_aggregation_id .............. [RUN]
14:03:24  5 of 7 PASS not_null_fct_payments_aggregations_aggregation_id .................. [PASS in 1.26s]
14:03:24  6 of 7 PASS not_null_fct_payments_aggregations_end_of_month_date ............... [PASS in 1.34s]
14:03:24  7 of 7 PASS unique_fct_payments_aggregations_aggregation_id .................... [PASS in 1.55s]
14:03:24  
14:03:24  Finished running 2 table models, 5 tests in 0 hours 0 minutes and 14.81 seconds (14.81s).
14:03:24  
14:03:24  Completed successfully
14:03:24  
14:03:24  Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
