### PR TITLE
ntd: staging and mart warehouse tables for agency and contractual relationship tables

### DIFF
--- a/warehouse/models/mart/ntd_fct_annual/_mart_ntd_fct_annual.yml
+++ b/warehouse/models/mart/ntd_fct_annual/_mart_ntd_fct_annual.yml
@@ -35,3 +35,5 @@ models:
   - name: fct_ntd_annual_data__track_and_roadway_guideway_age_distribution
   - name: fct_ntd_annual_data__vehicles_age_distribution
   - name: fct_ntd_annual_data__vehicles_type_count_by_agency
+  - name: fct_ntd_annual_data__2023_agency_information
+  - name: fct_ntd_annual_data__2023_contractual_relationships

--- a/warehouse/models/mart/ntd_fct_annual/fct_ntd_annual_data__2023_agency_information.sql
+++ b/warehouse/models/mart/ntd_fct_annual/fct_ntd_annual_data__2023_agency_information.sql
@@ -1,0 +1,11 @@
+WITH staging_agency_information AS (
+    SELECT *
+    FROM {{ ref('stg_ntd_annual_data__2023_agency_information') }}
+),
+
+fct_ntd_annual_data__2023_agency_information AS (
+    SELECT *
+    FROM staging_agency_information
+)
+
+SELECT * FROM fct_ntd_annual_data__2023_agency_information

--- a/warehouse/models/mart/ntd_fct_annual/fct_ntd_annual_data__2023_contractual_relationships.sql
+++ b/warehouse/models/mart/ntd_fct_annual/fct_ntd_annual_data__2023_contractual_relationships.sql
@@ -1,0 +1,11 @@
+WITH staging_contractual_relationships AS (
+    SELECT *
+    FROM {{ ref('stg_ntd_annual_data__2023_contractual_relationships') }}
+),
+
+fct_ntd_annual_data__2023_contractual_relationships AS (
+    SELECT *
+    FROM staging_contractual_relationships
+)
+
+SELECT * FROM fct_ntd_annual_data__2023_contractual_relationships

--- a/warehouse/models/staging/ntd_annual_data_tables/_src.yml
+++ b/warehouse/models/staging/ntd_annual_data_tables/_src.yml
@@ -613,3 +613,5 @@ sources:
       - name: multi_year__track_and_roadway_guideway_age_distribution
       - name: multi_year__vehicles_age_distribution
       - name: multi_year__vehicles_type_count_by_agency
+      - name: 2023__annual_database_agency_information
+      - name: 2023__annual_database_contractual_relationship

--- a/warehouse/models/staging/ntd_annual_data_tables/_stg_ntd_annual_data_tables.yml
+++ b/warehouse/models/staging/ntd_annual_data_tables/_stg_ntd_annual_data_tables.yml
@@ -608,3 +608,5 @@ models:
   - name: stg_ntd_annual_data__track_and_roadway_guideway_age_distribution
   - name: stg_ntd_annual_data__vehicles_age_distribution
   - name: stg_ntd_annual_data__vehicles_type_count_by_agency
+  - name: stg_ntd_annual_data__2023_agency_information
+  - name: stg_ntd_annual_data__2023_contractual_relationships

--- a/warehouse/models/staging/ntd_annual_data_tables/stg_ntd_annual_data__2023_agency_information.sql
+++ b/warehouse/models/staging/ntd_annual_data_tables/stg_ntd_annual_data__2023_agency_information.sql
@@ -1,0 +1,19 @@
+WITH external_agency_information AS (
+    SELECT *
+    FROM {{ source('external_ntd__annual_reporting', '2023__annual_database_agency_information') }}
+),
+
+get_latest_extract AS(
+
+    SELECT *
+    FROM external_agency_information
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd_annual_data__2023_agency_information AS (
+    SELECT *
+    FROM get_latest_extract
+)
+
+SELECT * FROM stg_ntd_annual_data__2023_agency_information

--- a/warehouse/models/staging/ntd_annual_data_tables/stg_ntd_annual_data__2023_contractual_relationships.sql
+++ b/warehouse/models/staging/ntd_annual_data_tables/stg_ntd_annual_data__2023_contractual_relationships.sql
@@ -1,0 +1,19 @@
+WITH external_contractual_relationships AS (
+    SELECT *
+    FROM {{ source('external_ntd__annual_reporting', '2023__annual_database_contractual_relationship') }}
+),
+
+get_latest_extract AS(
+
+    SELECT *
+    FROM external_contractual_relationships
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd_annual_data__2023_contractual_relationships AS (
+    SELECT *
+    FROM get_latest_extract
+)
+
+SELECT * FROM stg_ntd_annual_data__2023_contractual_relationships


### PR DESCRIPTION
# Description
Following up on #3584, this brings the external tables for agency and contractual relationships created in that PR into the Warehouse as MVP staging and mart tables.

New staging tables:
* stg_ntd_annual_data__2023_agency_information
* stg_ntd_annual_data__2023_contractual_relationships

New mart tables:
* fct_ntd_annual_data__2023_agency_information
* fct_ntd_annual_data__2023_contractual_relationships

## Type of change
- [x] New feature

## How has this been tested?
<img width="857" alt="Screenshot 2024-12-13 at 4 35 39 PM" src="https://github.com/user-attachments/assets/607d1c52-f7eb-48b2-843e-f3b7ce70dd74" />

## Post-merge follow-ups
- [x] Actions required (specified below)
Observe for expected behavior, follow up with documentation, tests, typecasting