### PR TITLE
Changes report evaluations for MTC from regional to subfeeds

### DIFF
--- a/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_organization_combined_guideline_checks.sql
@@ -3,7 +3,12 @@
 WITH int_gtfs_quality__guideline_checks_long AS (
     SELECT *
     FROM {{ ref('int_gtfs_quality__guideline_checks_long') }}
-    WHERE organization_key IS NOT NULL AND public_customer_facing_fixed_route
+    WHERE organization_key IS NOT NULL
+    AND (
+        (use_subfeed_for_reports AND public_customer_facing_or_regional_subfeed_fixed_route)
+    OR
+    (NOT use_subfeed_for_reports AND public_customer_facing_fixed_route)
+    )
 ),
 
 fct_daily_organization_combined_guideline_checks AS (


### PR DESCRIPTION
# Description
In [2023 a decision was made](https://docs.google.com/document/d/12klLxaKaGCz0_dYwvwNY4T1XXgOt57twFxxr0g2THNE/edit) on the reports site to evaluate gtfs checks on MTC sub feed sites like [SMART](https://reports.calitp.org/gtfs_schedule/2024/09/315/) but the checks are on MTC's regional feed.

It's impossible for individual agencies to notice this and SMART has complained that it's not fair for their evaluation to get a fail when it's the regional MTC's gtfs's fault instead.

Resolves #https://github.com/cal-itp/reports/issues/315

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

poetry run dbt run --full-refresh --models +fct_daily_organization_combined_guideline_checks

Lots of sql query analysis in staging.

This produces a differential of what is taken out and what stays in:
```SELECT * FROM `cal-itp-data-infra-staging.vb_staging.int_gtfs_quality__guideline_checks_long` 
where 
-- organization_name = 'Sonoma-Marin Area Rail Transit District' AND 
date = '2024-05-15'
AND check = 'No errors in MobilityData GTFS Schedule Validator'
AND organization_key IS NOT NULL 
and public_customer_facing_fixed_route
AND key not in (SELECT key FROM `cal-itp-data-infra-staging.vb_staging.int_gtfs_quality__guideline_checks_long` 
where 
-- organization_name = 'Sonoma-Marin Area Rail Transit District' AND 
date = '2024-05-15'
AND check = 'No errors in MobilityData GTFS Schedule Validator'
AND organization_key IS NOT NULL 
AND ((use_subfeed_for_reports and public_customer_facing_or_regional_subfeed_fixed_route) or (not use_subfeed_for_reports and public_customer_facing_fixed_route)))```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Evaluate - This fix makes two agencies disappear from downstream sql tables, but neither of these are on the reports website anyways:
- Dumbarton Bridge Regional Operations Consortium
- San Joaquin Joint Powers Authority
- 