### PR TITLE
Resolve npm command non-recognition on warehouse build

### DIFF
--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
+RUN apt-get update \
+    && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 

--- a/warehouse/Dockerfile.local
+++ b/warehouse/Dockerfile.local
@@ -7,7 +7,8 @@ RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
+RUN apt-get update \
+    && apt-get install -y nodejs libgdal-dev libgraphviz-dev graphviz-dev
 
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 


### PR DESCRIPTION
# Description

On Thursday, I made a series of changes to various Dockerfiles that have nodejs dependencies in the interest of resolving #3088. Those changes were made too casually - I tested the build for one of the Dockerfiles I was working with, but did not test the build from scratch (with `--no-cache` set) for each of them every time I made changes. This meant that the warehouse build failed when merged because the `npm` command was unrecognized immediately after the nodejs install. This resolves the issue, and has been fully tested with a cleared cache for each impacted image.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally with test builds of each modified Dockerfile. The previous state of the file would fail to build [just as it does in CI](https://github.com/cal-itp/data-infra/actions/runs/6818544770/job/18544334693), and the new state would succeed.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor the production CI run to ensure success.