### PR TITLE
fix(k8s): increase Sentry Clickhouse storage to 50Gi

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -102,3 +102,9 @@ sentry:
       enabled: false
     zookeeper:
       enabled: true
+
+  clickhouse:
+    clickhouse:
+      persistentVolumeClaim:
+        dataPersistentVolume:
+          storage: "50Gi"

--- a/runbooks/workflow/disk-space.md
+++ b/runbooks/workflow/disk-space.md
@@ -12,7 +12,7 @@ In the expanded details for the alert message posted to Slack, look for a line i
 persistentvolumeclaim=sentry-clickhouse-data-sentry-clickhouse-1,
 ```
 
-Using Lens, you can easily track down what service this PVC is associated with by first opening the **Storage** > **Persistent Volume Claims** section in Lens, then finding or searching for the named PVC. Once found, you can click the associated **Pod** and the **Controlled By** field will tell you what higher-level `Deployment` or `StatefulSet` that pod was created by—telling you which service is affected. The PVC shown above, for example, leads to the `StatefulSet` named `sentry-clickhouse`.
+If you're using [Lens](https://k8slens.dev/), you can easily track down what service this PVC is associated with by first opening the **Storage** > **Persistent Volume Claims** section in Lens, then finding or searching for the named PVC. Once found, you can click the associated **Pod** and the **Controlled By** field will tell you what higher-level `Deployment` or `StatefulSet` that pod was created by—telling you which service is affected. The PVC shown above, for example, leads to the `StatefulSet` named `sentry-clickhouse`.
 
 ## Possible actions
 
@@ -27,9 +27,9 @@ If however you determine that the growth in disk usage is likely legitimate and 
 
 ## Increasing disk capacity
 
-In a pinch, you can edit a PVC directly in Kubernetes to see if that resolves an issue. After a PVC's request size is increased, the pod it is bound too will need to be manually destroyed and then the new requested size will be applied by the cloud provider's storage controlled before the volume gets re-bound to the next instance of the pod. It may be additionally necessary to shell into the pod or node it's hosted on and execute `resize2fs` on the mounted volume to resize the filesystem within the volume to fill the newly available space.
+In a pinch, you can edit a PVC directly in Kubernetes to see if that resolves an issue. After a PVC's request size is increased, the pod it is bound to will need to be manually destroyed and then the new requested size will be applied by the cloud provider's storage controlled before the volume gets re-bound to the next instance of the pod. It may be additionally necessary to shell into the pod or node it's hosted on and execute `resize2fs` on the mounted volume to resize the filesystem within the volume to fill the newly available space.
 
-However it is important to apply the new requested disk capacity value upstream in source control so that future syncs from GitHub to Kubernetes will not reset it. This typically involved identifying the relevant Helm chart and configuration value to change within one of this repositories Helm values YAML files. [PR #3170](https://github.com/cal-itp/data-infra/pull/3170) provides an example of this being done for the Clickhouse data volume.
+However, it is important to apply the new requested disk capacity value upstream in source control so that future syncs from GitHub to Kubernetes will not reset it. This typically involved identifying the relevant Helm chart and configuration value to change within one of this repositories Helm values YAML files. [PR #3170](https://github.com/cal-itp/data-infra/pull/3170) provides an example of this being done for the Clickhouse data volume.
 
 ## Service-specific additional steps
 


### PR DESCRIPTION
# Description

A Grafana alert has been consistently firing as of late about one of Sentry's storage volumes hovering around 80% utilization. Investigating this I found that this was _not_ to do with Zookeeper which [routinely needs old log/snapshot data purged](https://github.com/cal-itp/data-infra/blob/main/runbooks/workflow/disk-space.md), but rather was an issue with Clickhouse's data volume which stores Sentry's events legitimately growing over time. Reducing disk usage here would require actually deleting some of Sentry's event history. Given the long time period covered by the initially-provisioned 30Gi of data storage (the [upstream default](https://github.com/sentry-kubernetes/charts/blob/20.0.0/sentry/values.yaml#L990) for the Helm chart we use to deploy Sentry) and relative cost of storage, I suggest it would be best to just expand the storage volume to 50Gi

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

I executed the following command within the `kubernetes/apps/charts/sentry` directory:

```bash
helm template sentry . -n sentry -f ../../values/sentry_sensitive.yaml -f ./values.yaml --debug
```

This renders the complete manifests offline for our Sentry deployment, and by diffing the before and after output I verified that only the storage request for the `sentry-clickhouse` StatefulSet was changed:

```diff
<           storage: "30Gi"
---
>           storage: "50Gi"
```

## Post-merge follow-ups

Ensure that the following 3 PersistentVolumeClaims change from 30Gi to 50Gi:

- `sentry-clickhouse-data-sentry-clickhouse-0`
- `sentry-clickhouse-data-sentry-clickhouse-1`
- `sentry-clickhouse-data-sentry-clickhouse-2`

It may additionally be necessary to log into the associated pods or nodes and use `resize2fs` to expand the filesystem to make use of the newly available physical disk space. Use `df -h` within each of the three pods to then confirm that the filesystems have 50Gi available and are now well below 80% utilization.