### PR TITLE
Fix payments aggregation column names in YAML

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -192,7 +192,7 @@ models:
         description: '{{ doc("lp_net_micropayment_amount_dollars") }}'
       - name: total_micropayment_nominal_amount_dollars
         description: '{{ doc("lp_total_nominal_amount_dollars") }}'
-      - name: latest_transaction_time
+      - name: latest_micropayment_transaction_datetime
         description: '{{ doc("lp_mp_latest_transaction_time") }}'
       - name: num_micropayments
         description: '{{ doc("lp_num_micropayments") }}'

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -190,7 +190,7 @@ models:
           This field can be used to map to Elavon data.
       - name: net_micropayment_amount_dollars
         description: '{{ doc("lp_net_micropayment_amount_dollars") }}'
-      - name: total_nominal_amount_dollars
+      - name: total_micropayment_nominal_amount_dollars
         description: '{{ doc("lp_total_nominal_amount_dollars") }}'
       - name: latest_transaction_time
         description: '{{ doc("lp_mp_latest_transaction_time") }}'


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

dbt Airflow job failed today because of mismatched column names between YAML and `fct_payments_aggregations`. This PR fixes the mismatches.

Resolves #\[issue\]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

Not aware of an easy way to test the Metabase docs sync locally; safe to merge and then confirm fix in prod tomorrow I think

```
laurie ~/git/data-infra/warehouse [fix-nominal-amt-col-name] $ poetry run dbt build -s fct_payments_aggregations
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
16:30:58  Running with dbt=1.5.1
16:31:01  Found 331 models, 907 tests, 0 snapshots, 0 analyses, 846 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
16:31:01  
16:31:04  Concurrency: 4 threads (target='dev')
16:31:04  
16:31:04  1 of 4 START sql table model laurie_mart_payments.fct_payments_aggregations .... [RUN]
16:31:16  1 of 4 OK created sql table model laurie_mart_payments.fct_payments_aggregations  [CREATE TABLE (169.1k rows, 54.2 MiB processed) in 11.57s]
16:31:16  2 of 4 START test not_null_fct_payments_aggregations_aggregation_id ............ [RUN]
16:31:16  3 of 4 START test not_null_fct_payments_aggregations_end_of_month_date ......... [RUN]
16:31:16  4 of 4 START test unique_fct_payments_aggregations_aggregation_id .............. [RUN]
16:31:17  3 of 4 PASS not_null_fct_payments_aggregations_end_of_month_date ............... [PASS in 1.47s]
16:31:17  2 of 4 PASS not_null_fct_payments_aggregations_aggregation_id .................. [PASS in 1.59s]
16:31:18  4 of 4 PASS unique_fct_payments_aggregations_aggregation_id .................... [PASS in 1.93s]
16:31:18  
16:31:18  Finished running 1 table model, 3 tests in 0 hours 0 minutes and 16.33 seconds (16.33s).
16:31:18  
16:31:18  Completed successfully
16:31:18  
16:31:18  Done. PASS=4 WARN=0 ERROR=0 SKIP=0 TOTAL=4
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
