### PR TITLE
fix(ci): only deploy maps app previews on relevant pull requests

### DIFF
--- a/.github/workflows/deploy-apps-maps.yml
+++ b/.github/workflows/deploy-apps-maps.yml
@@ -2,10 +2,14 @@ name: Build and publish apps/maps
 
 on:
   push:
+    branches:
+      - 'main'
     paths:
+      - '.github/workflows/deploy-apps-maps.yml'
       - 'apps/maps/**'
   pull_request:
     paths:
+      - '.github/workflows/deploy-apps-maps.yml'
       - 'apps/maps/**'
   workflow_dispatch:
 
@@ -34,7 +38,7 @@ jobs:
 
     # Preview on PRs
     - name: Deploy apps/maps preview to Netlify
-      if: ${{ github.ref != 'refs/heads/main' }}
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         npm install -g netlify-cli
         netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --alias=${GITHUB_REPOSITORY#*/}-${PR_NUMBER}


### PR DESCRIPTION
# Description

I noticed while working on #3452 that rebasing any branch would cause this workflow to run and then deploy to a netlify preview site with the PR # missing. The issue was that the branches event runs on any branch and then the deploy preview event is only filtered to the branch not being main rather than the event being a pull request. Since that step makes use of the PR number, it doesn't make sense for it to ever run on a non-PR event as the PR number will be blank. These updates bring the triggers in line with other workflows

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

This PR should trigger the workflow to run since it includes a change to the workflow script which is now included in the triggers.

## Post-merge follow-ups

- [ ] When this PR is merged it should to a prod deploy (with no changes to the actual application, just the workflow)
- [ ] When I rebase a Dependabot PR again this workflow should not run