### PR TITLE
fix(sentry): remove duplicate annotation

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -29,7 +29,6 @@ sentry:
     annotations:
       kubernetes.io/ingress.class: nginx
       kubernetes.io/ingress.allow-http: "false"
-      nginx.ingress.kubernetes.io/use-regex: "true"
       cert-manager.io/cluster-issuer: letsencrypt-prod
     hostname: sentry.calitp.org
     additionalHostNames:


### PR DESCRIPTION
The Sentry helm chart's default configuration already adds this annotation, so including it here too results in a duplicate key and invalid YAML

I'm going to merge and deploy this right away as it is part of my work to reconcile the state of the k8s cluster and I need to push the change through the GitHub Action workflow to verify