### PR TITLE
fix(ci): update gtfs-rt-archiver-v3 tagging and docs

### DIFF
--- a/.github/workflows/build-gtfs-rt-archiver-v3-image.yml
+++ b/.github/workflows/build-gtfs-rt-archiver-v3-image.yml
@@ -48,13 +48,15 @@ jobs:
           python-version: '3.10'
       - run: curl -sSL https://install.python-poetry.org | python -
       # from https://forcepush.tech/python-package-ci-cd-with-git-hub-actions
-      - name: Get image tag from pyproject.toml
+      - name: Get image tag from pyproject.toml and commit SHA
         run: |
           cd services/gtfs-rt-archiver-v3
           PROJECT_VERSION=$(poetry version --short)
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+
+          echo "GITHUB_SHA_SHORT=${GITHUB_SHA:0:6}" >> $GITHUB_ENV
       - uses: docker/build-push-action@v2
         with:
           context: services/gtfs-rt-archiver-v3
           push: ${{ github.ref == 'refs/heads/main' }}
-          tags: ghcr.io/${{github.repository}}/gtfs-rt-archiver-v3:${{env.PROJECT_VERSION}}
+          tags: ghcr.io/${{github.repository}}/gtfs-rt-archiver-v3:${{env.PROJECT_VERSION}}-${{env.GITHUB_SHA_SHORT}}

--- a/services/gtfs-rt-archiver-v3/README.md
+++ b/services/gtfs-rt-archiver-v3/README.md
@@ -92,12 +92,11 @@ Code changes require building and pushing a new Docker image, as well as applyin
 
 1. Make code changes and increment version in `pyproject.toml`
    1. Ex. `poetry version 2023.4.10`
-2. `docker build ... & docker push ...` (*from within the archiver directory*) or wait for [build-gtfs-rt-archiver-v3-image](../../.github/workflows/build-gtfs-rt-archiver-v3-image.yml) GitHub Action to run after merge to main
-   1. Ex. `docker build -t ghcr.io/cal-itp/data-infra/gtfs-rt-archiver-v3:2023.4.10 . && docker push ghcr.io/cal-itp/data-infra/gtfs-rt-archiver-v3:2023.4.10`
-   2. To push from your local machine, you must have [authenticated to ghcr.io](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)
-3. Change image tag version in the environments `kustomization.yaml`.
-   1. Ex. change the value of `newTag` to '`2023.4.10'`
-4. Finally, apply changes in production by opening and merging a second PR that includes the `kustomization.yaml` changes.
+2. Open a pull request and verify that the test container image build succeeds
+3. Merge the pull request and obtain the new image tag from the GitHub Actions build output or from <https://github.com/cal-itp/data-infra/pkgs/container/data-infra%2Fgtfs-rt-archiver-v3>
+4. Change image tag version in the environments `kustomization.yaml`.
+   1. Ex. change the value of `newTag` to '`2023.4.10-a66f90'`
+5. Finally, apply changes in production by opening and merging a second PR that includes the `kustomization.yaml` changes.
 
 ### Changing download configurations
 


### PR DESCRIPTION
# Description

The docs on how to deploy the `gtfs-rt-archiver-v3` image were out of date, and the workflow was prone to unexpectedly updating the already-deployed container image if the `pyproject.toml` version hadn't been manually updated.

For example, upon merging a dependabot PR that makes changes to `services/gtfs-rt-archiver-v3/*` and new image would get built and pushed over the already-deployed container image tag, leading production instances to start using the new version without any verification step or the designed manual new version deployment.

This change appends the short SHA to the container tag as a build number suffix, ensuring that each is build is uniquely identified and must be intentionally deployed to production. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

In a forked repo

## Post-merge follow-ups

- [ ] verify container image with new tagging scheme deploys
- [ ] deploy new image