### PR TITLE
Updating ntd_id_2022 using airtable

### DIFF
--- a/airflow/.gitignore
+++ b/airflow/.gitignore
@@ -1,1 +1,2 @@
 logs/*
+airflow.sh

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -254,3 +254,6 @@ schema_fields:
   - name: raw_ntd_id
     type: STRING
     mode: NULLABLE
+  - name: ntd_id_2022
+    type: STRING
+    mode: NULLABLE

--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
@@ -36,6 +36,7 @@ int_transit_database__organizations_dim AS (
         hq_county_geography,
         is_public_entity,
         raw_ntd_id,
+        ntd_id_2022,
         public_currently_operating,
         public_currently_operating_fixed_route,
         _is_current,

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -86,7 +86,7 @@ models:
           renamed to `_deprecated__ntd_agency_to_organizations`).
       - name: ntd_id_2022
         description: |
-          Just pulls out the 5 digit component of the raw_ntd_id
+          Pulled from airtable, the 5 digit component of raw_ntd_id
       - name: name
         description: Organization name
       - name: organization_type

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -32,9 +32,7 @@ dim_organizations AS (
             WHEN _valid_from >= '2023-05-23' THEN raw_ntd_id
             ELSE ntd_to_org.ntd_id
         END AS ntd_id,
-        IF(LENGTH(ntd_id) >= 10,
-            SUBSTR(ntd_id, -5),
-            ntd_id) AS ntd_id_2022,
+        ntd_id_2022,
         public_currently_operating,
         public_currently_operating_fixed_route,
         _is_current,

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -41,6 +41,7 @@ stg_transit_database__organizations AS (
         hq_county_geography,
         is_public_entity = "Yes" AS is_public_entity,
         raw_ntd_id,
+        ntd_id_2022,
         public_currently_operating = "Yes" AS public_currently_operating,
         public_currently_operating_fixed_route = "Yes" AS public_currently_operating_fixed_route,
     FROM once_daily_organizations


### PR DESCRIPTION
# Description

In a previous https://github.com/cal-itp/data-infra/pull/3364 PR a formula was used to generate ntd_id_2022, but it's better to put it in airtable.  This way joins from airtable table have this id available easily especially when one might want to join to other more recent ntd data.

Separately using a csv join ntd_id_2022 was calculated and added to the orgs table.  This also removes that calculation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

local airflow

poetry run dbt run -s +dim_organizations

## Post-merge follow-ups

- [x] No action required
