### PR TITLE
Update outdated Slack channel references in repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -36,7 +36,7 @@ Slack Username:
 
 - [ ] Added to Slack channels:
 
-  - [ ] #data-analyses
+  - [ ] #data-analysis
   - [ ] #data-office-hours
   - [ ] #data
   - [ ] #ct-bdat-internal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contribution guidelines
 
 These guidelines are meant to provide a foundation for collaboration in Cal-ITP's data services repos,
-primarily [#data-infra](https://github.com/cal-itp/data-infra).
+primarily [data-infra](https://github.com/cal-itp/data-infra).
 
 ## Issues
 

--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -7,7 +7,7 @@ from gusty import create_dag
 
 import airflow  # noqa
 
-# pointed at #data-infra-notify as of 2022-02-01
+# pointed at #alerts-data-infra as of 2024-02-05
 CALITP_SLACK_URL_KEY = "CALITP_SLACK_URL"
 
 # DAG Directories =============================================================

--- a/docs/airflow/dags-maintenance.md
+++ b/docs/airflow/dags-maintenance.md
@@ -6,7 +6,7 @@ We use [Airflow](https://airflow.apache.org/) to orchestrate our data ingest pro
 
 ## Monitoring DAGs
 
-When an Airflow DAG task fails, it will alert to the `#data-infra-alerts` channel in Slack.
+When an Airflow DAG task fails, it will alert to the `#alerts-data-infra` channel in Slack.
 
 In that case, someone should respond according to the considerations described below and in each individual DAG's documentation (available in [each DAG subdirectory](https://github.com/cal-itp/data-infra/tree/main/airflow/dags) in the `data-infra` GitHub repository).
 

--- a/docs/transit_database/transitdatabase.md
+++ b/docs/transit_database/transitdatabase.md
@@ -1,6 +1,6 @@
 # Transit Database (Airtable)
 
-The Cal-ITP Airtable Transit Database stores key relationships about how transit services are organized and operated in California as well as how well they are performing. See Evan or post in the `#airtable-data` Slack channel to get a link and gain access.
+The Cal-ITP Airtable Transit Database stores key relationships about how transit services are organized and operated in California as well as how well they are performing. See Evan or post in the `#data-airtable` Slack channel to get a link and gain access.
 
 Important Airtable documentation is maintained elsewhere:
 

--- a/runbooks/workflow/disk-space.md
+++ b/runbooks/workflow/disk-space.md
@@ -1,6 +1,6 @@
 # Resolving Disk Space Usage and Pod Offset Errors
 
-We have an [alert](https://monitoring.calitp.org/alerting/grafana/Geo72Nf4z/view) that will trigger when any Kubernetes volume is more than 80% full, placing a message in the #data-infra-alerts channel of the Cal-ITP Slack group. The resolution path will depend on the affected service.
+We have an [alert](https://monitoring.calitp.org/alerting/grafana/Geo72Nf4z/view) that will trigger when any Kubernetes volume is more than 80% full, placing a message in the `#alerts-data-infra` channel of the Cal-ITP Slack group. The resolution path will depend on the affected service.
 
 After following any of these specific runbook sections, check the Disk Usage section of the general [Kubernetes dashboard](https://monitoring.calitp.org/d/oWe9aYxmk/1-kubernetes-deployment-statefulset-daemonset-metrics) in Grafana to verify the disk space consumption has decreased to a safe level for any impacted volumes. The alert should also show as resolved in Slack a couple minutes after recovery.
 


### PR DESCRIPTION
# Description

In late 2023, several Cal-ITP Slack channels were renamed as part of a Slack reorganization effort. This PR updates some channel references in docs and in code comments, and also cleans up a couple older channel name typos (and one instance where the `data-infra` _repo_ was inadvertently referenced with a hashtag on the front as if it was a Slack channel.

Note that this PR focuses on Slack channels within the orbit of the Data Services team, so it's possible that references to Caltrans internal channels that I do not have access to may remain in need of changes.

Resolves #3167

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

Docs linted successfully locally

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
