### PR TITLE
Reset helm values

### DIFF
--- a/ci/channels/prod.yaml
+++ b/ci/channels/prod.yaml
@@ -99,6 +99,8 @@ calitp:
       namespace: sentry
       helm_name: sentry
       helm_chart: kubernetes/apps/charts/sentry
+      secret_helm_values:
+        - sentry_sentry-sensitive-helm-values
       secrets:
         - sentry_sentry-secret
         - sentry_sentry-sentry-postgresql

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -291,6 +291,7 @@ def release(
                         "--install",
                         f"--namespace {release.namespace}",
                         values_str,
+                        "--reset-values",  # prevent use of stored value overrides from previous releases
                         f"--timeout {release.timeout}" if release.timeout else "",
                     ]
                 )

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -220,6 +220,7 @@ def diff(
                             values_str,
                             "-C 5",  # only include 5 lines of context
                             "--no-hooks",  # exclude hooks that get recreated every upgrade from diff
+                            "--reset-values",  # prevent use of stored value overrides from previous releases
                         ]
                     ),
                     warn=True,

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -275,26 +275,20 @@ def release(
             c.run(f"helm dependency update {chart_path}", warn=True)
             values_str = " ".join(
                 [
-                    f"--values {c.calitp_config.git_root / Path(values_file)}"
+                    f"--values={c.calitp_config.git_root / Path(values_file)}"
                     for values_file in release.helm_values
                 ]
             )
-            result: Result = c.run(f"kubectl get ns {release.namespace}")
-            verb = "upgrade"
-
-            if result.exited != 0:
-                # namespace does not exist yet
-                c.run(f"kubectl create ns {release.namespace}")
-                verb = "install"
 
             assert release.helm_name is not None
             c.run(
                 " ".join(
                     [
                         "helm",
-                        verb,
+                        "upgrade",
                         release.helm_name,
                         str(chart_path),
+                        "--install",
                         f"--namespace {release.namespace}",
                         values_str,
                         f"--timeout {release.timeout}" if release.timeout else "",

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -201,8 +201,7 @@ def diff(
                         f"--values={c.calitp_config.git_root / Path(values_file)}"
                         for values_file in release.helm_values
                     ]
-                    +
-                    [
+                    + [
                         f"--values={secret_path}"
                         for secret_path in secret_helm_value_paths
                     ]
@@ -296,8 +295,7 @@ def release(
                         f"--values={c.calitp_config.git_root / Path(values_file)}"
                         for values_file in release.helm_values
                     ]
-                    +
-                    [
+                    + [
                         f"--values={secret_path}"
                         for secret_path in secret_helm_value_paths
                     ]

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -201,7 +201,7 @@ def diff(
                         f"--values={c.calitp_config.git_root / Path(values_file)}"
                         for values_file in release.helm_values
                     ]
-                ).join(
+                    +
                     [
                         f"--values={secret_path}"
                         for secret_path in secret_helm_value_paths

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -264,6 +264,8 @@ def release(
     assert c.calitp_config.git_root is not None
     actual_driver = ReleaseDriver[driver] if driver else None
 
+    secrets_client = secretmanager.SecretManagerServiceClient()
+
     for release in get_releases(c, driver=actual_driver, app=app):
         if release.driver == ReleaseDriver.kustomize:
             assert release.kustomize_dir is not None
@@ -273,28 +275,49 @@ def release(
             assert release.helm_chart is not None
             chart_path = c.calitp_config.git_root / Path(release.helm_chart)
             c.run(f"helm dependency update {chart_path}", warn=True)
-            values_str = " ".join(
-                [
-                    f"--values={c.calitp_config.git_root / Path(values_file)}"
-                    for values_file in release.helm_values
-                ]
-            )
 
-            assert release.helm_name is not None
-            c.run(
-                " ".join(
+            with tempfile.TemporaryDirectory() as tmpdir:
+                secret_helm_value_paths = []
+                for secret_helm_values in release.secret_helm_values:
+                    secret_path = Path(tmpdir) / Path(f"{secret_helm_values}.yaml")
+                    name = f"projects/1005246706141/secrets/{secret_helm_values}/versions/latest"
+                    secret_contents = secrets_client.access_secret_version(
+                        request={"name": name}
+                    ).payload.data.decode("UTF-8")
+
+                    with open(secret_path, "w") as f:
+                        f.write(secret_contents)
+
+                    secret_helm_value_paths.append(secret_path)
+                    print(f"Downloaded secret helm values: {secret_path}", flush=True)
+
+                values_str = " ".join(
                     [
-                        "helm",
-                        "upgrade",
-                        release.helm_name,
-                        str(chart_path),
-                        "--install",
-                        f"--namespace {release.namespace}",
-                        values_str,
-                        "--reset-values",  # prevent use of stored value overrides from previous releases
-                        f"--timeout {release.timeout}" if release.timeout else "",
+                        f"--values={c.calitp_config.git_root / Path(values_file)}"
+                        for values_file in release.helm_values
+                    ]
+                    +
+                    [
+                        f"--values={secret_path}"
+                        for secret_path in secret_helm_value_paths
                     ]
                 )
-            )
+
+                assert release.helm_name is not None
+                c.run(
+                    " ".join(
+                        [
+                            "helm",
+                            "upgrade",
+                            release.helm_name,
+                            str(chart_path),
+                            "--install",
+                            f"--namespace {release.namespace}",
+                            values_str,
+                            "--reset-values",  # prevent use of stored value overrides from previous releases
+                            f"--timeout {release.timeout}" if release.timeout else "",
+                        ]
+                    )
+                )
         else:
             _assert_never(release.driver)


### PR DESCRIPTION
Resolves issue with Sentry's postgresql version override stubbornly persisting by preventing previously applied value overrides persisted by Helm from being brought forward automatically into new releases. This also necessitates activating the sensitive values file for Sentry to replace bringing the existing PostgreSQL user password forward