### PR TITLE
Add exception handling for recent data scraping airflow operators

### DIFF
--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -21,73 +21,92 @@ xlsx_urls = {
 }
 
 
-# pushes the scraped URL value to XCom
 def push_url_to_xcom(key, scraped_url, context):
+    """Push the scraped URL value to XCom with proper error handling."""
+    task_instance = context.get("ti")
+    if task_instance is None:
+        raise AirflowException("Task instance not found in context")
+
     try:
-        task_instance = context.get("ti")
-        if task_instance is None:
-            raise AirflowException("Task instance not found in context")
         task_instance.xcom_push(key=key, value=scraped_url)
     except Exception as e:
         logging.error(f"Error pushing URL to XCom for key {key}: {e}")
         raise AirflowException(f"Failed to push URL to XCom: {e}")
 
 
-# Look for an anchor tag where the href ends with '.xlsx' and starts with '/sites/fta.dot.gov/files/'
 def href_matcher(href):
+    """Look for an anchor tag where the href ends with '.xlsx' and starts with '/sites/fta.dot.gov/files/'"""
     return (
         href and href.startswith("/sites/fta.dot.gov/files/") and href.endswith(".xlsx")
     )
 
 
+def make_http_request(url, key):
+    """Make HTTP request with proper error handling."""
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        return response
+    except requests.exceptions.HTTPError as e:
+        logging.error(f"HTTP error occurred while fetching {url}: {e}")
+        raise AirflowException(f"HTTP error for {key}: {e}")
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Error occurred while fetching {url}: {e}")
+        raise AirflowException(f"Request failed for {key}: {e}")
+
+
+def parse_html_content(response_text, url, key):
+    """Parse HTML content with error handling."""
+    try:
+        return BeautifulSoup(response_text, "html.parser")
+    except Exception as e:
+        logging.error(f"Error parsing HTML for {url}: {e}")
+        raise AirflowException(f"HTML parsing failed for {key}: {e}")
+
+
+def find_and_validate_xlsx_link(soup, key, url):
+    """Find and validate XLSX download link."""
+    link = soup.find("a", href=href_matcher)
+    if not link:
+        error_msg = f"No XLSX download link found for {key} at {url}"
+        logging.error(error_msg)
+        raise AirflowException(error_msg)
+
+    file_link = link.get("href")
+    if not file_link:
+        error_msg = f"Found link for {key} but href attribute is missing"
+        logging.error(error_msg)
+        raise AirflowException(error_msg)
+
+    updated_url = f"https://www.transit.dot.gov{file_link}"
+    try:
+        return parse_obj_as(HttpUrl, updated_url)
+    except ValidationError as e:
+        logging.error(f"URL validation failed for {updated_url}: {e}")
+        raise AirflowException(f"Invalid URL constructed for {key}: {e}")
+
+
 def scrape_ntd_xlsx_urls(**context):
+    """Main function to scrape XLSX URLs and push them to XCom."""
     for key, url in xlsx_urls.items():
         try:
-            # Make HTTP request with proper error handling
-            try:
-                response = requests.get(url)
-                response.raise_for_status()  # Raises HTTPError for bad responses
-            except requests.exceptions.HTTPError as e:
-                logging.error(f"HTTP error occurred while fetching {url}: {e}")
-                raise AirflowException(f"HTTP error for {key}: {e}")
-            except requests.exceptions.RequestException as e:
-                logging.error(f"Error occurred while fetching {url}: {e}")
-                raise AirflowException(f"Request failed for {key}: {e}")
+            # Make HTTP request
+            response = make_http_request(url, key)
 
-            # Parse HTML with error handling
-            try:
-                soup = BeautifulSoup(response.text, "html.parser")
-            except Exception as e:
-                logging.error(f"Error parsing HTML for {url}: {e}")
-                raise AirflowException(f"HTML parsing failed for {key}: {e}")
+            # Parse HTML content
+            soup = parse_html_content(response.text, url, key)
 
