### PR TITLE
Add new refund ID field to external table

### DIFF
--- a/airflow/dags/create_external_tables/payments/littlepay/settlements.yml
+++ b/airflow/dags/create_external_tables/payments/littlepay/settlements.yml
@@ -44,5 +44,7 @@ schema_fields:
     type: STRING
   - name: response_created_timestamp_utc
     type: STRING
+  - name: refund_id
+    type: STRING
   - name: _line_number
     type: STRING


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Adds the new `refund_id` field to the external settlements table. Larger changes deferred to #3150. 

Other new fields were already added in #2992

(Want to make this change in one PR and get it merged so subsequent modeling updates can be tested using the production external tables.)

Progress towards #3073. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

Ran it in local Airflow, confirmed data is queryable in BQ:

```sql
SELECT * 
FROM `cal-itp-data-infra-staging.external_littlepay.settlements`
WHERE refund_id != ""
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
I'm going to run this manually so I can test further updates downstream