### PR TITLE
Add explicit autodetect = true to load schema for NTD Ridership UPT, VOMS, VRH, and VRM

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__upt.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__upt.yml
@@ -10,6 +10,7 @@ source_objects:
 destination_project_dataset_table: "external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__upt"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
+autodetect: true
 hive_options:
   mode: AUTO
   require_partition_filter: false

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__voms.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__voms.yml
@@ -10,6 +10,7 @@ source_objects:
 destination_project_dataset_table: "external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__voms"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
+autodetect: true
 hive_options:
   mode: AUTO
   require_partition_filter: false

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrh.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrh.yml
@@ -10,6 +10,7 @@ source_objects:
 destination_project_dataset_table: "external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrh"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
+autodetect: true
 hive_options:
   mode: AUTO
   require_partition_filter: false

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm.yml
@@ -10,6 +10,7 @@ source_objects:
 destination_project_dataset_table: "external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
+autodetect: true
 hive_options:
   mode: AUTO
   require_partition_filter: false


### PR DESCRIPTION
# Description

There is a new file with a new column for month of October that for some reason wasn't created.
Trying to fix by adding explicitly an `autodetect = true` to load schema for NTD Ridership UPT, VOMS, VRH, and VRM.

[#3497]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally generating the external table on staging.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Run the Creation of those external tables manually and monitor the next DAG runs to see it will be creating new columns.
