### PR TITLE
create mart_ntd_validation

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -67,3 +67,5 @@ models:
         schema: mart_payments
       benefits:
         schema: mart_benefits
+      ntd_validation:
+        schema: mart_ntd_validation


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

In #3129, models were created in `mart/ntd_validation`, but we didn't create a configuration in the `dbt_project.yml` to actually create that dataset, so the models in that mart folder were created in the `staging` dataset in BigQuery. This PR adds configuration so that the tables will be created in a `mart_ntd_validation` dataset in BigQuery. 

Resolves #3171

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

Ran locally, confirmed mart is created:
![image](https://github.com/cal-itp/data-infra/assets/55149902/616f6074-2e4b-4f05-857f-6eea1092f01f)

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Delete the staging versions of the mart tables to avoid confusion later