### PR TITLE
Add pydantic 1.9 to Composer PyPI Packages

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,6 +1,7 @@
 calitp-data-infra==2024.1.3
 gusty==0.6.0
 pyairtable==2.2.1
+pydantic==1.9
 typer==0.4.1
 sentry-sdk==1.17.0
 platformdirs<3,>=2.5


### PR DESCRIPTION
# Description

When we upgraded to use pyairtable V2 in our Composer PyPI package list for auth reasons, it introduced a dependency conflict: pyairtable has a version-unbounded pydantic requirement that in turn brings in typing-extensions. Because the pydantic version being fetched relied on a newer version of typing-extensions than the one that comes with our Composer-Airflow instance (which we can't modify), we need to pin the pydantic version imported in Composer to avoid the conflict. I used 1.9, which is used elsewhere in `data-infra`.

Merging this PR will also conveniently allow us to test some additional current behavior related to #3215 - does the Action fail to run when a new _package_ is added to the requirements list, or just when the package version numbers are changed?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested via rollout on production Composer - a safe move because Composer automatically rejects changes that produce dependency conflicts, rather than getting into a bad state.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor merge CI behavior to continue investigating #3215.