### PR TITLE
Update criteria used to deploy package list changes to Composer

### DIFF
--- a/.github/workflows/deploy-airflow.yml
+++ b/.github/workflows/deploy-airflow.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Only update requirements if they have changed; Composer throws an error if there are no changes to apply
       - uses: tj-actions/changed-files@v35
-        if: github.event.pull_request.base.ref == 'main'
+        if: ${{ github.ref == 'refs/heads/main' }}
         id: changed-requirements
         with:
           files: 'airflow/requirements.txt'


### PR DESCRIPTION
# Description

It appears that changes to /airflow/requirements.txt weren't making their way to Composer's PyPI package list automatically because `deploy-airflow.yml` used an incorrect rule formulation to detect relevant merges to main. This should resolve the issue.

Resolves #3215

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

This can't be fully tested until merge. Upon merge, the `changed-requirements` task in the Airflow deployment CI workflow should fire, and then the next task should be skipped because the requirements list isn't changed by this PR. Seeing the first task fire will be enough to determine that the deployment bug has been fixed.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor the CI run upon merge to ensure behavior is as expected.