### PR TITLE
Add aggregation ID to fct payments rides

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -15,6 +15,9 @@ models:
         description: Aggregation ID for this micropayment. Can be used to map to subsequent aggregation processing steps.
         tests:
           - not_null
+          - relationships:
+              to: ref('fct_payments_aggregations')
+              field: aggregation_id
       - name: littlepay_transaction_id
         description: The littlepay_transaction_id of the first tap transaction
         tests:

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -11,6 +11,10 @@ models:
           - not_null
           - unique_proportion:
               at_least: 0.999
+      - name: aggregation_id
+        description: Aggregation ID for this micropayment. Can be used to map to subsequent aggregation processing steps.
+        tests:
+          - not_null
       - name: littlepay_transaction_id
         description: The littlepay_transaction_id of the first tap transaction
         tests:

--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -207,6 +207,7 @@ join_table AS (
 
         m.participant_id,
         m.micropayment_id,
+        m.aggregation_id,
 
         -- Customer and funding source information
         m.funding_source_vault_id,


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Adds `aggregation_id` to `fct_payments_rides_v2` per request

Resolves #3076
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

*The tests failing here are already failing in prod and under separate investigation / are not caused by the changes in this PR*

```
laurie ~/git/data-infra/warehouse [add-aggregation-id] $ poetry run dbt build -s fct_payments_rides_v2                                    
The currently activated Python version 3.11.4 is not supported by the project (~3.9).
Trying to find and use a compatible version. 
Using python3 (3.9.17)
20:05:15  Running with dbt=1.5.1
20:05:18  Found 338 models, 918 tests, 0 snapshots, 0 analyses, 847 macros, 0 operations, 8 seed files, 126 sources, 4 exposures, 0 metrics, 0 groups
20:05:18  
20:05:20  Concurrency: 4 threads (target='dev')
20:05:20  
20:05:20  1 of 7 START sql table model laurie_mart_payments.fct_payments_rides_v2 ........ [RUN]
20:05:49  1 of 7 OK created sql table model laurie_mart_payments.fct_payments_rides_v2 ... [CREATE TABLE (257.4k rows, 2.4 GiB processed) in 28.84s]
20:05:49  2 of 7 START test not_null_fct_payments_rides_v2_aggregation_id ................ [RUN]
20:05:49  3 of 7 START test not_null_fct_payments_rides_v2_littlepay_transaction_id ...... [RUN]
20:05:49  4 of 7 START test not_null_fct_payments_rides_v2_micropayment_id ............... [RUN]
20:05:49  5 of 7 START test relationships_fct_payments_rides_v2_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [RUN]
20:05:51  2 of 7 PASS not_null_fct_payments_rides_v2_aggregation_id ...................... [PASS in 1.55s]
20:05:51  6 of 7 START test unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id  [RUN]
20:05:51  4 of 7 PASS not_null_fct_payments_rides_v2_micropayment_id ..................... [PASS in 1.61s]
20:05:51  3 of 7 FAIL 2849 not_null_fct_payments_rides_v2_littlepay_transaction_id ....... [FAIL 2849 in 1.61s]
20:05:51  7 of 7 START test unique_proportion_fct_payments_rides_v2_0_999__micropayment_id  [RUN]
20:05:51  5 of 7 PASS relationships_fct_payments_rides_v2_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [PASS in 2.16s]
20:05:52  6 of 7 FAIL 1 unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id  [FAIL 1 in 1.58s]
20:05:52  7 of 7 PASS unique_proportion_fct_payments_rides_v2_0_999__micropayment_id ..... [PASS in 1.53s]
20:05:52  
20:05:52  Finished running 1 table model, 6 tests in 0 hours 0 minutes and 34.52 seconds (34.52s).
20:05:53  
20:05:53  Completed with 2 errors and 0 warnings:
20:05:53  
20:05:53  Failure in test not_null_fct_payments_rides_v2_littlepay_transaction_id (models/mart/payments/_payments.yml)
20:05:53    Got 2849 results, configured to fail if != 0
20:05:53  
20:05:53    compiled Code at target/compiled/calitp_warehouse/models/mart/payments/_payments.yml/not_null_fct_payments_rides_v2_littlepay_transaction_id.sql
20:05:53  
20:05:53  Failure in test unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id (models/mart/payments/_payments.yml)
20:05:53    Got 1 result, configured to fail if != 0
20:05:53  
20:05:53    compiled Code at target/compiled/calitp_warehouse/models/mart/payments/_payments.yml/unique_proportion_fct_payments_5ae765bfa0adf9c27b77002bb886a2c5.sql
20:05:53  
20:05:53  Done. PASS=5 WARN=0 ERROR=2 SKIP=0 TOTAL=7
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
