### PR TITLE
NTD: materialize marts as tables and add handling for report_year field

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -70,8 +70,11 @@ models:
       ntd_validation:
         schema: mart_ntd_validation
       ntd_annual_reporting:
+        +materialized: table
         schema: mart_ntd_annual_reporting
       ntd_safety_and_security:
+        +materialized: table
         schema: mart_ntd_safety_and_security
       ntd_ridership:
+        +materialized: table
         schema: mart_ntd_ridership

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__breakdowns.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__breakdowns.sql
@@ -29,7 +29,7 @@ SELECT
     SAFE_CAST(other_mechanical_failures AS NUMERIC) AS other_mechanical_failures,
     {{ trim_make_empty_string_null('other_mechanical_failures_1') }} AS other_mechanical_failures_1,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_mechanical_failures AS NUMERIC) AS total_mechanical_failures,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__breakdowns_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__breakdowns_by_agency.sql
@@ -32,7 +32,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_major_mechanical_failures AS NUMERIC) AS sum_major_mechanical_failures,
     SAFE_CAST(sum_other_mechanical_failures AS NUMERIC) AS sum_other_mechanical_failures,
     SAFE_CAST(sum_total_mechanical_failures AS NUMERIC) AS sum_total_mechanical_failures,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_by_capital_use.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_by_capital_use.sql
@@ -44,7 +44,7 @@ SELECT
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
     SAFE_CAST(reduced_reporter AS NUMERIC) AS reduced_reporter,
     {{ trim_make_empty_string_null('reduced_reporter_questionable') }} AS reduced_reporter_questionable,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(stations AS NUMERIC) AS stations,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_by_mode.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_by_mode.sql
@@ -37,7 +37,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('modecd') }} AS modecd,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_administrative_buildings AS NUMERIC) AS sum_administrative_buildings,
     SAFE_CAST(sum_communication_information AS NUMERIC) AS sum_communication_information,
     SAFE_CAST(sum_fare_collection_equipment AS NUMERIC) AS sum_fare_collection_equipment,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_for_existing_service.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_for_existing_service.sql
@@ -27,7 +27,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_administrative_buildings AS NUMERIC) AS sum_administrative_buildings,
     SAFE_CAST(sum_communication_information AS NUMERIC) AS sum_communication_information,
     SAFE_CAST(sum_fare_collection_equipment AS NUMERIC) AS sum_fare_collection_equipment,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_for_expansion_of_service.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__capital_expenses_for_expansion_of_service.sql
@@ -27,7 +27,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_administrative_buildings AS NUMERIC) AS sum_administrative_buildings,
     SAFE_CAST(sum_communication_information AS NUMERIC) AS sum_communication_information,
     SAFE_CAST(sum_fare_collection_equipment AS NUMERIC) AS sum_fare_collection_equipment,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_agency.sql
@@ -37,7 +37,7 @@ SELECT
     SAFE_CAST(max_primary_uza_population_1 AS NUMERIC) AS max_primary_uza_population_1,
     {{ trim_make_empty_string_null('max_state_1') }} AS max_state_1,
     {{ trim_make_empty_string_null('max_uza_name_1') }} AS max_uza_name_1,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_total_hours AS NUMERIC) AS sum_total_hours,
     SAFE_CAST(total_employees AS NUMERIC) AS total_employees,
     SAFE_CAST(total_operating_hours AS NUMERIC) AS total_operating_hours,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_mode.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_mode.sql
@@ -31,7 +31,7 @@ SELECT
     {{ trim_make_empty_string_null('max_mode_name') }} AS max_mode_name,
     {{ trim_make_empty_string_null('mode') }} AS mode,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_total_employee_count AS NUMERIC) AS sum_total_employee_count,
     SAFE_CAST(sum_total_hours AS NUMERIC) AS sum_total_hours,
     {{ trim_make_empty_string_null('type_of_service') }} AS type_of_service,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_mode_and_employee_type.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_mode_and_employee_type.sql
@@ -38,7 +38,7 @@ SELECT
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
     {{ trim_make_empty_string_null('organization_type') }} AS organization_type,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_employee_count AS NUMERIC) AS total_employee_count,
     {{ trim_make_empty_string_null('total_employee_count_q') }} AS total_employee_count_q,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__fuel_and_energy.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__fuel_and_energy.sql
