### PR TITLE
Fuzzy Key Uniqueness Threshold for fct_vehicle_locations

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -354,15 +354,7 @@ models:
       level.
     columns:
       - name: key
-        description: |
-          Synthetic primary key.
-        tests:
-          - unique:
-              config:
-                where: '__rt_sampled__'
-          - not_null:
-              config:
-                where: '__rt_sampled__'
+        tests: *almost_unique_rt_key_tests
       - <<: *rt_trip_id
         tests:
           - not_null:

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
@@ -1,8 +1,14 @@
 {{
     config(
         materialized='incremental',
-        unique_key = 'key',
-        cluster_by = ['service_date', 'base64_url'],
+        incremental_strategy='insert_overwrite',
+        partition_by = {
+            'field': 'dt',
+            'data_type': 'date',
+            'granularity': 'day',
+        },
+        cluster_by=['service_date', 'base64_url'],
+        on_schema_change='append_new_columns'
     )
 }}
 

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
@@ -7,7 +7,7 @@
             'data_type': 'date',
             'granularity': 'day',
         },
-        cluster_by=['service_date', 'base64_url'],
+        cluster_by=['dt', 'base64_url'],
         on_schema_change='append_new_columns'
     )
 }}


### PR DESCRIPTION
# Description

We recently encountered an issue in which a time zone change in a schedule feed caused semi-duplicate entries to appear in our raw GTFS-RT data, which mapped to true duplicate keys using our current key generation logic in models like `fct_vehicle_positions_trip_summaries` and prevented runs of the `fct_vehicle_locations` model. That issue is described in more detail in #3299.

We cannot change the behavior of raw incoming data, so this requires a workaround in modeling. Initially I believed that it might be possible to solve relatively early in the modeling process by choosing the incoming rows with the "correct" updated time zone, but implementing logic to do so would rely on too much guesswork about how the related data is being generated and sent by feed providers to arrive at a decision about correctness of one semi-duplicate row vs. another. There are some heuristics we could use that are _usually_ correct, but not guaranteed. This could break modeling down the road in less easily identifiable ways, so I wouldn't recommend going down that path.

Instead, this PR endeavors to loosen the uniqueness tests on `fct_vehicle_locations` and implement an updated incremental strategy on that table to support the loosened uniqueness constraints, using `insert_overwrite` based on `dt`. This is consistent with other related models like `fct_trip_updates_no_stop_times` that rely on similar sources and are too large to reload in full each day. Since `fct_vehicle_locations` has no direct descendant models, introducing a small number of key duplicates will not cause test issues on other models.

Another possible approach would be to add `schedule_feed_timezone` as a column for key generation on `fct_vehicle_locations` and some of its precursor models. That approach, which would guarantee a unique key in `fct_vehicle_locations`, is drafted in [this alternate branch](https://github.com/cal-itp/data-infra/compare/main...soren-timezone_change_bugfix). However, doing so would artificially tether time zone to more "fundamental" columns currently used for key generation on these models, would require us to re-key (AKA fully reload) each impacted model, and would also risk proliferating many new rows in `fct_vehicle_locations` depending on historic presence, absence, and changes to feed time zones before this most recent issue occurred. For that reason, I recommend taking the path laid out in this PR, wherein a small, manageable handful of semi-duplicate rows would get introduced under an allowable uniqueness threshold of 99.9% (like in `fct_trip_updates_no_stop_times`, `fct_stop_time_updates`, and other models that use the `almost_unique_rt_key_tests` test formulation).

Resolves #3299

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

This PR and alternate path tested locally with long lookback periods. This PR produced a handful of predicted semi-duplicates in the `fct_vehicle_locations` model. The alternate-approach branch linked in the description of this PR produced a larger number of new rows in `fct_vehicle_locations`, stemming from fanout from the new key formulation.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Rerun the impacted models and their predecessors over a lookback period pointing back to the first days of March to bring in rows that were previously deleted ad hoc in order to surmount the initial `fct_vehicle_locations` generation issue when it was first reported.