### PR TITLE
Update jupyter-singleuser version referenced in JupyterHub chart

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -8,7 +8,7 @@ jupyterhub:
     defaultUrl: "/lab"
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
-      tag: 2023.8.1
+      tag: 2024.2.5
     memory:
       # Much more than 10 and we risk bumping up against the actual capacity of e2-highmem-2
       limit: 10G


### PR DESCRIPTION
# Description

Following up on #3265 now that the new `jupyter-singleuser` image is merged and published, this changes the version of that image automatically brought in by our JupyterHub chart for notebooks.calitp.org.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

This will be tested upon rollout, and can be rolled back if needed. The changes to the image itself were tested in the previous PR.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor rollout to ensure no breakages of people's workflows.