### PR TITLE
New speedmap and speed variation maps

### DIFF
--- a/apps/maps/src/routes/+page.svelte
+++ b/apps/maps/src/routes/+page.svelte
@@ -135,6 +135,136 @@
       const layerType = layer.props.type;
 
       // TODO: this should probably be a map of functions?
+      if (layerType === "new_speedmap") {
+        const { tooltip_speed_key } = layer.props;
+        const { stop_pair_name, segment_id, route_short_name, route_id, avg_mph, trips_hr_sch, shape_id } = feature.properties;
+
+        let speed = avg_mph;
+
+        if (tooltip_speed_key && feature.properties[tooltip_speed_key]) {
+          speed = feature.properties[tooltip_speed_key];
+          console.log(speed);
+        }
+
+        let display_pair_name = stop_pair_name.replace("__", " &#8594 ");
+        let segment_postfix = segment_id.charAt(segment_id.length - 1);
+
+        let segment_type = "Stop to Stop";
+
+        if (segment_postfix !== "1") {
+          segment_type = "Interpolated";
+          console.log(segment_type);
+        }
+
+        return {
+          html: `
+            <h2 class="has-text-weight-bold has-text-teal-bold">
+              ${display_pair_name ?? 'Non-stop segment'}
+              <span class="tag ml-2">
+                <i class="fas fa-circle mr-2" style="color: rgb(${getColor(feature)})"></i>
+                ${speed}&nbsp;
+                <span class="has-text-weight-normal">mph</span>
+              </span>
+            </h2>
+
+            <ul class="tooltip-meta-list has-text-slate-bold">
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Route</div>
+                <div class="tooltip-meta-value">${route_short_name ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Segment ID</div>
+                <div class="tooltip-meta-value">${segment_id ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Route ID</div>
+                <div class="tooltip-meta-value">${route_id ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Trips/Hour</div>
+                <div class="tooltip-meta-value">${trips_hr_sch ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">GTFS Shape ID</div>
+                <div class="tooltip-meta-value">${shape_id ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Segment Type</div>
+                <div class="tooltip-meta-value">${segment_type ?? '\u2014'}</div>
+              </li>
+            </ul>
+          `,
+          style: style,
+        }
+      }
+
+      if (layerType === "new_speed_variation") {
+        const { tooltip_speed_key } = layer.props;
+        const { stop_pair_name, segment_id, route_short_name, route_id, p20_mph, p80_mph, avg_mph, fast_slow_ratio, trips_hr_sch, shape_id } = feature.properties;
+
+        let speed = avg_mph;
+
+        if (tooltip_speed_key && feature.properties[tooltip_speed_key]) {
+          speed = feature.properties[tooltip_speed_key];
+          console.log(speed);
+        }
+
+        let display_pair_name = stop_pair_name.replace("__", " &#8594 ");
+        let segment_postfix = segment_id.charAt(segment_id.length - 1);
+
+        let segment_type = "Stop to Stop";
+
+        if (segment_postfix !== "1") {
+          segment_type = "Interpolated";
+          console.log(segment_type);
+        }
+
+        return {
+          html: `
+            <h2 class="has-text-weight-bold has-text-teal-bold">
+              ${display_pair_name ?? 'Non-stop segment'}
+              <span class="tag ml-2">
+                <i class="fas fa-circle mr-2" style="color: rgb(${getColor(feature)})"></i>
+                <span class="has-text-weight-normal"><sup>p80</sup> &#8260; <sub>p20</sub> </span>
+                &nbsp;${fast_slow_ratio}
+              </span>
+            </h2>
+
+            <ul class="tooltip-meta-list has-text-slate-bold">
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key"><sup>p80</sup> &#8260; <sub>p20</sub></div>
+                <div class="tooltip-meta-value"><sup>${p80_mph} mph</sup> &#8260; <sub>${p20_mph} mph</sub></div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Route</div>
+                <div class="tooltip-meta-value">${route_short_name ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Segment ID</div>
+                <div class="tooltip-meta-value">${segment_id ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Route ID</div>
+                <div class="tooltip-meta-value">${route_id ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Trips/Hour</div>
+                <div class="tooltip-meta-value">${trips_hr_sch ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">GTFS Shape ID</div>
+                <div class="tooltip-meta-value">${shape_id ?? '\u2014'}</div>
+              </li>
+              <li class="tooltip-meta-item">
+                <div class="tooltip-meta-key">Segment Type</div>
+                <div class="tooltip-meta-value">${segment_type ?? '\u2014'}</div>
+              </li>
+            </ul>
+          `,
+          style: style,
+        }
+      }
+
       if (layerType === "speedmap") {
         const { tooltip_speed_key } = layer.props;
         const { stop_name, stop_id, route_short_name, route_id, avg_mph, trips_per_hour, shape_id, stop_sequence } = feature.properties;


### PR DESCRIPTION
# Description

Add two new `layerType` in Svelte map app to match the new `rt_segment_speeds` derived speedmap data schema. Improves display of speed segment info via tooltips. Old `layerType` from legacy speedmaps retained for now.

Required for https://github.com/cal-itp/data-analyses/issues/1186 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Successfully ran locally, including actual state and speedmap geojson on GCS.

<img width="545" alt="Screenshot 2024-11-13 at 18 18 33" src="https://github.com/user-attachments/assets/1caaa47a-37a7-4800-bfc2-faca7eee9267">

<img width="754" alt="Screenshot 2024-11-14 at 07 36 38" src="https://github.com/user-attachments/assets/1b27919b-c3f7-4593-9148-b6c7c7aeabbd">


## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