@@ -75,7 +75,7 @@ SELECT
     SAFE_CAST(other_fuel_gal_gal_equivalent AS NUMERIC) AS other_fuel_gal_gal_equivalent,
     {{ trim_make_empty_string_null('other_fuel_gal_gal_equivalent_1') }} AS other_fuel_gal_gal_equivalent_1,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     {{ trim_make_empty_string_null('typeofservicecd') }} AS typeofservicecd,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__fuel_and_energy_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__fuel_and_energy_by_agency.sql
@@ -28,7 +28,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_bio_diesel_gal AS NUMERIC) AS sum_bio_diesel_gal,
     SAFE_CAST(sum_compressed_natural_gas AS NUMERIC) AS sum_compressed_natural_gas,
     SAFE_CAST(sum_compressed_natural_gas_gal AS NUMERIC) AS sum_compressed_natural_gas_gal,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_by_expense_type.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_by_expense_type.sql
@@ -29,7 +29,7 @@ SELECT
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
     {{ trim_make_empty_string_null('organization_type') }} AS organization_type,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(state_1 AS NUMERIC) AS state_1,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_directly_generated.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_directly_generated.sql
@@ -34,7 +34,7 @@ SELECT
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
     SAFE_CAST(purchased_transportation AS NUMERIC) AS purchased_transportation,
     {{ trim_make_empty_string_null('purchased_transportation_1') }} AS purchased_transportation_1,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total AS NUMERIC) AS total,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_federal.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_federal.sql
@@ -28,7 +28,7 @@ SELECT
     SAFE_CAST(other_federal_funds AS NUMERIC) AS other_federal_funds,
     SAFE_CAST(other_fta_funds AS NUMERIC) AS other_fta_funds,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_federal_funds AS NUMERIC) AS total_federal_funds,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_local.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_local.sql
@@ -29,7 +29,7 @@ SELECT
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
     SAFE_CAST(property_tax AS NUMERIC) AS property_tax,
     SAFE_CAST(reduced_reporter_funds AS NUMERIC) AS reduced_reporter_funds,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     SAFE_CAST(sales_tax AS NUMERIC) AS sales_tax,
     {{ trim_make_empty_string_null('state') }} AS state,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_state.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_state.sql
@@ -24,7 +24,7 @@ SELECT
     {{ trim_make_empty_string_null('organization_type') }} AS organization_type,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
     SAFE_CAST(reduced_reporter_funds AS NUMERIC) AS reduced_reporter_funds,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total AS NUMERIC) AS total,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_taxes_levied_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__funding_sources_taxes_levied_by_agency.sql
@@ -27,7 +27,7 @@ SELECT
     SAFE_CAST(other_tax AS NUMERIC) AS other_tax,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
     SAFE_CAST(property_tax AS NUMERIC) AS property_tax,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     SAFE_CAST(sales_tax AS NUMERIC) AS sales_tax,
     {{ trim_make_empty_string_null('state') }} AS state,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__maintenance_facilities.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__maintenance_facilities.sql
@@ -45,7 +45,7 @@ SELECT
     SAFE_CAST(owned_by_public_agency AS NUMERIC) AS owned_by_public_agency,
     {{ trim_make_empty_string_null('owned_by_public_agency_1') }} AS owned_by_public_agency_1,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_facilities AS NUMERIC) AS total_facilities,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__maintenance_facilities_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__maintenance_facilities_by_agency.sql
@@ -26,7 +26,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_200_to_300_vehicles AS NUMERIC) AS sum_200_to_300_vehicles,
     SAFE_CAST(sum_heavy_maintenance_facilities AS NUMERIC) AS sum_heavy_maintenance_facilities,
     SAFE_CAST(sum_leased_by_pt_provider AS NUMERIC) AS sum_leased_by_pt_provider,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__metrics.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__metrics.sql
@@ -41,7 +41,7 @@ SELECT
     SAFE_CAST(passengers_per_hour AS NUMERIC) AS passengers_per_hour,
     {{ trim_make_empty_string_null('passengers_per_hour_1') }} AS passengers_per_hour_1,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_operating_expenses AS NUMERIC) AS total_operating_expenses,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_function.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_function.sql
