### PR TITLE
Fixing docs from errors generated from previous pr 

### DIFF
--- a/docs/analytics_onboarding/overview.md
+++ b/docs/analytics_onboarding/overview.md
@@ -19,7 +19,7 @@
 
 - [ ] [**Slack**](https://cal-itp.slack.com) | ([Docs](slack-intro))
 - [ ] [**Analytics Repo**](https://github.com/cal-itp/data-analyses) | ([Docs](analytics-repo))
-- [ ] [**Analyst Project Board**](https://github.com/cal-itp/data-analyses/projects/1) | ([Docs](analytics-project-board))
+- [ ] [**Analyst Project Board**](https://github.com/cal-itp/data-analyses/projects/1)
 - [ ] [**Google Cloud Storage**](https://console.cloud.google.com/storage/browser/calitp-analytics-data) | ([Docs](storing-new-data))
 
 **Analytics Tools:**

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -116,7 +116,7 @@ If you discover merge conflicts and they are within a single notebook that only 
     `git checkout --theirs path/to/notebook.ipynb`
 - From here, just add the file and commit with a message as you normally would and the conflict should be fixed in your Pull Request.
 
-(other-common-github-issues-encountered-during-saving-codes)
+(other-common-github-issues-encountered-during-saving-codes)=
 
 ### Other Common Issues
 

--- a/docs/contribute/submitting_changes.md
+++ b/docs/contribute/submitting_changes.md
@@ -85,6 +85,10 @@ The action is an automated service provided by GitHub that ensures suggested add
 
 Our GitHub action is triggered on pushes to the `data-infra` repository related to the `docs` directory.
 
+Another way to edit and test your markdown changes is using the jupyterhub.  Edit the text files directly then run this command from the base of the data-infra repo: `jb build docs --warningiserror`.
+
+This will locally build the docs and allow you to test your changes without having to make lots of commits.
+
 (docs-preview)=
 
 ## How do I preview my docs change?

--- a/docs/publishing/sections/7_gcs.md
+++ b/docs/publishing/sections/7_gcs.md
@@ -2,7 +2,7 @@
 
 # GCS
 
-### Public Data Access in GCS
+## Public Data Access in GCS
 
 Some data stored in Cloud Storage is configured to be publicly accessible, meaning anyone on the internet can read it at any time. In Google Cloud Storage, you can make data publicly accessible either at the bucket level or the object level. At the bucket level, you can grant public access to all objects within the bucket by modifying the bucket policy. Alternatively, you can provide public access to specific objects.
 


### PR DESCRIPTION
# Description

Fixing docs from errors generated from previous pr #3554

Adds a little documentation for how to build the docs site locally on jupyterhub

Resolves #3569

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?
```
jovyan@jupyter-vevetron:~/data-infra$ jb build docs --warningiserror
Running Jupyter-Book v1.0.0
Source Folder: /home/jovyan/data-infra/docs
Config Path: /home/jovyan/data-infra/docs/_config.yml
Output Path: /home/jovyan/data-infra/docs/_build/html
Running Sphinx v5.3.0
[etoc] Changing master_doc to 'intro'
loading pickled environment... done
myst v1.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'substitution', 'colon_fence', 'dollarmath', 'tasklist', 'linkify'}, disable_syntax=[], all_links_external=False, url_schemes=('mailto', 'http', 'https'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
myst-nb v1.0.0: NbParserConfig(custom_formats={}, metadata_key='mystnb', cell_metadata_key='mystnb', kernel_rgx_aliases={}, eval_name_regex='^[a-zA-Z_][a-zA-Z0-9_]*$', execution_mode='force', execution_cache_path='', execution_excludepatterns=[], execution_timeout=-1, execution_in_temp=False, execution_allow_errors=False, execution_raise_on_error=False, execution_show_tb=False, merge_streams=False, render_plugin='default', remove_code_source=False, remove_code_outputs=False, code_prompt_show='Show code cell {type}', code_prompt_hide='Hide code cell {type}', number_source_lines=False, output_stderr='show', render_text_lexer='myst-ansi', render_error_lexer='ipythontb', render_image_options={}, render_figure_options={}, render_markdown_format='commonmark', output_folder='build', append_css=True, metadata_to_fm=False)
Using jupyter-cache at: /home/jovyan/data-infra/docs/_build/.jupyter_cache
sphinx-multitoc-numbering v0.1.3: Loaded
The default value for `navigation_with_keys` will change to `False` in the next release. If you wish to preserve the old behavior for your site, set `navigation_with_keys=True` in the `html_theme_options` dict in your `conf.py` file. Be aware that `navigation_with_keys = True` has negative accessibility implications: https://github.com/pydata/pydata-sphinx-theme/issues/1492
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] contribute/submitting_changes                                                        
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] intro                                                                                 
generating indices... genindex done
writing additional pages... search done
copying images... [100%] contribute/assets/netlify-link.png                                                    
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in docs/_build/html.

===============================================================================

Finished generating HTML for book.
Your book's HTML pages are here:
    docs/_build/html/
You can look at your book by opening this file in a browser:
    docs/_build/html/index.html
Or paste this line directly into your browser bar:
    file:///home/jovyan/data-infra/docs/_build/html/index.html            

===============================================================================
```


## Post-merge follow-ups

- [x] No action required
- [] Actions required (specified below)