### PR TITLE
Unpin Python version used by lint Action now that dbt-core supports 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: '3.11.7'
       - uses: pre-commit/action@v3.0.0
       - uses: crate-ci/typos@master
         with:


### PR DESCRIPTION
# Description

Resolves #3184 now that dbt-core officially supports Python 3.12 as of [v1.79.0](https://github.com/dbt-labs/dbt-core/releases/tag/v1.7.9).

As described in the initial Issue description, we take slightly different approaches to managing Python version deps in different places, including in other CI tasks. This PR solves the Issue as planned, but we should likely more broadly scope a "standard" approach (or set of approaches) to version management across the `data-infra` ecosystem of images, services, and tasks sometime in the future.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Linting tested locally, and CI task tested on the PR during draft phase.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
