### PR TITLE
Switch Airtable fetch to use PAT instead of API Key

### DIFF
--- a/airflow/plugins/operators/airtable_to_gcs.py
+++ b/airflow/plugins/operators/airtable_to_gcs.py
@@ -136,8 +136,8 @@ class AirtableToGCSOperator(BaseOperator):
             air_table_name (str): The table name that should be extracted from the
                 Airtable Base
             personal_access_token (str, optional): The personal access token to use when downloading from airtable.
-                This can be someone's personal PAT. If not provided, the environment
-                variable of `CALITP_AIRTABLE_PERSONAL_ACCESS_TOKEN` is used.
+                This can be someone's personal PAT. If not provided, the Secret Manager
+                value for `CALITP_AIRTABLE_PERSONAL_ACCESS_TOKEN` is used.
         """
         self.bucket = bucket
         self.extract = AirtableExtract(

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,6 +1,6 @@
 calitp-data-infra==2024.1.3
 gusty==0.6.0
-pyairtable==1.0.0
+pyairtable==2.2.1
 typer==0.4.1
 sentry-sdk==1.17.0
 platformdirs<3,>=2.5


### PR DESCRIPTION
# Description
As described in #2187, Airtable is deprecating API Keys for Personal Access Tokens at the end of this month (January 2024). This PR:

* Updates the python client that we use for the Airtable API (`pyAirtable`) from `v1.0` to `v2.2.1`
* Migrate to new syntax used in updated `pyAirtable API`

Resolves #2187 

## Type of change

- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How has this been tested?
Tested using prod PAT and secrets manager

## Before merge
- [x] Actions required (specified below)
  - [x] Create PAT using bot@calitp.org, with read-access to three relevant bases (`california_transit`, `transit_data_quality_issues`, `transit_technology_stacks`)
  - [x] store PAT in Secrets Manager as value for `CALITP_AIRTABLE_PERSONAL_ACCESS_TOKEN`