### PR TITLE
Enhance ridership data - add vrm, vrh, and upt columns

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/monthly_ridership_with_adjustments_voms.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/monthly_ridership_with_adjustments_voms.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-data-products
+prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd_data_products.monthly_ridership_with_adjustments_voms
+  LIMIT 1;
+source_objects:
+  - "monthly-ridership-with-adjustments/voms/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd_data_products.monthly_ridership_with_adjustments_voms"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "monthly-ridership-with-adjustments/voms/{dt:DATE}/{ts:TIMESTAMP}/{year:INTEGER}/"

--- a/airflow/dags/create_external_tables/ntd_data_products/monthly_ridership_with_adjustments_vrh.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/monthly_ridership_with_adjustments_vrh.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-data-products
+prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd_data_products.monthly_ridership_with_adjustments_vrh
+  LIMIT 1;
+source_objects:
+  - "monthly-ridership-with-adjustments/vrh/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd_data_products.monthly_ridership_with_adjustments_vrh"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "monthly-ridership-with-adjustments/vrh/{dt:DATE}/{ts:TIMESTAMP}/{year:INTEGER}/"

--- a/airflow/dags/create_external_tables/ntd_data_products/monthly_ridership_with_adjustments_vrm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/monthly_ridership_with_adjustments_vrm.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-data-products
+prefix_bucket: true
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd_data_products.monthly_ridership_with_adjustments_vrm
+  LIMIT 1;
+source_objects:
+  - "monthly-ridership-with-adjustments/vrm/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd_data_products.monthly_ridership_with_adjustments_vrm"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "monthly-ridership-with-adjustments/vrm/{dt:DATE}/{ts:TIMESTAMP}/{year:INTEGER}/"

--- a/warehouse/models/intermediate/ntd/int_ntd.yml
+++ b/warehouse/models/intermediate/ntd/int_ntd.yml
@@ -2,6 +2,26 @@ version: 2
 models:
     - name: int_ntd__monthly_ridership_with_adjustments_upt
       description: |
-        Ridership
+        Ridership - upt
+      config:
+        materialized: table
+    - name: int_ntd__monthly_ridership_with_adjustments_vrm
+      description: |
+        Ridership - vrm
+      config:
+        materialized: table
+    - name: int_ntd__monthly_ridership_with_adjustments_vrh
+      description: |
+        Ridership - vrh
+      config:
+        materialized: table
+    - name: int_ntd__monthly_ridership_with_adjustments_voms
+      description: |
+        Ridership - voms
+      config:
+        materialized: table
+    - name: int_ntd__monthly_ridership_with_adjustments_joined
+      description: |
+        Ridership - joined
       config:
         materialized: table

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_joined.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_joined.sql
@@ -1,0 +1,56 @@
+{{ config(materialized="table") }}
+
+with
+    voms as (
+        select * from {{ ref("int_ntd__monthly_ridership_with_adjustments_voms") }}
+    ),
+
+    vrh as (select * from {{ ref("int_ntd__monthly_ridership_with_adjustments_vrh") }}),
+    vrm as (select * from {{ ref("int_ntd__monthly_ridership_with_adjustments_vrm") }}),
+    upt as (select * from {{ ref("int_ntd__monthly_ridership_with_adjustments_upt") }}),
+
+    int_ntd__monthly_ridership_with_adjustments_joined as (
+        select voms.*, upt.upt, vrm.vrm, vrh.vrh
+        from voms
+
+        full outer join
+            upt
+            on voms.ntd_id = upt.ntd_id
+            and voms.year = upt.year
+            and voms.mode = upt.mode
+            and voms.reporter_type = upt.reporter_type
+            and voms.agency = upt.agency
+            and voms._3_mode = upt._3_mode
+            and voms.period_month = upt.period_month
+            and voms.period_year = upt.period_year
+            and voms.tos = upt.tos
+            and voms.uza_name = upt.uza_name
+
+        full outer join
+            vrm
+            on voms.ntd_id = vrm.ntd_id
+            and voms.year = vrm.year
+            and voms.mode = vrm.mode
+            and voms.reporter_type = vrm.reporter_type
+            and voms.agency = vrm.agency
+            and voms._3_mode = vrm._3_mode
+            and voms.period_month = vrm.period_month
+            and voms.period_year = vrm.period_year
+            and voms.tos = vrm.tos
+            and voms.uza_name = vrm.uza_name
+
+        full outer join
+            vrh
+            on voms.ntd_id = vrh.ntd_id
+            and voms.year = vrh.year
+            and voms.mode = vrh.mode
+            and voms.reporter_type = vrh.reporter_type
+            and voms.agency = vrh.agency
+            and voms._3_mode = vrh._3_mode
+            and voms.period_month = vrh.period_month
+            and voms.period_year = vrh.period_year
+            and voms.tos = vrh.tos
+            and voms.uza_name = vrh.uza_name
+    )
+select *
+from int_ntd__monthly_ridership_with_adjustments_joined

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_joined.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_joined.sql
@@ -24,7 +24,7 @@ with
             and voms.period_month = upt.period_month
             and voms.period_year = upt.period_year
             and voms.tos = upt.tos
