### PR TITLE
Create NTD external tables for 2022 API data

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/2022__breakdowns.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__breakdowns.yml
@@ -1,0 +1,58 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "breakdowns/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "breakdowns/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__breakdowns"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__breakdowns LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: major_mechanical_failures
+    type: NUMERIC
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: NUMERIC
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other_mechanical_failures
+    type: NUMERIC
+  - name: primary_uza_population
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total_mechanical_failures
+    type: NUMERIC
+  - name: train_miles
+    type: NUMERIC
+  - name: train_revenue_miles
+    type: NUMERIC
+  - name: type_of_service
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: uza_name
+    type: STRING
+  - name: vehicle_passenger_car_miles
+    type: NUMERIC
+  - name: vehicle_passenger_car_revenue
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__breakdowns_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__breakdowns_by_agency.yml
@@ -1,0 +1,62 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "breakdowns_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "breakdowns_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__breakdowns_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__breakdowns_by_agency LIMIT 1;
+schema_fields:
+  - name: count_major_mechanical_failures_questionable
+    type: NUMERIC
+  - name: count_other_mechanical_failures_questionable
+    type: NUMERIC
+  - name: count_total_mechanical_failures_questionable
+    type: NUMERIC
+  - name: count_train_miles_questionable
+    type: NUMERIC
+  - name: count_train_revenue_miles_questionable
+    type: NUMERIC
+  - name: count_vehicle_passenger_car_miles_questionable
+    type: NUMERIC
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: NUMERIC
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: NUMERIC
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: sum_major_mechanical_failures
+    type: NUMERIC
+  - name: sum_other_mechanical_failures
+    type: NUMERIC
+  - name: sum_total_mechanical_failures
+    type: NUMERIC
+  - name: sum_train_miles
+    type: NUMERIC
+  - name: sum_train_revenue_miles
+    type: NUMERIC
+  - name: sum_vehicle_passenger_car_miles
+    type: NUMERIC
+  - name: sum_vehicle_passenger_car_revenue
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_by_capital_use.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_by_capital_use.yml
@@ -1,0 +1,62 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "capital_expenses_by_capital_use/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "capital_expenses_by_capital_use/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__capital_expenses_by_capital_use"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__capital_expenses_by_capital_use LIMIT 1;
+schema_fields:
+  - name: administrative_buildings
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: communication_information
+    type: STRING
+  - name: fare_collection_equipment
+    type: STRING
+  - name: form_type
+    type: STRING
+  - name: guideway
+    type: STRING
+  - name: maintenance_buildings
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: NUMERIC
+  - name: modecd
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other
+    type: STRING
+  - name: other_vehicles
+    type: STRING
+  - name: passenger_vehicles
+    type: STRING
+  - name: reduced_reporter
+    type: STRING
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: stations
+    type: STRING
+  - name: total
+    type: NUMERIC
+  - name: typeofservicecd
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_by_mode.yml
@@ -1,0 +1,76 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "capital_expenses_by_mode/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "capital_expenses_by_mode/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__capital_expenses_by_mode"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__capital_expenses_by_mode LIMIT 1;
+schema_fields:
+  - name: count_administrative_buildings_q
+    type: NUMERIC
+  - name: count_communication_information_q
+    type: NUMERIC
+  - name: count_fare_collection_equipment_q
+    type: NUMERIC
+  - name: count_maintenance_buildings_q
+    type: NUMERIC
+  - name: count_other_q
+    type: NUMERIC
+  - name: count_other_vehicles_q
+    type: NUMERIC
+  - name: count_passenger_vehicles_q
+    type: NUMERIC
+  - name: count_reduced_reporter_q
+    type: NUMERIC
+  - name: count_stations_q
+    type: NUMERIC
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_mode_name
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: modecd
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: sum_administrative_buildings
+    type: NUMERIC
+  - name: sum_communication_information
+    type: NUMERIC
+  - name: sum_fare_collection_equipment
+    type: NUMERIC
+  - name: sum_guideway
+    type: NUMERIC
+  - name: sum_maintenance_buildings
+    type: NUMERIC
+  - name: sum_other
+    type: NUMERIC
+  - name: sum_other_vehicles
+    type: NUMERIC
+  - name: sum_passenger_vehicles
+    type: NUMERIC
+  - name: sum_reduced_reporter
+    type: NUMERIC
+  - name: sum_stations
+    type: NUMERIC
+  - name: sum_total
+    type: NUMERIC
+  - name: typeofservicecd
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_for_existing_service.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_for_existing_service.yml
@@ -1,0 +1,60 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "capital_expenses_for_existing_service/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "capital_expenses_for_existing_service/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__capital_expenses_for_existing_service"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__capital_expenses_for_existing_service LIMIT 1;
+schema_fields:
+  - name: form_type
+    type: STRING
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: sum_administrative_buildings
+    type: NUMERIC
+  - name: sum_communication_information
+    type: NUMERIC
+  - name: sum_fare_collection_equipment
+    type: NUMERIC
+  - name: sum_guideway
+    type: NUMERIC
+  - name: sum_maintenance_buildings
+    type: NUMERIC
+  - name: sum_other
+    type: NUMERIC
+  - name: sum_other_vehicles
+    type: NUMERIC
+  - name: sum_passenger_vehicles
+    type: NUMERIC
+  - name: sum_reduced_reporter
+    type: NUMERIC
+  - name: sum_stations
+    type: NUMERIC
+  - name: sum_total
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_for_expansion_of_service.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__capital_expenses_for_expansion_of_service.yml
@@ -1,0 +1,60 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "capital_expenses_for_expansion_of_service/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "capital_expenses_for_expansion_of_service/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__capital_expenses_for_expansion_of_service"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__capital_expenses_for_expansion_of_service LIMIT 1;
+schema_fields:
+  - name: form_type
+    type: STRING
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: NUMERIC
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: sum_administrative_buildings
+    type: NUMERIC
+  - name: sum_communication_information
+    type: NUMERIC
+  - name: sum_fare_collection_equipment
+    type: NUMERIC
+  - name: sum_guideway
+    type: NUMERIC
+  - name: sum_maintenance_buildings
+    type: NUMERIC
+  - name: sum_other
+    type: NUMERIC
+  - name: sum_other_vehicles
+    type: NUMERIC
+  - name: sum_passenger_vehicles
+    type: NUMERIC
+  - name: sum_reduced_reporter
+    type: NUMERIC
+  - name: sum_stations
+    type: NUMERIC
+  - name: sum_total
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__employees_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__employees_by_agency.yml
@@ -1,0 +1,66 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "employees_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "employees_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__employees_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__employees_by_agency LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: avgwagerate
+    type: FLOAT
+  - name: count_capital_labor_count_q
+    type: NUMERIC
+  - name: count_capital_labor_hours_q
+    type: NUMERIC
+  - name: count_facility_maintenance_count_q
+    type: NUMERIC
+  - name: count_facility_maintenance_hours_q
+    type: NUMERIC
+  - name: count_general_administration_count_q
+    type: NUMERIC
+  - name: count_general_administration_hours_q
+    type: NUMERIC
+  - name: count_total_employee_count_q
+    type: NUMERIC
+  - name: count_total_employee_hours_q
+    type: NUMERIC
+  - name: count_vehicle_maintenance_count_q
+    type: NUMERIC
+  - name: count_vehicle_maintenance_hours_q
+    type: NUMERIC
+  - name: count_vehicle_operations_count_q
+    type: NUMERIC
+  - name: count_vehicle_operations_hours_q
+    type: NUMERIC
+  - name: max_agency_voms_1
+    type: STRING
+  - name: max_city_1
+    type: STRING
+  - name: max_mode_voms
+    type: NUMERIC
+  - name: max_ntd_id
+    type: NUMERIC
+  - name: max_primary_uza_population_1
+    type: STRING
+  - name: max_state_1
+    type: STRING
+  - name: max_uza_name_1
+    type: STRING
+  - name: report_year
+    type: NUMERIC
+  - name: sum_total_hours
+    type: NUMERIC
+  - name: total_employees
+    type: NUMERIC
+  - name: total_operating_hours
+    type: NUMERIC
+  - name: total_salaries
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__employees_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__employees_by_mode.yml
@@ -1,0 +1,52 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "employees_by_mode/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "employees_by_mode/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__employees_by_mode"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__employees_by_mode LIMIT 1;
+schema_fields:
+  - name: count_capital_labor_count_q
+    type: NUMERIC
+  - name: count_capital_labor_hours_q
+    type: NUMERIC
+  - name: count_facility_maintenance_count_q
+    type: NUMERIC
+  - name: count_facility_maintenance_hours_q
+    type: NUMERIC
+  - name: count_general_administration_count_q
+    type: NUMERIC
+  - name: count_general_administration_hours_q
+    type: NUMERIC
+  - name: count_total_employee_count_q
+    type: NUMERIC
+  - name: count_total_employee_hours_q
+    type: NUMERIC
+  - name: count_vehicle_maintenance_count_q
+    type: NUMERIC
+  - name: count_vehicle_maintenance_hours_q
+    type: NUMERIC
+  - name: count_vehicle_operations_count_q
+    type: NUMERIC
+  - name: count_vehicle_operations_hours_q
+    type: NUMERIC
+  - name: max_mode_name
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: sum_total_employee_count
+    type: NUMERIC
+  - name: sum_total_hours
+    type: NUMERIC
+  - name: type_of_service
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__employees_by_mode_and_employee_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__employees_by_mode_and_employee_type.yml
@@ -1,0 +1,68 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "employees_by_mode_and_employee_type/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "employees_by_mode_and_employee_type/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__employees_by_mode_and_employee_type"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__employees_by_mode_and_employee_type LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: capital_labor_count
+    type: NUMERIC
+  - name: capital_labor_hours
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: facility_maintenance_count
+    type: NUMERIC
+  - name: facility_maintenance_hours
+    type: NUMERIC
+  - name: full_or_part_time
+    type: STRING
+  - name: general_administration_count
+    type: NUMERIC
+  - name: general_administration_hours
+    type: NUMERIC
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: NUMERIC
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: primary_uza_population
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: state
+    type: STRING
+  - name: total_employee_count
+    type: NUMERIC
+  - name: total_hours
+    type: NUMERIC
+  - name: type_of_service
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: uza_name
+    type: STRING
+  - name: vehicle_maintenance_count
+    type: NUMERIC
+  - name: vehicle_maintenance_hours
+    type: NUMERIC
+  - name: vehicle_operations_count
+    type: NUMERIC
+  - name: vehicle_operations_hours
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__fuel_and_energy.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__fuel_and_energy.yml
@@ -1,0 +1,80 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "fuel_and_energy/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "fuel_and_energy/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__fuel_and_energy"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__fuel_and_energy LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: bio_diesel_gal
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: compressed_natural_gas
+    type: NUMERIC
+  - name: compressed_natural_gas_gal
+    type: NUMERIC
+  - name: diesel
+    type: NUMERIC
+  - name: diesel_gal
+    type: NUMERIC
+  - name: diesel_mpg
+    type: NUMERIC
+  - name: electric_battery
+    type: NUMERIC
+  - name: electric_battery_kwh
+    type: NUMERIC
+  - name: electric_propulsion
+    type: NUMERIC
+  - name: electric_propulsion_kwh
+    type: NUMERIC
+  - name: gasoline
+    type: NUMERIC
+  - name: gasoline_gal
+    type: NUMERIC
+  - name: hydrogen
+    type: NUMERIC
+  - name: hydrogen_kg_
+    type: NUMERIC
+  - name: liquefied_petroleum_gas
+    type: NUMERIC
+  - name: liquefied_petroleum_gas_gal
+    type: NUMERIC
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: NUMERIC
+  - name: modecd
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other_fuel
+    type: NUMERIC
+  - name: other_fuel_gal_gal_equivalent
+    type: NUMERIC
+  - name: primary_uza_population
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: typeofservicecd
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: uza_name
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__fuel_and_energy_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__fuel_and_energy_by_agency.yml
@@ -1,0 +1,74 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "fuel_and_energy_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "fuel_and_energy_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__fuel_and_energy_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__fuel_and_energy_by_agency LIMIT 1;
+schema_fields:
+  - name: diesel_gal_questionable
+    type: NUMERIC
+  - name: diesel_mpg_questionable
+    type: NUMERIC
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: NUMERIC
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: sum_bio_diesel_gal
+    type: NUMERIC
+  - name: sum_compressed_natural_gas
+    type: NUMERIC
+  - name: sum_compressed_natural_gas_gal
+    type: NUMERIC
+  - name: sum_diesel
+    type: NUMERIC
+  - name: sum_diesel_gal
+    type: NUMERIC
+  - name: sum_electric_battery
+    type: NUMERIC
+  - name: sum_electric_battery_kwh
+    type: NUMERIC
+  - name: sum_electric_propulsion
+    type: NUMERIC
+  - name: sum_electric_propulsion_kwh
+    type: NUMERIC
+  - name: sum_gasoline
+    type: NUMERIC
+  - name: sum_gasoline_gal
+    type: NUMERIC
+  - name: sum_hydrogen
+    type: NUMERIC
+  - name: sum_hydrogen_kg_
+    type: NUMERIC
+  - name: sum_liquefied_petroleum_gas
+    type: NUMERIC
+  - name: sum_liquefied_petroleum_gas_gal
+    type: NUMERIC
+  - name: sum_other_fuel
+    type: NUMERIC
+  - name: sum_other_fuel_gal_gal_equivalent
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_by_expense_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_by_expense_type.yml
@@ -1,0 +1,44 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "funding_sources_by_expense_type/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "funding_sources_by_expense_type/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__funding_sources_by_expense_type"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__funding_sources_by_expense_type LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: fares_and_other_directly
+    type: NUMERIC
+  - name: federal
+    type: NUMERIC
+  - name: fund_expenditure_type
+    type: STRING
+  - name: local
+    type: NUMERIC
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: state_1
+    type: NUMERIC
+  - name: taxes_fees_levied_by_transit
+    type: NUMERIC
+  - name: total
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_directly_generated.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_directly_generated.yml
@@ -1,0 +1,44 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "funding_sources_directly_generated/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "funding_sources_directly_generated/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__funding_sources_directly_generated"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__funding_sources_directly_generated LIMIT 1;
+schema_fields:
+  - name: advertising
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: concessions
+    type: STRING
+  - name: fares
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other
+    type: STRING
+  - name: park_and_ride
+    type: STRING
+  - name: purchased_transportation
+    type: STRING
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_federal.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_federal.yml
@@ -1,0 +1,44 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "funding_sources_federal/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "funding_sources_federal/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__funding_sources_federal"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__funding_sources_federal LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: fta_capital_program_5309
+    type: NUMERIC
+  - name: fta_rural_progam_5311
+    type: NUMERIC
+  - name: fta_urbanized_area_formula
+    type: NUMERIC
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other_dot_funds
+    type: NUMERIC
+  - name: other_federal_funds
+    type: NUMERIC
+  - name: other_fta_funds
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total_federal_funds
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_local.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_local.yml
@@ -1,0 +1,50 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "funding_sources_local/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "funding_sources_local/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__funding_sources_local"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__funding_sources_local LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: fuel_tax
+    type: STRING
+  - name: general_fund
+    type: STRING
+  - name: income_tax
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other_funds
+    type: STRING
+  - name: other_taxes
+    type: STRING
+  - name: property_tax
+    type: STRING
+  - name: reduced_reporter_funds
+    type: STRING
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: sales_tax
+    type: STRING
+  - name: state
+    type: STRING
+  - name: tolls
+    type: STRING
+  - name: total
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_state.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_state.yml
@@ -1,0 +1,38 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "funding_sources_state/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "funding_sources_state/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__funding_sources_state"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__funding_sources_state LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: general_funds
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: reduced_reporter_funds
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total
+    type: STRING
+  - name: transportation_funds
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_taxes_levied_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__funding_sources_taxes_levied_by_agency.yml
@@ -1,0 +1,46 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "funding_sources_taxes_levied_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "funding_sources_taxes_levied_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__funding_sources_taxes_levied_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__funding_sources_taxes_levied_by_agency LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: fuel_tax
+    type: NUMERIC
+  - name: income_tax
+    type: NUMERIC
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other_funds
+    type: NUMERIC
+  - name: other_tax
+    type: NUMERIC
+  - name: property_tax
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: sales_tax
+    type: NUMERIC
+  - name: state
+    type: STRING
+  - name: tolls
+    type: NUMERIC
+  - name: total
+    type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__maintenance_facilities.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__maintenance_facilities.yml
@@ -1,0 +1,54 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "maintenance_facilities/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "maintenance_facilities/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__maintenance_facilities"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__maintenance_facilities LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: leased_by_pt_provider
+    type: STRING
+  - name: leased_by_public_agency
+    type: STRING
+  - name: leased_from_a_private_entity
+    type: STRING
+  - name: leased_from_a_public_entity
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: NUMERIC
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: owned
+    type: STRING
+  - name: owned_by_pt_provider
+    type: STRING
+  - name: owned_by_public_agency
+    type: STRING
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total_facilities
+    type: NUMERIC
+  - name: type_of_service
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__maintenance_facilities_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__maintenance_facilities_by_agency.yml
@@ -1,0 +1,60 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "maintenance_facilities_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "maintenance_facilities_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__maintenance_facilities_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__maintenance_facilities_by_agency LIMIT 1;
+schema_fields:
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: STRING
+  - name: sum_200_to_300_vehicles
+    type: STRING
+  - name: sum_heavy_maintenance_facilities
+    type: STRING
+  - name: sum_leased_by_pt_provider
+    type: STRING
+  - name: sum_leased_by_public_agency
+    type: STRING
+  - name: sum_leased_from_a_private_entity
+    type: STRING
+  - name: sum_leased_from_a_public_entity
+    type: STRING
+  - name: sum_over_300_vehicles
+    type: STRING
+  - name: sum_owned
+    type: STRING
+  - name: sum_owned_by_pt_provider
+    type: STRING
+  - name: sum_owned_by_public_agency
+    type: STRING
+  - name: sum_total_facilities
+    type: STRING
+  - name: sum_under_200_vehicles
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__metrics.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__metrics.yml
@@ -1,0 +1,62 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "metrics/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "metrics/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__metrics"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__metrics LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: cost_per_hour
+    type: STRING
+  - name: cost_per_passenger
+    type: STRING
+  - name: cost_per_passenger_mile
+    type: STRING
+  - name: fare_revenues_earned
+    type: STRING
+  - name: fare_revenues_per_total
+    type: STRING
+  - name: fare_revenues_per_unlinked
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: passenger_miles
+    type: STRING
+  - name: passengers_per_hour
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total_operating_expenses
+    type: STRING
+  - name: type_of_service
+    type: STRING
+  - name: unlinked_passenger_trips
+    type: STRING
+  - name: vehicle_revenue_hours
+    type: STRING
+  - name: vehicle_revenue_miles
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_function.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_function.yml
@@ -1,0 +1,52 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "operating_expenses_by_function/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "operating_expenses_by_function/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__operating_expenses_by_function"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__operating_expenses_by_function LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: facility_maintenance
+    type: STRING
+  - name: general_administration
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: reduced_reporter_expenses
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: separate_report_amount
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total
+    type: STRING
+  - name: type_of_service
+    type: STRING
+  - name: vehicle_maintenance
+    type: STRING
+  - name: vehicle_operations
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_function_and_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_function_and_agency.yml
@@ -1,0 +1,50 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "operating_expenses_by_function_and_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "operating_expenses_by_function_and_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__operating_expenses_by_function_and_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__operating_expenses_by_function_and_agency LIMIT 1;
+schema_fields:
+  - name: Agency
+    type: STRING
+  - name: City
+    type: STRING
+  - name: State
+    type: STRING
+  - name: Total
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: STRING
+  - name: sum_facility_maintenance
+    type: STRING
+  - name: sum_general_administration
+    type: STRING
+  - name: sum_reduced_reporter_expenses
+    type: STRING
+  - name: sum_separate_report_amount
+    type: STRING
+  - name: sum_vehicle_maintenance
+    type: STRING
+  - name: sum_vehicle_operations
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_type.yml
@@ -1,0 +1,78 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "operating_expenses_by_type/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "operating_expenses_by_type/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__operating_expenses_by_type"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__operating_expenses_by_type LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: casualty_and_liability
+    type: STRING
+  - name: city
+    type: STRING
+  - name: fringe_benefits
+    type: STRING
+  - name: fuel_and_lube
+    type: STRING
+  - name: miscellaneous
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: operator_paid_absences
+    type: STRING
+  - name: operators_wages
+    type: STRING
+  - name: organization_type
+    type: STRING
+  - name: other_materials_supplies
+    type: STRING
+  - name: other_paid_absences
+    type: STRING
+  - name: other_salaries_wages
+    type: STRING
+  - name: primary_uza_population
+    type: STRING
+  - name: purchased_transportation
+    type: STRING
+  - name: reduced_reporter_expenses
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: separate_report_amount
+    type: STRING
+  - name: services
+    type: STRING
+  - name: state
+    type: STRING
+  - name: taxes
+    type: STRING
+  - name: tires
+    type: STRING
+  - name: total
+    type: STRING
+  - name: type_of_service
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: utilities
+    type: STRING
+  - name: uza_name
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_type_and_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__operating_expenses_by_type_and_agency.yml
@@ -1,0 +1,70 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "operating_expenses_by_type_and_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "operating_expenses_by_type_and_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__operating_expenses_by_type_and_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__operating_expenses_by_type_and_agency LIMIT 1;
+schema_fields:
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: STRING
+  - name: sum_casualty_and_liability
+    type: STRING
+  - name: sum_fringe_benefits
+    type: STRING
+  - name: sum_fuel_and_lube
+    type: STRING
+  - name: sum_miscellaneous
+    type: STRING
+  - name: sum_operator_paid_absences
+    type: STRING
+  - name: sum_operators_wages
+    type: STRING
+  - name: sum_other_materials_supplies
+    type: STRING
+  - name: sum_other_paid_absences
+    type: STRING
+  - name: sum_other_salaries_wages
+    type: STRING
+  - name: sum_purchased_transportation
+    type: STRING
+  - name: sum_reduced_reporter_expenses
+    type: STRING
+  - name: sum_separate_report_amount
+    type: STRING
+  - name: sum_services
+    type: STRING
+  - name: sum_taxes
+    type: STRING
+  - name: sum_tires
+    type: STRING
+  - name: sum_total
+    type: STRING
+  - name: sum_utilities
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__service_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__service_by_agency.yml
@@ -1,0 +1,84 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "service_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "service_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__service_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__service_by_agency LIMIT 1;
+schema_fields:
+  - name: _5_digit_ntd_id
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_area_sq_miles
+    type: STRING
+  - name: max_primary_uza_code
+    type: STRING
+  - name: max_primary_uza_name
+    type: STRING
+  - name: max_primary_uza_population
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_service_area_population
+    type: STRING
+  - name: max_service_area_sq_miles
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_deadhead_hours
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_hours
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_miles
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_revenue_hours
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_revenue_miles
+    type: STRING
+  - name: sum_actual_vehicles_passenger_deadhead_miles
+    type: STRING
+  - name: sum_ada_upt
+    type: STRING
+  - name: sum_charter_service_hours
+    type: STRING
+  - name: sum_directional_route_miles
+    type: STRING
+  - name: sum_passenger_miles
+    type: STRING
+  - name: sum_scheduled_vehicles_passenger_car_revenue_miles
+    type: STRING
+  - name: sum_school_bus_hours
+    type: STRING
+  - name: sum_sponsored_service_upt
+    type: STRING
+  - name: sum_train_deadhead_hours
+    type: STRING
+  - name: sum_train_deadhead_miles
+    type: STRING
+  - name: sum_train_hours
+    type: STRING
+  - name: sum_train_miles
+    type: STRING
+  - name: sum_train_revenue_hours
+    type: STRING
+  - name: sum_train_revenue_miles
+    type: STRING
+  - name: sum_trains_in_operation
+    type: STRING
+  - name: sum_unlinked_passenger_trips_upt
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__service_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__service_by_mode.yml
@@ -1,0 +1,86 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "service_by_mode/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "service_by_mode/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__service_by_mode"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__service_by_mode LIMIT 1;
+schema_fields:
+  - name: _5_digit_ntd_id
+    type: STRING
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_mode_name
+    type: STRING
+  - name: max_mode_voms
+    type: NUMERIC
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_area_sq_miles
+    type: STRING
+  - name: max_primary_uza_code
+    type: STRING
+  - name: max_primary_uza_name
+    type: STRING
+  - name: max_primary_uza_population
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_service_area_population
+    type: STRING
+  - name: max_service_area_sq_miles
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_time_period
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: questionable_record
+    type: STRING
+  - name: report_year
+    type: NUMERIC
+  - name: sum_actual_vehicles_passenger_car_deadhead_hours
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_hours
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_miles
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_revenue_hours
+    type: STRING
+  - name: sum_actual_vehicles_passenger_car_revenue_miles
+    type: STRING
+  - name: sum_actual_vehicles_passenger_deadhead_miles
+    type: STRING
+  - name: sum_charter_service_hours
+    type: STRING
+  - name: sum_directional_route_miles
+    type: STRING
+  - name: sum_passenger_miles
+    type: STRING
+  - name: sum_scheduled_vehicles_passenger_car_revenue_miles
+    type: STRING
+  - name: sum_train_hours
+    type: STRING
+  - name: sum_train_miles
+    type: STRING
+  - name: sum_train_revenue_hours
+    type: STRING
+  - name: sum_train_revenue_miles
+    type: STRING
+  - name: sum_trains_in_operation
+    type: STRING
+  - name: sum_unlinked_passenger_trips_upt
+    type: STRING
+  - name: type_of_service
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__service_by_mode_and_time_period.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__service_by_mode_and_time_period.yml
@@ -1,0 +1,76 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "service_by_mode_and_time_period/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "service_by_mode_and_time_period/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__service_by_mode_and_time_period"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__service_by_mode_and_time_period LIMIT 1;
+schema_fields:
+  - name: _5_digit_ntd_id
+    type: STRING
+  - name: actual_vehicles_passenger_car_deadhead_hours
+    type: STRING
+  - name: actual_vehicles_passenger_car_hours
+    type: STRING
+  - name: actual_vehicles_passenger_car_miles
+    type: STRING
+  - name: actual_vehicles_passenger_car_revenue_hours
+    type: STRING
+  - name: actual_vehicles_passenger_car_revenue_miles
+    type: STRING
+  - name: actual_vehicles_passenger_deadhead_miles
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: average_speed
+    type: STRING
+  - name: city
+    type: STRING
+  - name: directional_route_miles
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: STRING
+  - name: organization_type
+    type: STRING
+  - name: passenger_miles
+    type: STRING
+  - name: passengers_per_hour
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: scheduled_vehicles_passenger_car_revenue_miles
+    type: STRING
+  - name: sponsored_service_upt
+    type: STRING
+  - name: state
+    type: STRING
+  - name: time_period
+    type: STRING
+  - name: train_hours
+    type: STRING
+  - name: train_miles
+    type: STRING
+  - name: train_revenue_hours
+    type: STRING
+  - name: train_revenue_miles
+    type: STRING
+  - name: trains_in_operation
+    type: STRING
+  - name: type_of_service
+    type: STRING
+  - name: unlinked_passenger_trips_upt
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__stations_and_facilities_by_agency_and_facility_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__stations_and_facilities_by_agency_and_facility_type.yml
@@ -1,0 +1,88 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "stations_and_facilities_by_agency_and_facility_type/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "stations_and_facilities_by_agency_and_facility_type/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__stations_and_facilities_by_agency_and_facility_type"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__stations_and_facilities_by_agency_and_facility_type LIMIT 1;
+schema_fields:
+  - name: administrative_and_other_non_passenger_facilities
+    type: STRING
+  - name: administrative_office_sales
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: at_grade_fixed_guideway
+    type: STRING
+  - name: bus_transfer_center
+    type: STRING
+  - name: city
+    type: STRING
+  - name: combined_administrative_and
+    type: STRING
+  - name: elevated_fixed_guideway
+    type: STRING
+  - name: exclusive_grade_separated
+    type: STRING
+  - name: ferryboat_terminal
+    type: STRING
+  - name: general_purpose_maintenance
+    type: STRING
+  - name: heavy_maintenance_overhaul
+    type: STRING
+  - name: maintenance_facilities
+    type: STRING
+  - name: maintenance_facility_service
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other_administrative
+    type: STRING
+  - name: other_passenger_or_parking
+    type: STRING
+  - name: parking_and_other_passenger_facilities
+    type: STRING
+  - name: parking_structure
+    type: STRING
+  - name: passenger_stations_and_terminals
+    type: STRING
+  - name: primary_uza_population
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: revenue_collection_facility
+    type: STRING
+  - name: simple_at_grade_platform
+    type: STRING
+  - name: state
+    type: STRING
+  - name: surface_parking_lot
+    type: STRING
+  - name: total_facilities
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: underground_fixed_guideway
+    type: STRING
+  - name: uza_name
+    type: STRING
+  - name: vehicle_blow_down_facility
+    type: STRING
+  - name: vehicle_fueling_facility
+    type: STRING
+  - name: vehicle_testing_facility
+    type: STRING
+  - name: vehicle_washing_facility
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__stations_by_mode_and_age.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__stations_by_mode_and_age.yml
@@ -1,0 +1,64 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "stations_by_mode_and_age/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "stations_by_mode_and_age/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__stations_by_mode_and_age"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__stations_by_mode_and_age LIMIT 1;
+schema_fields:
+  - name: _1940s
+    type: STRING
+  - name: _1950s
+    type: STRING
+  - name: _1960s
+    type: STRING
+  - name: _1970s
+    type: STRING
+  - name: _1980s
+    type: STRING
+  - name: _1990s
+    type: STRING
+  - name: _2000s
+    type: STRING
+  - name: _2010s
+    type: STRING
+  - name: _2020s
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: facility_type
+    type: STRING
+  - name: mode_names
+    type: STRING
+  - name: modes
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: pre1940
+    type: STRING
+  - name: primary_uza_population
+    type: NUMERIC
+  - name: report_year
+    type: NUMERIC
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total_facilities
+    type: NUMERIC
+  - name: uace_code
+    type: STRING
+  - name: uza_name
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__track_and_roadway_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__track_and_roadway_by_agency.yml
@@ -1,0 +1,78 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "track_and_roadway_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "track_and_roadway_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__track_and_roadway_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__track_and_roadway_by_agency LIMIT 1;
+schema_fields:
+  - name: max_agency
+    type: STRING
+  - name: max_agency_voms
+    type: STRING
+  - name: max_city
+    type: STRING
+  - name: max_organization_type
+    type: STRING
+  - name: max_primary_uza_population
+    type: STRING
+  - name: max_reporter_type
+    type: STRING
+  - name: max_state
+    type: STRING
+  - name: max_uace_code
+    type: STRING
+  - name: max_uza_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: report_year
+    type: STRING
+  - name: sum_at_grade_ballast_including
+    type: STRING
+  - name: sum_at_grade_in_street_embedded
+    type: STRING
+  - name: sum_below_grade_bored_or_blasted
+    type: STRING
+  - name: sum_below_grade_cut_and_cover
+    type: STRING
+  - name: sum_below_grade_retained_cut
+    type: STRING
+  - name: sum_below_grade_submerged_tube
+    type: STRING
+  - name: sum_controlled_access_high
+    type: STRING
+  - name: sum_double_crossover
+    type: STRING
+  - name: sum_elevated_concrete
+    type: STRING
+  - name: sum_elevated_retained_fill
+    type: STRING
+  - name: sum_elevated_steel_viaduct_or
+    type: STRING
+  - name: sum_exclusive_fixed_guideway
+    type: STRING
+  - name: sum_exclusive_high_intensity
+    type: STRING
+  - name: sum_grade_crossings
+    type: STRING
+  - name: sum_lapped_turnout
+    type: STRING
+  - name: sum_rail_crossings
+    type: STRING
+  - name: sum_single_crossover
+    type: STRING
+  - name: sum_single_turnout
+    type: STRING
+  - name: sum_slip_switch
+    type: STRING
+  - name: sum_total_miles
+    type: STRING
+  - name: sum_total_track_miles
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__track_and_roadway_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__track_and_roadway_by_mode.yml
@@ -1,0 +1,86 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "track_and_roadway_by_mode/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "track_and_roadway_by_mode/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__track_and_roadway_by_mode"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__track_and_roadway_by_mode LIMIT 1;
+schema_fields:
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: at_grade_ballast_including
+    type: STRING
+  - name: at_grade_in_street_embedded
+    type: STRING
+  - name: below_grade_bored_or_blasted
+    type: STRING
+  - name: below_grade_cut_and_cover
+    type: STRING
+  - name: below_grade_retained_cut
+    type: STRING
+  - name: below_grade_submerged_tube
+    type: STRING
+  - name: city
+    type: STRING
+  - name: controlled_access_high
+    type: STRING
+  - name: double_crossover
+    type: STRING
+  - name: elevated_concrete
+    type: STRING
+  - name: elevated_retained_fill
+    type: STRING
+  - name: elevated_steel_viaduct_or
+    type: STRING
+  - name: exclusive_fixed_guideway
+    type: STRING
+  - name: exclusive_high_intensity
+    type: STRING
+  - name: grade_crossings
+    type: STRING
+  - name: lapped_turnout
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: mode_voms
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: primary_uza_population
+    type: STRING
+  - name: rail_crossings
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: single_crossover
+    type: STRING
+  - name: single_turnout
+    type: STRING
+  - name: slip_switch
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total_miles
+    type: STRING
+  - name: total_track_miles
+    type: STRING
+  - name: type_of_service
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: uza_name
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__track_and_roadway_guideway_age_distribution.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__track_and_roadway_guideway_age_distribution.yml
@@ -1,0 +1,64 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "track_and_roadway_guideway_age_distribution/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "track_and_roadway_guideway_age_distribution/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__track_and_roadway_guideway_age_distribution"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__track_and_roadway_guideway_age_distribution LIMIT 1;
+schema_fields:
+  - name: _1940s
+    type: STRING
+  - name: _1950s
+    type: STRING
+  - name: _1960s
+    type: STRING
+  - name: _1970s
+    type: STRING
+  - name: _1980s
+    type: STRING
+  - name: _1990s
+    type: STRING
+  - name: _2000s
+    type: STRING
+  - name: _2010s
+    type: STRING
+  - name: _2020s
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: city
+    type: STRING
+  - name: guideway_element
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: mode_name
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: pre1940s
+    type: STRING
+  - name: primary_uza_population
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: type_of_service
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: uza_name
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__vehicles_age_distribution.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__vehicles_age_distribution.yml
@@ -1,0 +1,82 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "vehicles_age_distribution/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "vehicles_age_distribution/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__vehicles_age_distribution"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__vehicles_age_distribution LIMIT 1;
+schema_fields:
+  - name: _0
+    type: STRING
+  - name: _1
+    type: STRING
+  - name: _10
+    type: STRING
+  - name: _11
+    type: STRING
+  - name: _12
+    type: STRING
+  - name: _13_15
+    type: STRING
+  - name: _16_20
+    type: STRING
+  - name: _2
+    type: STRING
+  - name: _21_25
+    type: STRING
+  - name: _26_30
+    type: STRING
+  - name: _3
+    type: STRING
+  - name: _31_60
+    type: STRING
+  - name: _4
+    type: STRING
+  - name: _5
+    type: STRING
+  - name: _6
+    type: STRING
+  - name: _60
+    type: STRING
+  - name: _7
+    type: STRING
+  - name: _8
+    type: STRING
+  - name: _9
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: average_age_of_fleet_in_years
+    type: STRING
+  - name: average_lifetime_miles_per
+    type: STRING
+  - name: city
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: primary_uza_population
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: state
+    type: STRING
+  - name: total_vehicles
+    type: STRING
+  - name: uace_code
+    type: STRING
+  - name: uza_name
+    type: STRING
+  - name: vehicle_type
+    type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__vehicles_type_count_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__vehicles_type_count_by_agency.yml
@@ -1,0 +1,200 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-api-products
+source_objects:
+  - "vehicles_type_count_by_agency/2022/*.jsonl.gz"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "vehicles_type_count_by_agency/2022/{dt:DATE}/{execution_ts:TIMESTAMP}"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__vehicles_type_count_by_agency"
+prefix_bucket: false
+post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__vehicles_type_count_by_agency LIMIT 1;
+schema_fields:
+  - name: aerial_tram
+    type: STRING
+  - name: aerial_tram_rptulb
+    type: STRING
+  - name: aerial_tram_ulb
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: agency_voms
+    type: NUMERIC
+  - name: articulated_bus
+    type: STRING
+  - name: articulated_bus_ulb
+    type: STRING
+  - name: articulated_busrptulb
+    type: STRING
+  - name: automated_guideway_vehicle
+    type: STRING
+  - name: automated_guideway_vehicle_1
+    type: STRING
+  - name: automated_guideway_vehicle_2
+    type: STRING
+  - name: automobile
+    type: STRING
+  - name: automobile_ulb
+    type: STRING
+  - name: automobilerptulb
+    type: STRING
+  - name: automobiles
+    type: STRING
+  - name: automobiles_ulb
+    type: STRING
+  - name: bus
+    type: STRING
+  - name: bus_ulb
+    type: STRING
+  - name: busrptulb
+    type: STRING
+  - name: cable_car
+    type: STRING
+  - name: cable_car_rptulb
+    type: STRING
+  - name: cable_car_ulb
+    type: STRING
+  - name: city
+    type: STRING
+  - name: commuter_rail_passenger_coach
+    type: STRING
+  - name: commuter_rail_passenger_coach_1
+    type: STRING
+  - name: commuter_rail_passenger_coach_2
+    type: STRING
+  - name: commuter_rail_self_propelled
+    type: STRING
+  - name: commuter_rail_self_propelled_1
+    type: STRING
+  - name: commuter_rail_self_propelled_2
+    type: STRING
+  - name: cutaway
+    type: STRING
+  - name: cutaway_ulb
+    type: STRING
+  - name: cutawayrptulb
+    type: STRING
+  - name: double_decker_bus
+    type: STRING
+  - name: double_decker_bus_ulb
+    type: STRING
+  - name: double_decker_busrptulb
+    type: STRING
+  - name: ferryboat
+    type: STRING
+  - name: ferryboat_rptulb
+    type: STRING
+  - name: ferryboat_ulb
+    type: STRING
+  - name: heavy_rail_passenger_car
+    type: STRING
+  - name: heavy_rail_passenger_car_1
+    type: STRING
+  - name: heavy_rail_passenger_car_2
+    type: STRING
+  - name: inclined_plane
+    type: STRING
+  - name: inclined_plane_rptulb
+    type: STRING
+  - name: inclined_plane_ulb
+    type: STRING
+  - name: light_rail_vehicle
+    type: STRING
+  - name: light_rail_vehicle_rptulb
+    type: STRING
+  - name: light_rail_vehicle_ulb
+    type: STRING
+  - name: locomotive
+    type: STRING
+  - name: locomotive_rptulb
+    type: STRING
+  - name: locomotive_ulb
+    type: STRING
+  - name: minivan
+    type: STRING
+  - name: minivan_ulb
+    type: STRING
+  - name: minivanrptulb
+    type: STRING
+  - name: monorail
+    type: STRING
+  - name: monorail_ulb
+    type: STRING
+  - name: ntd_id
+    type: NUMERIC
+  - name: organization_type
+    type: STRING
+  - name: other
+    type: STRING
+  - name: other_rptulb
+    type: STRING
+  - name: other_ulb
+    type: STRING
+  - name: over_the_road_bus
+    type: STRING
+  - name: over_the_road_bus_ulb
+    type: STRING
+  - name: over_the_road_busrptulb
+    type: STRING
+  - name: report_year
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: school_bus
+    type: STRING
+  - name: school_bus_ulb
+    type: STRING
+  - name: schoolbusrptulb
+    type: STRING
+  - name: sport_utility_vehicle
+    type: STRING
+  - name: sport_utility_vehicle_rptulb
+    type: STRING
+  - name: sport_utility_vehicle_ulb
+    type: STRING
+  - name: state
+    type: STRING
+  - name: steel_wheel_vehicles
+    type: STRING
+  - name: steel_wheel_vehicles_ulb
+    type: STRING
+  - name: streetcar
+    type: STRING
+  - name: streetcar_rptulb
+    type: STRING
+  - name: streetcar_ulb
+    type: STRING
+  - name: total_revenue_vehicles
+    type: STRING
+  - name: total_revenue_vehicles_ulb
+    type: STRING
+  - name: total_rptulb
+    type: STRING
+  - name: total_service_vehicles
+    type: STRING
+  - name: total_service_vehicles_ulb
+    type: STRING
+  - name: trolleybus
+    type: STRING
+  - name: trolleybus_ulb
+    type: STRING
+  - name: trolleybusrptulb
+    type: STRING
+  - name: trucks_and_other_rubber_tire
+    type: STRING
+  - name: trucks_and_other_rubber_tire_1
+    type: STRING
+  - name: van
+    type: STRING
+  - name: van_ulb
+    type: STRING
+  - name: vanrptulb
+    type: STRING
+  - name: vintage_historic_trolley
+    type: STRING
+  - name: vintage_historic_trolley_1
+    type: STRING
+  - name: vintage_historic_trolley_2
+    type: STRING


### PR DESCRIPTION
# Description

This PR creates [#3403] the NTD external tables for 2022 API data

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

It was tested with local Airflow and the tables were created on cal-itp-data-infra-staging.external_ntd__annual_reporting

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Validate the creation of the tables on cal-itp-data-infra.external_ntd__annual_reporting