### PR TITLE
Ignore frequency rows with 0-value headways in frequencies_stop_times

### DIFF
--- a/warehouse/models/intermediate/gtfs/int_gtfs_schedule__frequencies_stop_times.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_schedule__frequencies_stop_times.sql
@@ -67,6 +67,7 @@ int_gtfs_schedule__frequencies_stop_times AS (
         WITH OFFSET AS iteration_num
     -- if end time_sec = headway_secs * [some integer] + start_time_sec, then we're not actually supposed to have a trip that starts at end_time_sec
     WHERE start_time_sec + iteration_num * headway_secs < end_time_sec
+    AND headway_secs > 0
 )
 
 SELECT * FROM int_gtfs_schedule__frequencies_stop_times


### PR DESCRIPTION
# Description

In today's transform_warehouse DAG run, the dbt_run_and_upload_artifacts task tripped up on the `int_gtfs_schedule__frequencies_stop_times` model because two `headway_secs` values of 0 came in from an LAX FlyAway `frequencies.txt`, violating a GTFS standard rule that all such values need to be positive integers. This broke some array creation code.

This fix ignores `dim_frequencies` rows with improper 0-value headways when making the `frequencies_stop_times` model. No valid data will be ignored by the fix, since none of the impacted rows are compliant with the GTFS spec.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Model built and tested in the staging warehouse environment.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After merging, I'll clear and rerun today's transform_warehouse DAG run.