### PR TITLE
add exception handling to ckan upload script

### DIFF
--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -488,7 +488,7 @@ def _publish_exposure(
                                 )
                         except requests.exceptions.RequestException as e:
                             print(e)
-                            pass
+                            continue
 
                     else:
                         typer.secho(

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -486,9 +486,11 @@ def _publish_exposure(
                                     file=fp,
                                     resource_id=resource.id,
                                 )
-                        except requests.exceptions.RequestException as e:
-                            print(e)
-                            continue
+                        except requests.exceptions.HTTPError as e:
+                            typer.secho(
+                                f"Failed to upload to {fpath} due to error: {e}",
+                                fg=typer.colors.RED,
+                            )
 
                     else:
                         typer.secho(

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -477,14 +477,19 @@ def _publish_exposure(
 
                     if publish:
                         typer.secho(publish_msg, fg=typer.colors.GREEN)
-                        with open(fpath, "rb") as fp:
-                            upload_to_ckan(
-                                url=destination.url,
-                                fname=fname,
-                                fsize=fsize,
-                                file=fp,
-                                resource_id=resource.id,
-                            )
+                        try:
+                            with open(fpath, "rb") as fp:
+                                upload_to_ckan(
+                                    url=destination.url,
+                                    fname=fname,
+                                    fsize=fsize,
+                                    file=fp,
+                                    resource_id=resource.id,
+                                )
+                        except requests.exceptions.RequestException as e:
+                            print(e)
+                            pass
+
                     else:
                         typer.secho(
                             f"would be {publish_msg} if --publish",


### PR DESCRIPTION
# Description

As described in #3182, when trying to upload data to the open data portal (CKAN), if one file fails (specifically, stop times tends to fail because of its size), then the subsequent files (in alphabetical order) are not even attempted.

This PR adds exception handling to `warehouse/scripts/publish.py` so that if one file upload fails the others are attemped.

Resolves #3182 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature

## How has this been tested?

Will have to test in prod as this is an error generated by Caltrans servers

## Post-merge follow-ups
- [x] No action required

