### PR TITLE
Preventing private datasets to be published to california_open_data portal.

### DIFF
--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -326,7 +326,7 @@ models:
           and is no longer active.
       - name: private_dataset
         description: |
-          If True, indicates that dataset is marked non-public and the feeds will be published to any public open data portal.
+          If True, indicates that dataset is marked non-public and the feeds will not be published to any public open data portal.
       - *valid_from_actual
       - *valid_to_actual
       - *is_current_actual

--- a/warehouse/models/mart/transit_database_latest/dim_gtfs_datasets_latest.sql
+++ b/warehouse/models/mart/transit_database_latest/dim_gtfs_datasets_latest.sql
@@ -2,6 +2,7 @@ WITH
 unfiltered_entries_latest AS (
     SELECT * FROM {{ ref('dim_gtfs_datasets') }}
     WHERE _is_current
+        AND !private_dataset
 ),
 
 bridge_schedule_dataset_for_validation AS (

--- a/warehouse/models/mart/transit_database_latest/dim_gtfs_datasets_latest.sql
+++ b/warehouse/models/mart/transit_database_latest/dim_gtfs_datasets_latest.sql
@@ -2,7 +2,7 @@ WITH
 unfiltered_entries_latest AS (
     SELECT * FROM {{ ref('dim_gtfs_datasets') }}
     WHERE _is_current
-        AND !private_dataset
+        AND private_dataset IS NOT TRUE
 ),
 
 bridge_schedule_dataset_for_validation AS (


### PR DESCRIPTION
# Description

Preventing private datasets to be published to [california_open_data](https://data.ca.gov/dataset/cal-itp-gtfs-ingest-pipeline-dataset/resource/e4ca5bd4-e9ce-40aa-a58a-3a6d78b042bd) portal .

Resolves https://github.com/cal-itp/data-infra/issues/3416

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`poetry run dbt run -s +dim_gtfs_datasets_latest`

`18:55:39  Completed successfully`
`18:55:39  Done. PASS=5 WARN=0 ERROR=0 SKIP=0 TOTAL=5`


## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)
