### PR TITLE
Update external_airtable_california_transit_gtfs_datasets.yml

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
@@ -170,3 +170,6 @@ schema_fields:
   - name: manual_check__grading_scheme_v1
     type: STRING
     mode: NULLABLE
+  - name: private_dataset
+    type: BOOLEAN
+    mode: NULLABLE


### PR DESCRIPTION
Adding private_dataset field to this table.

# Description

In this PR, we added a new field, `private_dataset`, to the `external_airtable.california_transit__gtfs_datasets` table. This field was already created in the Airtable `california_transit.gtfs_datasets` table and has been ingested into the Google Cloud Storage Raw bucket (`california_transit__gtfs_datasets` json file) by the `airtable_loader_v2` Airflow DAG.
We added this field to the `schema_fields` section of the external table's YML file. The next step is to modify the warehouse to propagate this field into various models in dbt.

Resolves [#\[issue\]](https://github.com/cal-itp/data-infra/issues/3416)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


## Post-merge follow-ups

- [ ] No action required
- [X] Actions required (specified below)

The next step is to modify the warehouse to propagate this field into various models in dbt.