### PR TITLE
fix(k8s): use Recreate strategy to deploy updates

### DIFF
--- a/kubernetes/apps/charts/metabase/templates/metabase.yaml
+++ b/kubernetes/apps/charts/metabase/templates/metabase.yaml
@@ -8,6 +8,8 @@ metadata:
     name: metabase
 spec:
   replicas: {{ .Values.workloads.metabase.replicas }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: metabase


### PR DESCRIPTION
# Description

While watching the latest Metabase update deploy, I noticed that we don't have the Metabase deployment explicitly set to use the `Recreate` strategy, allowing replicas of different versions to run at the same time under the default rolling strategy

While deploying new versions, it is lower risk to shut down all the old version instances before spinning up the first new version instance and running migrations. This will result in a longer period of Metabase not being available (low minutes) but ensure no issues are created by Metabase's config database being simultaneously written to by different versions of Metabase.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

PR preview action will show applied change

## Post-merge follow-ups

- [ ] Watch the post-merge deployment of this PR shut down all metabase pods before spinning up new ones
