### PR TITLE
include `fct_elavon_transactions` in row access policy

### DIFF
--- a/warehouse/models/mart/payments/fct_elavon__transactions.sql
+++ b/warehouse/models/mart/payments/fct_elavon__transactions.sql
@@ -1,4 +1,5 @@
-{{ config(materialized='table') }}
+{{ config(materialized = 'table',
+    post_hook="{{ payments_elavon_row_access_policy() }}") }}
 
 WITH
 


### PR DESCRIPTION
# Description

PR #3229 added a row-access policy to Elavon mart tables, similar to the policy we implemented for Littlepay data. Since merging that PR we've realized that we would also like to apply the row-access policy to the table `fct_elavon_transactions`. This PR adds the policy to that table.

## Type of change

- [x] New feature

## Post-merge follow-ups

- [x] No action required