### PR TITLE
Update Validator Upgrade Instructions with New Example PR

### DIFF
--- a/jobs/gtfs-schedule-validator/README.md
+++ b/jobs/gtfs-schedule-validator/README.md
@@ -10,13 +10,12 @@ of the underlying data. The RT code was written prior to substantial changes to
 `calitp-py` and therefore bundles together shared functionality that will eventually
 live in `calitp-py`.
 
-See [this PR](https://github.com/cal-itp/data-infra/pull/2893) for an example of how
-to integrate new versions of the underlying MD-stewarded validator into our validation
-process - specifically, changes to [`gtfs_schedule_validator_hourly.py`](https://github.com/cal-itp/data-infra/pull/2893/files#diff-f970d61c9ce49b3899e7b309610f43fca51d29eaae4d5db192208540bc4da702) and
-[the `Dockerfile`](https://github.com/cal-itp/data-infra/pull/2893/files#diff-de54f054016ca4e44544d4081d2798a21aa43790c3faea3967f6f5b255529f1a), and the
-addition of [a new JAR file](https://github.com/cal-itp/data-infra/pull/2893/files#diff-628dcc44a01286366e42ab8fd440d213d764d8a76f41f268e378a14628e8447c)
-corresponding to the new validator version being referenced (taken from the Assets
-section at the bottom of [the new validator version's release page](https://github.com/MobilityData/gtfs-validator/releases/tag/v4.1.0)).
+See [this PR](https://github.com/cal-itp/data-infra/pull/3238) for an example of how to
+integrate new versions of the underlying MD-stewarded validator into our validation
+process - note the addition of a new JAR file corresponding to the new validator version
+being referenced (taken from the Assets section at the bottom of [the new validator version's release page](https://github.com/MobilityData/gtfs-validator/releases/tag/v4.2.0)),
+and a corresponding list of rules and their short descriptions adopted from the canonical
+validator [rules list](https://gtfs-validator.mobilitydata.org/rules.html).
 
 In order to respect past validation outcomes, we don't re-validate old data using the latest
 available version of the validator. Instead, we use extract dates to determine which


### PR DESCRIPTION
# Description

Following up on #3152, updates the upgrade documentation for the GTFS validator version we use internally to use that PR as an example of the upgrade steps necessary to take in code. This replaces some links to specific commits on an older, messier PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

New docs and their links tested and linted successfully.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
