### PR TITLE
fix(jupyterhub): updated admin and increases disk size

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -14,6 +14,8 @@ jupyterhub:
       limit: 10G
       # Very roughly I have seen most usage in the 2-3GB range
       guarantee: 3G
+    storage:
+      capacity: 32Gi
     cpu:
       # this is to put 2 pods per e2-highmem-2 which has 1.93 allocatable
       guarantee: 0.7
@@ -49,10 +51,11 @@ jupyterhub:
         authenticator_class: github
         Authenticator:
           admin_users:
-            - atvaccaro
-            - machow
+            - vevetron
+            - tiffanychu90
             - themightchris
-            - lottspot
+            - evansiroky
+            - charlie-costanzo
     # holds github OAuth creds
     existingSecret: jupyterhub-github-config
   ingress:


### PR DESCRIPTION
# Description

Updates admins and increases disk size for new jupyterhub images.

Resolves #3421

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

YOLO (I really don't know how)

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Check if default disk sizes are updated with `df -h`
Currently it looks like:
```
jovyan@jupyter-vevetron:~/data-analyses$ df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay          95G   17G   78G  18% /
tmpfs            64M     0   64M   0% /dev
tmpfs           7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sdc        9.8G  6.7G  3.2G  68% /home/jovyan
/dev/sda1        95G   17G   78G  18% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs           7.9G     0  7.9G   0% /proc/acpi
tmpfs           7.9G     0  7.9G   0% /proc/scsi
tmpfs           7.9G     0  7.9G   0% /sys/firmware
```
