### PR TITLE
Fix: correct column names in Benefits backfill CTE

### DIFF
--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -101,9 +101,9 @@ fct_old_enrollments AS (
       WHEN client_event_time >= '2022-08-12T07:00:00Z'
         THEN "(MST) CDT claims via Login.gov"
     END as event_properties_eligibility_verifier,
-    event_properties_error.name,
-    event_properties_error.status,
-    event_properties_error.sub,
+    event_properties_error_name,
+    event_properties_error_status,
+    event_properties_error_sub,
     event_properties_href,
     event_properties_language,
     event_properties_origin,


### PR DESCRIPTION
Follow up to #3325 / #3329.

`json_extract_column` normalizes the JSON structure and flattens to columns named with underscores. There was a bug in how some of these JSON extracted columns were being selected.

# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Fixes DAG failure for this job, see e.g. https://b2062ffca77d44a28b4e05f8f5bf4996-dot-us-west2.composer.googleusercontent.com/log?execution_date=2024-04-25T14%3A00%3A00%2B00%3A00&task_id=dbt_run_and_upload_artifacts&dag_id=transform_warehouse&map_index=-1

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
  - [ ] Ensure the DAG run does not throw an error