@@ -31,7 +31,7 @@ SELECT
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
     SAFE_CAST(reduced_reporter_expenses AS NUMERIC) AS reduced_reporter_expenses,
     {{ trim_make_empty_string_null('reduced_reporter_expenses_1') }} AS reduced_reporter_expenses_1,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     SAFE_CAST(separate_report_amount AS NUMERIC) AS separate_report_amount,
     {{ trim_make_empty_string_null('separate_report_amount_1') }} AS separate_report_amount_1,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_function_and_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_function_and_agency.sql
@@ -25,7 +25,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(sum_facility_maintenance AS NUMERIC) AS sum_facility_maintenance,
     SAFE_CAST(sum_general_administration AS NUMERIC) AS sum_general_administration,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_type.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_type.sql
@@ -47,7 +47,7 @@ SELECT
     {{ trim_make_empty_string_null('purchased_transportation_1') }} AS purchased_transportation_1,
     SAFE_CAST(reduced_reporter_expenses AS NUMERIC) AS reduced_reporter_expenses,
     {{ trim_make_empty_string_null('reduced_reporter_expenses_1') }} AS reduced_reporter_expenses_1,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     SAFE_CAST(separate_report_amount AS NUMERIC) AS separate_report_amount,
     {{ trim_make_empty_string_null('separate_report_amount_1') }} AS separate_report_amount_1,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_type_and_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__operating_expenses_by_type_and_agency.sql
@@ -26,7 +26,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_casualty_and_liability AS NUMERIC) AS sum_casualty_and_liability,
     SAFE_CAST(sum_fringe_benefits AS NUMERIC) AS sum_fringe_benefits,
     SAFE_CAST(sum_fuel_and_lube AS NUMERIC) AS sum_fuel_and_lube,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__service_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__service_by_agency.sql
@@ -29,7 +29,7 @@ SELECT
     SAFE_CAST(max_service_area_population AS NUMERIC) AS max_service_area_population,
     SAFE_CAST(max_service_area_sq_miles AS NUMERIC) AS max_service_area_sq_miles,
     {{ trim_make_empty_string_null('max_state') }} AS max_state,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_actual_vehicles_passenger_car_deadhead_hours AS NUMERIC) AS sum_actual_vehicles_passenger_car_deadhead_hours,
     SAFE_CAST(sum_actual_vehicles_passenger_car_hours AS NUMERIC) AS sum_actual_vehicles_passenger_car_hours,
     SAFE_CAST(sum_actual_vehicles_passenger_car_miles AS NUMERIC) AS sum_actual_vehicles_passenger_car_miles,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__service_by_mode.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__service_by_mode.sql
@@ -36,7 +36,7 @@ SELECT
     {{ trim_make_empty_string_null('max_time_service_ends') }} AS max_time_service_ends,
     {{ trim_make_empty_string_null('mode') }} AS mode,
     {{ trim_make_empty_string_null('questionable_record') }} AS questionable_record,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_actual_vehicles_passenger_car_deadhead_hours AS NUMERIC) AS sum_actual_vehicles_passenger_car_deadhead_hours,
     SAFE_CAST(sum_actual_vehicles_passenger_car_hours AS NUMERIC) AS sum_actual_vehicles_passenger_car_hours,
     SAFE_CAST(sum_actual_vehicles_passenger_car_miles AS NUMERIC) AS sum_actual_vehicles_passenger_car_miles,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__service_by_mode_and_time_period.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__service_by_mode_and_time_period.sql
@@ -54,7 +54,7 @@ SELECT
     SAFE_CAST(primary_uza_code AS NUMERIC) AS primary_uza_code,
     {{ trim_make_empty_string_null('primary_uza_name') }} AS primary_uza_name,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('scheduled_revenue_miles_questionable') }} AS scheduled_revenue_miles_questionable,
     SAFE_CAST(scheduled_vehicles_passenger_car_revenue_miles AS NUMERIC) AS scheduled_vehicles_passenger_car_revenue_miles,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__stations_and_facilities_by_agency_and_facility_type.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__stations_and_facilities_by_agency_and_facility_type.sql
