### PR TITLE
Updated seed mapping of elavon payments entities to organization names

### DIFF
--- a/warehouse/seeds/payments_entity_mapping.csv
+++ b/warehouse/seeds/payments_entity_mapping.csv
@@ -10,6 +10,7 @@ recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA OFFICE SALES
 recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA PARATRANSIT
 recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA VIRTUAL
 rec7FygKkATPJZtFR,recPwXKbGLL4aIqXV,lake-transit-authority,LAKE TRANSIT AUTHORITY
+rec7FygKkATPJZtFR,recPwXKbGLL4aIqXV,lake-transit-authority,LTA DIAL A RIDE
 recxvrgxNkScGIidy,recpWBEjXzLHqCjhE,mendocino-transit-authority,MENDOCINO TRANSIT AUTHORITY
 recxvrgxNkScGIidy,recpWBEjXzLHqCjhE,mendocino-transit-authority,MTA DIAL A RIDE
 recGGy7HVkFGILMgO,recZgWVXkpix390of,,SAN JOAQUIN REGIONAL TRANSIT DIS

--- a/warehouse/seeds/payments_entity_mapping.csv
+++ b/warehouse/seeds/payments_entity_mapping.csv
@@ -11,6 +11,8 @@ recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA PARATRANSIT
 recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA VIRTUAL
 rec7FygKkATPJZtFR,recPwXKbGLL4aIqXV,lake-transit-authority,LAKE TRANSIT AUTHORITY
 recxvrgxNkScGIidy,recpWBEjXzLHqCjhE,mendocino-transit-authority,MENDOCINO TRANSIT AUTHORITY
+recxvrgxNkScGIidy,recpWBEjXzLHqCjhE,mendocino-transit-authority,MTA DIAL A RIDE
+recGGy7HVkFGILMgO,recZgWVXkpix390of,,SAN JOAQUIN REGIONAL TRANSIT DIS
 recWJJ4dRk4lHXaWX,recOnKhqF25crJt4q,redwood-coast-transit,REDWOOD COAST TRANSIT AUTHORITY
 recWJJ4dRk4lHXaWX,recOnKhqF25crJt4q,,RCTA DIAL A RIDE
 recrxmzfLImgBGwUH,recsrIZdx5Wt6n3ol,atn,ANAHEIM TRANSPORTATION NETWORK

--- a/warehouse/seeds/payments_entity_mapping.csv
+++ b/warehouse/seeds/payments_entity_mapping.csv
@@ -10,9 +10,9 @@ recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA OFFICE SALES
 recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA PARATRANSIT
 recGTiyx7VcxcUkRu,recaa3naoNR4a5RsJ,,HTA VIRTUAL
 rec7FygKkATPJZtFR,recPwXKbGLL4aIqXV,lake-transit-authority,LAKE TRANSIT AUTHORITY
-rec7FygKkATPJZtFR,recPwXKbGLL4aIqXV,lake-transit-authority,LTA DIAL A RIDE
+rec7FygKkATPJZtFR,recPwXKbGLL4aIqXV,,LTA DIAL A RIDE
 recxvrgxNkScGIidy,recpWBEjXzLHqCjhE,mendocino-transit-authority,MENDOCINO TRANSIT AUTHORITY
-recxvrgxNkScGIidy,recpWBEjXzLHqCjhE,mendocino-transit-authority,MTA DIAL A RIDE
+recxvrgxNkScGIidy,recpWBEjXzLHqCjhE,,MTA DIAL A RIDE
 recGGy7HVkFGILMgO,recZgWVXkpix390of,,SAN JOAQUIN REGIONAL TRANSIT DIS
 recWJJ4dRk4lHXaWX,recOnKhqF25crJt4q,redwood-coast-transit,REDWOOD COAST TRANSIT AUTHORITY
 recWJJ4dRk4lHXaWX,recOnKhqF25crJt4q,,RCTA DIAL A RIDE


### PR DESCRIPTION
# Description
As requested in #3398, we updated the mapping of Elavon entities to organization names to facilitate analysis for:
- Mendocino Transit Authority/MTA DIAL A RIDE
- San Joaquin RTD/SAN JOAQUIN REGIONAL TRANSIT DIS
- Lake Transit Authority/LTA DIAL A RIDE

Resolves #3398 

## Type of change

- [x] New feature

## How has this been tested?

local dbt run, dbt test

- [x] No action required
