### PR TITLE
Test calitp-data-infra package changes with Airflow

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -79,6 +79,8 @@ docker-compose run airflow tasks test unzip_and_validate_gtfs_schedule_hourly va
 
 - `docker-compose up` exits with code 137 - Check that Docker has enough RAM (e.g. 8Gbs). See [this post](https://stackoverflow.com/questions/44533319/how-to-assign-more-memory-to-docker-container) on how to increase its resources.
 
+- When testings new an updated `requirements.txt`, you might not see packages update.  You may need to run `docker-compose down --rmi all` to clear out older docker images and recreate with `docker build . --no-cache`.
+
 ## Deploying Changes to Production
 
 We have a [GitHub Action](../.github/workflows/deploy-airflow.yml) that runs when PRs touching this directory merge to the `main` branch. The GitHub Action updates the requirements sourced from [requirements.txt](./requirements.txt) and syncs the [DAGs](./dags) and [plugins](./plugins) directories to the bucket that Composer watches for code/data to parse. As of 2024-02-12, this bucket is `us-west2-calitp-airflow2-pr-88ca8ec6-bucket`.

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_services.yml
@@ -14,13 +14,3 @@ hive_options:
   require_partition_filter: false
   mode: AUTO
   source_uri_prefix: "transit_data_quality_issues__services/"
-schema_fields:
-  - name: id
-    type: STRING
-    mode: NULLABLE
-  - name: name
-    type: STRING
-    mode: NULLABLE
-  - name: operator
-    type: STRING
-    mode: NULLABLE

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp-data-infra==2024.2.12.post1
+calitp-data-infra==2024.4.1
 gusty==0.6.0
 pyairtable==2.2.1
 pydantic==1.9


### PR DESCRIPTION
# Description

Changes the packages of requirements.txt for the airflow and changes the schema of external_airtable_transit_data_quality_issues_services.yml.  This allows us to handle column names from airtable that might start with a number.

Resolves #3283 (again)

## Type of change

- [x] New feature

## How has this been tested?
Needed to run these commands:
```
docker-compose down --rmi all

docker build . --no-cache

docker-compose run airflow tasks test airtable_loader_v2 transit_data_quality_issues_services

docker-compose run airflow tasks test create_external_tables external_airtable_transit_data_quality_issues_services
```
Afterwards this table:
`SELECT * FROM `cal-itp-data-infra-staging.external_airtable.transit_data_quality_issues__services` LIMIT 1000`
Goes from having 5 columns to all the columns from the airtable including `_2021_ntd_id__from_provider_`

Also reran `airtable_loader_v2` with local docker and it does fine.
## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
Perhaps test the whole dbt run.