### PR TITLE
correct inaccurate NTD extract object name

### DIFF
--- a/airflow/dags/sync_ntd_data_api/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_api/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Scrape NTD endpoints from DOT API monthly"
-schedule_interval: "0 11 1 * *" # 11am GMT first day of every month
+schedule_interval: "0 11 1 * *" # 11am UTC first day of every month
 tags:
   - all_gusty_features
 default_args:

--- a/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Scrape tables from DOT Ridership XLSX file daily"
-schedule_interval: "0 10 * * *" # 10am GMT every day
+schedule_interval: "0 10 * * *" # 10am UTC every day
 tags:
   - all_gusty_features
 default_args:

--- a/airflow/plugins/operators/scrape_ntd_api.py
+++ b/airflow/plugins/operators/scrape_ntd_api.py
@@ -69,7 +69,7 @@ class NtdDataProductAPIExtract(PartitionedGCSArtifact):
             raise
 
 
-class CSVExtract(NtdDataProductAPIExtract):
+class JSONExtract(NtdDataProductAPIExtract):
     bucket = API_BUCKET
 
 
@@ -91,11 +91,11 @@ class NtdDataProductAPIOperator(BaseOperator):
         self.endpoint_id = endpoint_id
         self.file_format = file_format
         """An operator that downloads all data from a NTD API
-            and saves it as one CSV file hive-partitioned by date in Google Cloud
+            and saves it as one JSONL file, hive-partitioned by date in Google Cloud
         """
 
-        # Save CSV files to the bucket
-        self.extract = CSVExtract(
+        # Save JSON files to the bucket
+        self.extract = JSONExtract(
             year=self.year,
             product=self.product + "/" + self.year,
             root_url=self.root_url,

--- a/airflow/plugins/operators/scrape_ntd_api.py
+++ b/airflow/plugins/operators/scrape_ntd_api.py
@@ -90,11 +90,11 @@ class NtdDataProductAPIOperator(BaseOperator):
         self.root_url = root_url
         self.endpoint_id = endpoint_id
         self.file_format = file_format
-        """An operator that downloads all data from a NTD API
+        """An operator that extracts and saves JSON data from the NTD API
             and saves it as one JSONL file, hive-partitioned by date in Google Cloud
         """
 
-        # Save JSON files to the bucket
+        # Save JSONL files to the bucket
         self.extract = JSONExtract(
             year=self.year,
             product=self.product + "/" + self.year,


### PR DESCRIPTION
# Description

In PR #3415, the object for an extract in JSON format was incorrectly named `CSVExtract`. This PR clarifies the object created by renaming it `JSONExtract ` and improves some description

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
local airflow environment

## Post-merge follow-ups
- [x] No action required
