### PR TITLE
Add line number to refunds dedupe sorting to make it deterministic

### DIFF
--- a/warehouse/models/intermediate/payments/int_payments__refunds_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__refunds_deduped.sql
@@ -162,7 +162,8 @@ int_payments__refunds AS (
     FROM refunds_union
     -- this dedupes on coalesced_id (which is comprised of retrieval_reference_number or aggregation_id if it is null) and refund_amount
     -- because we observe some duplicate refunds by retrieval_reference_number/aggregation_id and refund_amount
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY coalesced_id, refund_amount ORDER BY littlepay_export_ts DESC) = 1
+    -- add line number to sorting to make this deterministic
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY coalesced_id, refund_amount ORDER BY littlepay_export_ts DESC, _line_number DESC) = 1
 
 )
 


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

I am running into issues testing #3123 because the sorting in the refunds dedupe logic is not deterministic (there are a bunch of ties on export timestamp). I'd like to make the sorting deterministic separately in this PR so I can test #3123 and more accurately assess the impact of logic changes being introduced there (i.e., it's hard to compare staging and prod right now because there is this nondeterministic sorting that introduces variation that is not actually meaningful. By making this sorting deterministic, I can compare between staging and prod and know that the differences are due to actual logic differences as opposed to just sorting ties.) 

Resolves #\[issue\]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

`poetry run dbt build -s int_payments__refunds_deduped` passes and the prod & test tables have the exact same row count (indicating this change does not change inclusion criteria, as we'd expect)

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
