### PR TITLE
Optimize fct_daily_rt_feed_validation_notices

### DIFF
--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
@@ -1,11 +1,16 @@
 {{ config(materialized='table') }}
 
-WITH fct_daily_rt_feed_files AS (
-    SELECT * FROM {{ ref('fct_daily_rt_feed_files') }}
-),
-
-codes AS (
-    SELECT * FROM {{ ref('stg_gtfs_quality__rt_validation_code_descriptions') }}
+WITH daily_feeds_codes AS (
+    SELECT
+        daily_feeds.date,
+        daily_feeds.base64_url,
+        daily_feeds.key,
+        daily_feeds.parse_success_file_count,
+        codes.code,
+        codes.description,
+        codes.is_critical
+    FROM {{ ref('fct_daily_rt_feed_files') }} AS daily_feeds
+    CROSS JOIN {{ ref('stg_gtfs_quality__rt_validation_code_descriptions') }} AS codes
 ),
 
 outcomes AS (
@@ -16,42 +21,46 @@ notices AS (
     SELECT * FROM {{ ref('int_gtfs_quality__rt_validation_notices') }}
 ),
 
--- This CTE starts with daily RT feeds, then pulls in validation outcomes
--- to give us a row per actual validation execution (outcome) that we have;
--- then cross-join codes to give us "buckets" per outcome since the
--- underlying notices will not contain a code that did not trigger a notice;
--- finally, we aggregate everything back up to the date/URL/code level
--- and count how many parsed and validated files we have, and sum the
--- notice occurrences; if we have successful validations but no occurrences,
--- we assume the feeds passed the code 100% of the time
+-- This table reports on each entry in the daily GTFS-RT feeds table.
+-- For each feed, on each day, create a row for the codes table, which
+-- contains a potential validation error with its description and error level.
+-- For each feed/day/code, retrieve outcomes and notices, then report on
+-- the total number of extractions, successes, exceptions, occurrences of
+-- that specific code, and the GTFS-RT validator version used.
+-- If a code does not appear for a feed on a day, total_notices will be 0.
+-- If there a feed was not validated on a day, total_notices will be NULL.
 fct_daily_rt_feed_validation_notices AS (
     SELECT
-        {{ dbt_utils.generate_surrogate_key(['daily_feeds.date', 'daily_feeds.base64_url', 'codes.code', 'codes.is_critical']) }} AS key,
-        daily_feeds.date,
-        daily_feeds.base64_url,
-        codes.code,
-        codes.description,
-        codes.is_critical,
+        {{ dbt_utils.generate_surrogate_key(['daily_feeds_codes.date', 'daily_feeds_codes.base64_url', 'daily_feeds_codes.code', 'daily_feeds_codes.is_critical']) }} AS key,
+        daily_feeds_codes.date,
+        daily_feeds_codes.base64_url,
+        daily_feeds_codes.code,
+        daily_feeds_codes.description,
+        daily_feeds_codes.is_critical,
         -- TODO: at some point, these codes will be versioned by validator version
         ARRAY_AGG(DISTINCT notices.gtfs_validator_version IGNORE NULLS) AS gtfs_validator_versions,
-        SUM(daily_feeds.parse_success_file_count) / COUNT(daily_feeds.key) AS parsed_files,
+        SUM(daily_feeds_codes.parse_success_file_count) / COUNT(daily_feeds_codes.key) AS parsed_files,
         COUNT(DISTINCT outcomes.extract_ts) AS validated_extracts,
         COUNTIF(outcomes.validation_success) AS validation_successes,
         COUNT(outcomes.validation_exception) AS validation_exceptions,
         COALESCE(
-            SUM(ARRAY_LENGTH(occurrence_list)),
-            CASE WHEN COUNTIF(outcomes.validation_success) > 0 THEN 0 END
-        ) AS total_notices,
-    FROM fct_daily_rt_feed_files AS daily_feeds
+          SUM(ARRAY_LENGTH(notices.occurrence_list)),
+          CASE WHEN COUNTIF(outcomes.validation_success) > 0 THEN 0 END
+        ) AS total_notices
+    FROM daily_feeds_codes
     LEFT JOIN outcomes
-        ON daily_feeds.base64_url = outcomes.base64_url
-        AND daily_feeds.date = EXTRACT(DATE FROM outcomes.extract_ts)
-    CROSS JOIN codes
+         ON daily_feeds_codes.base64_url = outcomes.base64_url
+         AND daily_feeds_codes.date = EXTRACT(DATE FROM outcomes.extract_ts)
     LEFT JOIN notices
-        ON outcomes.extract_ts = notices.ts
-        AND outcomes.base64_url = notices.base64_url
-        AND codes.code = notices.error_message_validation_rule_error_id
-    GROUP BY 1, 2, 3, 4, 5, 6
+         ON outcomes.extract_ts = notices.ts
+         AND daily_feeds_codes.base64_url = notices.base64_url
+         AND daily_feeds_codes.code = notices.error_message_validation_rule_error_id
+    GROUP BY
+        daily_feeds_codes.date,
+        daily_feeds_codes.base64_url,
+        daily_feeds_codes.code,
+        daily_feeds_codes.description,
+        daily_feeds_codes.is_critical
 )
 
 SELECT * FROM fct_daily_rt_feed_validation_notices


### PR DESCRIPTION
# Description

This PR optimizes `fct_daily_rt_feed_validation_notices` for issue #3481.

The structure of the query:
1) Get all daily feeds (a record of retrievals per URL and day)
2) For each URL/day, create a row for each error code (there are 57)
3) For each URL/day/code, aggregate the validation runs, aggregate the warning/error messages, and calculate some metrics
After pairing with @ohrite we believe the issue is the location of the CROSS JOIN, and are investigating moving the cross join out to a CTE with the daily feeds table, resulting in a query that finishes at about the 50 minute mark.

After removing the join to notices, the query finishes at the 20 minute mark. Re-adding the join to notices bumps up to just under 40 minutes. Our ongoing investigation will be into speeding up the notice occurrence list aggregation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

It was tested locally generating the table on staging `cal-itp-data-infra-staging.erika_mart_gtfs_quality.fct_daily_rt_feed_validation_notices`

```
❯ poetry run dbt run -s "models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql"
22:26:36  Running with dbt=1.5.1
22:26:38  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
22:26:39  Found 420 models, 949 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 175 sources, 4 exposures, 0 metrics, 0 groups
22:26:39
22:26:41  Concurrency: 8 threads (target='dev')
22:26:41
22:26:41  1 of 1 START sql table model erika_mart_gtfs_quality.fct_daily_rt_feed_validation_notices  [RUN]
22:27:27  1 of 1 OK created sql table model erika_mart_gtfs_quality.fct_daily_rt_feed_validation_notices  [CREATE TABLE (183.3k rows, 33.5 GiB processed) in 46.58s]
22:27:27
22:27:27  Finished running 1 table model in 0 hours 0 minutes and 48.83 seconds (48.83s).
Optimize fct_daily_rt_feed_validation_notices
22:27:28
22:27:28  Completed successfully
22:27:28
22:27:28  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitoring DAGs `transform_warehouse` and `transform_warehouse_full_refresh_sunday` to see if there are no more errors happening when building `fct_daily_rt_feed_validation_notices`.