### PR TITLE
Match metabase-test config with prod config for future testing needs

### DIFF
--- a/kubernetes/apps/values/metabase-test.yaml
+++ b/kubernetes/apps/values/metabase-test.yaml
@@ -1,6 +1,6 @@
 images:
   metabase:
-    src: metabase/metabase:v0.47.0-RC1
+    src: metabase/metabase:v0.46.6.1
 
 workloads:
   metabase:


### PR DESCRIPTION
# Description

At some point, our test Metabase environment took on a different configuration than the prod environment - we brought in v0.47.0-RC1 but never rolled it out to prod. This PR reverts the environment to v0.46.6.1, after which point we'll pull a DB backup off of prod and make the two mirror each other for safe future testing of infra changes.

Partial progress toward #3247

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Risks of breakage are minimal from this downgrade - our intent is to demolish the current config on the test Metabase instance and restore a prod-like config there, so errors resulting from the downgrade are of little importance.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Restore the test Metabase DB to a prod-like state to use for future testing