### PR TITLE
Refactor: Benefits Amplitude events

### DIFF
--- a/warehouse/models/mart/benefits/_mart_benefits.yml
+++ b/warehouse/models/mart/benefits/_mart_benefits.yml
@@ -84,7 +84,13 @@ models:
       - name: event_properties_path
         description: The `path` value from the `event_properties` column
       - name: event_properties_payment_group
-        description: The `payment_group` value from the `event_properties` column
+        description: The `enrollment_group` value from the `event_properties` column
+        deprecated:
+          enabled: true
+          reason: "This column is deprecated, use `event_properties_enrollment_group` instead"
+          date: "2024-10-10"
+      - name: event_properties_enrollment_group
+        description: The `enrollment_group` value from the `event_properties` column
       - name: event_properties_status
         description: The `status` value from the `event_properties` column
       - name: event_properties_transit_agency

--- a/warehouse/models/mart/benefits/_mart_benefits.yml
+++ b/warehouse/models/mart/benefits/_mart_benefits.yml
@@ -56,7 +56,13 @@ models:
       - name: processed_time
         description: UTC ISO-8601 timestamp
       - name: event_properties_auth_provider
-        description: The `auth_provider` value from the `event_properties` column
+        description: The `claims_provider` value from the `event_properties` column
+        deprecated:
+          enabled: true
+          reason: "This column is deprecated, use `event_properties_claims_provider` instead"
+          date: "2024-10-10"
+      - name: event_properties_claims_provider
+        description: The `claims_provider` value from the `event_properties` column
       - name: event_properties_card_tokenize_func
         description: The `card_tokenize_func` value from the `event_properties` column
       - name: event_properties_card_tokenize_url

--- a/warehouse/models/mart/benefits/_mart_benefits.yml
+++ b/warehouse/models/mart/benefits/_mart_benefits.yml
@@ -55,6 +55,8 @@ models:
         description: UUID
       - name: processed_time
         description: UTC ISO-8601 timestamp
+      - name: event_properties_enrollment_method
+        description: The `enrollment_method` value from the `event_properties` column
       - name: event_properties_auth_provider
         description: The `claims_provider` value from the `event_properties` column
         deprecated:
@@ -103,6 +105,8 @@ models:
           date: "2024-09-19"
       - name: event_properties_enrollment_flows
         description: A semi-colon delimited list of `enrollment_flows` values from the `event_properties` column
+      - name: user_properties_enrollment_method
+        description: The `enrollment_method` value from the `user_properties` column
       - name: user_properties_eligibility_verifier
         description: The `eligibility_verifier` value from the `user_properties` column
       - name: user_properties_initial_referrer

--- a/warehouse/models/mart/benefits/_mart_benefits.yml
+++ b/warehouse/models/mart/benefits/_mart_benefits.yml
@@ -84,7 +84,13 @@ models:
       - name: event_properties_transit_agency
         description: The `transit_agency` value from the `event_properties` column
       - name: event_properties_eligibility_types
-        description: A semi-colon delimited list of `eligibility_types` values from the `event_properties` column
+        description: A semi-colon delimited list of `enrollment_flows` values from the `event_properties` column
+        deprecated:
+          enabled: true
+          reason: "This column is deprecated, use `event_properties_enrollment_flows` instead"
+          date: "2024-09-19"
+      - name: event_properties_enrollment_flows
+        description: A semi-colon delimited list of `enrollment_flows` values from the `event_properties` column
       - name: user_properties_eligibility_verifier
         description: The `eligibility_verifier` value from the `user_properties` column
       - name: user_properties_initial_referrer
@@ -100,4 +106,10 @@ models:
       - name: user_properties_user_agent
         description: The `user_agent` value from the `user_properties` column
       - name: user_properties_eligibility_types