-            # Find link with error handling
-            link = soup.find("a", href=href_matcher)
-            if not link:
-                error_msg = f"No XLSX download link found for {key} at {url}"
-                logging.error(error_msg)
-                raise AirflowException(error_msg)
-
-            # Extract href with error handling
-            file_link = link.get("href")
-            if not file_link:
-                error_msg = f"Found link for {key} but href attribute is missing"
-                logging.error(error_msg)
-                raise AirflowException(error_msg)
-
-            # Construct and validate URL
-            updated_url = f"https://www.transit.dot.gov{file_link}"
-            try:
-                validated_url = parse_obj_as(HttpUrl, updated_url)
-            except ValidationError as e:
-                logging.error(f"URL validation failed for {updated_url}: {e}")
-                raise AirflowException(f"Invalid URL constructed for {key}: {e}")
+            # Find and validate XLSX link
+            validated_url = find_and_validate_xlsx_link(soup, key, url)
 
             logging.info(f"Successfully validated URL for {key}: {validated_url}")
 
             # Push to XCom
             push_url_to_xcom(key=key, scraped_url=validated_url, context=context)
 
+        except AirflowException:
+            # Re-raise AirflowExceptions as they already have proper error messages
+            raise
         except Exception as e:
             # Log any unhandled exceptions and re-raise as AirflowException
             logging.error(f"Unexpected error processing {key}: {e}")

--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -6,7 +6,9 @@ import logging
 
 import requests
 from bs4 import BeautifulSoup
