### PR TITLE
adding private_dataset field to the warehouse Staging, Intermediate, …

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__gtfs_datasets_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__gtfs_datasets_dim.sql
@@ -50,6 +50,7 @@ int_transit_database__gtfs_datasets_dim AS (
         url_to_encode,
         base64_url,
         type,
+        private_dataset,
         _is_current,
         _valid_from,
         _valid_to

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: fct_dailytrip_updates_vehicle_positions_completeness
+  - name: fct_daily_trip_updates_vehicle_positions_completeness
     description: |
       A daily model of how many trips had either a single trip update or a single vehicle position message
   - name: fct_daily_rt_feed_validation_notices

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -324,6 +324,9 @@ models:
         description: |
           If populated, indicates that dataset was deprecated on listed date
           and is no longer active.
+      - name: private_dataset
+        description: |
+          If True, indicates that dataset is marked non-public and the feeds will be published to any public open data portal.
       - *valid_from_actual
       - *valid_to_actual
       - *is_current_actual

--- a/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
+++ b/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
@@ -31,6 +31,7 @@ dim_gtfs_datasets AS (
         manual_check__localized_stop_tts,
         manual_check__grading_scheme_v1,
         base64_url,
+        private_dataset,
         _is_current,
         _valid_from,
         _valid_to

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -101,6 +101,7 @@ stg_transit_database__gtfs_datasets AS (
             WHEN data = "GTFS VehiclePositions" THEN "vehicle_positions"
             WHEN data = "GTFS TripUpdates" THEN "trip_updates"
         END AS type,
+        private_dataset,
         ts,
         dt
     FROM construct_base64_url


### PR DESCRIPTION
# Description
In this PR I added `private_dataset` field to  the data-infra warehouse Staging, Intermediate, and Mart gtfs_datasets. I also updated the related YML file with the description about this field and its purpose. This field was already added to the external table gtfs_datasets per [this PR](https://github.com/cal-itp/data-infra/pull/3423) 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`poetry run dbt test`
`poetry run dbt compile`
`poetry run dbt docs generate`
`poetry run dbt run -s +dim_gtfs_datasets`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
The next step is to add a filter to the  weekly `gtfs_schedule_latest` bundle to suppress the feeds on the base of this field.