-        description: A semi-colon delimited list of `eligibility_types` values from the `user_properties` column
+        description: A semi-colon delimited list of `enrollment_flows` values from the `user_properties` column
+        deprecated:
+          enabled: true
+          reason: "This column is deprecated, use `user_properties_enrollment_flows` instead"
+          date: "2024-09-19"
+      - name: user_properties_enrollment_flows
+        description: A semi-colon delimited list of `enrollment_flows` values from the `user_properties` column

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -48,7 +48,15 @@ WITH fct_benefits_events AS (
         {{ json_extract_column('event_properties', 'payment_group') }},
         {{ json_extract_column('event_properties', 'status') }},
         {{ json_extract_column('event_properties', 'transit_agency') }},
-        {{ json_extract_flattened_column('event_properties', 'eligibility_types') }},
+
+        -- Historical data existed in `eligibility_types` but new data is in `enrollment_flows`
+        -- https://github.com/cal-itp/benefits/pull/2379
+        COALESCE(
+            {{ json_extract_flattened_column('event_properties', 'enrollment_flows', no_alias = true) }},
+            {{ json_extract_flattened_column('event_properties', 'eligibility_types', no_alias = true) }}
+        ) AS event_properties_enrollment_flows,
+        -- include the old field as well, deprecated in the mart definition
+        event_properties_enrollment_flows AS event_properties_eligibility_types,
 
         -- User Properties (https://app.amplitude.com/data/compiler/Benefits/properties/main/latest/user)
         {{ json_extract_column('user_properties', 'eligibility_verifier') }},
@@ -65,7 +73,15 @@ WITH fct_benefits_events AS (
         {{ json_extract_column('user_properties', 'referrer') }},
         {{ json_extract_column('user_properties', 'referring_domain') }},
         {{ json_extract_column('user_properties', 'user_agent') }},
-        {{ json_extract_flattened_column('user_properties', 'eligibility_types') }}
+
+        -- Historical data existed in `eligibility_types` but new data is in `enrollment_flows`
+        -- https://github.com/cal-itp/benefits/pull/2379
+        COALESCE(
+            {{ json_extract_flattened_column('user_properties', 'enrollment_flows', no_alias = true) }},
+            {{ json_extract_flattened_column('user_properties', 'eligibility_types', no_alias = true) }}
+        ) AS user_properties_enrollment_flows,
+        -- include the old field as well, deprecated in the mart definition
+        user_properties_enrollment_flows as user_properties_eligibility_types
 
     FROM {{ ref('stg_amplitude__benefits_events') }}
 ),
@@ -115,7 +131,8 @@ fct_old_enrollments AS (
     "5170d37b-43d5-4049-899c-b4d850e14990" as event_properties_payment_group,
     "success" as event_properties_status,
     "Monterey-Salinas Transit" as event_properties_transit_agency,
-    "senior" as event_properties_eligibility_types,
+    "senior" as event_properties_enrollment_flows,
+    event_properties_enrollment_flows as event_properties_eligibility_types,
     CASE
       WHEN client_event_time < '2022-08-12T07:00:00Z'
         THEN "DMV"
@@ -128,7 +145,8 @@ fct_old_enrollments AS (
     user_properties_user_agent,
     user_properties_referrer,
     user_properties_referring_domain,
-    "senior" as user_properties_eligibility_types
+    "senior" as user_properties_enrollment_flows,
+    user_properties_enrollment_flows as user_properties_eligibility_types
   FROM fct_benefits_events
   WHERE client_event_time >= '2021-12-08T08:00:00Z'
     and client_event_time < '2022-08-29T07:00:00Z'

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -18,7 +18,23 @@ WITH fct_benefits_events AS (
             then "finished card tokenization"
           else event_type
         end as event_type,
-        version_name,
+        -- Fix bug in Docker build process resulting in incorrect version strings
+        -- https://github.com/cal-itp/benefits/pull/2392
+        case
+          when version_name = "2024.7.3.dev0+gcd3b083.d20240731"
+            then "2024.7.2"
+          when version_name = "2024.8.2.dev0+g7664917.d20240821"
+            then "2024.8.1"
+          when version_name = "2024.9.2.dev0+gadf41b9.d20240909"
+            then "2024.9.1"
+          when version_name = "2024.9.3.dev0+gfeb06d2.d20240918"
+            then "2024.9.2"
+          when version_name = "2024.9.4.dev0+g861519e.d20240926"
+            then "2024.9.3"
+          when version_name = "2024.10.2.dev0+g158e1b0.d20241010"
+            then "2024.10.1"
+          else version_name
+        end as version_name,
         os_name,
         os_version,
         device_family,
@@ -33,7 +49,23 @@ WITH fct_benefits_events AS (
         server_upload_time,
         server_received_time,
         amplitude_id,
-        start_version,
+        -- Fix bug in Docker build process resulting in incorrect version strings
+        -- https://github.com/cal-itp/benefits/pull/2392
+        case
+          when start_version = "2024.7.3.dev0+gcd3b083.d20240731"
+            then "2024.7.2"
+          when start_version = "2024.8.2.dev0+g7664917.d20240821"
+            then "2024.8.1"
+          when start_version = "2024.9.2.dev0+gadf41b9.d20240909"
+            then "2024.9.1"
+          when start_version = "2024.9.3.dev0+gfeb06d2.d20240918"
+            then "2024.9.2"
+          when start_version = "2024.9.4.dev0+g861519e.d20240926"
+            then "2024.9.3"
+          when start_version = "2024.10.2.dev0+g158e1b0.d20241010"
+            then "2024.10.1"
+          else start_version
+        end as start_version,
         uuid,
         processed_time,
 

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -96,8 +96,6 @@ WITH fct_benefits_events AS (
           {{ json_extract_column('event_properties', 'claims_provider', no_alias = true) }},
           {{ json_extract_column('event_properties', 'auth_provider', no_alias = true) }}
         ) AS event_properties_claims_provider,
-        -- include the old field as well, deprecated in the mart definition
-        event_properties_claims_provider AS event_properties_auth_provider,
 
         -- Historical data existed in `eligibility_types` but new data is in `enrollment_flows`
         -- https://github.com/cal-itp/benefits/pull/2379
@@ -105,8 +103,6 @@ WITH fct_benefits_events AS (
             {{ json_extract_flattened_column('event_properties', 'enrollment_flows', no_alias = true) }},
             {{ json_extract_flattened_column('event_properties', 'eligibility_types', no_alias = true) }}
         ) AS event_properties_enrollment_flows,
-        -- include the old field as well, deprecated in the mart definition
-        event_properties_enrollment_flows AS event_properties_eligibility_types,
 
         -- Historical data existed in `payment_group` but new data is in `enrollment_group`
         -- https://github.com/cal-itp/benefits/pull/2391
@@ -114,8 +110,6 @@ WITH fct_benefits_events AS (
             {{ json_extract_flattened_column('event_properties', 'enrollment_group', no_alias = true) }},
             {{ json_extract_flattened_column('event_properties', 'payment_group', no_alias = true) }}
         ) AS event_properties_enrollment_group,
-        -- include the old field as well, deprecated in the mart definition
-        event_properties_enrollment_group AS event_properties_payment_group,
 
         -- User Properties (https://app.amplitude.com/data/compiler/Benefits/properties/main/latest/user)
         {{ json_extract_column('user_properties', 'eligibility_verifier') }},
@@ -145,9 +139,7 @@ WITH fct_benefits_events AS (
         COALESCE(
             {{ json_extract_flattened_column('user_properties', 'enrollment_flows', no_alias = true) }},
             {{ json_extract_flattened_column('user_properties', 'eligibility_types', no_alias = true) }}
-        ) AS user_properties_enrollment_flows,
-        -- include the old field as well, deprecated in the mart definition
-        user_properties_enrollment_flows as user_properties_eligibility_types
+        ) AS user_properties_enrollment_flows
 
     FROM {{ ref('stg_amplitude__benefits_events') }}
 ),
@@ -185,7 +177,6 @@ fct_old_enrollments AS (
       WHEN client_event_time >= '2022-08-12T07:00:00Z'
         THEN "cdt-logingov"
     END as event_properties_claims_provider,
-    event_properties_claims_provider as event_properties_auth_provider,
     event_properties_card_tokenize_func,
     event_properties_card_tokenize_url,
     CASE
@@ -202,11 +193,9 @@ fct_old_enrollments AS (
     event_properties_origin,
     event_properties_path,
     "5170d37b-43d5-4049-899c-b4d850e14990" as event_properties_enrollment_group,
-    event_properties_enrollment_group as event_properties_payment_group,
     "success" as event_properties_status,
     "Monterey-Salinas Transit" as event_properties_transit_agency,
     "senior" as event_properties_enrollment_flows,
-    event_properties_enrollment_flows as event_properties_eligibility_types,
     "digital" as user_properties_enrollment_method,
     CASE
       WHEN client_event_time < '2022-08-12T07:00:00Z'
@@ -220,8 +209,7 @@ fct_old_enrollments AS (
     user_properties_user_agent,
     user_properties_referrer,
     user_properties_referring_domain,
-    "senior" as user_properties_enrollment_flows,
-    user_properties_enrollment_flows as user_properties_eligibility_types
+    "senior" as user_properties_enrollment_flows
   FROM fct_benefits_events
   WHERE client_event_time >= '2021-12-08T08:00:00Z'
     and client_event_time < '2022-08-29T07:00:00Z'

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -51,6 +51,13 @@ WITH fct_benefits_events AS (
         {{ json_extract_column('event_properties', 'status') }},
         {{ json_extract_column('event_properties', 'transit_agency') }},
 
+        -- New column `enrollment_method`, historical values should be set to "digital"
+        -- https://github.com/cal-itp/benefits/pull/2402
+        COALESCE(
+          {{ json_extract_column('event_properties', 'enrollment_method', no_alias = true) }},
+          "digital"
+        ) AS event_properties_enrollment_method,
+
         -- Historical data existed in `auth_provider` but new data is in `claims_provider`
         -- https://github.com/cal-itp/benefits/pull/2401
         COALESCE(
@@ -94,6 +101,13 @@ WITH fct_benefits_events AS (
         {{ json_extract_column('user_properties', 'referring_domain') }},
         {{ json_extract_column('user_properties', 'user_agent') }},
 
+        -- New column `enrollment_method`, historical values should be set to "digital"
+        -- https://github.com/cal-itp/benefits/pull/2402
+        COALESCE(
+          {{ json_extract_column('user_properties', 'enrollment_method', no_alias = true) }},
+          "digital"
+        ) AS user_properties_enrollment_method,
+
         -- Historical data existed in `eligibility_types` but new data is in `enrollment_flows`
         -- https://github.com/cal-itp/benefits/pull/2379
         COALESCE(
@@ -132,6 +146,7 @@ fct_old_enrollments AS (
     start_version,
     uuid,
     processed_time,
+    "digital" as event_properties_enrollment_method,
     CASE
       WHEN client_event_time < '2022-08-12T07:00:00Z'
         THEN "ca-dmv"
@@ -160,6 +175,7 @@ fct_old_enrollments AS (
     "Monterey-Salinas Transit" as event_properties_transit_agency,
     "senior" as event_properties_enrollment_flows,
     event_properties_enrollment_flows as event_properties_eligibility_types,
+    "digital" as user_properties_enrollment_method,
     CASE
       WHEN client_event_time < '2022-08-12T07:00:00Z'
         THEN "ca-dmv"

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -117,9 +117,9 @@ fct_old_enrollments AS (
     event_properties_card_tokenize_url,
     CASE
       WHEN client_event_time < '2022-08-12T07:00:00Z'
-        THEN "DMV"
+        THEN "ca-dmv"
       WHEN client_event_time >= '2022-08-12T07:00:00Z'
-        THEN "(MST) CDT claims via Login.gov"
+        THEN "cdt-logingov"
     END as event_properties_eligibility_verifier,
     event_properties_error_name,
     event_properties_error_status,
@@ -135,9 +135,9 @@ fct_old_enrollments AS (
     event_properties_enrollment_flows as event_properties_eligibility_types,
     CASE
       WHEN client_event_time < '2022-08-12T07:00:00Z'
-        THEN "DMV"
+        THEN "ca-dmv"
       WHEN client_event_time >= '2022-08-12T07:00:00Z'
-        THEN "(MST) CDT claims via Login.gov"
+        THEN "cdt-logingov"
     END as user_properties_eligibility_verifier,
     user_properties_initial_referrer,
     user_properties_initial_referring_domain,

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -9,7 +9,11 @@ WITH fct_benefits_events AS (
         client_event_time,
         event_id,
         session_id,
-        event_type,
+        case
+          when event_type = "selected eligibility verifier"
+            then "selected enrollment flow"
+          else event_type
+        end as event_type,
         version_name,
         os_name,
         os_version,

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -12,6 +12,10 @@ WITH fct_benefits_events AS (
         case
           when event_type = "selected eligibility verifier"
             then "selected enrollment flow"
+          when event_type = "started payment connection"
+            then "started card tokenization"
+          when event_type = "closed payment connection" or event_type = "ended card tokenization"
+            then "finished card tokenization"
           else event_type
         end as event_type,
         version_name,


### PR DESCRIPTION
# Description

We recently completed a big refactor of the models in Benefits, see cal-itp/benefits#1666 for more background.

The last piece of this refactor is updating our new and historic analytics events. The following PRs update the logic for generating new events:

- [x] cal-itp/benefits#2379
- [x] cal-itp/benefits#2391
- [x] cal-itp/benefits#2401

And this PR is for the warehouse side, to handle the new fields and adjust historical data already captured in GCS.

We don't want to merge this PR until all of the above PRs are merged _and_ released to our `prod` environment.

Closes cal-itp/benefits#2247
Closes cal-itp/benefits#2248
Closes cal-itp/benefits#2249
Closes cal-itp/benefits#2390

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```shell
 poetry run dbt run -s +fct_benefits_events
```

```console
$ poetry run dbt run -s +fct_benefits_events
19:38:34  Running with dbt=1.5.1
19:38:35  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
19:38:35  Found 420 models, 950 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 175 sources, 4 exposures, 0 metrics, 0 groups
19:38:35  
19:39:53  Concurrency: 8 threads (target='dev')
19:39:53  
19:39:53  1 of 2 START sql view model kegan_staging.stg_amplitude__benefits_events ....... [RUN]
19:39:54  1 of 2 OK created sql view model kegan_staging.stg_amplitude__benefits_events .. [CREATE VIEW (0 processed) in 1.22s]
19:39:54  2 of 2 START sql table model kegan_mart_benefits.fct_benefits_events ........... [RUN]
19:40:15  2 of 2 OK created sql table model kegan_mart_benefits.fct_benefits_events ...... [CREATE TABLE (26.9m rows, 73.1 GiB processed) in 20.37s]
19:40:15  
19:40:15  Finished running 1 view model, 1 table model in 0 hours 1 minutes and 39.82 seconds (99.82s).
19:40:15  
19:40:15  Completed successfully
19:40:15  
19:40:15  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] Go through any charts etc. using the deprecated fields, and update to the new fields
- [ ] Go through any charts etc. using old values for e.g. `eligibility_verifier`, and update to the new values
- [x] Delete the deprecated fields