-from pydantic import HttpUrl, parse_obj_as
+from pydantic import HttpUrl, ValidationError, parse_obj_as
+
+from airflow.exceptions import AirflowException
 
 xlsx_urls = {
     "ridership_url": "https://www.transit.dot.gov/ntd/data-product/monthly-module-raw-data-release",
@@ -21,8 +23,14 @@ xlsx_urls = {
 
 # pushes the scraped URL value to XCom
 def push_url_to_xcom(key, scraped_url, context):
-    task_instance = context["ti"]
-    task_instance.xcom_push(key=key, value=scraped_url)
+    try:
+        task_instance = context.get("ti")
+        if task_instance is None:
+            raise AirflowException("Task instance not found in context")
+        task_instance.xcom_push(key=key, value=scraped_url)
+    except Exception as e:
+        logging.error(f"Error pushing URL to XCom for key {key}: {e}")
+        raise AirflowException(f"Failed to push URL to XCom: {e}")
 
 
 # Look for an anchor tag where the href ends with '.xlsx' and starts with '/sites/fta.dot.gov/files/'
@@ -33,20 +41,54 @@ def href_matcher(href):
 
 
 def scrape_ntd_xlsx_urls(**context):
-    for key, value in xlsx_urls.items():
-        url = value
-        req = requests.get(url)
-        soup = BeautifulSoup(req.text, "html.parser")
+    for key, url in xlsx_urls.items():
+        try:
+            # Make HTTP request with proper error handling
+            try:
+                response = requests.get(url)
+                response.raise_for_status()  # Raises HTTPError for bad responses
+            except requests.exceptions.HTTPError as e:
+                logging.error(f"HTTP error occurred while fetching {url}: {e}")
+                raise AirflowException(f"HTTP error for {key}: {e}")
+            except requests.exceptions.RequestException as e:
+                logging.error(f"Error occurred while fetching {url}: {e}")
+                raise AirflowException(f"Request failed for {key}: {e}")
 
-        link = soup.find("a", href=href_matcher)
+            # Parse HTML with error handling
+            try:
+                soup = BeautifulSoup(response.text, "html.parser")
+            except Exception as e:
+                logging.error(f"Error parsing HTML for {url}: {e}")
+                raise AirflowException(f"HTML parsing failed for {key}: {e}")
 
-        # Extract the href if the link is found
-        file_link = link["href"] if link else None
+            # Find link with error handling
+            link = soup.find("a", href=href_matcher)
+            if not link:
+                error_msg = f"No XLSX download link found for {key} at {url}"
+                logging.error(error_msg)
+                raise AirflowException(error_msg)
 
-        updated_url = f"https://www.transit.dot.gov{file_link}"
+            # Extract href with error handling
+            file_link = link.get("href")
+            if not file_link:
+                error_msg = f"Found link for {key} but href attribute is missing"
+                logging.error(error_msg)
+                raise AirflowException(error_msg)
 
-        validated_url = parse_obj_as(HttpUrl, updated_url)
+            # Construct and validate URL
+            updated_url = f"https://www.transit.dot.gov{file_link}"
+            try:
+                validated_url = parse_obj_as(HttpUrl, updated_url)
+            except ValidationError as e:
+                logging.error(f"URL validation failed for {updated_url}: {e}")
+                raise AirflowException(f"Invalid URL constructed for {key}: {e}")
 
-        logging.info(f"Validated URL: {validated_url}.")
+            logging.info(f"Successfully validated URL for {key}: {validated_url}")
 
-        push_url_to_xcom(key=key, scraped_url=validated_url, context=context)
+            # Push to XCom
+            push_url_to_xcom(key=key, scraped_url=validated_url, context=context)
+
+        except Exception as e:
+            # Log any unhandled exceptions and re-raise as AirflowException
+            logging.error(f"Unexpected error processing {key}: {e}")
+            raise AirflowException(f"Failed to process {key}: {e}")

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -52,6 +52,8 @@ x-airflow-common:
     AIRFLOW__CORE__BASE_LOG_FOLDER: /opt/airflow/gcs/logs
     AIRFLOW__CORE__PLUGINS_FOLDER: /opt/airflow/gcs/plugins
     AIRFLOW__WEBSERVER__RELOAD_ON_PLUGIN_CHANGE: 'true'
+    # AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 120
+
 
     # this option prevents a DAG from trying to run all dagruns back to its
     # start date. this lets you it spin up docker, unpause a dag, and just

--- a/airflow/plugins/operators/scrape_ntd_api.py
+++ b/airflow/plugins/operators/scrape_ntd_api.py
@@ -41,39 +41,49 @@ class NtdDataProductAPIExtract(PartitionedGCSArtifact):
     class Config:
         arbitrary_types_allowed = True
 
-    def fetch_from_ntd_api(self):
-        """ """
-
-        logging.info(f"Downloading NTD data for {self.year} / {self.product}.")
-
+    def _make_api_request(self, url: str) -> bytes:
+        """Make API request with proper error handling."""
         try:
-            url = (
-                self.root_url + self.endpoint_id + self.file_format + "?$limit=5000000"
-            )
-
-            validated_url = parse_obj_as(HttpUrl, url)
-
-            response = requests.get(validated_url)
-            response.raise_for_status()  # Raises an HTTPError for bad responses
-            response_content = response.content
-
-            if response_content is None or len(response_content) == 0:
-                logging.info(
-                    f"There is no data to download for {self.year} / {self.product}. Ending pipeline."
-                )
-                return None
-
-            logging.info(
-                f"Downloaded {self.product} data for {self.year} with {len(response_content)} rows!"
-            )
-            return response_content
-
+            response = requests.get(url)
+            response.raise_for_status()
+            return response.content
         except requests.exceptions.HTTPError as e:
             logging.error(f"HTTP error occurred: {e}")
             raise AirflowException(f"HTTP error in NTD API request: {e}")
         except requests.exceptions.RequestException as e:
             logging.error(f"Request error occurred: {e}")
             raise AirflowException(f"Error in NTD API request: {e}")
+
+    def _validate_response_content(self, content: bytes) -> bytes:
+        """Validate API response content."""
+        if content is None or len(content) == 0:
+            logging.info(
+                f"There is no data to download for {self.year} / {self.product}. Ending pipeline."
+            )
+            return None
+        logging.info(
+            f"Downloaded {self.product} data for {self.year} with {len(content)} rows!"
+        )
+        return content
+
+    def fetch_from_ntd_api(self):
+        """Fetch data from NTD API with proper error handling."""
+        try:
+            # Construct and validate URL
+            url = (
+                self.root_url + self.endpoint_id + self.file_format + "?$limit=5000000"
+            )
+            validated_url = parse_obj_as(HttpUrl, url)
+
+            # Make API request
+            response_content = self._make_api_request(validated_url)
+
+            # Validate response content
+            return self._validate_response_content(response_content)
+
+        except AirflowException:
+            # Re-raise AirflowExceptions as they already have proper error messages
+            raise
         except Exception as e:
             logging.error(f"Unexpected error occurred: {e}")
             raise AirflowException(f"Unexpected error in NTD API request: {e}")
@@ -116,25 +126,47 @@ class NtdDataProductAPIOperator(BaseOperator):
 
         super().__init__(**kwargs)
 
-    def execute(self, **kwargs):
+    def _process_api_content(self, api_content: bytes) -> pd.DataFrame:
+        """Process API content into a DataFrame with error handling."""
         try:
+            decode_api_content = api_content.decode("utf-8")
+            df = pd.read_json(decode_api_content)
+            return df.rename(make_name_bq_safe, axis="columns")
+        except ValueError as e:
+            logging.error(f"Error parsing JSON data: {e}")
+            raise AirflowException(f"Failed to parse JSON data: {e}")
+        except Exception as e:
+            logging.error(f"Error processing API content: {e}")
+            raise AirflowException(f"Failed to process API content: {e}")
+
+    def _save_dataframe(self, df: pd.DataFrame) -> None:
+        """Save DataFrame as compressed JSONL with error handling."""
+        try:
+            gzipped_content = gzip.compress(
+                df.to_json(orient="records", lines=True).encode()
+            )
+            self.extract.save_content(fs=get_fs(), content=gzipped_content)
+        except Exception as e:
+            logging.error(f"Error saving processed data: {e}")
+            raise AirflowException(f"Failed to save processed data: {e}")
+
+    def execute(self, **kwargs):
+        """Execute the operator with proper error handling."""
+        try:
+            # Fetch API content
             api_content = self.extract.fetch_from_ntd_api()
             if api_content is None:
                 return None
 
-            decode_api_content = api_content.decode("utf-8")
-            df = pd.read_json(decode_api_content)
-            df = df.rename(make_name_bq_safe, axis="columns")
+            # Process API content
+            df = self._process_api_content(api_content)
 
-            self.gzipped_content = gzip.compress(
-                df.to_json(orient="records", lines=True).encode()
-            )
+            # Save processed data
+            self._save_dataframe(df)
 
-            self.extract.save_content(fs=get_fs(), content=self.gzipped_content)
-
-        except ValueError as e:
-            logging.error(f"Error parsing JSON data: {e}")
-            raise AirflowException(f"Failed to parse JSON data: {e}")
+        except AirflowException:
+            # Re-raise AirflowExceptions as they already have proper error messages
+            raise
         except Exception as e:
             logging.error(f"Error processing NTD API data: {e}")
             raise AirflowException(f"Failed to process NTD API data: {e}")

--- a/airflow/plugins/operators/scrape_state_geoportal.py
+++ b/airflow/plugins/operators/scrape_state_geoportal.py
@@ -9,6 +9,7 @@ import requests
 from calitp_data_infra.storage import PartitionedGCSArtifact, get_fs  # type: ignore
 from pydantic import HttpUrl, parse_obj_as
 
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator  # type: ignore
 
 API_BUCKET = os.environ["CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS"]
@@ -82,57 +83,72 @@ class StateGeoportalAPIExtract(PartitionedGCSArtifact):
             offset = 0
 
             while True:
-                # Update the resultOffset for each request
-                params["resultOffset"] = offset
+                try:
+                    # Update the resultOffset for each request
+                    params["resultOffset"] = offset
 
-                # Make the request
-                response = requests.get(validated_url, params=params)
-                response.raise_for_status()
-                data = response.json()
+                    # Make the request
+                    response = requests.get(validated_url, params=params)
+                    response.raise_for_status()  # Raises an HTTPError for bad responses
+                    data = response.json()
 
-                # Break the loop if there are no more features
-                if "features" not in data or not data["features"]:
-                    break
+                    # Break the loop if there are no more features
+                    if "features" not in data or not data["features"]:
+                        break
 
-                # Append the retrieved features
-                all_features.extend(data["features"])
+                    # Append the retrieved features
+                    all_features.extend(data["features"])
 
-                # Increment the offset
-                offset += params["resultRecordCount"]
+                    # Increment the offset
+                    offset += params["resultRecordCount"]
 
-            if all_features is None or len(all_features) == 0:
+                except requests.exceptions.HTTPError as e:
+                    logging.error(
+                        f"HTTP error in batch request at offset {offset}: {e}"
+                    )
+                    raise AirflowException(f"HTTP error in geoportal request: {e}")
+                except requests.exceptions.RequestException as e:
+                    logging.error(f"Request error in batch at offset {offset}: {e}")
+                    raise AirflowException(f"Request error in geoportal request: {e}")
+                except Exception as e:
+                    logging.error(f"Error processing batch at offset {offset}: {e}")
+                    raise AirflowException(f"Error processing geoportal batch: {e}")
+
+            if not all_features:
                 logging.info(
                     f"There is no data to download for {self.product}. Ending pipeline."
                 )
+                return None
 
-                pass
-            else:
-                logging.info(
-                    f"Downloaded {self.product} data with {len(all_features)} rows!"
-                )
+            logging.info(
+                f"Downloaded {self.product} data with {len(all_features)} rows!"
+            )
+            return all_features
 
-                return all_features
-
-        except requests.exceptions.RequestException as e:
-            logging.info(f"An error occurred: {e}")
-
-            raise
+        except Exception as e:
+            logging.error(f"Error in geoportal data fetch: {e}")
+            raise AirflowException(f"Failed to fetch geoportal data: {e}")
 
 
-# # Function to convert coordinates to WKT format
+# Function to convert coordinates to WKT format
 def to_wkt(geometry_type, coordinates):
-    if geometry_type == "LineString":
-        # Format as a LineString
-        coords_str = ", ".join([f"{lng} {lat}" for lng, lat in coordinates])
-        return f"LINESTRING({coords_str})"
-    elif geometry_type == "MultiLineString":
-        # Format as a MultiLineString
-        multiline_coords_str = ", ".join(
-            f"({', '.join([f'{lng} {lat}' for lng, lat in line])})"
-            for line in coordinates
-        )
-        return f"MULTILINESTRING({multiline_coords_str})"
-    else:
+    try:
+        if geometry_type == "LineString":
+            # Format as a LineString
+            coords_str = ", ".join([f"{lng} {lat}" for lng, lat in coordinates])
+            return f"LINESTRING({coords_str})"
+        elif geometry_type == "MultiLineString":
+            # Format as a MultiLineString
+            multiline_coords_str = ", ".join(
+                f"({', '.join([f'{lng} {lat}' for lng, lat in line])})"
+                for line in coordinates
+            )
+            return f"MULTILINESTRING({multiline_coords_str})"
+        else:
+            logging.warning(f"Unsupported geometry type: {geometry_type}")
+            return None
+    except Exception as e:
+        logging.error(f"Error converting coordinates to WKT: {e}")
         return None
 
 
@@ -181,37 +197,58 @@ class StateGeoportalAPIOperator(BaseOperator):
         super().__init__(**kwargs)
 
     def execute(self, **kwargs):
-        api_content = self.extract.fetch_from_state_geoportal()
+        try:
+            api_content = self.extract.fetch_from_state_geoportal()
+            if api_content is None:
+                return None
 
-        df = pd.json_normalize(api_content)
+            try:
+                df = pd.json_normalize(api_content)
+            except Exception as e:
+                logging.error(f"Error normalizing JSON data: {e}")
+                raise AirflowException(f"Failed to normalize geoportal data: {e}")
 
-        if self.product == "state_highway_network":
-            # Select columns to keep, have to be explicit before renaming because there are duplicate values after normalizing
-            df = df[
-                [
-                    "properties.Route",
-                    "properties.County",
-                    "properties.District",
-                    "properties.RouteType",
-                    "properties.Direction",
-                    "geometry.type",
-                    "geometry.coordinates",
-                ]
-            ]
+            if self.product == "state_highway_network":
+                try:
+                    # Select columns to keep, have to be explicit before renaming because there are duplicate values after normalizing
+                    df = df[
+                        [
+                            "properties.Route",
+                            "properties.County",
+                            "properties.District",
+                            "properties.RouteType",
+                            "properties.Direction",
+                            "geometry.type",
+                            "geometry.coordinates",
+                        ]
+                    ]
 
-            # Dynamically create a mapping by removing known prefixes
-            columns = {col: col.split(".")[-1] for col in df.columns}
+                    # Dynamically create a mapping by removing known prefixes
+                    columns = {col: col.split(".")[-1] for col in df.columns}
 
-            # Rename columns using the dynamically created mapping
-            df = df.rename(columns=columns)
+                    # Rename columns using the dynamically created mapping
+                    df = df.rename(columns=columns)
 
-            # Create new column with WKT format
-            df["wkt_coordinates"] = df.apply(
-                lambda row: to_wkt(row["type"], row["coordinates"]), axis=1
-            )
+                    # Create new column with WKT format
+                    df["wkt_coordinates"] = df.apply(
+                        lambda row: to_wkt(row["type"], row["coordinates"]), axis=1
+                    )
+                except Exception as e:
+                    logging.error(f"Error processing state highway network data: {e}")
+                    raise AirflowException(
+                        f"Failed to process state highway network data: {e}"
+                    )
 
-        # Compress the DataFrame content and save it
-        self.gzipped_content = gzip.compress(
-            df.to_json(orient="records", lines=True).encode()
-        )
-        self.extract.save_content(fs=get_fs(), content=self.gzipped_content)
+            # Compress the DataFrame content and save it
+            try:
+                self.gzipped_content = gzip.compress(
+                    df.to_json(orient="records", lines=True).encode()
+                )
+                self.extract.save_content(fs=get_fs(), content=self.gzipped_content)
+            except Exception as e:
+                logging.error(f"Error saving processed data: {e}")
+                raise AirflowException(f"Failed to save processed geoportal data: {e}")
+
+        except Exception as e:
+            logging.error(f"Error in geoportal operator execution: {e}")
+            raise AirflowException(f"Geoportal operator execution failed: {e}")


### PR DESCRIPTION
# Description
We recently introduced MVP data syncs of the DOT NTD data portal and the state geodata portal. This PR goes back and introduces the appropriate exception handling to catch unwanted behavior.

Operators impacted:
* airflow/plugins/operators/scrape_ntd_api.py
* airflow/plugins/operators/scrape_ntd_xlsx.py
* airflow/plugins/operators/scrape_state_geoportal.py
* airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py

## Type of change
- [x] New feature

## How has this been tested?
<img width="395" alt="Screenshot 2024-12-19 at 1 39 21 PM" src="https://github.com/user-attachments/assets/9d99d0b2-fa27-4128-88c4-5589e945d4cd" />
<img width="713" alt="Screenshot 2024-12-19 at 1 35 49 PM" src="https://github.com/user-attachments/assets/c68974bf-736a-4211-97a2-9330e1cfe546" />
<img width="695" alt="Screenshot 2024-12-19 at 1 31 46 PM" src="https://github.com/user-attachments/assets/532bad8d-52e6-412f-bb22-e139c9924c7e" />

## Post-merge follow-ups
- [x] Actions required (specified below)
ensure these operators run as expected