### PR TITLE
expand aggregations where `settlement_status` should be `REJECTED`

### DIFF
--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__settlements.sql
@@ -68,7 +68,7 @@ stg_littlepay__settlements AS (
         -- manual backfill of ccjpa data for specific reporting needs
         -- information on how to backfill comes from manual LP extracts provided by Rebel
         CASE
-            WHEN _key IN ("4e0bf943884f81fd6e524f4e175139c0", "910e0fe9c6f78de301b69f35798ec613", "8df624e5048128983c9693faaa32f27d", "67e002b1be3f07b2c06b4335364d7fde", "f658f3201463764ceea23816e9c27a54")
+            WHEN _key IN ("4e0bf943884f81fd6e524f4e175139c0", "910e0fe9c6f78de301b69f35798ec613", "8df624e5048128983c9693faaa32f27d", "67e002b1be3f07b2c06b4335364d7fde", "f658f3201463764ceea23816e9c27a54", "5878d1e840d94938d8fd2f1d33d44f1d", "df5c48e3d9d21f20be7da9d5973d1b8e", "58f6955a6b52f5b12d0999bcccb712fb", "6724c21016dc153517bc0b55fe4bc6b2")
                 THEN "REJECTED"
             WHEN participant_id = "ccjpa"
                 AND littlepay_export_date < "2023-11-28"


### PR DESCRIPTION
# Description

After receiving the revised data feed from Littlepay and performing a manual backfill, we've discovered several Littlepay `aggregation_id`s for the month of November that are incorrectly attributed as `settlement_status = SETTLED`, when they should be `= REJECTED`.

This PR expands the aggregations manually identified as `REJECTED` for the month of October resolved in #3187 (and described in #3186) to include four more from the month of November.

Resolves #3193

## Type of change

- [x] New feature

## How has this been tested?

poetry run dbt run -s stg_littlepay__settlements+ and poetry run dbt test -s stg_littlepay__settlements+ passes

## Post-merge follow-ups

- [x] No action required
