### PR TITLE
Refine GTFS-RT validator error messaging

### DIFF
--- a/jobs/gtfs-rt-parser-v2/poetry.lock
+++ b/jobs/gtfs-rt-parser-v2/poetry.lock
@@ -508,6 +508,22 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "flake8"
+version = "7.1.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8-7.1.1-py2.py3-none-any.whl", hash = "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"},
+    {file = "flake8-7.1.1.tar.gz", hash = "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.12.0,<2.13.0"
+pyflakes = ">=3.2.0,<3.3.0"
+
+[[package]]
 name = "fonttools"
 version = "4.54.1"
 description = "Tools to manipulate font files"
@@ -1358,6 +1374,17 @@ pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
 name = "memory-profiler"
 version = "0.60.0"
 description = "A module for monitoring memory usage of a python program"
@@ -2008,6 +2035,17 @@ files = [
 pyasn1 = ">=0.4.6,<0.7.0"
 
 [[package]]
+name = "pycodestyle"
+version = "2.12.1"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
+    {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
+]
+
+[[package]]
 name = "pydantic"
 version = "1.9.2"
 description = "Data validation and settings management using python type hints"
@@ -2057,6 +2095,17 @@ typing-extensions = ">=3.7.4.3"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pyflakes"
+version = "3.2.0"
+description = "passive checker of Python programs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
+    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
+]
 
 [[package]]
 name = "pyparsing"
@@ -2583,5 +2632,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<3.10"
-content-hash = "2ff33638394c0014c2e5df03ad30b6e2e57ec5f048c5087b75a2546e0e0bd9fa"
+python-versions = ">=3.8.1,<3.10"
+content-hash = "51e6481ee50e162cc336f8581791ba5a2864a56bf00d722091837931f1a75f0f"

--- a/jobs/gtfs-rt-parser-v2/pyproject.toml
+++ b/jobs/gtfs-rt-parser-v2/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.10"
+python = ">=3.8.1,<3.10"
 gtfs-realtime-bindings = "0.0.7"
 google-auth = "1.32.1"
 pathy = {extras = ["gcs"], version = "^0.6.1"}
@@ -26,6 +26,7 @@ types-protobuf = "^5.28.0.20240924"
 types-tqdm = "^4.66.0.20240417"
 isort = "^5.13.2"
 pytest-env = "^1.1.5"
+flake8 = "^7.1.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
# Description

Provide a better message when GTFS-RT validator jar skips a file. Previously, the `validation_exception` logged was a raw byte string representing the MD5 of a file evaluated by the gtfs-realtime-validator jar file.

<img width="712" alt="Screenshot 2024-11-26 at 12 17 38" src="https://github.com/user-attachments/assets/f0b75daf-cde2-4ff6-b3f9-83d089952282">

This has been amended to print the message "No validator output" instead, mirroring the command line output.

Resolves #2780 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `cal-itp-data-infra.staging.int_gtfs_quality__rt_validation_outcomes` to ensure that friendly error messages appear rather than byte strings.