-            and voms.uza_name = upt.uza_name
+            and voms.mode_type_of_service_status = upt.mode_type_of_service_status
 
         full outer join
             vrm
@@ -37,7 +37,7 @@ with
             and voms.period_month = vrm.period_month
             and voms.period_year = vrm.period_year
             and voms.tos = vrm.tos
-            and voms.uza_name = vrm.uza_name
+            and voms.mode_type_of_service_status = vrm.mode_type_of_service_status
 
         full outer join
             vrh
@@ -50,7 +50,11 @@ with
             and voms.period_month = vrh.period_month
             and voms.period_year = vrh.period_year
             and voms.tos = vrh.tos
-            and voms.uza_name = vrh.uza_name
+            and voms.mode_type_of_service_status = vrh.mode_type_of_service_status
+    -- where voms.ntd_id not in ("10089", "20170", "30069", "90178", "90179")
+    -- These agencies have null for uace_cd and uza_name and perhaps are not good to
+    -- have in the dataset.
+    -- If you don't want them then add that where clause back in.
     )
 select *
 from int_ntd__monthly_ridership_with_adjustments_joined

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_upt.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_upt.sql
@@ -28,10 +28,10 @@ with
         select
             uza_name,
             uace_cd,
-            dt,
+            dt as _dt,
             ts,
             year,
