### PR TITLE
Upgrade custom image base to :python-3.11.6

### DIFF
--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:python-3.9
+FROM jupyter/datascience-notebook:python-3.11.6
 
 LABEL org.opencontainers.image.source https://github.com/cal-itp/data-infra
 


### PR DESCRIPTION
# Description

Should fix a necessary [follow-up step](https://z2jh.jupyter.org/en/stable/administrator/upgrading/index.html#custom-docker-images-jupyterhub-version-match) to our JupyterHub upgrade, as evidenced by notebooks complaining during startup:

![Screenshot 2024-05-23 at 5 00 03 PM](https://github.com/cal-itp/data-infra/assets/458494/7b263889-8c76-4a79-83db-5a72f97e68f8)

## How has this been tested?

YOLO

## Post-merge follow-ups

- [ ] Ensure JupyterHub notebooks can be launched
- [ ] Check notebook logs for errors
- [ ] Get feedback from analysts if they run into any issues due to the Python upgrade