### PR TITLE
Fix Errno2 on GTFS RT validation

### DIFF
--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -287,6 +287,9 @@ class MostRecentSchedule:
             try:
                 schedule_extract = ScheduleStorage().get_day(day).get_url_schedule(self.base64_validation_url)
             except KeyError:
+                print(
+                    f"no schedule data found for {self.base64_validation_url} on day {day}"
+                )
                 continue
 
             try:
@@ -294,6 +297,9 @@ class MostRecentSchedule:
                 self.fs.get(schedule_extract.path, gtfs_zip)
                 return gtfs_zip
             except FileNotFoundError:
+                print(
+                    f"no schedule file found for {self.base64_validation_url} on day {day}"
+                )
                 continue
 
 
@@ -462,6 +468,7 @@ class ValidationProcessor:
             e = ScheduleDataNotFound(
                 f"no recent schedule data found for {self.aggregation.extracts[0].path}"
             )
+            print(e)
 
             scope.fingerprint = [
                 type(e),

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -268,7 +268,7 @@ class MostRecentSchedule:
         self.path = path
         self.base64_validation_url = base64_validation_url
 
-    def download(self, date: datetime.datetime) -> str:
+    def download(self, date: datetime.datetime) -> Optional[str]:
         for day in reversed(list(date - date.subtract(days=7))):
             try:
                 schedule_extract = (
@@ -285,13 +285,13 @@ class MostRecentSchedule:
             try:
                 gtfs_zip = "/".join([self.path, schedule_extract.filename])
                 self.fs.get(schedule_extract.path, gtfs_zip)
-                break
+                return gtfs_zip
             except FileNotFoundError:
                 print(
                     f"no schedule file found for {self.base64_validation_url} on day {day}"
                 )
                 continue
-        return gtfs_zip
+        return None
 
 
 class AggregationExtract:
@@ -365,7 +365,7 @@ class AggregationExtracts:
             lpath=list(self.get_local_paths().keys()),
         )
 
-    def download_most_recent_schedule(self) -> str:
+    def download_most_recent_schedule(self) -> Optional[str]:
         first_extract = self.aggregation.extracts[0]
         schedule = MostRecentSchedule(
             self.fs, self.path, first_extract.config.base64_validation_url

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -484,9 +484,7 @@ class ValidationProcessor:
     def validator(self):
         return RtValidator()
 
-    def process(
-        self, tmp_dir: str, scope
-    ) -> List[RTFileProcessingOutcome]:
+    def process(self, tmp_dir: str, scope) -> List[RTFileProcessingOutcome]:
         outcomes: List[RTFileProcessingOutcome] = []
         fs = get_fs()
 
@@ -649,9 +647,7 @@ class ParseProcessor:
         self.aggregation = aggregation
         self.verbose = verbose
 
-    def process(
-        self, tmp_dir: str, scope
-    ) -> List[RTFileProcessingOutcome]:
+    def process(self, tmp_dir: str, scope) -> List[RTFileProcessingOutcome]:
         outcomes: List[RTFileProcessingOutcome] = []
         fs = get_fs()
         dst_path_rt = f"{tmp_dir}/rt_{self.aggregation.name_hash}/"
@@ -798,9 +794,7 @@ def parse_and_validate(
                 raise RuntimeError("we should not be here")
 
             if aggregation.step == RTProcessingStep.validate:
-                return ValidationProcessor(aggregation, verbose).process(
-                    tmp_dir, scope
-                )
+                return ValidationProcessor(aggregation, verbose).process(tmp_dir, scope)
 
             if aggregation.step == RTProcessingStep.parse:
                 return ParseProcessor(aggregation, verbose).process(tmp_dir, scope)

--- a/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
@@ -54,10 +54,7 @@ def test_rt_file_processing_outcome_construction() -> None:
 
 @pytest.mark.skipif("not config.getoption('--gcs')", reason="requires GCS credentials")
 def test_vehicle_positions():
-    result = runner.invoke(
-        app,
-        ["parse", "vehicle_positions", "1999-10-22T18:00:00"]
-    )
+    result = runner.invoke(app, ["parse", "vehicle_positions", "1999-10-22T18:00:00"])
     assert result.exit_code == 0
     assert (
         "test-calitp-gtfs-rt-raw-v2/vehicle_positions/dt=1999-10-22/hour=1999-10-22T18:00:00+00:00"
@@ -77,7 +74,7 @@ def test_no_vehicle_positions_for_date():
     )
     result = runner.invoke(
         app,
-        ["parse", "vehicle_positions", "2022-09-14T18:00:00", "--base64url", base64url]
+        ["parse", "vehicle_positions", "2022-09-14T18:00:00", "--base64url", base64url],
     )
     assert result.exit_code == 0
     assert "0 vehicle_positions files in 0 aggregations" in result.stdout
@@ -89,7 +86,7 @@ def test_no_vehicle_positions_for_date():
 def test_no_vehicle_positions_for_url():
     result = runner.invoke(
         app,
-        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", "nope"]
+        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", "nope"],
     )
     assert result.exit_code == 0
     assert "found 5158 vehicle_positions files in 136 aggregations" in result.stdout
@@ -104,7 +101,7 @@ def test_no_records_for_url_vehicle_positions_on_date():
     )
     result = runner.invoke(
         app,
-        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", base64url]
+        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", base64url],
     )
     assert result.exit_code == 0
     assert "found 5158 vehicle_positions files in 136 aggregations" in result.stdout
@@ -117,8 +114,7 @@ def test_no_records_for_url_vehicle_positions_on_date():
 def test_trip_updates():
     base64url = "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1TQQ=="
     result = runner.invoke(
-        app,
-        ["parse", "trip_updates", "2024-10-22T18:00:00", "--base64url", base64url]
+        app, ["parse", "trip_updates", "2024-10-22T18:00:00", "--base64url", base64url]
     )
     assert result.exit_code == 0
     assert (
@@ -138,7 +134,7 @@ def test_service_alerts():
     base64url = "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3NlcnZpY2VhbGVydHM_YWdlbmN5PUFN"
     result = runner.invoke(
         app,
-        ["parse", "service_alerts", "2024-10-22T18:00:00", "--base64url", base64url]
+        ["parse", "service_alerts", "2024-10-22T18:00:00", "--base64url", base64url],
     )
     assert result.exit_code == 0
     assert (
@@ -185,7 +181,7 @@ def test_no_recent_schedule_for_vehicle_positions_on_validation():
             "2024-09-14T18:00:00",
             "--base64url",
             base64url,
-        ]
+        ],
     )
     assert result.exit_code == 0
     assert (

--- a/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
@@ -200,7 +200,8 @@ def test_no_recent_schedule_for_vehicle_positions_on_validation():
     )
     assert "5158 vehicle_positions files in 136 aggregations" in result.stdout
     assert f"url filter applied, only processing {base64url}" in result.stdout
-    # assert "no schedule data found" in result.stdout
+    assert "no schedule data found" in result.stdout
+    assert "no recent schedule data found" in result.stdout
     assert "test-calitp-gtfs-rt-validation" in result.stdout
     assert "saving 38 outcomes" in result.stdout
 

--- a/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
@@ -222,7 +222,6 @@ def test_no_output_file_for_vehicle_positions_on_validation():
         ],
         catch_exceptions=True,
     )