@@ -39,7 +39,7 @@ SELECT
     SAFE_CAST(parking_structure AS NUMERIC) AS parking_structure,
     SAFE_CAST(passenger_stations_and_terminals AS NUMERIC) AS passenger_stations_and_terminals,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     SAFE_CAST(revenue_collection_facility AS NUMERIC) AS revenue_collection_facility,
     SAFE_CAST(simple_at_grade_platform AS NUMERIC) AS simple_at_grade_platform,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__stations_by_mode_and_age.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__stations_by_mode_and_age.sql
@@ -35,7 +35,7 @@ SELECT
     {{ trim_make_empty_string_null('organization_type') }} AS organization_type,
     SAFE_CAST(pre1940 AS NUMERIC) AS pre1940,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_facilities AS NUMERIC) AS total_facilities,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_agency.sql
@@ -26,7 +26,7 @@ SELECT
     {{ trim_make_empty_string_null('max_uace_code') }} AS max_uace_code,
     {{ trim_make_empty_string_null('max_uza_name') }} AS max_uza_name,
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     SAFE_CAST(sum_at_grade_ballast_including AS NUMERIC) AS sum_at_grade_ballast_including,
     SAFE_CAST(sum_at_grade_in_street_embedded AS NUMERIC) AS sum_at_grade_in_street_embedded,
     SAFE_CAST(sum_below_grade_bored_or_blasted AS NUMERIC) AS sum_below_grade_bored_or_blasted,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_mode.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_mode.sql
@@ -57,7 +57,7 @@ SELECT
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
     SAFE_CAST(rail_crossings AS NUMERIC) AS rail_crossings,
     {{ trim_make_empty_string_null('rail_crossings_q') }} AS rail_crossings_q,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     SAFE_CAST(single_crossover AS NUMERIC) AS single_crossover,
     {{ trim_make_empty_string_null('single_crossover_q') }} AS single_crossover_q,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_guideway_age_distribution.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_guideway_age_distribution.sql
@@ -45,7 +45,7 @@ SELECT
     SAFE_CAST(pre1940s AS NUMERIC) AS pre1940s,
     {{ trim_make_empty_string_null('pre1940s_q') }} AS pre1940s_q,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     {{ trim_make_empty_string_null('type_of_service') }} AS type_of_service,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__vehicles_age_distribution.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__vehicles_age_distribution.sql
@@ -43,7 +43,7 @@ SELECT
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
     {{ trim_make_empty_string_null('organization_type') }} AS organization_type,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    SAFE_CAST(report_year AS INT64) AS report_year,
+    CAST(SAFE_CAST(report_year AS FLOAT64) AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_vehicles AS NUMERIC) AS total_vehicles,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__vehicles_age_distribution.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__vehicles_age_distribution.sql
@@ -43,7 +43,7 @@ SELECT
     {{ trim_make_empty_string_null('ntd_id') }} AS ntd_id,
     {{ trim_make_empty_string_null('organization_type') }} AS organization_type,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('state') }} AS state,
     SAFE_CAST(total_vehicles AS NUMERIC) AS total_vehicles,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__vehicles_type_count_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__vehicles_type_count_by_agency.sql
@@ -80,7 +80,7 @@ SELECT
     SAFE_CAST(over_the_road_bus_ulb AS NUMERIC) AS over_the_road_bus_ulb,
     SAFE_CAST(over_the_road_busrptulb AS NUMERIC) AS over_the_road_busrptulb,
     SAFE_CAST(primary_uza_population AS NUMERIC) AS primary_uza_population,
-    {{ trim_make_empty_string_null('report_year') }} AS report_year,
+    SAFE_CAST(report_year AS INT64) AS report_year,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     SAFE_CAST(school_bus AS NUMERIC) AS school_bus,
     SAFE_CAST(school_bus_ulb AS NUMERIC) AS school_bus_ulb,


### PR DESCRIPTION
# Description
Following up in our MVP ingestion of NTD tables, this PR materializes our NTD mart data as tables and handles the report_year field as an integer in tables where relevant.

## Type of change
- [x] New feature

## How has this been tested?
<img width="766" alt="Screenshot 2024-12-18 at 1 41 55 PM" src="https://github.com/user-attachments/assets/b03bfd0a-0dc1-46df-bff8-4024fa95e68b" />


## Post-merge follow-ups
- [x] No action required
