### PR TITLE
Bug Fix Display the organization name from last year if this year does not exist

### DIFF
--- a/warehouse/models/intermediate/ntd_validation/int_ntd_rr20_financial_specific_funds.sql
+++ b/warehouse/models/intermediate/ntd_validation/int_ntd_rr20_financial_specific_funds.sql
@@ -18,7 +18,7 @@ WITH longform_this_year AS (
     MAX(api_report_last_modified_date) AS max_api_report_last_modified_date
      FROM {{ ref('stg_ntd_rr20_rural') }}
     WHERE item LIKE ANY("%Directly Generated Funds%","%Formula Grants for Rural Areas%","Local Funds")
-      AND api_report_period = {{this_year}}
+      AND api_report_period = {{ this_year }}
     GROUP BY organization, fiscal_year, total_expended, item
 ),
 
@@ -26,7 +26,6 @@ wide_this_year AS (
     SELECT * FROM
     (SELECT * FROM longform_this_year)
     PIVOT(AVG(total_expended) FOR item IN ('FTA_Formula_Grants_for_Rural_Areas_5311', 'Other_Directly_Generated_Funds', 'Local_Funds'))
-    ORDER BY organization
 ),
 
 longform_last_year AS (
@@ -42,7 +41,7 @@ longform_last_year AS (
     MAX(api_report_last_modified_date) AS max_api_report_last_modified_date
      FROM {{ ref('stg_ntd_rr20_rural') }}
     WHERE item LIKE ANY("%Directly Generated Funds%","%Formula Grants for Rural Areas%","Local Funds")
-      AND api_report_period = {{last_year}}
+      AND api_report_period = {{ last_year }}
     GROUP BY organization, fiscal_year, total_expended, item
 ),
 
@@ -50,10 +49,9 @@ wide_last_year AS (
     SELECT * FROM
     (SELECT * FROM longform_last_year)
     PIVOT(AVG(total_expended) FOR item IN ('FTA_Formula_Grants_for_Rural_Areas_5311', 'Other_Directly_Generated_Funds', 'Local_Funds'))
-    ORDER BY organization
 )
 
-SELECT wide_this_year.organization,
+SELECT COALESCE(wide_this_year.organization, wide_last_year.organization) AS organization,
        wide_this_year.FTA_Formula_Grants_for_Rural_Areas_5311 AS FTA_Formula_Grants_for_Rural_Areas_5311_This_Year,
        wide_this_year.Other_Directly_Generated_Funds AS Other_Directly_Generated_Funds_This_Year,
        wide_this_year.Local_Funds AS Local_Funds_This_Year,


### PR DESCRIPTION
# Description

The query for `int_ntd_rr20_financial_specific_funds` was returning blank Organizations when the previous year returns more Organizations than the current year.
It was fixed by returning the organization on the other side of the full join (last year's information) when the this year organization is blank.

It also fixes blank organizations on `fct_ntd_rr20_funds_checks`.

[#3483]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally and models properly created on staging:
* `cal-itp-data-infra-staging.erika_staging.int_ntd_rr20_financial_specific_funds`
* `cal-itp-data-infra-staging.erika_mart_ntd_validation.fct_ntd_rr20_funds_checks`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After the next `transform_warhouse` runs, confirm the Organization field has no blank records on `staging.int_ntd_rr20_financial_specific_funds` and `mart_ntd_validation.fct_ntd_rr20_funds_checks`.