-    print(result.stdout)
     assert result.exit_code == 0
     assert (
         "test-calitp-gtfs-rt-raw-v2/vehicle_positions/dt=2024-10-17/hour=2024-10-17T00:00:00+00:00"
@@ -232,4 +231,4 @@ def test_no_output_file_for_vehicle_positions_on_validation():
     assert "limit of 3 feeds was set" in result.stdout
     # "WARNING: no validation output file found" was previously generating the error "[Errno 2] No such file or directory"
     assert "WARNING: no validation output file found" in result.stdout
-    assert "saving 122 outcomes" in result.stdout
+    assert "saving 114 outcomes" in result.stdout

--- a/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
@@ -56,8 +56,7 @@ def test_rt_file_processing_outcome_construction() -> None:
 def test_vehicle_positions():
     result = runner.invoke(
         app,
-        ["parse", "vehicle_positions", "1999-10-22T18:00:00"],
-        catch_exceptions=False,
+        ["parse", "vehicle_positions", "1999-10-22T18:00:00"]
     )
     assert result.exit_code == 0
     assert (
@@ -78,8 +77,7 @@ def test_no_vehicle_positions_for_date():
     )
     result = runner.invoke(
         app,
-        ["parse", "vehicle_positions", "2022-09-14T18:00:00", "--base64url", base64url],
-        catch_exceptions=False,
+        ["parse", "vehicle_positions", "2022-09-14T18:00:00", "--base64url", base64url]
     )
     assert result.exit_code == 0
     assert "0 vehicle_positions files in 0 aggregations" in result.stdout
@@ -91,8 +89,7 @@ def test_no_vehicle_positions_for_date():
 def test_no_vehicle_positions_for_url():
     result = runner.invoke(
         app,
-        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", "nope"],
-        catch_exceptions=False,
+        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", "nope"]
     )
     assert result.exit_code == 0
     assert "found 5158 vehicle_positions files in 136 aggregations" in result.stdout
@@ -107,8 +104,7 @@ def test_no_records_for_url_vehicle_positions_on_date():
     )
     result = runner.invoke(
         app,
-        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", base64url],
-        catch_exceptions=False,
+        ["parse", "vehicle_positions", "2024-09-14T18:00:00", "--base64url", base64url]
     )
     assert result.exit_code == 0
     assert "found 5158 vehicle_positions files in 136 aggregations" in result.stdout
