### PR TITLE
fix(amplitude): change folder from test app to production app

### DIFF
--- a/airflow/dags/create_external_tables/amplitude/benefits_events.yml
+++ b/airflow/dags/create_external_tables/amplitude/benefits_events.yml
@@ -1,7 +1,7 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AMPLITUDE_BENEFITS_EVENTS') }}"
 source_objects:
-  - "304109/*.json.gz" # 304109 is the project id from Amplitude
+  - "304110/*.json.gz" # 304110 is the project id from Amplitude for the Benefits Production app
 destination_project_dataset_table: "external_amplitude.benefits_events"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true


### PR DESCRIPTION
# Description

Previously, the Amplitude Data Destination was pulling data from Benefit's _Test environment application_ into Google Cloud Storage, and this _Test environment data_ was being processed via Airflow, and getting cleaned, transformed and ultimately sent to Metabase. But we need Production data, not Test data.

Last week, we updated the Amplitude Data Destination to send data from Benefit's **Production** environment application into Google Cloud Storage, and we started and completed a data backfill job to get all data from August 2022 from Production into this same bucket. The previous Test site data was saved in a folder called `304109/ `, while this new Production data now goes into a new folder called `304110/ `:

<img width="751" alt="image" src="https://github.com/cal-itp/data-infra/assets/3673236/1e2d23e3-7108-4668-9d9e-4650ee6b0465">

This pull request changes the Airflow DAG to pull data from this _new Production folder_, `304110`.

## Outstanding questions

@lauriemerrell We had a question - We were wondering if this change will trigger the rest of the resulting flow steps to only display and send data from this new folder `304110`, and delete data from `304109`. What I mean by that is, once this PR is merged, will the resulting Benefits Fact Tables and Metabase charts only show data from `304110`? Or do we have to take some other steps to delete all the old data from `304109`?


Resolves #3134

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation: Added details that this data comes from the Production app.

## How has this been tested?

_Include commands/logs/screenshots as relevant._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below): @machikoyasuda to confirm that data in Metabase, GCS are correctly coming from Production app.
