### PR TITLE
Settlements schema updates

### DIFF
--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -82,6 +82,24 @@ Numbers in this column are negative because they represent amounts credited (ref
 i.e., these values represent costs for the participant (agency).
 {% enddocs %}
 
+{% docs lp_aggregation_is_settled %}
+Boolean indicating whether all settlements in this aggregation have `settlement_status = SETTLED`.
+`settlement_status` is only available for all agencies starting on November 28, 2023 so
+this field does not account for activity before that date and aggregations that only contain activity before that date have nulls in this field.
+{% enddocs %}
+
+{% docs lp_debit_is_settled %}
+Same as `aggregation_is_settled` but only includes the aggregation's debit (fare payment) settlements.
+{% enddocs %}
+
+{% docs lp_credit_is_settled %}
+Same as `aggregation_is_settled` but only includes the aggregation's credit (refund) settlements.
+If there is no credit activity for the aggregation, this field is null.
+(So, a null in this field can mean either that there was no credit activity at all or that all credit
+activity was prior to November 28, 2023.)
+{% enddocs %}
+
+
 ---------------- SETTLEMENTS TABLE ----------------
 
 {% docs lp_settlement_id %}

--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -85,7 +85,10 @@ i.e., these values represent costs for the participant (agency).
 {% docs lp_aggregation_is_settled %}
 Boolean indicating whether all settlements in this aggregation have `settlement_status = SETTLED`.
 `settlement_status` is only available for all agencies starting on November 28, 2023 so
-this field does not account for activity before that date and aggregations that only contain activity before that date have nulls in this field.
+this field does not account for activity before that date and aggregations that only contain activity before that date have nulls in this field. If `false`, there was a settlement present that has a `settlement_status` other than `SETTLED` (i.e., `PENDING`, `REJECTED`, or `FAILED`.)
+
+When this column appears in models where not all aggregations have settlements at all, this field is also null for aggregations
+that don't have any settlements. So, this field can be null if there are no settlements or if all settlement activity occurred before November 28, 2023.
 {% enddocs %}
 
 {% docs lp_debit_is_settled %}

--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -1,4 +1,5 @@
 Documentation related to Littlepay data schema
+In many cases, taken or adapted directly from Littlepay documentation: https://docs.littlepay.io/data/
 
 {% docs lp_participant_id %}
 Littlepay identifier for the participant (transit agency) associated with this entity or event.
@@ -137,4 +138,30 @@ to interpret this field as a "last updated" value.
 
 {% docs lp_acquirer %}
 Identifies the acquirer used to settle the transaction.
+{% enddocs %}
+
+{% docs lp_acquirer_response_rrn %}
+When returned by supported acquirers, uniquely identifies a card transaction as supplied by the acquirer in the settlement response, based on the ISO 8583 standard.
+
+This field is supported for when the acquirer is Nets DK. When not supported or in use, this field will be empty.
+{% enddocs %}
+
+{% docs lp_settlement_status %}
+The status of the settlement. Options are:
+* `PENDING` - for settlements that have had a request but no response
+* `REJECTED`
+* `SETTLED`
+* `FAILED` - an error occurred during processing
+{% enddocs %}
+
+{% docs lp_request_created_timestamp_utc %}
+Time settlement request was created.
+{% enddocs %}
+
+{% docs lp_response_created_timestamp_utc %}
+Time settlement response was created.
+{% enddocs %}
+
+{% docs lp_refund_id %}
+Populated if the settlement is a refund; can be used when linking to the refunds table.
 {% enddocs %}

--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -60,7 +60,7 @@ If `true`, this aggregation settlement included at least one row with settlement
 {% enddocs %}
 
 {% docs lp_settlement_latest_update_timestamp %}
-Most recent `settlement_requested_date_time_utc` value for this aggregation settlement.
+Most recent `record_updated_timestamp_utc` value for this aggregation settlement.
 If a credit (refund) was issued after the initial debit, this will be the timestamp of the credit.
 {% enddocs %}
 
@@ -130,10 +130,9 @@ Uniquely identifies a card transaction.
 If the acquirer is Elavon, then this key will contain the second part of the string from `retrieval_reference_number`.
 {% enddocs %}
 
-{% docs lp_settlement_requested_date_time_utc %}
-Timestamp of when the settlement request was submitted to the acquirer.
-Per October 2023 updates from Littlepay, it may be more appropriate
-to interpret this field as a "last updated" value.
+{% docs lp_record_updated_timestamp_utc %}
+Settlement last updated timestamp.
+Formerly known as settlement_requested_date_time_utc.
 {% enddocs %}
 
 {% docs lp_acquirer %}

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -85,6 +85,12 @@ models:
         description: '{{ doc("lp_settlement_debit_amount") }}'
       - name: credit_amount
         description: '{{ doc("lp_settlement_credit_amount") }}'
+      - name: aggregation_is_settled
+        description: '{{ doc("lp_aggregation_is_settled") }}'
+      - name: debit_is_settled
+        description: '{{ doc("lp_debit_is_settled") }}'
+      - name: credit_is_settled
+        description: '{{ doc("lp_credit_is_settled") }}'
   - name: int_payments__micropayments_to_aggregations
     description: |
       Littlepay micropayments grouped to the aggregation (`aggregation_id`) level.

--- a/warehouse/models/intermediate/payments/int_payments__settlements_to_aggregations.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_to_aggregations.sql
@@ -15,7 +15,7 @@ summarize_by_type AS (
         retrieval_reference_number,
         settlement_type,
         LOGICAL_OR(imputed_type) AS type_contains_imputed_type,
-        MAX(settlement_requested_date_time_utc) AS type_latest_update_timestamp,
+        MAX(record_updated_timestamp_utc) AS type_latest_update_timestamp,
         SUM(transaction_amount) AS total_amount,
     FROM settlements
     GROUP BY 1, 2, 3, 4

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -256,7 +256,7 @@ models:
       - *organization_source_record_id
       - name: end_of_month_date
         description: |
-          The last day of the month of the settlement_requested_date_time_utc.
+          The last day of the month of the record_updated_timestamp_utc.
           This column is primarily for use in BI tooling to support consistent dates across activity types.
       - *participant_id
       - name: aggregation_id
@@ -287,8 +287,8 @@ models:
         description: '{{ doc("lp_littlepay_reference_number") }}'
       - name: external_reference_number
         description: '{{ doc("lp_external_reference_number") }}'
-      - name: settlement_requested_date_time_utc
-        description: '{{ doc("lp_settlement_requested_date_time_utc") }}'
+      - name: record_updated_timestamp_utc
+        description: '{{ doc("lp_record_updated_timestamp_utc") }}'
       - name: acquirer
         description: '{{ doc("lp_acquirer") }}'
 

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -245,6 +245,12 @@ models:
         description: '{{ doc("lp_settlement_debit_amount") }}'
       - name: settlement_credit_amount
         description: '{{ doc("lp_settlement_credit_amount") }}'
+      - name: aggregation_is_settled
+        description: '{{ doc("lp_aggregation_is_settled") }}'
+      - name: debit_is_settled
+        description: '{{ doc("lp_debit_is_settled") }}'
+      - name: credit_is_settled
+        description: '{{ doc("lp_credit_is_settled") }}'
 
   - name: fct_payments_settlements
     description: Littlepay settlements (completed transactions.)

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -291,6 +291,16 @@ models:
         description: '{{ doc("lp_record_updated_timestamp_utc") }}'
       - name: acquirer
         description: '{{ doc("lp_acquirer") }}'
+      - name: acquirer_response_rrn
+        description: '{{ doc("lp_acquirer_response_rrn") }}'
+      - name: settlement_status
+        description: '{{ doc("lp_settlement_status") }}'
+      - name: request_created_timestamp_utc
+        description: '{{ doc("lp_request_created_timestamp_utc") }}'
+      - name: response_created_timestamp_utc
+        description: '{{ doc("lp_response_created_timestamp_utc") }}'
+      - name: refund_id
+        description: '{{ doc("lp_refund_id") }}'
 
   - name: fct_elavon__transactions
     description: Transactions processed by Elavon

--- a/warehouse/models/mart/payments/elavon_littlepay__transaction_reconciliation.sql
+++ b/warehouse/models/mart/payments/elavon_littlepay__transaction_reconciliation.sql
@@ -18,7 +18,7 @@ elavon_littlepay__transaction_reconciliation AS (
         t1.retrieval_reference_number AS littlepay_retrieval_reference_number,
         t1.littlepay_reference_number AS littlepay_reference_number,
         t1.external_reference_number AS littlepay_external_reference_number,
-        t1.settlement_requested_date_time_utc AS littlepay_settlement_requested_date_time_utc,
+        t1.record_updated_timestamp_utc AS littlepay_record_updated_timestamp_utc,
         t1.transaction_amount AS littlepay_transaction_amount,
 
         t2.amount AS elavon_amount,

--- a/warehouse/models/mart/payments/fct_payments_aggregations.sql
+++ b/warehouse/models/mart/payments/fct_payments_aggregations.sql
@@ -95,7 +95,10 @@ fct_payments_aggregations AS (
         net_settled_amount_dollars,
         contains_refund AS settlement_contains_refund,
         debit_amount AS settlement_debit_amount,
-        credit_amount AS settlement_credit_amount
+        credit_amount AS settlement_credit_amount,
+        aggregation_is_settled,
+        debit_is_settled,
+        credit_is_settled
     FROM join_orgs
 )
 

--- a/warehouse/models/mart/payments/fct_payments_settlements.sql
+++ b/warehouse/models/mart/payments/fct_payments_settlements.sql
@@ -26,7 +26,7 @@ impute_settlement_type AS (
             -- when a settlement (aggregation_id / RRN) appears multiple times, it is generally because the subsequent lines are refunds
             -- vast majority of refunds have exactly one debit line and one credit (refund) line, but there are a few oddities with multiple credit (refund) lines
             CASE
-                WHEN ROW_NUMBER() OVER(PARTITION BY aggregation_id, retrieval_reference_number ORDER BY settlement_requested_date_time_utc) > 1 THEN "CREDIT"
+                WHEN ROW_NUMBER() OVER(PARTITION BY aggregation_id, retrieval_reference_number ORDER BY record_updated_timestamp_utc) > 1 THEN "CREDIT"
                 ELSE "DEBIT"
             END
         ) AS settlement_type,
@@ -43,7 +43,7 @@ join_orgs AS (
     LEFT JOIN payments_entity_mapping USING (participant_id)
     LEFT JOIN orgs
         ON payments_entity_mapping.organization_source_record_id = orgs.source_record_id
-        AND CAST(impute_settlement_type.settlement_requested_date_time_utc AS TIMESTAMP) BETWEEN orgs._valid_from AND orgs._valid_to
+        AND CAST(impute_settlement_type.record_updated_timestamp_utc AS TIMESTAMP) BETWEEN orgs._valid_from AND orgs._valid_to
 ),
 
 -- TODO: add "new schema" columns that are present only for ATN as of 10/6/23
@@ -60,12 +60,17 @@ fct_payments_settlements AS (
         littlepay_reference_number,
         external_reference_number,
         settlement_type,
-        settlement_requested_date_time_utc,
+        record_updated_timestamp_utc,
+        refund_id,
+        acquirer_response_rrn,
+        settlement_status,
+        request_created_timestamp_utc,
+        response_created_timestamp_utc,
         CASE
             WHEN settlement_type = "CREDIT" THEN -1*(transaction_amount)
             WHEN settlement_type = "DEBIT" THEN transaction_amount
         END AS transaction_amount,
-        LAST_DAY(EXTRACT(DATE FROM settlement_requested_date_time_utc), MONTH) AS end_of_month_date,
+        LAST_DAY(EXTRACT(DATE FROM record_updated_timestamp_utc), MONTH) AS end_of_month_date,
         imputed_type,
         acquirer,
         _line_number,

--- a/warehouse/models/mart/payments/fct_payments_settlements.sql
+++ b/warehouse/models/mart/payments/fct_payments_settlements.sql
@@ -46,7 +46,6 @@ join_orgs AS (
         AND CAST(impute_settlement_type.record_updated_timestamp_utc AS TIMESTAMP) BETWEEN orgs._valid_from AND orgs._valid_to
 ),
 
--- TODO: add "new schema" columns that are present only for ATN as of 10/6/23
 fct_payments_settlements AS (
     SELECT
         organization_name,

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -784,8 +784,8 @@ models:
         description: '{{ doc("lp_littlepay_reference_number") }}'
       - name: external_reference_number
         description: '{{ doc("lp_external_reference_number") }}'
-      - name: settlement_requested_date_time_utc
-        description: '{{ doc("lp_settlement_requested_date_time_utc") }}'
+      - name: record_updated_timestamp_utc
+        description: '{{ doc("lp_record_updated_timestamp_utc") }}'
       - name: acquirer
         description: '{{ doc("lp_acquirer") }}'
       - name: acquirer_response_rrn

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -788,6 +788,16 @@ models:
         description: '{{ doc("lp_settlement_requested_date_time_utc") }}'
       - name: acquirer
         description: '{{ doc("lp_acquirer") }}'
+      - name: acquirer_response_rrn
+        description: '{{ doc("lp_acquirer_response_rrn") }}'
+      - name: settlement_status
+        description: '{{ doc("lp_settlement_status") }}'
+      - name: request_created_timestamp_utc
+        description: '{{ doc("lp_request_created_timestamp_utc") }}'
+      - name: response_created_timestamp_utc
+        description: '{{ doc("lp_response_created_timestamp_utc") }}'
+      - name: refund_id
+        description: '{{ doc("lp_refund_id") }}'
       - *lp_export_date
       - *lp_export_ts
       - *lp_line_number

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
@@ -17,9 +17,9 @@ clean_columns AS (
         -- prior to 11/28/23, only ATN had record_updated_timestamp_utc
         -- per communication from LP, that column is the new name of settlement_requested_date_time_utc
         COALESCE(
-            {{ safe_cast('settlement_requested_date_time_utc', type_timestamp()) }},
-            {{ safe_cast('record_updated_timestamp_utc', type_timestamp()) }}
-            ) AS settlement_requested_date_time_utc,
+            {{ safe_cast('record_updated_timestamp_utc', type_timestamp()) }},
+            {{ safe_cast('settlement_requested_date_time_utc', type_timestamp()) }}
+            ) AS record_updated_timestamp_utc,
         {{ trim_make_empty_string_null('acquirer') }} AS acquirer,
         {{ trim_make_empty_string_null('refund_id') }} AS refund_id,
         {{ safe_cast('request_created_timestamp_utc', type_timestamp()) }} AS request_created_timestamp_utc,
@@ -35,7 +35,7 @@ clean_columns AS (
         {{ dbt_utils.generate_surrogate_key(['participant_id',
         'settlement_id', 'aggregation_id', 'customer_id', 'funding_source_id', 'transaction_amount',
         'retrieval_reference_number', 'littlepay_reference_number', 'external_reference_number',
-        'settlement_type', 'settlement_requested_date_time_utc', 'acquirer']) }} AS _content_hash,
+        'settlement_type', 'record_updated_timestamp_utc', 'acquirer']) }} AS _content_hash,
     FROM source
 ),
 
@@ -61,7 +61,7 @@ stg_littlepay__settlements AS (
         littlepay_reference_number,
         external_reference_number,
         settlement_type,
-        settlement_requested_date_time_utc,
+        record_updated_timestamp_utc,
         acquirer,
         refund_id,
         acquirer_response_rrn,

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
@@ -14,15 +14,19 @@ clean_columns AS (
         {{ trim_make_empty_string_null('littlepay_reference_number') }} AS littlepay_reference_number,
         {{ trim_make_empty_string_null('external_reference_number') }} AS external_reference_number,
         {{ trim_make_empty_string_null('settlement_type') }} AS settlement_type,
-        -- as of 10/6/23, only ATN has record_updated_timestamp_utc
+        -- prior to 11/28/23, only ATN had record_updated_timestamp_utc
         -- per communication from LP, that column is the new name of settlement_requested_date_time_utc
         COALESCE(
             {{ safe_cast('settlement_requested_date_time_utc', type_timestamp()) }},
             {{ safe_cast('record_updated_timestamp_utc', type_timestamp()) }}
             ) AS settlement_requested_date_time_utc,
         {{ trim_make_empty_string_null('acquirer') }} AS acquirer,
+        {{ trim_make_empty_string_null('refund_id') }} AS refund_id,
+        {{ safe_cast('request_created_timestamp_utc', type_timestamp()) }} AS request_created_timestamp_utc,
+        {{ safe_cast('response_created_timestamp_utc', type_timestamp()) }} AS response_created_timestamp_utc,
+        {{ trim_make_empty_string_null('acquirer_response_rrn') }} AS acquirer_response_rrn,
+        {{ trim_make_empty_string_null('settlement_status') }} AS settlement_status,
         CAST(_line_number AS INTEGER) AS _line_number,
-        -- TODO: add "new schema" columns that are present only for ATN as of 10/6/23
         `instance`,
         extract_filename,
         ts,
@@ -59,8 +63,12 @@ stg_littlepay__settlements AS (
         settlement_type,
         settlement_requested_date_time_utc,
         acquirer,
+        refund_id,
+        acquirer_response_rrn,
+        settlement_status,
+        request_created_timestamp_utc,
+        response_created_timestamp_utc,
         _line_number,
-        -- TODO: add "new schema" columns that are present only for ATN as of 10/6/23
         `instance`,
         extract_filename,
         ts,


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Handles Littlepay settlements schema updates.

Resolves #3073 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

`poetry run dbt build -s +fct_payments_aggregations` passes. 

The following query's results look reasonable; there are no refunds since the schema change so can't test that part yet. 

```sql
SELECT aggregation_is_settled,credit_is_settled,debit_is_settled, COUNT(*)
FROM `cal-itp-data-infra-staging.laurie_mart_payments.fct_payments_aggregations`
GROUP BY 1,2,3
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
