### PR TITLE
Add row access policy for Elavon data

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -33,9 +33,9 @@ filter using (
 ) }};
 
 {{ create_row_access_policy(
-filter_column = 'participant_id',
-filter_value = 'sbmtd',
-principals = ['serviceAccount:sbmtd-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+    filter_column = 'participant_id',
+    filter_value = 'sbmtd',
+    principals = ['serviceAccount:sbmtd-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
 ) }};
 
 {{ create_row_access_policy(
@@ -77,6 +77,82 @@ principals = ['serviceAccount:sbmtd-payments-user@cal-itp-data-infra.iam.gservic
 {{ create_row_access_policy(
     filter_column = 'participant_id',
     filter_value = 'atn',
+    principals = ['serviceAccount:atn-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+                  'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
+                  'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
+                  'group:cal-itp@jarv.us',
+                  'domain:calitp.org',
+                  'user:angela@compiler.la',
+                  'user:easall@gmail.com',
+                  'user:jeremyscottowades@gmail.com',
+                 ]
+) }};
+-- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context
+{% endmacro %}
+
+{% macro payments_elavon_row_access_policy() %}
+
+{{ create_row_access_policy(
+    filter_column = 'Monterey-Salinas Transit',
+    filter_value = 'mst',
+    principals = ['serviceAccount:mst-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Sacramento Regional Transit District',
+    principals = ['serviceAccount:sacrt-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Santa Barbara Metropolitan Transit District',
+    principals = ['serviceAccount:sbmtd-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Santa Barbara County Association of Governments',
+    principals = ['serviceAccount:clean-air-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }}   ;
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Capitol Corridor Joint Powers Authority',
+    principals = ['serviceAccount:ccjpa-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Humboldt Transit Authority',
+    principals = ['serviceAccount:humboldt-transit-authority@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Lake Transit Authority',
+    principals = ['serviceAccount:lake-transit-authority@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Mendocino Transit Authority',
+    principals = ['serviceAccount:mendocino-transit-authority@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Redwood Coast Transit Authority',
+    principals = ['serviceAccount:redwood-coast-transit@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Anaheim Transportation Network',
     principals = ['serviceAccount:atn-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
 ) }};
 

--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -18,7 +18,7 @@ filter using (
 )
 {% endmacro %}
 
-{% macro payments_row_access_policy() %}
+{% macro payments_littlepay_row_access_policy() %}
 
 {{ create_row_access_policy(
     filter_column = 'participant_id',

--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -86,9 +86,6 @@ filter using (
                   'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',
                   'domain:calitp.org',
-                  'user:angela@compiler.la',
-                  'user:easall@gmail.com',
-                  'user:jeremyscottowades@gmail.com',
                  ]
 ) }};
 -- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context
@@ -162,9 +159,6 @@ filter using (
                   'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',
                   'domain:calitp.org',
-                  'user:angela@compiler.la',
-                  'user:easall@gmail.com',
-                  'user:jeremyscottowades@gmail.com',
                  ]
 ) }};
 -- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context

--- a/warehouse/models/mart/payments/fct_payments_adjustment_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_adjustment_transactions.sql
@@ -1,3 +1,6 @@
+{{ config(materialized = 'table',
+    post_hook="{{ payments_elavon_row_access_policy() }}") }}
+
 WITH adjustments AS ( -- noqa: ST03
     SELECT *
     FROM {{ ref('stg_elavon__transactions') }}

--- a/warehouse/models/mart/payments/fct_payments_aggregations.sql
+++ b/warehouse/models/mart/payments/fct_payments_aggregations.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized = 'table',
-    post_hook="{{ payments_row_access_policy() }}"
+    post_hook="{{ payments_littlepay_row_access_policy() }}"
     )
 }}
 

--- a/warehouse/models/mart/payments/fct_payments_billing_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_billing_transactions.sql
@@ -1,3 +1,6 @@
+{{ config(materialized = 'table',
+    post_hook="{{ payments_elavon_row_access_policy() }}") }}
+
 WITH billing AS ( -- noqa: ST03
     SELECT *
     FROM {{ ref('int_elavon__billing_transactions') }}

--- a/warehouse/models/mart/payments/fct_payments_chargeback_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_chargeback_transactions.sql
@@ -1,3 +1,6 @@
+{{ config(materialized = 'table',
+    post_hook="{{ payments_elavon_row_access_policy() }}") }}
+
 WITH chargebacks AS ( -- noqa: ST03
     SELECT *
     FROM {{ ref('stg_elavon__transactions') }}

--- a/warehouse/models/mart/payments/fct_payments_deposit_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_deposit_transactions.sql
@@ -1,3 +1,6 @@
+{{ config(materialized = 'table',
+    post_hook="{{ payments_elavon_row_access_policy() }}") }}
+
 WITH deposits AS ( -- noqa: ST03
     SELECT *
     FROM {{ ref('int_elavon__deposit_transactions') }}

--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -1,5 +1,5 @@
 {{ config(
-    post_hook="{{ payments_row_access_policy() }}"
+    post_hook="{{ payments_littlepay_row_access_policy() }}"
 ) }}
 
 WITH

--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -1,6 +1,5 @@
-{{ config(
-    post_hook="{{ payments_littlepay_row_access_policy() }}"
-) }}
+{{ config(materialized = 'table',
+    post_hook="{{ payments_littlepay_row_access_policy() }}") }}
 
 WITH
 

--- a/warehouse/models/mart/payments/fct_payments_settlements.sql
+++ b/warehouse/models/mart/payments/fct_payments_settlements.sql
@@ -1,5 +1,5 @@
 {{ config(materialized = 'table',
-    post_hook="{{ payments_row_access_policy() }}") }}
+    post_hook="{{ payments_littlepay_row_access_policy() }}") }}
 
 WITH settlements AS (
     SELECT *

--- a/warehouse/models/mart/payments/reliability/v2_payments_reliability_weekly_unlabeled_routes.sql
+++ b/warehouse/models/mart/payments/reliability/v2_payments_reliability_weekly_unlabeled_routes.sql
@@ -1,3 +1,6 @@
+{{ config(materialized = 'table',
+    post_hook="{{ payments_littlepay_row_access_policy() }}") }}
+
 WITH payments_rides AS (
     SELECT * FROM {{ ref('fct_payments_rides_v2') }}
 ),


### PR DESCRIPTION
# Description

In order to expose Elavon-related data in Metabase for use in agency-specific dashboards and by agencies, we need to implement a row-access policy similar to what we previously implemented for Littlepay data. This PR accomplishes that by creating a new macro called `payments_elavon_row_access_policy` and adding it to the tables that consume Elavon data which will be exposed in Metabase (`fct_payments_deposit_transactions`, `fct_payments_chargeback_transactions`, `fct_payments_billing_transactions`, `fct_payments_adjustment_transactions`)

Note: This row access policy groups broadly by organization, so that all of their their sub-Elavon `customer_name`s are included in the filter (ex `Humboldt Transit Authority` includes `HTA TAP TO PAY`, `HTA OFFICE SALES`, `HTA PARATRANSIT`, `HTA VIRTUAL`). When trying to reconcile transactions with Littlepay, some of these `customer_name`s may need to be filtered out at time of analysis as they don't get run through Littlepay's system (only Elavon's) and thus aren't represented in Littlepay's data.

This PR also adds a row access policy for the only other table used in agency-specific Metabase dashboards (`v2_payments_reliability_weekly_unlabeled_routes`), and specifies the materialization for the `fct_payments_rides_v2` as table (which it was already doing by default, just added specificity to the file)

Resolves: #3230 

## Type of change

- [x] New feature

## How has this been tested?

is there a way to test with these service accounts specified? otherwise the logic in this macro works elsewhere

## Post-merge follow-ups
Remove the unnecessary `participant_id` filter from the `Journeys with Unlabeled Routes`
