### PR TITLE
Use More Recent nodejs Version In Build Tasks

### DIFF
--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -3,14 +3,14 @@ FROM jupyter/datascience-notebook:python-3.9
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
 USER root
-RUN NODE_MAJOR=20
-RUN apt update
-RUN apt install -y ca-certificates curl gnupg
+RUN NODE_MAJOR=18
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update \
-    && apt install -y keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
+    && apt-get install -y keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null

--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -3,12 +3,11 @@ FROM jupyter/datascience-notebook:python-3.9
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
 USER root
-RUN NODE_MAJOR=18
 RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update \
     && apt-get install -y keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md

--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update \
     && apt-get install -y keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md

--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 USER root
 RUN apt update \
     && apt install -y curl keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null

--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update \
     && apt-get install -y keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md

--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -3,9 +3,14 @@ FROM jupyter/datascience-notebook:python-3.9
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
 USER root
+RUN NODE_MAJOR=20
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update \
     && apt install -y curl keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null

--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -4,13 +4,13 @@ LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
 USER root
 RUN NODE_MAJOR=20
-RUN apt-get update
-RUN apt-get install -y ca-certificates curl gnupg
+RUN apt update
+RUN apt install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update \
-    && apt install -y curl keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
+    && apt install -y keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null

--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -2,7 +2,7 @@ FROM  --platform=linux/amd64 python:3.9-buster as build
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN NODE_MAJOR=20
+RUN NODE_MAJOR=18
 RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings

--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -2,12 +2,11 @@ FROM  --platform=linux/amd64 python:3.9-buster as build
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN NODE_MAJOR=18
 RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli

--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -2,7 +2,7 @@ FROM  --platform=linux/amd64 python:3.9-buster as build
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get update \
   && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 

--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -2,9 +2,13 @@ FROM  --platform=linux/amd64 python:3.9-buster as build
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get update \
-  && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
+RUN NODE_MAJOR=20
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 

--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -2,7 +2,7 @@ FROM python:3.9-buster
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN NODE_MAJOR=20
+RUN NODE_MAJOR=18
 RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings

--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -2,9 +2,13 @@ FROM python:3.9-buster
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get update \
-  && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev libunwind-dev liblz4-dev
+RUN NODE_MAJOR=20
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 

--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -2,7 +2,7 @@ FROM python:3.9-buster
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get update \
   && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev libunwind-dev liblz4-dev
 

--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -2,12 +2,11 @@ FROM python:3.9-buster
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 
-RUN NODE_MAJOR=18
 RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli


### PR DESCRIPTION
# Description

Following #3089, we discovered that an operator used in a dependency is [not supported](https://github.com/vercel/next.js/discussions/49923) by the version of node we were trying to use to load the `netlify-cli` package. The brings in a later version of node in order to successfully build, which also involved a move to a new install system.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

The build-push action for Jupyterhub tested relevant functionality here, but a full build of everything will not take place until merging.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
 
Monitor for regressions in prod post-merge.