### PR TITLE
Move setup-gcloud to floating V2 release

### DIFF
--- a/.github/workflows/build-calitp-data-analysis.yml
+++ b/.github/workflows/build-calitp-data-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: google-github-actions/setup-gcloud@v2
       - name: Run checks
         run: |
           curl -sSL https://install.python-poetry.org | python -

--- a/.github/workflows/build-calitp-data-analysis.yml
+++ b/.github/workflows/build-calitp-data-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/build-calitp-data-analysis.yml
+++ b/.github/workflows/build-calitp-data-analysis.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/setup-gcloud@v1
       - name: Run checks
         run: |
           curl -sSL https://install.python-poetry.org | python -

--- a/.github/workflows/build-calitp-data-analysis.yml
+++ b/.github/workflows/build-calitp-data-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/build-calitp-data-infra.yml
+++ b/.github/workflows/build-calitp-data-infra.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/build-calitp-data-infra.yml
+++ b/.github/workflows/build-calitp-data-infra.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/build-calitp-data-infra.yml
+++ b/.github/workflows/build-calitp-data-infra.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          export_default_credentials: true
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/setup-gcloud@v2
       - name: Run checks
         run: |
           curl -sSL https://install.python-poetry.org | python -

--- a/.github/workflows/build-warehouse-image.yml
+++ b/.github/workflows/build-warehouse-image.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: '3.9'
       - run: curl -sSL https://install.python-poetry.org | python -
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/build-warehouse-image.yml
+++ b/.github/workflows/build-warehouse-image.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: '3.9'
       - run: curl -sSL https://install.python-poetry.org | python -
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/build-warehouse-image.yml
+++ b/.github/workflows/build-warehouse-image.yml
@@ -39,10 +39,10 @@ jobs:
         with:
           python-version: '3.9'
       - run: curl -sSL https://install.python-poetry.org | python -
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          export_default_credentials: true
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/setup-gcloud@v2
       - name: Compile dbt project
         working-directory: warehouse
         run: |

--- a/.github/workflows/deploy-airflow.yml
+++ b/.github/workflows/deploy-airflow.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/deploy-airflow.yml
+++ b/.github/workflows/deploy-airflow.yml
@@ -16,10 +16,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          export_default_credentials: true
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      - uses: google-github-actions/setup-gcloud@v2
 
       # Only update requirements if they have changed; Composer throws an error if there are no changes to apply
       - uses: tj-actions/changed-files@v35

--- a/.github/workflows/deploy-airflow.yml
+++ b/.github/workflows/deploy-airflow.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.12.0'
+          python-version: '3.11.7'
       - uses: pre-commit/action@v3.0.0
       - uses: crate-ci/typos@master
         with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: 3.9
     - run: pip install -r docs/requirements.txt
-    - uses: google-github-actions/setup-gcloud@v2
+    - uses: google-github-actions/setup-gcloud@v1
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: 3.9
     - run: pip install -r docs/requirements.txt
-    - uses: google-github-actions/setup-gcloud@v0
+    - uses: google-github-actions/setup-gcloud@v2
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,10 +22,10 @@ jobs:
       with:
         python-version: 3.9
     - run: pip install -r docs/requirements.txt
-    - uses: google-github-actions/setup-gcloud@v1
+    - uses: 'google-github-actions/auth@v2'
       with:
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+    - uses: google-github-actions/setup-gcloud@v2
 
     - name: Build jupyter book
       run: jb build docs --warningiserror --keep-going # set doc to fail on any sphinx warning

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -9,10 +9,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          export_default_credentials: true
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/setup-gcloud@v2
       - uses: 'google-github-actions/get-secretmanager-secrets@v1'
         id: secrets
         with:

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           export_default_credentials: true
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/service-release-channel.yml
+++ b/.github/workflows/service-release-channel.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/service-release-channel.yml
+++ b/.github/workflows/service-release-channel.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/service-release-channel.yml
+++ b/.github/workflows/service-release-channel.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/setup-gcloud@v2
       - name: install auth plugin
         run: gcloud components install gke-gcloud-auth-plugin
       - uses: google-github-actions/get-gke-credentials@v1

--- a/.github/workflows/service-release-diff.yml
+++ b/.github/workflows/service-release-diff.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/service-release-diff.yml
+++ b/.github/workflows/service-release-diff.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/service-release-diff.yml
+++ b/.github/workflows/service-release-diff.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/setup-gcloud@v2
       - run: gcloud components install gke-gcloud-auth-plugin
       - uses: google-github-actions/get-gke-credentials@v1
         with:

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/terraform-report.yml
+++ b/.github/workflows/terraform-report.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/terraform-report.yml
+++ b/.github/workflows/terraform-report.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/terraform-report.yml
+++ b/.github/workflows/terraform-report.yml
@@ -20,10 +20,11 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - uses: google-github-actions/setup-gcloud@v1
+      - uses: 'google-github-actions/auth@v2'
         with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      - uses: google-github-actions/setup-gcloud@v2
 
       - uses: hashicorp/setup-terraform@v2
         with:


### PR DESCRIPTION
# Description

Resolves #3203 by upgrading the `google-github-actions/setup-gcloud` Action to use a supported version, which also required adding the `google-github-actions/auth` action since the current version of `setup-gcloud` cleaves away authentication.

Additionally, moves our linting step back to use Python 3.11.7 instead of 3.12 due to [PEP 632](https://peps.python.org/pep-0632/) impacting an underlying tool that we don't have direct control over.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Many of the relevant workflows were tested automatically within this PR. Changes made in the others are identical, and those workflows have access to the same creds, so no differing behavior is expected.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
