### PR TITLE
Remove a field that isn't parsing to resolve dbt errors

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -288,9 +288,6 @@ schema_fields:
   - name: public_currently_operating_fixed_route
     type: STRING
     mode: NULLABLE
-  - name: holiday_website__from_provider_
-    type: STRING
-    mode: NULLABLE
   - name: holiday_schedule___veterans_day__observed_
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION
# Description

This field `holiday_website__from_provider_` is causing problems with ingestion.  I don't think we need it so let's remove it to resolve the errors:
`19:36:31    Error while reading table: cal-itp-data-infra-staging.external_airtable.california_transit__services, error message: JSON parsing error in row starting at position 4758: Array specified for non-repeated field: holiday_website__from_provider_. File: gs://test-calitp-airtable/california_transit__services/dt=2024-10-15/ts=2024-10-15T17:37:25.484855+00:00/services.jsonl.gz
19:36:31    compiled Code at target/run/calitp_warehouse/models/intermediate/transit_database/dimensions/int_transit_database__services_dim.sql`

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #3487

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
(poetry_env) VevePro:warehouse vivek$ poetry run dbt run -s int_transit_database__services_dim
19:44:30  Running with dbt=1.5.1
19:44:37  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
19:44:38  Found 420 models, 950 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 175 sources, 4 exposures, 0 metrics, 0 groups
19:44:39
19:44:44  Concurrency: 8 threads (target='dev')
19:44:44
19:44:44  1 of 1 START sql table model vb_staging.int_transit_database__services_dim ..... [RUN]
19:44:52  1 of 1 OK created sql table model vb_staging.int_transit_database__services_dim  [CREATE TABLE (3.9k rows, 521.7 MiB processed) in 8.11s]
19:44:52
19:44:52  Finished running 1 table model in 0 hours 0 minutes and 13.69 seconds (13.69s).
19:44:53
19:44:53  Completed successfully
19:44:53
19:44:53  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Double check dbt errors on the next day to make sure it's resolved.