### PR TITLE
Fix missing Littlepay transaction ids

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -21,7 +21,8 @@ models:
       - name: littlepay_transaction_id
         description: The littlepay_transaction_id of the first tap transaction
         tests:
-          - not_null
+          - dbt_utils.not_null_proportion:
+              at_least: 0.998
           - unique_proportion:
               at_least: 0.999
       - &participant_id

--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -85,9 +85,17 @@ participants_to_routes_and_agency AS (
             AND r.feed_key = a.feed_key
 ),
 
+-- micropayments that don't appear in the cleaned table are subject to issue #647
+-- they are pending payments that incorrectly had a different micropayment ID created from their associated completed payment
+valid_micropayments AS (
+    SELECT DISTINCT micropayment_id
+    FROM int_littlepay__cleaned_micropayment_device_transactions
+),
+
 debited_micropayments AS (
     SELECT *
     FROM stg_littlepay__micropayments
+    INNER JOIN valid_micropayments USING(micropayment_id)
     WHERE type = 'DEBIT'
 ),
 


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

This PR addresses an outstanding bug with the same root cause as #647. Rows that were specifically being dropped from `int_littlepay__cleaned_micropayment_device_transactions` were not actually being dropped from `fct_payments_rides_v2` because of the order in which the joins are performed. This PR also adjusts the relevant tests accordingly so that we won't have any failures. 

The remaining rows identified in #3038 are caused by upstream data issues from the raw data which have been spun out into new issues #3085 and #3086. Also identified one more data issue to be written up shortly after which we can make a full uniqueness test for the `littlepay_transaction_id` (i.e., no more threshold).

Resolves #3038

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

In addition to the below, I confirmed that the only rows that are dropped by this change all have null transaction ID and are subject to #647.

**Confirmed tests are now passing:**

```
laurie ~/git/data-infra/warehouse [fix-missing-transaction-ids] $ poetry run dbt build -s fct_payments_rides_v2
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
19:17:28  Running with dbt=1.5.1
19:17:31  Found 338 models, 916 tests, 0 snapshots, 0 analyses, 847 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
19:17:31  
19:17:35  Concurrency: 4 threads (target='dev')
19:17:35  
19:17:35  1 of 7 START sql table model laurie_mart_payments.fct_payments_rides_v2 ........ [RUN]
19:18:20  1 of 7 OK created sql table model laurie_mart_payments.fct_payments_rides_v2 ... [CREATE TABLE in 45.51s]
19:18:20  2 of 7 START test dbt_utils_not_null_proportion_fct_payments_rides_v2_0_998__littlepay_transaction_id  [RUN]
19:18:20  3 of 7 START test not_null_fct_payments_rides_v2_aggregation_id ................ [RUN]
19:18:20  4 of 7 START test not_null_fct_payments_rides_v2_micropayment_id ............... [RUN]
19:18:20  5 of 7 START test relationships_fct_payments_rides_v2_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [RUN]
19:18:22  3 of 7 PASS not_null_fct_payments_rides_v2_aggregation_id ...................... [PASS in 1.50s]
19:18:22  6 of 7 START test unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id  [RUN]
19:18:22  4 of 7 PASS not_null_fct_payments_rides_v2_micropayment_id ..................... [PASS in 1.51s]
19:18:22  7 of 7 START test unique_proportion_fct_payments_rides_v2_0_999__micropayment_id  [RUN]
19:18:22  2 of 7 PASS dbt_utils_not_null_proportion_fct_payments_rides_v2_0_998__littlepay_transaction_id  [PASS in 1.82s]
19:18:22  5 of 7 PASS relationships_fct_payments_rides_v2_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [PASS in 1.92s]
19:18:23  6 of 7 PASS unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id  [PASS in 1.44s]
19:18:24  7 of 7 PASS unique_proportion_fct_payments_rides_v2_0_999__micropayment_id ..... [PASS in 1.55s]
19:18:24  
19:18:24  Finished running 1 table model, 6 tests in 0 hours 0 minutes and 52.08 seconds (52.08s).
19:18:24  
19:18:24  Completed successfully
19:18:24  
19:18:24  Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
```

**Confirmed that only rows that are missing are historical rows with missing transaction IDs**:

```sql
WITH stage AS (
  SELECT *
  FROM `cal-itp-data-infra-staging.laurie_mart_payments.fct_payments_rides_v2`
),

prod AS (
  SELECT *
  FROM `cal-itp-data-infra.mart_payments.fct_payments_rides_v2`
)

SELECT
  prod.participant_id,
  prod.littlepay_transaction_id IS NULL AS missing_transaction_id,
  MIN(prod.earliest_tap) AS first_transaction,
  MAX(prod.earliest_tap) AS latest_transaction
FROM prod
LEFT JOIN stage USING(micropayment_id)
WHERE stage.micropayment_id IS NULL
GROUP BY 1,2
```

**Confirmed we don't lose any actual aggregations -- i.e., the rows that we drop are part of aggregations that are still represented in the table after these changes:**

```sql
WITH stage AS (
  SELECT *
  FROM `cal-itp-data-infra-staging.laurie_mart_payments.fct_payments_rides_v2`
),

prod AS (
  SELECT *
  FROM `cal-itp-data-infra.mart_payments.fct_payments_rides_v2`
)

SELECT
  COUNT(*)
FROM prod
LEFT JOIN stage USING(aggregation_id)
WHERE stage.micropayment_id IS NULL
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required (will write up one unrelated issue found while testing)
- [ ] Actions required (specified below)
