### PR TITLE
Fixes dbt errors around transit - services - holiday_website_status

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -309,6 +309,6 @@ schema_fields:
   - name: holiday_schedule_notes
     type: STRING
     mode: NULLABLE
-  - name: holiday_website_status
+  - name: holiday_website_condition
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION
# Description
This should fix the dbt bug.

I think what is happening is that in June we used the column named holiday_website_status for an array, [Current] [Missing] [Off-Season], etc.  But starting a few weeks ago we made it a string (“Current Implicit Dates”., etc).
Last night I declared that `holiday_website_status` should be a string.

But dbt and our pipeline is processing data from months ago and thinking it’s a string, when it used to be an array.

Thus in airtable we changed the column name to `holiday_website_condition`.

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #3487

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not really

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Watch dbt errors for 2 days