### PR TITLE
Fix two problematic Payments model tests

### DIFF
--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -19,6 +19,10 @@ models:
           - relationships:
               to: ref('int_payments__latest_authorisations_by_aggregation')
               field: aggregation_id
+              config:
+                # there is a single update from 2021 where there's only one update with a null status
+                # we're comfortable letting this row get dropped
+                where: "_key != '60e1a87f2cafe52c08589cb13fb39707'"
   - name: int_payments__latest_authorisations_by_aggregation
     description: |
       This model contains only the most recent authorisations data per `aggregation_id`.

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -255,7 +255,7 @@ models:
         description: '{{ doc("lp_aggregation_id") }}'
         tests:
             - relationships:
-                to: ref('int_payments__settlements_to_aggregations')
+                to: ref('fct_payments_aggregations')
                 field: aggregation_id
       - name: customer_id
         description: '{{ doc("lp_customer_id") }}'
@@ -273,8 +273,8 @@ models:
         description: '{{ doc("lp_retrieval_reference_number") }}'
         tests:
             - relationships:
-                to: ref('int_payments__settlements_to_aggregations')
-                field: retrieval_reference_number
+                to: ref('fct_payments_aggregations')
+                field: settlement_retrieval_reference_number
       - name: littlepay_reference_number
         description: '{{ doc("lp_littlepay_reference_number") }}'
       - name: external_reference_number


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

This PR:
* Changes a foreign key test that pointed from mart settlements to intermediate settlements to point from mart settlements to mart aggregations, which should be logically equivalent. Foreign key test pointing from mart to intermediate causes dbt Metabase sync to fail because intermediate table is not available in Metabase. 
* Adds an exception to authorisations test for an authorisation from 2021 that only has one update with a null status. Since it's so old and there are no other cases we are comfortable excluding it from the test. 

Fixes CAL-ITP-DATA-INFRA-26T9 ([x](https://sentry.calitp.org/organizations/sentry/issues/73029/?project=2))
Fixes CAL-ITP-DATA-INFRA-26T8 ([x](https://sentry.calitp.org/organizations/sentry/issues/73028/?project=2))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

```
laurie ~/git/data-infra/warehouse [payments-test-failures-20231031] $ poetry run dbt test -s fct_payments_settlements                                  
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
15:04:34  Running with dbt=1.5.1
15:04:36  Found 338 models, 916 tests, 0 snapshots, 0 analyses, 847 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
15:04:36  
15:04:38  Concurrency: 4 threads (target='dev')
15:04:38  
15:04:38  1 of 2 START test relationships_fct_payments_settlements_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [RUN]
15:04:38  2 of 2 START test relationships_fct_payments_settlements_retrieval_reference_number__settlement_retrieval_reference_number__ref_fct_payments_aggregations_  [RUN]
15:04:40  2 of 2 PASS relationships_fct_payments_settlements_retrieval_reference_number__settlement_retrieval_reference_number__ref_fct_payments_aggregations_  [PASS in 1.92s]
15:04:40  1 of 2 PASS relationships_fct_payments_settlements_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [PASS in 1.96s]
15:04:40  
15:04:40  Finished running 2 tests in 0 hours 0 minutes and 4.33 seconds (4.33s).
15:04:41  
15:04:41  Completed successfully
15:04:41  
15:04:41  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```

```
laurie ~/git/data-infra/warehouse [payments-test-failures-20231031] $ poetry run dbt test -s relationships_int_payments__authorisations_deduped_aggregation_id__aggregation_id__ref_int_payments__latest_authorisations_by_aggregation_
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
15:24:06  Running with dbt=1.5.1
15:24:08  Unable to do partial parsing because profile has changed
15:24:20  Found 338 models, 916 tests, 0 snapshots, 0 analyses, 847 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
15:24:21  
15:24:23  Concurrency: 4 threads (target='dev')
15:24:23  
15:24:23  1 of 1 START test relationships_int_payments__authorisations_deduped_aggregation_id__aggregation_id__ref_int_payments__latest_authorisations_by_aggregation_  [RUN]
15:24:25  1 of 1 PASS relationships_int_payments__authorisations_deduped_aggregation_id__aggregation_id__ref_int_payments__latest_authorisations_by_aggregation_  [PASS in 1.94s]
15:24:25  
15:24:25  Finished running 1 test in 0 hours 0 minutes and 4.49 seconds (4.49s).
15:24:25  
15:24:25  Completed successfully
15:24:25  
15:24:25  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
