### PR TITLE
revise misleading name of state highway network flag column on dim_stops_latest

### DIFF
--- a/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
+++ b/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
@@ -40,7 +40,7 @@ dim_stops_latest_with_shn_boolean AS (
 
 SELECT
     dim_stops_latest.*,
-    IF(stops_on_shn._gtfs_key IS NOT NULL, TRUE, FALSE) AS exists_in_dim_stops_latest
+    IF(stops_on_shn._gtfs_key IS NOT NULL, TRUE, FALSE) AS on_state_highway_network
 FROM
     dim_stops_latest
 LEFT JOIN


### PR DESCRIPTION
# Description

Realized the column name for the state highway network boolean on the dim_stops_latest table was misleading, renamed to: `on_state_highway_network`

## Type of change
- [x] New feature

## How has this been tested?

locally with dbt

## Post-merge follow-ups
- [x] Actions required (specified below)
run table in production as requested