### PR TITLE
Chore: more Benefits data migration

### DIFF
--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -195,7 +195,34 @@ fct_benefits_events AS (
       ELSE start_version
     END AS start_version,
     user_id,
-    user_properties_eligibility_verifier,
+    -- Normalize historic data into current format
+    -- https://github.com/cal-itp/benefits/issues/2521
+    CASE
+      WHEN user_properties_eligibility_verifier IN (
+        '(MST) CDT claims via Login.gov',
+        '(SBMTD) CDT claims via Login.gov',
+        'CDT claims via Login.gov (MST)',
+        'CDT claims via Login.gov (SBMTD)',
+        'OAuth claims via Login.gov',
+        'senior'
+      ) THEN "cdt-logingov"
+      WHEN user_properties_eligibility_verifier IN (
+        '(MST) VA.gov - Veteran',
+        'VA.gov - Veteran (MST)',
+        'veteran'
+      ) THEN "cdt-vagov"
+      WHEN user_properties_eligibility_verifier IN (
+        '(MST) Courtesy Card Eligibility Server Verifier (prod)',
+        'MST Courtesy Card Eligibility Server Verifier',
+        'courtesy_card'
+      ) THEN "https://mst-courtesy-cards-eligibility-server-prod-azcscsbmembwcugk.z01.azurefd.net/verify"
+      WHEN user_properties_eligibility_verifier IN (
+        '(SBMTD) Mobility Pass Eligibility Server Verifier (prod)',
+        'SBMTD Mobility Pass Eligibility Server Verifier (prod)',
+        'mobility_pass'
+      ) THEN "https://sbmtd-mobility-pass-eligibility-server-prod-h3d3djedb7ahfqeg.z01.azurefd.net/verify"
+      ELSE user_properties_eligibility_verifier
+    END AS user_properties_eligibility_verifier,
     user_properties_enrollment_flows,
     user_properties_enrollment_method,
     user_properties_initial_referrer,

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -31,8 +31,8 @@ WITH fct_benefits_events AS (
     -- Historical data existed in `payment_group` but new data is in `enrollment_group`
     -- https://github.com/cal-itp/benefits/pull/2391
     COALESCE(
-        {{ json_extract_flattened_column('event_properties', 'enrollment_group', no_alias = true) }},
-        {{ json_extract_flattened_column('event_properties', 'payment_group', no_alias = true) }}
+        {{ json_extract_column('event_properties', 'enrollment_group', no_alias = true) }},
+        {{ json_extract_column('event_properties', 'payment_group', no_alias = true) }}
     ) AS event_properties_enrollment_group,
     -- New column `enrollment_method`, historical values should be set to "digital"
     -- https://github.com/cal-itp/benefits/pull/2402

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -1,8 +1,12 @@
 {{ config(materialized='table') }}
 
-WITH fct_benefits_events AS (
+WITH fct_benefits_events_raw AS (
+  -- fct_benefits_events_raw extracts JSON columns and
+  -- COALESCEs old columns as they evolve
+  -- this is an intermediate CTE used to build the final table
+
+  -- Keep fields in alphabetical order, list all fields in the final table
   SELECT
-    -- Keep fields in alphabetical order
     amplitude_id,
     app,
     city,
@@ -50,6 +54,80 @@ WITH fct_benefits_events AS (
     {{ json_extract_column('event_properties', 'status') }},
     {{ json_extract_column('event_properties', 'transit_agency') }},
     event_time,
+    event_type,
+    language,
+    library,
+    os_name,
+    os_version,
+    processed_time,
+    region,
+    server_received_time,
+    server_upload_time,
+    session_id,
+    start_version,
+    user_id,
+    {{ json_extract_column('user_properties', 'eligibility_verifier') }},
+    -- Historical data existed in `eligibility_types` but new data is in `enrollment_flows`
+    -- https://github.com/cal-itp/benefits/pull/2379
+    COALESCE(
+        {{ json_extract_flattened_column('user_properties', 'enrollment_flows', no_alias = true) }},
+        {{ json_extract_flattened_column('user_properties', 'eligibility_types', no_alias = true) }}
+    ) AS user_properties_enrollment_flows,
+    -- New column `enrollment_method`, historical values should be set to "digital"
+    -- https://github.com/cal-itp/benefits/pull/2402
+    COALESCE(
+      {{ json_extract_column('user_properties', 'enrollment_method', no_alias = true) }},
+      "digital"
+    ) AS user_properties_enrollment_method,
+    {{ json_extract_column('user_properties', 'initial_referrer') }},
+    {{ json_extract_column('user_properties', 'initial_referring_domain') }},
+    {{ json_extract_column('user_properties', 'referrer') }},
+    {{ json_extract_column('user_properties', 'referring_domain') }},
+    -- Historical data existed in `provider_name` but new data is in `transit_agency`
+    -- https://github.com/cal-itp/benefits/pull/901
+    COALESCE(
+        {{ json_extract_column('user_properties', 'transit_agency', no_alias = true) }},
+        {{ json_extract_column('user_properties', 'provider_name', no_alias = true) }}
+    ) AS user_properties_transit_agency,
+    {{ json_extract_column('user_properties', 'user_agent') }},
+    uuid,
+    version_name
+  FROM {{ ref('stg_amplitude__benefits_events') }}
+),
+fct_benefits_events AS (
+  -- fct_benefits_events applies data cleanup and transformations
+  -- on top of the fct_benefits_events_raw CTE
+  -- this is an intermediate CTE used to build the final table
+
+  -- Keep fields in alphabetical order, list all fields in the final table
+  SELECT
+    amplitude_id,
+    app,
+    city,
+    client_event_time,
+    client_upload_time,
+    country,
+    device_family,
+    device_id,
+    device_type,
+    event_id,
+    event_properties_card_tokenize_func,
+    event_properties_card_tokenize_url,
+    event_properties_claims_provider,
+    event_properties_eligibility_verifier,
+    event_properties_enrollment_flows,
+    event_properties_enrollment_group,
+    event_properties_enrollment_method,
+    event_properties_error_name,
+    event_properties_error_status,
+    event_properties_error_sub,
+    event_properties_href,
+    event_properties_language,
+    event_properties_origin,
+    event_properties_path,
+    event_properties_status,
+    event_properties_transit_agency,
+    event_time,
     CASE
       WHEN event_type = "selected eligibility verifier"
         THEN "selected enrollment flow"
@@ -86,30 +164,15 @@ WITH fct_benefits_events AS (
       ELSE start_version
     END AS start_version,
     user_id,
-    {{ json_extract_column('user_properties', 'eligibility_verifier') }},
-    -- Historical data existed in `eligibility_types` but new data is in `enrollment_flows`
-    -- https://github.com/cal-itp/benefits/pull/2379
-    COALESCE(
-        {{ json_extract_flattened_column('user_properties', 'enrollment_flows', no_alias = true) }},
-        {{ json_extract_flattened_column('user_properties', 'eligibility_types', no_alias = true) }}
-    ) AS user_properties_enrollment_flows,
-    -- New column `enrollment_method`, historical values should be set to "digital"
-    -- https://github.com/cal-itp/benefits/pull/2402
-    COALESCE(
-      {{ json_extract_column('user_properties', 'enrollment_method', no_alias = true) }},
-      "digital"
-    ) AS user_properties_enrollment_method,
-    {{ json_extract_column('user_properties', 'initial_referrer') }},
-    {{ json_extract_column('user_properties', 'initial_referring_domain') }},
-    {{ json_extract_column('user_properties', 'referrer') }},
-    {{ json_extract_column('user_properties', 'referring_domain') }},
-    -- Historical data existed in `provider_name` but new data is in `transit_agency`
-    -- https://github.com/cal-itp/benefits/pull/901
-    COALESCE(
-        {{ json_extract_column('user_properties', 'transit_agency', no_alias = true) }},
-        {{ json_extract_column('user_properties', 'provider_name', no_alias = true) }}
-    ) AS user_properties_transit_agency,
-    {{ json_extract_column('user_properties', 'user_agent') }},
+    user_properties_eligibility_verifier,
+    user_properties_enrollment_flows,
+    user_properties_enrollment_method,
+    user_properties_initial_referrer,
+    user_properties_initial_referring_domain,
+    user_properties_referrer,
+    user_properties_referring_domain,
+    user_properties_transit_agency,
+    user_properties_user_agent,
     uuid,
     -- Fix bug in Docker build process resulting in incorrect version strings
     -- https://github.com/cal-itp/benefits/pull/2392
@@ -128,85 +191,91 @@ WITH fct_benefits_events AS (
         THEN "2024.10.1"
       ELSE version_name
     END AS version_name
+  FROM fct_benefits_events_raw
+),
+fct_benefits_historic_enrollments AS (
+  -- fct_benefits_historic_enrollments transforms old enrollment events
+  -- from the fct_benefits_events CTE into the newer style
+  -- this is an intermediate CTE used to build the final table
 
-    FROM {{ ref('stg_amplitude__benefits_events') }}
+  -- Keep fields in alphabetical order, list all fields in the final table
+  SELECT
+    amplitude_id,
+    app,
+    city,
+    client_event_time,
+    client_upload_time,
+    country,
+    device_family,
+    device_id,
+    device_type,
+    event_id,
+    event_properties_card_tokenize_func,
+    event_properties_card_tokenize_url,
+    CASE
+      WHEN client_event_time < '2022-08-12T07:00:00Z'
+        THEN "ca-dmv"
+      WHEN client_event_time >= '2022-08-12T07:00:00Z'
+        THEN "cdt-logingov"
+    END AS event_properties_claims_provider,
+    CASE
+      WHEN client_event_time < '2022-08-12T07:00:00Z'
+        THEN "ca-dmv"
+      WHEN client_event_time >= '2022-08-12T07:00:00Z'
+        THEN "cdt-logingov"
+    END AS event_properties_eligibility_verifier,
+    "senior" AS event_properties_enrollment_flows,
+    "5170d37b-43d5-4049-899c-b4d850e14990" AS event_properties_enrollment_group,
+    event_properties_enrollment_method,
+    event_properties_error_name,
+    event_properties_error_status,
+    event_properties_error_sub,
+    event_properties_href,
+    event_properties_language,
+    event_properties_origin,
+    event_properties_path,
+    "success" AS event_properties_status,
+    "Monterey-Salinas Transit" AS event_properties_transit_agency,
+    event_time,
+    "returned enrollment" AS event_type,
+    language,
+    library,
+    os_name,
+    os_version,
+    processed_time,
+    region,
+    server_received_time,
+    server_upload_time,
+    session_id,
+    start_version,
+    user_id,
+    CASE
+      WHEN client_event_time < '2022-08-12T07:00:00Z'
+        THEN "ca-dmv"
+      WHEN client_event_time >= '2022-08-12T07:00:00Z'
+        THEN "cdt-logingov"
+    END AS user_properties_eligibility_verifier,
+    "senior" AS user_properties_enrollment_flows,
+    user_properties_enrollment_method,
+    user_properties_initial_referrer,
+    user_properties_initial_referring_domain,
+    user_properties_referrer,
+    user_properties_referring_domain,
+    "Monterey-Salinas Transit" AS user_properties_transit_agency,
+    user_properties_user_agent,
+    uuid,
+    version_name
+  FROM fct_benefits_events
+  WHERE client_event_time >= '2021-12-08T08:00:00Z'
+    and client_event_time < '2022-08-29T07:00:00Z'
+    and (region = 'California' or region is null)
+    and (city != 'Los Angeles' or city is null)
+    and event_type = 'viewed page'
+    and event_properties_path = '/enrollment/success'
 )
 
-SELECT
-  -- Keep fields in alphabetical order, match fields from fct_benefits_events CTE
-  amplitude_id,
-  app,
-  city,
-  client_event_time,
-  client_upload_time,
-  country,
-  device_family,
-  device_id,
-  device_type,
-  event_id,
-  event_properties_card_tokenize_func,
-  event_properties_card_tokenize_url,
-  CASE
-    WHEN client_event_time < '2022-08-12T07:00:00Z'
-      THEN "ca-dmv"
-    WHEN client_event_time >= '2022-08-12T07:00:00Z'
-      THEN "cdt-logingov"
-  END AS event_properties_claims_provider,
-  CASE
-    WHEN client_event_time < '2022-08-12T07:00:00Z'
-      THEN "ca-dmv"
-    WHEN client_event_time >= '2022-08-12T07:00:00Z'
-      THEN "cdt-logingov"
-  END AS event_properties_eligibility_verifier,
-  "senior" AS event_properties_enrollment_flows,
-  "5170d37b-43d5-4049-899c-b4d850e14990" AS event_properties_enrollment_group,
-  event_properties_enrollment_method,
-  event_properties_error_name,
-  event_properties_error_status,
-  event_properties_error_sub,
-  event_properties_href,
-  event_properties_language,
-  event_properties_origin,
-  event_properties_path,
-  "success" AS event_properties_status,
-  "Monterey-Salinas Transit" AS event_properties_transit_agency,
-  event_time,
-  "returned enrollment" AS event_type,
-  language,
-  library,
-  os_name,
-  os_version,
-  processed_time,
-  region,
-  server_received_time,
-  server_upload_time,
-  session_id,
-  start_version,
-  user_id,
-  CASE
-    WHEN client_event_time < '2022-08-12T07:00:00Z'
-      THEN "ca-dmv"
-    WHEN client_event_time >= '2022-08-12T07:00:00Z'
-      THEN "cdt-logingov"
-  END AS user_properties_eligibility_verifier,
-  "senior" AS user_properties_enrollment_flows,
-  user_properties_enrollment_method,
-  user_properties_initial_referrer,
-  user_properties_initial_referring_domain,
-  user_properties_referrer,
-  user_properties_referring_domain,
-  "Monterey-Salinas Transit" AS user_properties_transit_agency,
-  user_properties_user_agent,
-  uuid,
-  version_name
-FROM fct_benefits_events
-WHERE client_event_time >= '2021-12-08T08:00:00Z'
-  and client_event_time < '2022-08-29T07:00:00Z'
-  and (region = 'California' or region is null)
-  and (city != 'Los Angeles' or city is null)
-  and event_type = 'viewed page'
-  and event_properties_path = '/enrollment/success'
-
+-- the final table is the combination of
+-- fct_benefits_historic_enrollments + fct_benefits_events
+SELECT * FROM fct_benefits_historic_enrollments
 UNION DISTINCT
-
 SELECT * FROM fct_benefits_events

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -118,7 +118,34 @@ fct_benefits_events AS (
         THEN "cdt-logingov"
       ELSE event_properties_claims_provider
     END AS event_properties_claims_provider,
-    event_properties_eligibility_verifier,
+    -- Normalize historic data into current format
+    -- https://github.com/cal-itp/benefits/issues/2521
+    CASE
+      WHEN event_properties_eligibility_verifier IN (
+        '(MST) CDT claims via Login.gov',
+        '(SBMTD) CDT claims via Login.gov',
+        'CDT claims via Login.gov (MST)',
+        'CDT claims via Login.gov (SBMTD)',
+        'OAuth claims via Login.gov',
+        'senior'
+      ) THEN "cdt-logingov"
+      WHEN event_properties_eligibility_verifier IN (
+        '(MST) VA.gov - Veteran',
+        'VA.gov - Veteran (MST)',
+        'veteran'
+      ) THEN "cdt-vagov"
+      WHEN event_properties_eligibility_verifier IN (
+        '(MST) Courtesy Card Eligibility Server Verifier (prod)',
+        'MST Courtesy Card Eligibility Server Verifier',
+        'courtesy_card'
+      ) THEN "https://mst-courtesy-cards-eligibility-server-prod-azcscsbmembwcugk.z01.azurefd.net/verify"
+      WHEN event_properties_eligibility_verifier IN (
+        '(SBMTD) Mobility Pass Eligibility Server Verifier (prod)',
+        'SBMTD Mobility Pass Eligibility Server Verifier (prod)',
+        'mobility_pass'
+      ) THEN "https://sbmtd-mobility-pass-eligibility-server-prod-h3d3djedb7ahfqeg.z01.azurefd.net/verify"
+      ELSE event_properties_eligibility_verifier
+    END AS event_properties_eligibility_verifier,
     event_properties_enrollment_flows,
     event_properties_enrollment_group,
     event_properties_enrollment_method,

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -113,7 +113,11 @@ fct_benefits_events AS (
     event_id,
     event_properties_card_tokenize_func,
     event_properties_card_tokenize_url,
-    event_properties_claims_provider,
+    CASE
+      WHEN event_properties_claims_provider = "cdt-logingov-ial2"
+        THEN "cdt-logingov"
+      ELSE event_properties_claims_provider
+    END AS event_properties_claims_provider,
     event_properties_eligibility_verifier,
     event_properties_enrollment_flows,
     event_properties_enrollment_group,


### PR DESCRIPTION
# Description

This PR restructures (again) the SQL for the `fct_benefits_events` model. Follows from:

- https://github.com/cal-itp/data-infra/pull/3468
- https://github.com/cal-itp/data-infra/pull/3518

Here we split processing of Amplitude data into two phases (via intermediate CTEs): 

1. Data definition: extract JSON columns, `COALESCE` old columns into new as they evolve
2. Data migration: update any data values that have changed over time e.g. changing the name of a flow, or creating new records from historical records.

Resolves https://github.com/cal-itp/benefits/issues/2521

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and include the output in this section of the PR._

```console
$ poetry run dbt run -s +fct_benefits_events
02:13:25  Running with dbt=1.5.1
02:13:27  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
02:13:27  Found 422 models, 963 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 174 sources, 4 exposures, 0 metrics, 0 groups
02:13:27  
02:13:30  Concurrency: 8 threads (target='dev')
02:13:30  
02:13:30  1 of 2 START sql view model kegan_staging.stg_amplitude__benefits_events ....... [RUN]
02:13:31  1 of 2 OK created sql view model kegan_staging.stg_amplitude__benefits_events .. [CREATE VIEW (0 processed) in 0.96s]
02:13:31  2 of 2 START sql table model kegan_mart_benefits.fct_benefits_events ........... [RUN]
02:13:44  2 of 2 OK created sql table model kegan_mart_benefits.fct_benefits_events ...... [CREATE TABLE (26.9m rows, 73.1 GiB processed) in 12.94s]
02:13:44  
02:13:44  Finished running 1 view model, 1 table model in 0 hours 0 minutes and 17.00 seconds (17.00s).
02:13:44  
02:13:44  Completed successfully
02:13:44  
02:13:44  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
