### PR TITLE
fix(airtable_transit_services): add relevant fields to yml to populate them in bigquery

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -288,9 +288,6 @@ schema_fields:
   - name: public_currently_operating_fixed_route
     type: STRING
     mode: NULLABLE
-  - name: holiday_website_status__from_provider_
-    type: STRING
-    mode: NULLABLE
   - name: holiday_website__from_provider_
     type: STRING
     mode: NULLABLE

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -288,3 +288,30 @@ schema_fields:
   - name: public_currently_operating_fixed_route
     type: STRING
     mode: NULLABLE
+  - name: holiday_website_status__from_provider_
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_website__from_provider_
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_schedule___veterans_day__observed_
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_schedule___veterans_day
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_schedule___day_after_thanksgiving_day
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_schedule___christmas_eve
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_schedule___new_year_s_eve
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_schedule_notes
+    type: STRING
+    mode: NULLABLE
+  - name: holiday_website_status
+    type: STRING
+    mode: NULLABLE


### PR DESCRIPTION
# Description
Adds a few columns relevant to holiday research to make sure they appear in external tables - airtable

Resolves #3487 

## Type of change

- [x] New feature

## How has this been tested?

Nope

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
Rerun airtable loading, make sure everything is okay.