### PR TITLE
Fix primary key for `fct_monthly_route_service_by_timeofday` 

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2125,7 +2125,7 @@ models:
     columns:
       - name: key
         description: |
-          Synthetic primary key constructed from `source_record_id`, `route_id`, `month`, `year`, and `time_of_day`.
+          Synthetic primary key constructed from `source_record_id`, `route_id`, `month`, `year`, `day_type`, and `time_of_day`.
         tests: *primary_key_tests
       - name: name
       - name: source_record_id
@@ -2143,12 +2143,12 @@ models:
           Actual calendar year (Pacific Time dates) in which this service was scheduled to occur.
       - name: day_type
         description: |
-          Actual calendar day type (Pacific Time dates) in which this service was scheduled to occur.
+          Actual calendar day type (Pacific Time dates) in which this service was scheduled to occur (Monday, Tuesday, etc).
           This means that overnight service is associated with the calendar date on which it was scheduled,
           even if it was associated with the prior `service_date` by the agency.
       - name: n_trips
         description: |
-          Total trips that occurred for the route for this month and `time_of_day`.
+          Total trips that occurred for the route for this month, `day_type` and `time_of_day`.
       - name: ttl_service_hours
         description: |
-          Total scheduled service hours that occurred for the route for this month and `time_of_day`.
+          Total scheduled service hours that occurred for the route for this month, `day_type`, and `time_of_day`.

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2094,7 +2094,8 @@ models:
     columns:
       - name: key
         description: |
-          Synthetic primary key constructed from `base64_url`, `route_id`, `month`, and `year`.
+          Synthetic primary key constructed from `base64_url`, `route_id`, `month`,
+          and `year`.
         tests: *primary_key_tests
       - name: source_record_id
         description: |
@@ -2118,14 +2119,17 @@ models:
           to look up feed and GTFS dataset attributes.
       - name: pt_array
         description: |
-          Array of points describing this shape, looked up from `dim_shapes_arrays` via `shape_array_key`.
+          Array of points describing this shape, looked up from `dim_shapes_arrays`
+          via `shape_array_key`.
   - name: fct_monthly_route_service_by_timeofday
     description: |
       An aggregation of GTFS schedule service by day and time characteristics.
     columns:
       - name: key
         description: |
-          Synthetic primary key constructed from `source_record_id`, `route_id`, `route_short_name`, `route_long_name`, `time_of_day`, `month`, `year`, and `day_type`.
+          Synthetic primary key constructed from `source_record_id`, `route_id`,
+          `route_short_name`, `route_long_name`, `time_of_day`, `month`, `year`,
+          and `day_type`.
         tests: *primary_key_tests
       - name: name
       - name: source_record_id
@@ -2143,12 +2147,14 @@ models:
           Actual calendar year (Pacific Time dates) in which this service was scheduled to occur.
       - name: day_type
         description: |
-          Actual calendar day type (Pacific Time dates) in which this service was scheduled to occur (Monday, Tuesday, etc).
-          This means that overnight service is associated with the calendar date on which it was scheduled,
-          even if it was associated with the prior `service_date` by the agency.
+          Actual calendar day type (Pacific Time dates) in which this service was scheduled to
+          occur (Monday, Tuesday, etc).
+          This means that overnight service is associated with the calendar date on which it was
+          scheduled, even if it was associated with the prior `service_date` by the agency.
       - name: n_trips
         description: |
           Total trips that occurred for the route for this month, `day_type` and `time_of_day`.
       - name: ttl_service_hours
         description: |
-          Total scheduled service hours that occurred for the route for this month, `day_type`, and `time_of_day`.
+          Total scheduled service hours that occurred for the route for this month, `day_type`,
+          and `time_of_day`.

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2125,7 +2125,7 @@ models:
     columns:
       - name: key
         description: |
-          Synthetic primary key constructed from `source_record_id`, `route_id`, `month`, `year`, `day_type`, and `time_of_day`.
+          Synthetic primary key constructed from `source_record_id`, `route_id`, `route_short_name`, `route_long_name`, `time_of_day`, `month`, `year`, and `day_type`.
         tests: *primary_key_tests
       - name: name
       - name: source_record_id

--- a/warehouse/models/mart/gtfs/fct_monthly_route_service_by_timeofday.sql
+++ b/warehouse/models/mart/gtfs/fct_monthly_route_service_by_timeofday.sql
@@ -94,7 +94,7 @@ daypart_aggregations AS (
 
 fct_monthly_route_service_by_timeofday AS (
     SELECT
-       {{ dbt_utils.generate_surrogate_key(['source_record_id', 'route_id', 'route_short_name', 'route_long_Name', 'day_type', 'month', 'year', 'time_of_day']) }} AS key,
+       {{ dbt_utils.generate_surrogate_key(['source_record_id', 'route_id', 'route_short_name', 'route_long_name', 'time_of_day', 'month', 'year', 'day_type']) }} AS key,
         name,
         source_record_id,
         route_id,

--- a/warehouse/models/mart/gtfs/fct_monthly_route_service_by_timeofday.sql
+++ b/warehouse/models/mart/gtfs/fct_monthly_route_service_by_timeofday.sql
@@ -94,7 +94,7 @@ daypart_aggregations AS (
 
 fct_monthly_route_service_by_timeofday AS (
     SELECT
-       {{ dbt_utils.generate_surrogate_key(['source_record_id', 'route_id', 'month', 'year', 'time_of_day']) }} AS key,
+       {{ dbt_utils.generate_surrogate_key(['source_record_id', 'route_id', 'route_short_name', 'route_long_Name', 'day_type', 'month', 'year', 'time_of_day']) }} AS key,
         name,
         source_record_id,
         route_id,


### PR DESCRIPTION
# Description

Add all the columns, `source_record_id`, all route columns, `day_type`, and `time_of_day` into generating the key. 

Resolves #3301 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

* Create table: `poetry run dbt run -s fct_monthly_route_service_by_timeofday`
* Test table for uniqueness `poetry run dbt test -s fct_monthly_route_service_by_timeofday`

<img width="552" alt="fct_monthly_service" src="https://github.com/cal-itp/data-infra/assets/49657200/f71040f4-bb03-4d31-a2e8-3874f215ddff">


## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
