### PR TITLE
Adds ntd modes seed file and easy conversions from two letter ntd modes

### DIFF
--- a/warehouse/models/intermediate/ntd/int_ntd__modes.sql
+++ b/warehouse/models/intermediate/ntd/int_ntd__modes.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized='table',
+    )
+}}
+
+WITH int_ntd__modes as (
+    SELECT * FROM {{ ref('ntd_modes_to_full_names') }}
+)
+SELECT * FROM int_ntd__modes

--- a/warehouse/models/mart/ntd/_mart_ntd.yml
+++ b/warehouse/models/mart/ntd/_mart_ntd.yml
@@ -68,6 +68,7 @@ models:
         description: The mode of service operated under the contract. A contractor can
           operate more than one mode/TOS under a contract (only one B-30 for
           that contractor).
+      - name: mode_full_name
       - name: tos
         description: The type of service operated under the contract.
       - name: time_period

--- a/warehouse/models/mart/ntd/dim_annual_ntd_agency_service.sql
+++ b/warehouse/models/mart/ntd/dim_annual_ntd_agency_service.sql
@@ -2,8 +2,11 @@
 with source as (
         select * from {{ ref("stg_ntd__annual_database_service") }}
     ),
+ntd_modes as (
+    select * from {{ ref("int_ntd__modes") }}
+),
 
-dim_annual_ntd_agency_service AS (
+dim_annual_ntd_agency_service as (
     SELECT
         _dt,
         year,
@@ -14,6 +17,7 @@ dim_annual_ntd_agency_service AS (
         subrecipient_type,
         reporting_module,
         mode,
+        n.ntd_mode_full_name as mode_full_name,
         tos,
         time_period,
         time_service_begins,
@@ -48,6 +52,9 @@ dim_annual_ntd_agency_service AS (
         emergency_comment,
         non_statutory_mixed_traffic,
         drm_mixed_traffic_row,
-    FROM source
+    FROM source s
+    LEFT JOIN ntd_modes n
+    ON
+    s.mode = n.ntd_mode_abbreviation
 )
 SELECT * FROM dim_annual_ntd_agency_service

--- a/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments.sql
+++ b/warehouse/models/mart/ntd/dim_monthly_ntd_ridership_with_adjustments.sql
@@ -2,7 +2,10 @@
 with
     dim_monthly_ntd_ridership_with_adjustments as (
         select * from {{ ref("int_ntd__monthly_ridership_with_adjustments_joined") }}
-    )
+    ),
+ntd_modes as (
+    select * from {{ ref("int_ntd__modes") }}
+)
 select
     uza_name,
     uace_cd,
@@ -14,6 +17,7 @@ select
     agency,
     mode_type_of_service_status,
     mode,
+    ntd_mode_full_name as mode_full_name,
     _3_mode,
     tos,
     legacy_ntd_id,
@@ -24,3 +28,6 @@ select
     vrh,
     voms
 from dim_monthly_ntd_ridership_with_adjustments
+LEFT JOIN ntd_modes
+ON
+dim_monthly_ntd_ridership_with_adjustments.mode = ntd_modes.ntd_mode_abbreviation

--- a/warehouse/seeds/_seeds.yml
+++ b/warehouse/seeds/_seeds.yml
@@ -16,6 +16,17 @@ seeds:
       - name: distance_miles
         description: Distance in miles between location_name and off_location_name.
 
+  - name: ntd_modes_to_full_names
+    description: |
+      A list of ntd 2 letter mode codes and their full names
+    columns:
+      - name: ntd_mode_abbreviation
+        description: The two letter abbreviation mode
+        tests:
+          - unique
+      - name: ntd_mode_full_name
+        description: The mode's full name
+
   - name: payments_entity_mapping
     columns:
       - name: gtfs_dataset_source_record_id

--- a/warehouse/seeds/ntd_modes_to_full_names.csv
+++ b/warehouse/seeds/ntd_modes_to_full_names.csv
@@ -1,0 +1,23 @@
+ntd_mode_abbreviation,ntd_mode_full_name
+AG,Automated Guideway
+AR,Alaska Railroad
+CB,Commuter Bus
+CC,Cable Car
+CR,Commuter Rail
+DR,Demand Response
+DT,Demand Taxi
+FB,Ferryboat
+HR,Heavy Rail
+IP,Inclined Plane
+JT,Jitney
+LR,Light Rail
+MB,Motor Bus
+MG,Monorail
+MO,Monorail
+PB,Publico
+RB,Bus Rapid Transit
+SR,Streetcar
+TB,Trolleybus
+TR,Aerial Tramway
+VP,Vanpool
+YR,Hybrid Rail


### PR DESCRIPTION
# Description
Adds ntd modes seed file and easy conversions from two letter ntd modes to the full name.

Makes it easier to make dashboards.

Chose not to extend [dim_modes](https://github.com/cal-itp/data-infra/blob/main/warehouse/models/mart/transit_database/dim_modes.sql) since that describes more California modes, not national modes.

Uses descriptions from https://github.com/cal-itp/data-infra/pull/3378

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
poetry run dbt seed
poetry run dbt run -s +dim_monthly_ntd_ridership_with_adjustments --full-refresh
poetry run dbt run -s +dim_annual_ntd_agency_service --full-refresh

```
## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
