### PR TITLE
payments: expose remaining elavon batch types and modify row access policy

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -82,6 +82,7 @@ filter using (
 
 {{ create_row_access_policy(
     principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+                  'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',
@@ -156,6 +157,7 @@ filter using (
 
 {{ create_row_access_policy(
     principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+                  'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
                   'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
                   'group:cal-itp@jarv.us',

--- a/warehouse/models/staging/payments/elavon/_elavon.yml
+++ b/warehouse/models/staging/payments/elavon/_elavon.yml
@@ -156,3 +156,103 @@ models:
       - name: ent_num
       - name: dt
       - name: execution_ts
+
+  - name: int_elavon__chargeback_transactions
+    description: Chargeback-specific transactions processed by Elavon
+    columns:
+      - name: payment_reference
+      - name: payment_date
+      - name: account_number
+      - name: routing_number
+      - name: fund_amt
+      - name: batch_reference
+      - name: batch_type
+      - name: customer_batch_reference
+      - name: customer_name
+      - name: merchant_number
+      - name: external_mid
+      - name: store_number
+      - name: chain
+      - name: batch_amt
+      - name: amount
+      - name: surchg_amount
+      - name: convnce_amt
+      - name: card_type
+      - name: charge_type
+      - name: charge_type_description
+      - name: card_plan
+      - name: card_no
+      - name: chk_num
+      - name: transaction_date
+      - name: settlement_date
+      - name: authorization_code
+      - name: chargeback_control_no
+      - name: roc_text
+      - name: trn_aci
+      - name: card_scheme_ref
+      - name: trn_ref_num
+        tests:
+          - unique
+      - name: settlement_method
+      - name: currency_code
+      - name: cb_acq_ref_id
+      - name: chgbk_rsn_code
+      - name: chgbk_rsn_desc
+      - name: mer_ref
+      - name: purch_id
+      - name: cust_cod
+      - name: trn_arn
+      - name: term_id
+      - name: ent_num
+      - name: dt
+      - name: execution_ts
+
+  - name: int_elavon__adjustment_transactions
+    description: Adjustment-specific transactions processed by Elavon
+    columns:
+      - name: payment_reference
+      - name: payment_date
+      - name: account_number
+      - name: routing_number
+      - name: fund_amt
+      - name: batch_reference
+      - name: batch_type
+      - name: customer_batch_reference
+      - name: customer_name
+      - name: merchant_number
+      - name: external_mid
+      - name: store_number
+      - name: chain
+      - name: batch_amt
+      - name: amount
+      - name: surchg_amount
+      - name: convnce_amt
+      - name: card_type
+      - name: charge_type
+      - name: charge_type_description
+      - name: card_plan
+      - name: card_no
+      - name: chk_num
+      - name: transaction_date
+      - name: settlement_date
+      - name: authorization_code
+      - name: chargeback_control_no
+      - name: roc_text
+      - name: trn_aci
+      - name: card_scheme_ref
+      - name: trn_ref_num
+        tests:
+          - unique
+      - name: settlement_method
+      - name: currency_code
+      - name: cb_acq_ref_id
+      - name: chgbk_rsn_code
+      - name: chgbk_rsn_desc
+      - name: mer_ref
+      - name: purch_id
+      - name: cust_cod
+      - name: trn_arn
+      - name: term_id
+      - name: ent_num
+      - name: dt
+      - name: execution_ts

--- a/warehouse/models/staging/payments/elavon/int_elavon__adjustment_transactions.sql
+++ b/warehouse/models/staging/payments/elavon/int_elavon__adjustment_transactions.sql
@@ -1,0 +1,64 @@
+{{ config(materialized='table') }}
+
+WITH
+
+adjustment_transactions AS (
+
+  SELECT * FROM {{ ref('stg_elavon__transactions') }}
+  WHERE batch_type = 'A'
+
+),
+
+int_elavon__adjustment_transactions AS (
+
+    SELECT
+        payment_reference,
+        payment_date,
+        account_number,
+        routing_number,
+        fund_amt,
+        batch_reference,
+        batch_type,
+        customer_batch_reference,
+        customer_name,
+        merchant_number,
+        external_mid,
+        store_number,
+        chain,
+        batch_amt,
+        amount,
+        surchg_amount,
+        convnce_amt,
+        card_type,
+        charge_type,
+        charge_type_description,
+        card_plan,
+        card_no,
+        chk_num,
+        transaction_date,
+        settlement_date,
+        authorization_code,
+        chargeback_control_no,
+        roc_text,
+        trn_aci,
+        card_scheme_ref,
+        trn_ref_num,
+        settlement_method,
+        currency_code,
+        cb_acq_ref_id,
+        chgbk_rsn_code,
+        chgbk_rsn_desc,
+        mer_ref,
+        purch_id,
+        cust_cod,
+        trn_arn,
+        term_id,
+        ent_num,
+        dt,
+        execution_ts
+
+    FROM adjustment_transactions
+
+)
+
+SELECT * FROM int_elavon__adjustment_transactions

--- a/warehouse/models/staging/payments/elavon/int_elavon__chargeback_transactions.sql
+++ b/warehouse/models/staging/payments/elavon/int_elavon__chargeback_transactions.sql
@@ -1,0 +1,90 @@
+{{ config(materialized='table') }}
+
+WITH
+
+chargeback_transactions AS (
+
+  SELECT * FROM {{ ref('stg_elavon__transactions') }}
+  WHERE batch_type = 'C'
+
+),
+
+int_elavon__chargeback_transactions AS (
+
+  SELECT
+
+        payment_reference,
+        payment_date,
+        account_number,
+        routing_number,
+        fund_amt,
+        batch_reference,
+        batch_type,
+        customer_batch_reference,
+        customer_name,
+        merchant_number,
+        external_mid,
+        store_number,
+        chain,
+        batch_amt,
+        amount,
+        surchg_amount,
+        convnce_amt,
+        card_type,
+        charge_type,
+        charge_type_description,
+        card_plan,
+        card_no,
+        chk_num,
+        transaction_date,
+        settlement_date,
+        authorization_code,
+        chargeback_control_no,
+        roc_text,
+        trn_aci,
+        card_scheme_ref,
+        trn_ref_num,
+        settlement_method,
+        currency_code,
+        cb_acq_ref_id,
+        chgbk_rsn_code,
+        chgbk_rsn_desc,
+        mer_ref,
+        purch_id,
+        cust_cod,
+        trn_arn,
+        term_id,
+        ent_num,
+        dt,
+        execution_ts
+
+-- if we remove the need for a union between billing and deposit data downstream, these are the columns to keep
+-- (ie deposit-specific, always null columns are removed)
+      -- payment_reference,
+      -- payment_date,
+      -- account_number,
+      -- routing_number,
+      -- fund_amt,
+      -- batch_reference,
+      -- batch_type,
+      -- customer_name,
+      -- merchant_number,
+      -- external_mid,
+      -- chain,
+      -- batch_amt,
+      -- amount,
+      -- card_type,
+      -- charge_type,
+      -- charge_type_description,
+      -- card_plan,
+      -- settlement_method,
+      -- currency_code,
+      -- ent_num,
+      -- dt,
+      -- execution_ts
+
+  FROM chargeback_transactions
+
+)
+
+SELECT * FROM int_elavon__chargeback_transactions


### PR DESCRIPTION
# Description

This PR creates new unique intermediate tables for the two remaining batch types of Elavon transactions found in `stg_elavon__transactions` that are not yet exposed in tables

New batch types and tables:
* `A` found in new table `int_elavon__adjustment_transactions`
* `C` found in new table `int_elavon__chargeback_transactions`

the YML file for these tables have also been updated in the dbt project

This PR also adds the service account for `metabase-payments-team` to the create_row_access_policy macro to more easily facilitate access to payments tables with row access policies by payments data team members

Resolves #3411 

As some background:
we used batch types `B` and `D` when creating the `fct_elavon__transactions` table. When constructing that, we tried to incorporate these other two batch types for reconciliation (the batch types above, `A` and `C` ) but they are aggregated at a different grain so we were unable to use them for those calculations.
However, as this batch data is valuable on it's own, once this PR is merged they will be available as their own tables in the warehouse and Metabase to be used for analysis.

## Type of change

- [x] New feature

## How has this been tested?

locally with dbt run and dbt test

## Post-merge follow-ups
- [x] Actions required (specified below)
- [ ] 
Metabase will need to be configured to expose these two new tables in the staging scheme to the `Payments Team Warehouse` in Metabase

We will also need to verify that the payments team service account is successfully accessing the payments tables protected by the row access policy