### PR TITLE
Change NTD ridership schedule to run once a week

### DIFF
--- a/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
@@ -1,5 +1,5 @@
-description: "Scrape tables from DOT Ridership XLSX file daily"
-schedule_interval: "0 10 * * *" # 10am UTC every day
+description: "Scrape tables from DOT Ridership XLSX file weekly"
+schedule_interval: "0 10 * * 1" # 10am UTC every Monday
 tags:
   - all_gusty_features
 default_args:


### PR DESCRIPTION
# Description

This PR changes the schedule of the NTD monthly ridership scrape (`sync_ntd_data_xlsx` DAG ) to run once a week (every Monday) instead of every day.
There is no need to run every day since it is a monthly file, but having the process running once a week give us a better window to add and process new files once it is released.

Part of the issue #3519.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running airflow locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After merge, check the schedule for `sync_ntd_data_xlsx` to see if the next run is for Monday.