### PR TITLE
Include year 2023 on test for staging NTD service tables

### DIFF
--- a/warehouse/models/staging/ntd_annual_data_tables/_src.yml
+++ b/warehouse/models/staging/ntd_annual_data_tables/_src.yml
@@ -41,7 +41,7 @@ sources:
             description: The year for which the data was reported.
             tests:
               - accepted_values:
-                  values: [2022]
+                  values: [2022, 2023]
           - name: _5_digit_ntd_id
             description: A five-digit identifying number for each agency used in the current NTD system.
           - name: agency
@@ -247,7 +247,7 @@ sources:
             description: The year for which the data was reported.
             tests:
               - accepted_values:
-                  values: [2022]
+                  values: [2022, 2023]
           - name: _5_digit_ntd_id
             description: A five-digit identifying number for each agency used in the current NTD system.
           - name: type_of_service
@@ -275,7 +275,7 @@ sources:
             description: The year for which the data was reported.
             tests:
               - accepted_values:
-                  values: [2022]
+                  values: [2022, 2023]
           - name: _5_digit_ntd_id
             description: A five-digit identifying number for each agency used in the current NTD system.
           - name: agency


### PR DESCRIPTION
# Description

Add year 2023 on tests for staging NTD service tables as part of the rename and fix tests for issue #3523.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally:
```
❯ poetry run dbt test -s models/staging/ntd_annual_data_tables/
19:09:20  Running with dbt=1.5.1
19:09:21  Found 418 models, 987 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 170 sources, 4 exposures, 0 metrics, 0 groups
19:09:21
19:09:23  Concurrency: 8 threads (target='dev')
19:09:23
19:09:23  1 of 10 START test accepted_values_stg_ntd_annual_data__service_by_agency_report_year__2022__2023  [RUN]
19:09:23  2 of 10 START test accepted_values_stg_ntd_annual_data__service_by_mode_and_time_period_report_year__2022__2023  [RUN]
19:09:23  3 of 10 START test accepted_values_stg_ntd_annual_data__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [RUN]
19:09:23  4 of 10 START test accepted_values_stg_ntd_annual_data__service_by_mode_max_time_period__Annual_Total  [RUN]
19:09:23  5 of 10 START test accepted_values_stg_ntd_annual_data__service_by_mode_report_year__2022__2023  [RUN]
19:09:23  6 of 10 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_agency_report_year__2022__2023  [RUN]
19:09:23  7 of 10 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year__2022__2023  [RUN]
19:09:23  8 of 10 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [RUN]
19:09:24  6 of 10 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_agency_report_year__2022__2023  [PASS in 1.03s]
19:09:24  2 of 10 PASS accepted_values_stg_ntd_annual_data__service_by_mode_and_time_period_report_year__2022__2023  [PASS in 1.04s]
19:09:24  9 of 10 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_max_time_period__Annual_Total  [RUN]
19:09:24  10 of 10 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_report_year__2022__2023  [RUN]
19:09:24  7 of 10 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year__2022__2023  [PASS in 1.08s]
19:09:24  1 of 10 PASS accepted_values_stg_ntd_annual_data__service_by_agency_report_year__2022__2023  [PASS in 1.09s]
19:09:24  8 of 10 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [PASS in 1.08s]
19:09:24  3 of 10 PASS accepted_values_stg_ntd_annual_data__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [PASS in 1.10s]
19:09:24  4 of 10 PASS accepted_values_stg_ntd_annual_data__service_by_mode_max_time_period__Annual_Total  [PASS in 1.13s]
19:09:24  5 of 10 PASS accepted_values_stg_ntd_annual_data__service_by_mode_report_year__2022__2023  [PASS in 1.15s]
19:09:25  10 of 10 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_report_year__2022__2023  [PASS in 0.75s]
19:09:25  9 of 10 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_max_time_period__Annual_Total  [PASS in 0.78s]
19:09:25
19:09:25  Finished running 10 tests in 0 hours 0 minutes and 3.33 seconds (3.33s).
19:09:25
19:09:25  Completed successfully
19:09:25
19:09:25  Done. PASS=10 WARN=0 ERROR=0 SKIP=0 TOTAL=10
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check after the next DAG runs to confirm no more errors validating year.
