### PR TITLE
update payments row access policy to include new contributors

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -85,6 +85,7 @@ filter using (
                   'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',
+                  'group:mov-project-team@jarv.us',
                   'domain:calitp.org',
                  ]
 ) }};
@@ -158,6 +159,7 @@ filter using (
                   'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',
+                  'group:mov-project-team@jarv.us',
                   'domain:calitp.org',
                  ]
 ) }};


### PR DESCRIPTION
# Description

Update payments row access polices in macro [create_row_access_policy](https://github.com/cal-itp/data-infra/blob/main/warehouse/macros/create_row_access_policy.sql) to include new GCP group: `mov-project-team@jarv.us` to facilitate querying and contributions to row access policy-protected tables (primarily [fct_payments__rides_v2](https://github.com/cal-itp/data-infra/blob/fd71594f3a59cc7fa44e2a128a45b034cfd090a7/warehouse/models/mart/payments/fct_payments_rides_v2.sql#L2) and [fct_elavon__transactions](https://github.com/cal-itp/data-infra/blob/fd71594f3a59cc7fa44e2a128a45b034cfd090a7/warehouse/models/mart/payments/fct_elavon__transactions.sql#L2))

## Type of change

- [x] New feature
