### PR TITLE
Creating an incremental table for vendor vehicle message age by day.

### DIFF
--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -576,6 +576,29 @@ models:
         tests:
           - not_null
 
+  - name: fct_daily_vendor_vehicle_positions_message_age_summary
+    description: |
+      Table summarizing the age in seconds of various message components by vendor by date.
+      Terms:
+      - For definitions of the underlying `header_message_age`, `vehicle_message_age`, and `vehice_message_age_vs_header`
+        values, see `fct_vehicle_positions_messages`. In particular, note that a negative value indicates that the
+        referenced item happened *after* the item it's being compared to; i.e., a negative `header_message_age` indicates
+        that the `header_timestamp` was later than `_extract_ts`.
+      - `pX` refers to a percentile, so `p25` refers to 25th percentile.
+      - `avg` refers to the mean.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - dt
+            - organization_name
+    columns:
+      - name: dt
+        tests:
+          - not_null
+      - name: organization_name
+        tests:
+          - not_null
+
   - name: fct_daily_trip_updates_message_age_summary
     description: |
       Table summarizing the age in seconds of various message components by RT URL by date.

--- a/warehouse/models/mart/gtfs_quality/fct_daily_vendor_vehicle_positions_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_vendor_vehicle_positions_message_age_summary.sql
@@ -26,6 +26,7 @@ vendor_vehicle_positions_ages AS (
     SELECT DISTINCT
         dt,
         organization_name,
+        organization_key,
         _header_message_age,
         _vehicle_message_age,
         _vehicle_message_age_vs_header
@@ -51,6 +52,7 @@ summarize_vehicle_ages AS (
     SELECT
         dt,
         organization_name,
+        organization_key,
         median_vehicle_message_age,
         p25_vehicle_message_age,
         p75_vehicle_message_age,
@@ -61,7 +63,9 @@ summarize_vehicle_ages AS (
         AVG(_vehicle_message_age) AS avg_vehicle_message_age
     FROM vehicle_age_percentiles
     GROUP BY
-        dt, organization_name,
+        dt,
+        organization_name,
+        organization_key,
         median_vehicle_message_age,
         p25_vehicle_message_age,
         p75_vehicle_message_age,
@@ -71,9 +75,10 @@ summarize_vehicle_ages AS (
 
 fct_daily_vendor_vehicle_positions_message_age_summary AS (
     SELECT
-        {{ dbt_utils.generate_surrogate_key(['dt', 'organization_name']) }} AS key,
+        {{ dbt_utils.generate_surrogate_key(['dt', 'organization_key']) }} AS key,
         dt,
         organization_name,
+        organization_key,
         median_vehicle_message_age,
         p25_vehicle_message_age,
         p75_vehicle_message_age,

--- a/warehouse/models/mart/gtfs_quality/fct_daily_vendor_vehicle_positions_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_vendor_vehicle_positions_message_age_summary.sql
@@ -1,0 +1,108 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='insert_overwrite',
+    partition_by = {
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
+
+WITH vehicle_positions_ages AS (
+    SELECT DISTINCT
+        dt,
+        gtfs_dataset_name,
+        _header_message_age,
+        _vehicle_message_age,
+        _vehicle_message_age_vs_header
+    FROM {{ ref('fct_vehicle_positions_messages') }} AS VPM
+    INNER JOIN {{ ref('dim_gtfs_service_data') }} AS GSD
+        ON VPM.gtfs_dataset_key = GSD.gtfs_dataset_key
+    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }}
+    AND customer_facing IS TRUE
+),
+
+-- these values are repeated because one row in the source table is one vehicle message so the header is identical for all messages on a given request
+-- select distinct to deduplicate these to the overall message level to make summary statistics more meaningful
+
+bridge_organization_x_gtfs_dataset AS (
+    SELECT
+        organization_name,
+        gtfs_dataset_name,
+        MIN(_valid_from) AS valid_from,
+        MAX(_valid_to) AS valid_to
+    FROM {{ ref('bridge_organizations_x_gtfs_datasets_produced') }}
+    WHERE
+        (gtfs_dataset_name LIKE '%VehiclePositions%'
+        OR gtfs_dataset_name LIKE '%Vehicle Positions%'
+        OR gtfs_dataset_name LIKE '%VehiclePosition%'
+        OR gtfs_dataset_name LIKE '%Vehicle Position%')
+    GROUP BY
+        organization_name, gtfs_dataset_name
+),
+
+vendor_vehicle_positions_ages AS (
+    SELECT DISTINCT
+        dt,
+        organization_name,
+        _header_message_age,
+        _vehicle_message_age,
+        _vehicle_message_age_vs_header
+    FROM vehicle_positions_ages AS VPA
+    INNER JOIN bridge_organization_x_gtfs_dataset AS BOGD
+        ON VPA.gtfs_dataset_name = BOGD.gtfs_dataset_name
+        AND dt BETWEEN DATE(valid_from) AND DATE(valid_to)
+),
+
+
+vehicle_age_percentiles AS (
+    SELECT
+        *,
+        PERCENTILE_CONT(_vehicle_message_age, 0.5) OVER(PARTITION BY dt, organization_name) AS median_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, 0.25) OVER(PARTITION BY dt, organization_name) AS p25_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, 0.75) OVER(PARTITION BY dt, organization_name) AS p75_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, 0.90) OVER(PARTITION BY dt, organization_name) AS p90_vehicle_message_age,
+        PERCENTILE_CONT(_vehicle_message_age, 0.99) OVER(PARTITION BY dt, organization_name) AS p99_vehicle_message_age
+    FROM vendor_vehicle_positions_ages
+),
+
+summarize_vehicle_ages AS (
+    SELECT
+        dt,
+        organization_name,
+        median_vehicle_message_age,
+        p25_vehicle_message_age,
+        p75_vehicle_message_age,
+        p90_vehicle_message_age,
+        p99_vehicle_message_age,
+        MAX(_vehicle_message_age) AS max_vehicle_message_age,
+        MIN(_vehicle_message_age) AS min_vehicle_message_age,
+        AVG(_vehicle_message_age) AS avg_vehicle_message_age
+    FROM vehicle_age_percentiles
+    GROUP BY
+        dt, organization_name,
+        median_vehicle_message_age,
+        p25_vehicle_message_age,
+        p75_vehicle_message_age,
+        p90_vehicle_message_age,
+        p99_vehicle_message_age
+),
+
+fct_daily_vendor_vehicle_positions_message_age_summary AS (
+    SELECT
+        {{ dbt_utils.generate_surrogate_key(['dt', 'organization_name']) }} AS key,
+        dt,
+        organization_name,
+        median_vehicle_message_age,
+        p25_vehicle_message_age,
+        p75_vehicle_message_age,
+        p90_vehicle_message_age,
+        p99_vehicle_message_age,
+        max_vehicle_message_age,
+        min_vehicle_message_age,
+        avg_vehicle_message_age
+    FROM summarize_vehicle_ages
+)
+
+SELECT *
+FROM fct_daily_vendor_vehicle_positions_message_age_summary


### PR DESCRIPTION
## Creating a new incremental table for vendor vehicle position message age by day.

Resolves issue  https://github.com/cal-itp/data-infra/issues/3478

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Yes,
_poetry run dbt run -s +fct_daily_vendor_vehicle_positions_message_age_summary_

`20:17:15  Finished running 12 view models, 11 table models, 1 incremental model in 0 hours 4 minutes and 39.96 seconds (279.96s).
20:17:15  
20:17:15  Completed successfully
20:17:15  
20:17:15  Done. PASS=24 WARN=0 ERROR=0 SKIP=0 TOTAL=24
`

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
