### PR TITLE
Upgrade python publish workflows

### DIFF
--- a/.github/workflows/build-calitp-map-utils.yml
+++ b/.github/workflows/build-calitp-map-utils.yml
@@ -27,7 +27,7 @@ jobs:
       - run: sudo apt-get install -y libgraphviz-dev graphviz-dev
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - run: |
           curl -sSL https://install.python-poetry.org | python -
           poetry install

--- a/apps/maps/README.md
+++ b/apps/maps/README.md
@@ -15,8 +15,7 @@ data validation as well as Typescript types for type-hinting in the Svelte app. 
 a few CLI commands to facilitate validating pre-existing data with those types and/or generate a quick URL
 with state for testing.
 
-TODO: a GitHub Action workflow exists to build the package, but it does not currently publish to pypi; right now
-that is done manually with `poetry publish`.
+A GitHub Action workflow exists to build the package and publish it to PyPi. Be sure to bump the version date in `pyproject.toml` in any pull request that updates the library.
 
 ## Developing the maps app
 


### PR DESCRIPTION
# Description

We need to use Python 3.11 to build and publish updated Python libraries
