### PR TITLE
Change order of new columns on External Annual Agency Information to try to force it creation

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/annual_database_agency_information.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/annual_database_agency_information.yml
@@ -45,6 +45,10 @@ schema_fields:
     type: STRING
   - name: ueid
     type: STRING
+  - name: division_department
+    type: STRING
+  - name: state_parent_ntd_id
+    type: STRING
   - name: address_line_2
     type: STRING
   - name: number_of_counties_with_service
@@ -96,8 +100,4 @@ schema_fields:
   - name: agency_name
     type: STRING
   - name: ntd_id
-    type: STRING
-  - name: division_department
-    type: STRING
-  - name: state_parent_ntd_id
     type: STRING


### PR DESCRIPTION
# Description

Somehow the process to create external tables are not creating the new columns for `external_ntd_data_products.annual_database_agency_information`.
I changed the order of those new columns on the configuration file to try to force it creation.

[#3497]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally creating the table on staging.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check if the DAG was able to create the table with the new columns
