### PR TITLE
HOTFIX: Pin version of Netlify CLI used in docs publication

### DIFF
--- a/.github/workflows/deploy-apps-maps.yml
+++ b/.github/workflows/deploy-apps-maps.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Deploy apps/maps production to Netlify
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
-        npm install -g netlify-cli
+        npm install -g netlify-cli@17.1.0
         netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --prod
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
     - name: Deploy apps/maps preview to Netlify
       if: ${{ github.ref != 'refs/heads/main' }}
       run: |
-        npm install -g netlify-cli
+        npm install -g @17.1.0
         netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --alias=${GITHUB_REPOSITORY#*/}-${PR_NUMBER}
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deploy-apps-maps.yml
+++ b/.github/workflows/deploy-apps-maps.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Deploy apps/maps preview to Netlify
       if: ${{ github.ref != 'refs/heads/main' }}
       run: |
-        npm install -g @17.1.0
+        npm install -g netlify-cli@17.1.0
         netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --alias=${GITHUB_REPOSITORY#*/}-${PR_NUMBER}
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -44,11 +44,12 @@ jobs:
         publish_dir: docs/_build/html
         publish_branch: gh-pages
 
-    # Preview on PRs
+    # Preview on PRs - netlify-cli version pinned at time of 17.2.0 release due to bug:
+    # https://github.com/cal-itp/data-infra/actions/runs/6803984777/job/18500834451#step:5:1100
     - name: Deploy docs preview to Netlify
       if: ${{ github.ref != 'refs/heads/main' }}
       run: |
-        npm install -g netlify-cli
+        npm install -g netlify-cli@17.1.0
         netlify deploy --dir=docs/_build/html --alias=docs-${GITHUB_REPOSITORY#*/}-${PR_NUMBER}
       env:
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -26,7 +26,7 @@ USER $NB_UID
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="$POETRY_HOME/bin:$PATH"
 
-RUN npm install -g --unsafe-perm=true --allow-root netlify-cli vega-cli vega-lite sql-language-server
+RUN npm install -g --unsafe-perm=true --allow-root netlify-cli@17.1.0 vega-cli vega-lite sql-language-server
 
 # gcloud CLI https://cloud.google.com/sdk/docs/install#deb
 RUN cd $GCLOUD_HOME \

--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update \
   && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 
-RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
+RUN npm install -g --unsafe-perm=true --allow-root netlify-cli@17.1.0
 
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:${PATH}"

--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -6,7 +6,7 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update \
   && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev libunwind-dev liblz4-dev
 
-RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
+RUN npm install -g --unsafe-perm=true --allow-root netlify-cli@17.1.0
 
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
# Description

When [Netlify CLI 17.2.0 ](https://github.com/netlify/cli/releases/tag/v17.2.0) released, we began seeing an as-of-yet undiagnosed error in our warehouse image build runs. This PR pins our version to 17.1.0 across the board in order to keep these CI runs passing while we investigate. A new Issue will be opened for a longer-term resolution that allows us to hopefully unpin the version that's currently causing us problems.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Previous CI runs using this version of `netlify-cli` were successful

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Create follow-up Issue for a fuller investigation and longer-term resolution to the underlying issue.