### PR TITLE
Temporarily restore transform_warehouse DAG to daily cadence

### DIFF
--- a/airflow/dags/transform_warehouse/METADATA.yml
+++ b/airflow/dags/transform_warehouse/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Builds and tests the warehouse, and uploads artifacts"
-schedule_interval: "0 14 * * 1-6"
+schedule_interval: "0 14 * * *"
 tags:
   - all_gusty_features
 default_args:


### PR DESCRIPTION
# Description

See [this thread](https://cal-itp.slack.com/archives/C01FNDG1ZPA/p1712007741803359?thread_ts=1711999007.700889&cid=C01FNDG1ZPA) for context. Can be merged as/if desired while I am offline.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

This crontab configuration was previously live for this DAG until a few weeks ago.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

This is intended as a temporary fix until we can get the scheduled Sunday full refresh DAG to kick off as expected.