### PR TITLE
Temporarily pin crate-ci/typos to avoid broken alerting on "png"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v3.0.0
-      - uses: crate-ci/typos@v1.19.0
+      - uses: crate-ci/typos@v1.19.0 # Set back to `master` after #967 on the typos repo is fixed
         with:
           files: ./docs/**
       - uses: snok/install-poetry@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v3.0.0
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@v1.19.0
         with:
           files: ./docs/**
       - uses: snok/install-poetry@v1


### PR DESCRIPTION
# Description

We use a source code spell checker to audit our `/docs` folder during each run of our linting CI task. Its most recent release, v1.20, introduced a false positive on variations of the "png" file extension, causing failed CI runs like [this one](https://github.com/cal-itp/data-infra/actions/runs/8514299791/job/23319759609). An Issue is open on the typos repository [here](https://github.com/crate-ci/typos/issues/967), but in the meantime we should revert to the previous version until a fix is out.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Will test live in CI, since this impacts the linting GitHub Action

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Unpin once the open issue about this problem on the typos repository is resolved in a new release.