-            ntd_id,
+            format("%06d", cast(ntd_id as int64)) as ntd_id,
             reporter_type,
             agency,
             mode_type_of_service_status,

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_upt.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_upt.sql
@@ -27,20 +27,20 @@ with
     int_ntd__monthly_ridership_with_adjustments_upt as (
         select
             uza_name,
-            uace_cd,
+            format("%05d", cast(uace_cd as int64)) as uace_cd,
             dt as _dt,
             ts,
             year,
             format("%06d", cast(ntd_id as int64)) as ntd_id,
+            legacy_ntd_id,
             reporter_type,
             agency,
             mode_type_of_service_status,
             mode,
             _3_mode,
             tos,
-            legacy_ntd_id,
-            split(period, '_')[offset(1)] as period_month,
             split(period, '_')[offset(2)] as period_year,
+            split(period, '_')[offset(1)] as period_month,
             upt
         from source_pivoted
         where

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_upt.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_upt.sql
@@ -31,7 +31,7 @@ with
             dt as _dt,
             ts,
             year,
-            format("%06d", cast(ntd_id as int64)) as ntd_id,
+            format("%05d", cast(ntd_id as int64)) as ntd_id,
             legacy_ntd_id,
             reporter_type,
             agency,

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_voms.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_voms.sql
@@ -1,0 +1,72 @@
+with
+    source_pivoted as (
+        {{
+            dbt_utils.unpivot(
+                cast_to="int",
+                relation=ref("stg_ntd__monthly_ridership_with_adjustments_voms"),
+                exclude=[
+                    "uza_name",
+                    "uace_cd",
+                    "dt",
+                    "ts",
+                    "year",
+                    "ntd_id",
+                    "reporter_type",
+                    "agency",
+                    "mode_type_of_service_status",
+                    "mode",
+                    "_3_mode",
+                    "tos",
+                    "legacy_ntd_id",
+                ],
+                field_name="period",
+                value_name="voms",
+            )
+        }}
+    ),
+    int_ntd__monthly_ridership_with_adjustments_voms as (
+        select
+            uza_name,
+            format("%05d", cast(uace_cd as int64)) as uace_cd,
+            dt as _dt,
+            ts,
+            year,
+            format("%06d", cast(ntd_id as int64)) as ntd_id,
+            legacy_ntd_id,
+            reporter_type,
+            agency,
+            mode_type_of_service_status,
+            mode,
+            _3_mode,
+            tos,
+            split(period, '_')[offset(2)] as period_year,
+            split(period, '_')[offset(1)] as period_month,
+            voms
+        from source_pivoted
+        where
+            mode in (
+                "DR",
+                "FB",
+                "LR",
+                "MB",
+                "SR",
+                "TB",
+                "VP",
+                "CB",
+                "RB",
+                "CR",
+                "YR",
+                "MG",
+                "MO",
+                "AR",
+                "TR",
+                "HR",
+                "OR",
+                "IP",
+                "AG",
+                "PB",
+                "CC"
+            )
+    )
+select *
+from int_ntd__monthly_ridership_with_adjustments_voms

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_voms.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_voms.sql
@@ -31,7 +31,7 @@ with
             dt as _dt,
             ts,
             year,
-            format("%06d", cast(ntd_id as int64)) as ntd_id,
+            format("%05d", cast(ntd_id as int64)) as ntd_id,
             legacy_ntd_id,
             reporter_type,
             agency,

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrh.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrh.sql
@@ -31,7 +31,7 @@ with
             dt as _dt,
             ts,
             year,
-            format("%06d", cast(ntd_id as int64)) as ntd_id,
+            format("%05d", cast(ntd_id as int64)) as ntd_id,
             legacy_ntd_id,
             reporter_type,
             agency,

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrh.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrh.sql
@@ -1,0 +1,72 @@
+with
+    source_pivoted as (
+        {{
+            dbt_utils.unpivot(
+                cast_to="int",
+                relation=ref("stg_ntd__monthly_ridership_with_adjustments_vrh"),
+                exclude=[
+                    "uza_name",
+                    "uace_cd",
+                    "dt",
+                    "ts",
+                    "year",
+                    "ntd_id",
+                    "reporter_type",
+                    "agency",
+                    "mode_type_of_service_status",
+                    "mode",
+                    "_3_mode",
+                    "tos",
+                    "legacy_ntd_id",
+                ],
+                field_name="period",
+                value_name="vrh",
+            )
+        }}
+    ),
+    int_ntd__monthly_ridership_with_adjustments_vrh as (
+        select
+            uza_name,
+            format("%05d", cast(uace_cd as int64)) as uace_cd,
+            dt as _dt,
+            ts,
+            year,
+            format("%06d", cast(ntd_id as int64)) as ntd_id,
+            legacy_ntd_id,
+            reporter_type,
+            agency,
+            mode_type_of_service_status,
+            mode,
+            _3_mode,
+            tos,
+            split(period, '_')[offset(2)] as period_year,
+            split(period, '_')[offset(1)] as period_month,
+            vrh
+        from source_pivoted
+        where
+            mode in (
+                "DR",
+                "FB",
+                "LR",
+                "MB",
+                "SR",
+                "TB",
+                "VP",
+                "CB",
+                "RB",
+                "CR",
+                "YR",
+                "MG",
+                "MO",
+                "AR",
+                "TR",
+                "HR",
+                "OR",
+                "IP",
+                "AG",
+                "PB",
+                "CC"
+            )
+    )
+select *
+from int_ntd__monthly_ridership_with_adjustments_vrh

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrm.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrm.sql
@@ -1,0 +1,72 @@
+with
+    source_pivoted as (
+        {{
+            dbt_utils.unpivot(
+                cast_to="int",
+                relation=ref("stg_ntd__monthly_ridership_with_adjustments_vrm"),
+                exclude=[
+                    "uza_name",
+                    "uace_cd",
+                    "dt",
+                    "ts",
+                    "year",
+                    "ntd_id",
+                    "reporter_type",
+                    "agency",
+                    "mode_type_of_service_status",
+                    "mode",
+                    "_3_mode",
+                    "tos",
+                    "legacy_ntd_id",
+                ],
+                field_name="period",
+                value_name="vrm",
+            )
+        }}
+    ),
+    int_ntd__monthly_ridership_with_adjustments_vrm as (
+        select
+            uza_name,
+            format("%05d", cast(uace_cd as int64)) as uace_cd,
+            dt as _dt,
+            ts,
+            year,
+            format("%06d", cast(ntd_id as int64)) as ntd_id,
+            legacy_ntd_id,
+            reporter_type,
+            agency,
+            mode_type_of_service_status,
+            mode,
+            _3_mode,
+            tos,
+            split(period, '_')[offset(2)] as period_year,
+            split(period, '_')[offset(1)] as period_month,
+            vrm
+        from source_pivoted
+        where
+            mode in (
+                "DR",
+                "FB",
+                "LR",
+                "MB",
+                "SR",
+                "TB",
+                "VP",
+                "CB",
+                "RB",
+                "CR",
+                "YR",
+                "MG",
+                "MO",
+                "AR",
+                "TR",
+                "HR",
+                "OR",
+                "IP",
+                "AG",
+                "PB",
+                "CC"
+            )
+    )
+select *
+from int_ntd__monthly_ridership_with_adjustments_vrm

--- a/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrm.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__monthly_ridership_with_adjustments_vrm.sql
@@ -31,7 +31,7 @@ with
             dt as _dt,
             ts,
             year,
-            format("%06d", cast(ntd_id as int64)) as ntd_id,
+            format("%05d", cast(ntd_id as int64)) as ntd_id,
             legacy_ntd_id,
             reporter_type,
             agency,

--- a/warehouse/models/mart/ntd/_mart_ntd.yml
+++ b/warehouse/models/mart/ntd/_mart_ntd.yml
@@ -45,13 +45,18 @@ models:
       - name: _is_current
         tests:
           - not_null
-  - name: dim_monthly_ntd_ridership_with_adjustments_upt
+  - name: dim_monthly_ntd_ridership_with_adjustments
     description: >-
-      Extracts of the NTD Monthly Ridership with adjustments - UPT tab
+      Extracts of the NTD Monthly Ridership with adjustments - VRM, VOMS, VRH,
+      and UPT
 
       For example, the Feb 2024 dataset is found at
       https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release.
 
+      Users are encouraged to use the glossary of transit terms located at
+      https://www.transit.dot.gov/ntd/national-transit-database-ntd-glossary or
+      the reporting manuals located at https://www.transit.dot.gov/ntd/manuals
+      for more detailed information.
 
       A Master File of all properties that currently report or reported monthly
       data during the period January 2002 - Current Calendar Year. The following
@@ -155,6 +160,9 @@ models:
           Next Generation NTD Database
         tests:
           - not_null
+      - name: year
+        description: The year this data was added to the mart and thus the ntd_id's year
+          as well.
       - name: reporter_type
         description: Reporter Type - Indicates the agency's reporter type (Building
           Reporter, Full Reporter, Reduced Asset Reporter,  Rural Reporter,
@@ -185,5 +193,58 @@ models:
       - name: period_year
         description: ""
       - name: upt
-        description: "Unlinked Passenger Trips – For the most recent closed-out annual
-          report year. "
+        description: >-
+          Unlinked Passenger Trips (UPT)
+
+          The number of passengers who board public transportation vehicles.
+          Passengers are counted each time they board vehicles no matter how
+          many vehicles they use to travel from their origin to their
+          destination.
+      - name: vrm
+        description: >-
+          Vehicle Revenue Miles (VRM)
+
+          The miles that vehicles are scheduled to or actually travel while in
+          revenue service. Vehicle revenue miles include:
+
+          •   Layover / recovery time.
+
+          Vehicle revenue miles exclude:
+
+          •   Deadhead;
+
+          •   Operator training;
+
+          •   Vehicle maintenance testing; and
+
+          •   Other non-revenue uses of vehicles.
+      - name: vrh
+        description: >-
+          Vehicle Revenue Hours (VRH)
+
+          The hours that vehicles are scheduled to or actually travel while in
+          revenue service. Vehicle revenue hours include:
+
+          •   Layover / recovery time.
+
+          Vehicle revenue hours exclude:
+
+          •   Deadhead;
+
+          •   Operator training;
+
+          •   Vehicle maintenance testing; and
+
+          •   Other non-revenue uses of vehicles.
+      - name: voms
+        description: >-
+          Vehicles Operated in Annual Maximum Service (VOMS)
+
+          The number of revenue vehicles operated to meet the annual maximum
+          service requirement. This is the revenue vehicle count during the peak
+          season of the year; on the week and day that maximum service is
+          provided. Vehicles operated in maximum service (VOMS) exclude:
+
+          •   Atypical days; or
+
+          •   One-time special events.

--- a/warehouse/models/mart/ntd/_mart_ntd.yml
+++ b/warehouse/models/mart/ntd/_mart_ntd.yml
@@ -50,7 +50,7 @@ models:
       Extracts of the NTD Monthly Ridership with adjustments - UPT tab
 
       For example, the Feb 2024 dataset is found at
-      https://www.transit.dot.gov/sites/fta.dot.gov/files/2024-04/February%202024%20Complete%20Monthly%20Ridership%20%28with%20adjustments%20and%20estimates%29_240402_0.xlsx.
+      https://www.transit.dot.gov/ntd/data-product/monthly-module-adjusted-data-release.
 
 
       A Master File of all properties that currently report or reported monthly
@@ -146,14 +146,10 @@ models:
       - name: uace_cd
         description: "Urban Area Census Code (UACE)  – A unique numeric identifier
           associated with the 2020 urban areas as defined by the U.S. Census. "
-      - name: dt
+      - name: _dt
         description: ""
       - name: ts
         description: ""
-      - name: year
-        tests:
-          - not_null
-        description: Manually entered during ingestion
       - name: ntd_id
         description: NTD ID – The Transit Property’s NTD identification number in the
           Next Generation NTD Database

--- a/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments.sql
+++ b/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments.sql
@@ -1,7 +1,7 @@
 {{ config(materialized="table") }}
 with
-    dim_monthly_ntd_ridership_with_adjustments_upt as (
-        select * from {{ ref("int_ntd__monthly_ridership_with_adjustments_upt") }}
+    dim_monthly_ntd_ridership_with_adjustments as (
+        select * from {{ ref("int_ntd__monthly_ridership_with_adjustments_joined") }}
     )
 select
     uza_name,
@@ -9,6 +9,7 @@ select
     _dt,
     ts,
     ntd_id,
+    year,
     reporter_type,
     agency,
     mode_type_of_service_status,
@@ -19,4 +20,7 @@ select
     period_year,
     period_month,
     upt,
-from dim_monthly_ntd_ridership_with_adjustments_upt
+    vrm,
+    vrh,
+    voms
+from dim_monthly_ntd_ridership_with_adjustments

--- a/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments_upt.sql
+++ b/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments_upt.sql
@@ -16,7 +16,7 @@ select
     _3_mode,
     tos,
     legacy_ntd_id,
-    period_month,
     period_year,
+    period_month,
     upt,
 from dim_monthly_ntd_ridership_with_adjustments_upt

--- a/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments_upt.sql
+++ b/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments_upt.sql
@@ -6,9 +6,8 @@ with
 select
     uza_name,
     uace_cd,
-    dt,
+    _dt,
     ts,
-    year,
     ntd_id,
     reporter_type,
     agency,

--- a/warehouse/models/staging/ntd/_src.yml
+++ b/warehouse/models/staging/ntd/_src.yml
@@ -8,3 +8,6 @@ sources:
     tables:
       - name: annual_database_agency_information
       - name: monthly_ridership_with_adjustments_upt
+      - name: monthly_ridership_with_adjustments_vrm
+      - name: monthly_ridership_with_adjustments_vrh
+      - name: monthly_ridership_with_adjustments_voms

--- a/warehouse/models/staging/ntd/_stg_ntd.yml
+++ b/warehouse/models/staging/ntd/_stg_ntd.yml
@@ -13,3 +13,6 @@ models:
         tests:
           - not_null
   - name: stg_ntd__monthly_ridership_with_adjustments_upt
+  - name: stg_ntd__monthly_ridership_with_adjustments_vrm
+  - name: stg_ntd__monthly_ridership_with_adjustments_vrh
+  - name: stg_ntd__monthly_ridership_with_adjustments_voms

--- a/warehouse/models/staging/ntd/stg_ntd__monthly_ridership_with_adjustments_voms.sql
+++ b/warehouse/models/staging/ntd/stg_ntd__monthly_ridership_with_adjustments_voms.sql
@@ -1,0 +1,17 @@
+-- {{ config(materialized='table') }}
+with
+    source as (
+        select *
+        from
+            {{ source("ntd_data_products", "monthly_ridership_with_adjustments_voms") }}
+    ),
+    stg_ntd__monthly_ridership_with_adjustments_voms as (
+
+        select *
+        from source
+        -- we can have old months data in the source so this gets only the latest
+        -- extract
+        qualify dense_rank() over (order by ts desc) = 1
+    )
+select *
+from stg_ntd__monthly_ridership_with_adjustments_voms

--- a/warehouse/models/staging/ntd/stg_ntd__monthly_ridership_with_adjustments_vrh.sql
+++ b/warehouse/models/staging/ntd/stg_ntd__monthly_ridership_with_adjustments_vrh.sql
@@ -1,0 +1,16 @@
+-- {{ config(materialized='table') }}
+with
+    source as (
+        select *
+        from {{ source("ntd_data_products", "monthly_ridership_with_adjustments_vrh") }}
+    ),
+    stg_ntd__monthly_ridership_with_adjustments_vrh as (
+
+        select *
+        from source
+        -- we can have old months data in the source so this gets only the latest
+        -- extract
+        qualify dense_rank() over (order by ts desc) = 1
+    )
+select *
+from stg_ntd__monthly_ridership_with_adjustments_vrh

--- a/warehouse/models/staging/ntd/stg_ntd__monthly_ridership_with_adjustments_vrm.sql
+++ b/warehouse/models/staging/ntd/stg_ntd__monthly_ridership_with_adjustments_vrm.sql
@@ -1,0 +1,16 @@
+-- {{ config(materialized='table') }}
+with
+    source as (
+        select *
+        from {{ source("ntd_data_products", "monthly_ridership_with_adjustments_vrm") }}
+    ),
+    stg_ntd__monthly_ridership_with_adjustments_vrm as (
+
+        select *
+        from source
+        -- we can have old months data in the source so this gets only the latest
+        -- extract
+        qualify dense_rank() over (order by ts desc) = 1
+    )
+select *
+from stg_ntd__monthly_ridership_with_adjustments_vrm


### PR DESCRIPTION
# Description

1. Cleans up some of the column names in upt, taking them from floats to strings
2.  Copies these changes to vrm, vrh, and voms
3.  Joins all this data in an intermediate table then pulls from a final ridership table
4. Adds a little bit of documentation for these fields

Continues work on #3164

## Type of change

- [x] New feature
- [x] Documentation

## How has this been tested?

`poetry run dbt run -s +dim_monthly_ntd_ridership_with_adjustments --full-refresh`

```
SELECT * FROM `cal-itp-data-infra-staging.vb_mart_ntd.dim_monthly_ntd_ridership_with_adjustments` 
where upt is null
```
Returns no data, so all the joins worked correctly.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
