### PR TITLE
Fix transform_warehouse schedule to run on Mondays

### DIFF
--- a/airflow/dags/transform_warehouse/METADATA.yml
+++ b/airflow/dags/transform_warehouse/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2024-09-17"
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/transform_warehouse/README.md
+++ b/airflow/dags/transform_warehouse/README.md
@@ -6,6 +6,10 @@ This DAG orchestrates the running of the Cal-ITP dbt project and deployment of a
 
 This DAG has some special considerations:
 
+- The schedule interval is 14:00 UTC Mondays to Saturdays. Mondays will be actually running the data interval for the previous Saturday-Sunday.
+
+- This DAG should not run on Sundays because of the other DAG `transform_warehouse_full_refresh_sunday`.
+
 - If a task fails, look carefully before assuming that clearing the task will help. If the failure was caused by a `DbtModelError`, there is an issue with the SQL or data in an individual model and clearing the task will not help until that issue is fixed.
 
 - While this DAG does not have any formal dependencies on other DAGs, the data transformations within the dbt project do depend on successful upstream data capture and parsing.


### PR DESCRIPTION
# Description

The transform_warehouse DAG is not running on Mondays and this PR is intended to fix the issue #3420.

Based on Airflow concept, Mondays should be running the data interval Saturday-Sunday, but since the `start_date` is configured to only One Day Ago, it does not have anything to run on Mondays because Sundays are not part of the schedule.

As @mjumbewu mentioned on the Issue and going through the problem with him, we found out that setting up a real start date would fix the problem.

There is also a previous issue that was fixed the same way: https://github.com/cal-itp/data-infra/pull/3323

For more information about the problem see the screenshot bellow that shows (on the left side) a list of dates from Mondays to Fridays, but they are actually running from Tuesdays to Saturdays as the TIMESTAMP, Start date, and End date shows.
![Screenshot 2024-09-10 at 11 17 00 AM](https://github.com/user-attachments/assets/7ecbaa19-607a-464f-966b-651c79e00c8f)

Airflow schedule works different than regular "jobs", to clarify here what the documentation says:

What does [execution_date](https://airflow.apache.org/docs/apache-airflow/stable/faq.html#what-does-execution-date-mean) mean?

Airflow was developed as a solution for ETL needs. In the ETL world, you typically summarize data. So, if you want to summarize data for 2016-02-19, you would do it at 2016-02-20 midnight UTC, which would be right after all data for 2016-02-19 becomes available. This interval between midnights of 2016-02-19 and 2016-02-20 is called the data interval, and since it represents data in the date of 2016-02-19, this date is also called the run’s logical date, or the date that this DAG run is executed for, thus execution date.

[Dates Concept from airflow](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dag-run.html#data-interval)
`All dates in Airflow are tied to the data interval concept in some way. The “logical date” (also called execution_date in Airflow versions prior to 2.2) of a DAG run, for example, denotes the start of the data interval, not when the DAG is actually executed.`

`Similarly, since the start_date argument for the DAG and its tasks points to the same logical date, it marks the start of the DAG’s first data interval, not when tasks in the DAG will start running. In other words, a DAG run will only be scheduled one interval after start_date.`


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested schedules on Airflow locally.

## Post-merge follow-ups

- [ ] No action required
- [X] Actions required (specified below)

Monitor production Airflow to ensure that the changes take effect as expected.
