### PR TITLE
Move Elavon Secret Fetch Away from Top Level of Raw Sync DAG

### DIFF
--- a/airflow/dags/sync_elavon/elavon_to_gcs_raw.py
+++ b/airflow/dags/sync_elavon/elavon_to_gcs_raw.py
@@ -12,7 +12,6 @@ from calitp_data_infra.storage import get_fs
 CALITP__ELAVON_SFTP_HOSTNAME = os.environ["CALITP__ELAVON_SFTP_HOSTNAME"]
 CALITP__ELAVON_SFTP_PORT = os.environ["CALITP__ELAVON_SFTP_PORT"]
 CALITP__ELAVON_SFTP_USERNAME = os.environ["CALITP__ELAVON_SFTP_USERNAME"]
-CALITP__ELAVON_SFTP_PASSWORD = get_secret_by_name("CALITP__ELAVON_SFTP_PASSWORD")
 CALITP_BUCKET__ELAVON_RAW = os.environ["CALITP_BUCKET__ELAVON_RAW"]
 
 
@@ -29,7 +28,7 @@ def mirror_raw_files_from_elavon():
         hostname=CALITP__ELAVON_SFTP_HOSTNAME,
         port=CALITP__ELAVON_SFTP_PORT,
         username=CALITP__ELAVON_SFTP_USERNAME,
-        password=CALITP__ELAVON_SFTP_PASSWORD,
+        password=get_secret_by_name("CALITP__ELAVON_SFTP_PASSWORD"),
     )
 
     # Create SFTP client and navigate to data directory


### PR DESCRIPTION
# Description

This moves a function call to `get_secret_by_name()` out of the top level of the `sync_elavon` DAG's Python code, where it was getting run regularly as Airflow parsed each DAG. The previous behavior was fine in prod, but stymied local developers who lacked permissions on the Google Secret Manager secret being fetched by that function call, preventing the DAG from loading correctly. This solution has the added advantage of reducing the number of API calls to Google Secret Manager, since this function won't be run under the hood by Airflow anymore.

Resolves #3289 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested function of the new code placement via local Airflow

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
