### PR TITLE
Designate a real start_date for two weekly DAGs that previously used unworkable dynamic values

### DIFF
--- a/airflow/dags/copy_prod_archiver_configs_to_test/METADATA.yml
+++ b/airflow/dags/copy_prod_archiver_configs_to_test/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2024-03-28"
     email:
       - "evan.siroky@dot.ca.gov"
       - "hunter.owens@dot.ca.gov"

--- a/airflow/dags/copy_prod_archiver_configs_to_test/METADATA.yml
+++ b/airflow/dags/copy_prod_archiver_configs_to_test/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2024-03-28"
+    start_date: "2024-03-24"
     email:
       - "evan.siroky@dot.ca.gov"
       - "hunter.owens@dot.ca.gov"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/METADATA.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2024-03-28"
     email:
       - "evan.siroky@dot.ca.gov"
       - "hunter.owens@dot.ca.gov"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/METADATA.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2024-03-28"
+    start_date: "2024-03-24"
     email:
       - "evan.siroky@dot.ca.gov"
       - "hunter.owens@dot.ca.gov"


### PR DESCRIPTION
# Description

In #2626 and #3110, we created two weekly DAGs whose dynamic values for `start_date` tripped up scheduler expectations for the data interval. Setting `start_date` dynamically [is not generally recommended](https://airflow.apache.org/docs/apache-airflow/stable/faq.html#what-s-the-deal-with-start-date), but we've historically used the !days_ago setting in a few daily DAGs. The typical !days_ago configuration we used for daily DAGs don't work the same way for weekly DAGs.

This PR sets an explicit `start_date` for the two impacted DAGs, which have failed to start since they were first merged because their data interval and start date were misaligned (you can read more about the "why" in [this blog post](https://whigy.medium.com/why-my-scheduled-dag-does-not-run-9e2811b5030b)). Once merged, we should see one catchup run of each of them and then correct function on their weekly schedule.

Note that the full refresh DAG may produce errors on its first run - that is expected, since we haven't regularly run a full refresh of non-RT data before and we probably have kinks to work out.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

New `start_date` setting tested on local Airflow.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor production Airflow to ensure that the changes take effect as expected, kicking off one run of each DAG aligning with the previous data interval.

In the long term, Airflow 2.2 and above introduced [timetables](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timetable.html#timetables), which may simplify scheduling for our use case somewhat. We should investigate feasibility to switch to timetable-based scheduling in the future.