@@ -122,8 +118,7 @@ def test_trip_updates():
     base64url = "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1TQQ=="
     result = runner.invoke(
         app,
-        ["parse", "trip_updates", "2024-10-22T18:00:00", "--base64url", base64url],
-        catch_exceptions=False,
+        ["parse", "trip_updates", "2024-10-22T18:00:00", "--base64url", base64url]
     )
     assert result.exit_code == 0
     assert (
@@ -143,8 +138,7 @@ def test_service_alerts():
     base64url = "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3NlcnZpY2VhbGVydHM_YWdlbmN5PUFN"
     result = runner.invoke(
         app,
-        ["parse", "service_alerts", "2024-10-22T18:00:00", "--base64url", base64url],
-        catch_exceptions=False,
+        ["parse", "service_alerts", "2024-10-22T18:00:00", "--base64url", base64url]
     )
     assert result.exit_code == 0
     assert (
@@ -191,7 +185,7 @@ def test_no_recent_schedule_for_vehicle_positions_on_validation():
             "2024-09-14T18:00:00",
             "--base64url",
             base64url,
-        ],
+        ]
     )
     assert result.exit_code == 0
     assert (

--- a/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
@@ -165,7 +165,6 @@ def test_validation():
     result = runner.invoke(
         app,
         ["validate", "trip_updates", "2024-08-28T19:00:00", "--base64url", base64url],
-        catch_exceptions=False,
     )
     assert result.exit_code == 0
     assert (
@@ -193,7 +192,6 @@ def test_no_recent_schedule_for_vehicle_positions_on_validation():
             "--base64url",
             base64url,
         ],
-        catch_exceptions=True,
     )
     assert result.exit_code == 0
     assert (
@@ -219,7 +217,6 @@ def test_no_output_file_for_vehicle_positions_on_validation():
             3,
             "--verbose",
         ],
-        catch_exceptions=True,
     )
     assert result.exit_code == 0
     assert (
@@ -228,6 +225,4 @@ def test_no_output_file_for_vehicle_positions_on_validation():
     )
     assert "5487 vehicle_positions files in 139 aggregations" in result.stdout
     assert "limit of 3 feeds was set" in result.stdout
-    # "WARNING: no validation output file found" was previously generating the error "[Errno 2] No such file or directory"
-    assert "WARNING: no validation output file found" in result.stdout
     assert "saving 114 outcomes" in result.stdout

--- a/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
@@ -173,7 +173,6 @@ def test_validation():
         in result.stdout
     )
     assert "3269 trip_updates files in 125 aggregations" in result.stdout
-    assert "Fetching gtfs schedule data" in result.stdout
     assert "validating" in result.stdout
     assert "executing rt_validator" in result.stdout
     assert "writing 50 lines" in result.stdout
@@ -203,7 +202,7 @@ def test_no_recent_schedule_for_vehicle_positions_on_validation():
     )
     assert "5158 vehicle_positions files in 136 aggregations" in result.stdout
     assert f"url filter applied, only processing {base64url}" in result.stdout
-    assert "no schedule data found" in result.stdout
+    # assert "no schedule data found" in result.stdout
     assert "test-calitp-gtfs-rt-validation" in result.stdout
     assert "saving 38 outcomes" in result.stdout
 

--- a/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/tests/test_gtfs_rt_parser.py
@@ -226,4 +226,7 @@ def test_no_output_file_for_vehicle_positions_on_validation():
     )
     assert "5487 vehicle_positions files in 139 aggregations" in result.stdout
     assert "limit of 3 feeds was set" in result.stdout
+    assert "validating" in result.stdout
+    assert "executing rt_validator" in result.stdout
+    assert "writing 69 lines" in result.stdout
     assert "saving 114 outcomes" in result.stdout


### PR DESCRIPTION
# Description

@ohrite and I refactored the code on `gtfs_rt_parser.py` using the tests created on the previous PR to then fix the issue #2780 to properly skip duplicate extracts instead of generating the error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally:
```
❯ poetry run pytest --gcs
================================================ test session starts ================================================
platform darwin -- Python 3.9.19, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/erikaypacheco/Documents/workspace/data-infra/jobs/gtfs-rt-parser-v2
configfile: pyproject.toml
plugins: env-1.1.5
collected 10 items

tests/test_gtfs_rt_parser.py ..........                                                                       [100%]

================================================= warnings summary ==================================================
...
========================================= 10 passed, 111 warnings in 44.72s =========================================
```


## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check after the merge if the results on `cal-itp-data-infra.staging.int_gtfs_quality__rt_validation_outcomes` for next days/hours does not contain the `Errno 2` reported on the issue.