### PR TITLE
payments: merge United States issuer_country values in stg_littlepay__customer_funding_source

### DIFF
--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__customer_funding_source.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__customer_funding_source.sql
@@ -11,7 +11,10 @@ clean_columns AS (
         {{ trim_make_empty_string_null('masked_pan') }} AS masked_pan,
         {{ trim_make_empty_string_null('card_scheme') }} AS card_scheme,
         {{ trim_make_empty_string_null('issuer') }} AS issuer,
-        {{ trim_make_empty_string_null('issuer_country') }} AS issuer_country,
+        CASE
+          WHEN {{ trim_make_empty_string_null('issuer_country') }} = 'UNITED STATES OF AMERICA (THE)' THEN 'UNITED STATES'
+        ELSE {{ trim_make_empty_string_null('issuer_country') }}
+        END AS issuer_country,
         {{ trim_make_empty_string_null('form_factor') }} AS form_factor,
         {{ trim_make_empty_string_null('principal_customer_id') }} AS principal_customer_id,
         -- some early/historical rows are missing participant ID


### PR DESCRIPTION
# Description
This pull request alters the Littlepay payments staging table `stg_littlepay__customer_funding_source` table to force one value related to the `issuer_country` field for the United States.

Previously, two values existed: ‘UNITED STATES’ and ‘UNITED STATES OF AMERICA (THE)’. This PR adds SQL code to change both fields to the ‘UNITED STATES’ value.

Resolves #3392 

## Type of change

- [x] New feature

## How has this been tested?

local `dbt run` and `dbt test`

## Post-merge follow-ups

- [x] No action required