### PR TITLE
Fix Not Unique Error on dim_calendar_dates._gtfs_key

### DIFF
--- a/warehouse/models/mart/gtfs/dim_calendar_dates.sql
+++ b/warehouse/models/mart/gtfs/dim_calendar_dates.sql
@@ -8,7 +8,7 @@ WITH make_dim AS (
 dim_calendar_dates AS (
     SELECT
         {{ dbt_utils.generate_surrogate_key(['feed_key', '_line_number']) }} AS key,
-        {{ dbt_utils.generate_surrogate_key(['feed_key', 'service_id', 'date']) }} AS _gtfs_key,
+        {{ dbt_utils.generate_surrogate_key(['feed_key', 'service_id', 'date', 'exception_type']) }} AS _gtfs_key,
         feed_key,
         service_id,
         date,


### PR DESCRIPTION
# Description

This PR fixes the error on issue #3065 adding `exception_type` column as part of the generate_surrogate_key in order to make _gtfs_key on dim_calendar_dates pass the unique key test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally generating table on stating.

![Screenshot 2024-12-10 at 6 00 21 PM](https://github.com/user-attachments/assets/6d94ddb5-6f78-4f5b-bed0-9c2bf568716f)

![Screenshot 2024-12-10 at 6 00 35 PM](https://github.com/user-attachments/assets/96c535ae-8e06-4bd2-b9af-477bc6db6c4c)

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Since the table is set to incremental materialization, if the error still happening after merging and running the process we need to run a `Full Refresh` to regenerate the `_gtfs_key` for old records.