### PR TITLE
HOTFIX TDQI Airtable external table to enable CT services ID mapping

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_services.yml
@@ -18,6 +18,9 @@ schema_fields:
   - name: id
     type: STRING
     mode: NULLABLE
+  - name: name
+    type: STRING
+    mode: NULLABLE
   - name: operator
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION
# Description

Iterating on #3285, this brings in the "name" field in our `transit_data_quality_issues__services` external table, which is required by the `transit_database_synced_table_id_mapping` macro. This should be our last step to resolve the current modeling failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested dbt macro locally with a faked version of the external table

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Rerun the `base_tdqi_services_ct_services_map` model and failed models downstream of it
