### PR TITLE
Fare systems: Update columns & types

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
@@ -41,7 +41,7 @@ schema_fields:
     type: FLOAT
   - name: ticket_validation
     mode: NULLABLE
-    type: STRING
+    type: JSON
   - name: electronic_fare_program
     mode: NULLABLE
     type: STRING
@@ -50,10 +50,10 @@ schema_fields:
     type: FLOAT
   - name: ticket_media
     mode: NULLABLE
-    type: STRING
+    type: JSON
   - name: ticket_pass_sales_methods
     mode: NULLABLE
-    type: STRING
+    type: JSON
   - name: pass_price_min
     mode: NULLABLE
     type: FLOAT
@@ -116,13 +116,73 @@ schema_fields:
     type: STRING
   - name: payment_accepted
     mode: NULLABLE
-    type: STRING
+    type: JSON
   - name: fare_capping
     mode: NULLABLE
-    type: STRING
+    type: JSON
   - name: fare_system
     mode: NULLABLE
     type: STRING
   - name: id
+    mode: NULLABLE
+    type: STRING
+  - name: fare_products
+    mode: REPEATED
+    type: STRING
+  - name: youth_specific_fare
+    mode: NULLABLE
+    type: BOOLEAN
+  - name: free_fare
+    mode: NULLABLE
+    type: BOOLEAN
+  - name: distance_fares
+    mode: NULLABLE
+    type: BOOLEAN
+  - name: zone_fares
+    mode: NULLABLE
+    type: BOOLEAN
+  - name: route_fares
+    mode: NULLABLE
+    type: BOOLEAN
+  - name: market_based_fares
+    mode: NULLABLE
+    type: BOOLEAN
+  - name: num_reduced_fare_categories
+    mode: NULLABLE
+    type: STRING
+  - name: intra_system_xfer_discounts
+    mode: NULLABLE
+    type: STRING
+  - name: intra_system_xfer_time
+    mode: NULLABLE
+    type: STRING
+  - name: intra_system_xfer_cost
+    mode: NULLABLE
+    type: STRING
+  - name: interagency_xfer_discounts
+    mode: NULLABLE
+    type: STRING
+  - name: interagency_xfer_systems
+    mode: NULLABLE
+    type: STRING
+  - name: interagency_xfer_notes
+    mode: NULLABLE
+    type: STRING
+  - name: fare_products_notes
+    mode: NULLABLE
+    type: STRING
+  - name: fare_account
+    mode: NULLABLE
+    type: STRING
+  - name: fare_media
+    mode: REPEATED
+    type: STRING
+  - name: smartcard_discount
+    mode: NULLABLE
+    type: BOOLEAN
+  - name: fare_product_price_min
+    mode: NULLABLE
+    type: STRING
+  - name: fare_product_price_max
     mode: NULLABLE
     type: STRING

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
@@ -101,7 +101,7 @@ schema_fields:
     type: STRING
   - name: reduced_fare_categories
     mode: NULLABLE
-    type: STRING
+    type: JSON
   - name: itp_id
     mode: NULLABLE
     type: FLOAT


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

This PR updates the `fare_systems` external table with new columns that have been added to the table's schema in Airtable and changes the type of existing columns that were change from strings to multi-select in Airtable to be JSON typed in the external table. This will stop a `dbt ModelError` that has been causing the daily dbt job to fail. 

Resolves #3063

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

Ran the updated external table locally pointed at prod data bucket (so that it sees the current schemas for the exported data)
<img width="692" alt="image" src="https://github.com/cal-itp/data-infra/assets/55149902/c44ff06b-336d-4418-8518-2fe14b1e71e5">

Then ran the downstream data models.

```
laurie ~/git/data-infra/warehouse [fare-systems-reduced-fare-category-column-type] $ poetry run dbt build -s +dim_fare_systems                        
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
18:27:17  Running with dbt=1.5.1
18:27:20  Found 338 models, 916 tests, 0 snapshots, 0 analyses, 847 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
18:27:20  
18:27:24  Concurrency: 4 threads (target='dev')
18:27:24  
18:27:24  1 of 10 START sql view model laurie_staging.stg_transit_database__fare_systems . [RUN]
18:27:25  1 of 10 OK created sql view model laurie_staging.stg_transit_database__fare_systems  [CREATE VIEW (0 processed) in 1.52s]
18:27:25  2 of 10 START sql table model laurie_staging.int_transit_database__fare_systems_dim  [RUN]
18:27:29  2 of 10 OK created sql table model laurie_staging.int_transit_database__fare_systems_dim  [CREATE TABLE (285.0 rows, 143.3 MiB processed) in 3.60s]
18:27:29  3 of 10 START test dbt_utils_mutually_exclusive_ranges_int_transit_database__fare_systems_dim_required___valid_from__source_record_id___valid_to  [RUN]
18:27:29  4 of 10 START test not_null_int_transit_database__fare_systems_dim_key ......... [RUN]
18:27:29  5 of 10 START test unique_int_transit_database__fare_systems_dim_key ........... [RUN]
18:27:30  4 of 10 PASS not_null_int_transit_database__fare_systems_dim_key ............... [PASS in 1.29s]
18:27:30  5 of 10 PASS unique_int_transit_database__fare_systems_dim_key ................. [PASS in 1.30s]
18:27:30  3 of 10 PASS dbt_utils_mutually_exclusive_ranges_int_transit_database__fare_systems_dim_required___valid_from__source_record_id___valid_to  [PASS in 1.40s]
18:27:30  6 of 10 START sql table model laurie_mart_transit_database.dim_fare_systems .... [RUN]
18:27:33  6 of 10 OK created sql table model laurie_mart_transit_database.dim_fare_systems  [CREATE TABLE (285.0 rows, 73.1 KiB processed) in 2.62s]
18:27:33  7 of 10 START test dbt_utils_mutually_exclusive_ranges_dim_fare_systems_required___valid_from__source_record_id___valid_to  [RUN]
18:27:33  8 of 10 START test not_null_dim_fare_systems_key ............................... [RUN]
18:27:33  9 of 10 START test relationships_bridge_fare_systems_x_services_fare_system_key__key__ref_dim_fare_systems_  [RUN]
18:27:33  10 of 10 START test unique_dim_fare_systems_key ................................ [RUN]
18:27:34  8 of 10 PASS not_null_dim_fare_systems_key ..................................... [PASS in 1.05s]
18:27:34  10 of 10 PASS unique_dim_fare_systems_key ...................................... [PASS in 1.19s]
18:27:34  9 of 10 PASS relationships_bridge_fare_systems_x_services_fare_system_key__key__ref_dim_fare_systems_  [PASS in 1.23s]
18:27:34  7 of 10 PASS dbt_utils_mutually_exclusive_ranges_dim_fare_systems_required___valid_from__source_record_id___valid_to  [PASS in 1.42s]
18:27:34  
18:27:34  Finished running 1 view model, 2 table models, 7 tests in 0 hours 0 minutes and 13.94 seconds (13.94s).
18:27:35  
18:27:35  Completed successfully
18:27:35  
18:27:35  Done. PASS=10 WARN=0 ERROR=0 SKIP=0 TOTAL=10
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)

Steps to handle these changes in dbt if needed in the future are documented in #3068 
