### PR TITLE
NTD: enrich mart tables with caltrans_district, handle ntd_id type

### DIFF
--- a/warehouse/models/mart/ntd_annual_reporting/dim_2022_agency_information.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/dim_2022_agency_information.sql
@@ -3,9 +3,21 @@ WITH staging_agency_information AS (
     FROM {{ ref('stg_ntd__2022_agency_information') }}
 ),
 
-dim_2022_agency_information AS (
+dim_organizations AS (
+
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+
+),
+
+dim_2022_agency_information AS (
+    SELECT
+        staging_agency_information.*,
+        dim_organizations.caltrans_district
     FROM staging_agency_information
+    LEFT JOIN dim_organizations
+        ON staging_agency_information.ntd_id = dim_organizations.ntd_id_2022
 )
 
 SELECT
@@ -51,6 +63,7 @@ SELECT
     reported_by_ntd_id,
     density,
     state_parent_ntd_id,
+    caltrans_district,
     dt,
     execution_ts
 FROM dim_2022_agency_information

--- a/warehouse/models/mart/ntd_annual_reporting/dim_2023_agency_information.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/dim_2023_agency_information.sql
@@ -3,9 +3,21 @@ WITH staging_agency_information AS (
     FROM {{ ref('stg_ntd__2023_agency_information') }}
 ),
 
-dim_2023_agency_information AS (
+dim_organizations AS (
+
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+
+),
+
+dim_2023_agency_information AS (
+    SELECT
+        staging_agency_information.*,
+        dim_organizations.caltrans_district
     FROM staging_agency_information
+    LEFT JOIN dim_organizations
+        ON staging_agency_information.ntd_id = dim_organizations.ntd_id
 )
 
 SELECT

--- a/warehouse/models/mart/ntd_annual_reporting/fct_2023_contractual_relationships.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_2023_contractual_relationships.sql
@@ -3,9 +3,21 @@ WITH staging_contractual_relationships AS (
     FROM {{ ref('stg_ntd__2023_contractual_relationships') }}
 ),
 
-fct_2023_contractual_relationships AS (
+dim_organizations AS (
+
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+
+),
+
+fct_2023_contractual_relationships AS (
+    SELECT
+        staging_contractual_relationships.*,
+        dim_organizations.caltrans_district
     FROM staging_contractual_relationships
+    LEFT JOIN dim_organizations
+        ON staging_contractual_relationships.ntd_id = dim_organizations.ntd_id
 )
 
 SELECT

--- a/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_by_capital_use.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_by_capital_use.sql
@@ -3,9 +3,24 @@ WITH staging_capital_expenses_by_capital_use AS (
     FROM {{ ref('stg_ntd__capital_expenses_by_capital_use') }}
 ),
 
-fct_capital_expenses_by_capital_use AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_capital_expenses_by_capital_use AS (
+    SELECT
+        staging_capital_expenses_by_capital_use.*,
+        dim_organizations.caltrans_district
     FROM staging_capital_expenses_by_capital_use
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_capital_expenses_by_capital_use.report_year = 2022 THEN
+                staging_capital_expenses_by_capital_use.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_capital_expenses_by_capital_use.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -47,6 +62,7 @@ SELECT
     typeofservicecd,
     uace_code,
     uza_name,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_capital_expenses_by_capital_use

--- a/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_for_expansion_of_service.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_for_expansion_of_service.sql
@@ -3,9 +3,24 @@ WITH staging_capital_expenses_for_expansion_of_service AS (
     FROM {{ ref('stg_ntd__capital_expenses_for_expansion_of_service') }}
 ),
 
-fct_capital_expenses_for_expansion_of_service AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_capital_expenses_for_expansion_of_service AS (
+    SELECT
+        staging_capital_expenses_for_expansion_of_service.*,
+        dim_organizations.caltrans_district
     FROM staging_capital_expenses_for_expansion_of_service
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_capital_expenses_for_expansion_of_service.report_year = 2022 THEN
+                staging_capital_expenses_for_expansion_of_service.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_capital_expenses_for_expansion_of_service.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -32,6 +47,7 @@ SELECT
     sum_reduced_reporter,
     sum_stations,
     sum_total,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_capital_expenses_for_expansion_of_service

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_by_expense_type.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_by_expense_type.sql
@@ -3,9 +3,24 @@ WITH staging_funding_sources_by_expense_type AS (
     FROM {{ ref('stg_ntd__funding_sources_by_expense_type') }}
 ),
 
-fct_funding_sources_by_expense_type AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_funding_sources_by_expense_type AS (
+    SELECT
+        staging_funding_sources_by_expense_type.*,
+        dim_organizations.caltrans_district
     FROM staging_funding_sources_by_expense_type
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_funding_sources_by_expense_type.report_year = 2022 THEN
+                staging_funding_sources_by_expense_type.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_funding_sources_by_expense_type.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -33,6 +48,7 @@ SELECT
     total_questionable,
     uace_code,
     uza_name,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_funding_sources_by_expense_type

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_local.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_local.sql
@@ -3,9 +3,24 @@ WITH staging_funding_sources_local AS (
     FROM {{ ref('stg_ntd__funding_sources_local') }}
 ),
 
-fct_funding_sources_local AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_funding_sources_local AS (
+    SELECT
+        staging_funding_sources_local.*,
+        dim_organizations.caltrans_district
     FROM staging_funding_sources_local
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_funding_sources_local.report_year = 2022 THEN
+                staging_funding_sources_local.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_funding_sources_local.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -30,6 +45,7 @@ SELECT
     total,
     uace_code,
     uza_name,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_funding_sources_local

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_state.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_state.sql
@@ -3,9 +3,24 @@ WITH staging_funding_sources_state AS (
     FROM {{ ref('stg_ntd__funding_sources_state') }}
 ),
 
-fct_funding_sources_state AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_funding_sources_state AS (
+    SELECT
+        staging_funding_sources_state.*,
+        dim_organizations.caltrans_district
     FROM staging_funding_sources_state
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_funding_sources_state.report_year = 2022 THEN
+                staging_funding_sources_state.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_funding_sources_state.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -25,6 +40,7 @@ SELECT
     transportation_funds,
     uace_code,
     uza_name,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_funding_sources_state

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_taxes_levied_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_taxes_levied_by_agency.sql
@@ -3,9 +3,24 @@ WITH staging_funding_sources_taxes_levied_by_agency AS (
     FROM {{ ref('stg_ntd__funding_sources_taxes_levied_by_agency') }}
 ),
 
-fct_funding_sources_taxes_levied_by_agency AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_funding_sources_taxes_levied_by_agency AS (
+    SELECT
+        staging_funding_sources_taxes_levied_by_agency.*,
+        dim_organizations.caltrans_district
     FROM staging_funding_sources_taxes_levied_by_agency
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_funding_sources_taxes_levied_by_agency.report_year = 2022 THEN
+                staging_funding_sources_taxes_levied_by_agency.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_funding_sources_taxes_levied_by_agency.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -28,6 +43,7 @@ SELECT
     total,
     uace_code,
     uza_name,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_funding_sources_taxes_levied_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type.sql
@@ -3,9 +3,24 @@ WITH staging_operating_expenses_by_type AS (
     FROM {{ ref('stg_ntd__operating_expenses_by_type') }}
 ),
 
-fct_operating_expenses_by_type AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_operating_expenses_by_type AS (
+    SELECT
+        staging_operating_expenses_by_type.*,
+        dim_organizations.caltrans_district
     FROM staging_operating_expenses_by_type
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_operating_expenses_by_type.report_year = 2022 THEN
+                staging_operating_expenses_by_type.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_operating_expenses_by_type.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -58,6 +73,7 @@ SELECT
     utilities,
     utilities_questionable,
     uza_name,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_operating_expenses_by_type

--- a/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type_and_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type_and_agency.sql
@@ -3,9 +3,24 @@ WITH staging_operating_expenses_by_type_and_agency AS (
     FROM {{ ref('stg_ntd__operating_expenses_by_type_and_agency') }}
 ),
 
-fct_operating_expenses_by_type_and_agency AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_operating_expenses_by_type_and_agency AS (
+    SELECT
+        staging_operating_expenses_by_type_and_agency.*,
+        dim_organizations.caltrans_district
     FROM staging_operating_expenses_by_type_and_agency
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_operating_expenses_by_type_and_agency.report_year = 2022 THEN
+                staging_operating_expenses_by_type_and_agency.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_operating_expenses_by_type_and_agency.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -37,6 +52,7 @@ SELECT
     sum_tires,
     sum_total,
     sum_utilities,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_operating_expenses_by_type_and_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_service_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_service_by_agency.sql
@@ -3,9 +3,24 @@ WITH staging_service_by_agency AS (
     FROM {{ ref('stg_ntd__service_by_agency') }}
 ),
 
-fct_service_by_agency AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_service_by_agency AS (
+    SELECT
+        staging_service_by_agency.*,
+        dim_organizations.caltrans_district
     FROM staging_service_by_agency
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_service_by_agency.report_year = 2022 THEN
+                staging_service_by_agency._5_digit_ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_service_by_agency._5_digit_ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -44,6 +59,7 @@ SELECT
     sum_train_revenue_miles,
     sum_trains_in_operation,
     sum_unlinked_passenger_trips_upt,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_service_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_agency.sql
@@ -3,9 +3,24 @@ WITH staging_track_and_roadway_by_agency AS (
     FROM {{ ref('stg_ntd__track_and_roadway_by_agency') }}
 ),
 
-fct_track_and_roadway_by_agency AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_track_and_roadway_by_agency AS (
+    SELECT
+        staging_track_and_roadway_by_agency.*,
+        dim_organizations.caltrans_district
     FROM staging_track_and_roadway_by_agency
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_track_and_roadway_by_agency.report_year = 2022 THEN
+                staging_track_and_roadway_by_agency.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_track_and_roadway_by_agency.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -41,6 +56,7 @@ SELECT
     sum_slip_switch,
     sum_total_miles,
     sum_total_track_miles,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_track_and_roadway_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_mode.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_mode.sql
@@ -3,9 +3,24 @@ WITH staging_track_and_roadway_by_mode AS (
     FROM {{ ref('stg_ntd__track_and_roadway_by_mode') }}
 ),
 
-fct_track_and_roadway_by_mode AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_track_and_roadway_by_mode AS (
+    SELECT
+        staging_track_and_roadway_by_mode.*,
+        dim_organizations.caltrans_district
     FROM staging_track_and_roadway_by_mode
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_track_and_roadway_by_mode.report_year = 2022 THEN
+                staging_track_and_roadway_by_mode.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_track_and_roadway_by_mode.ntd_id = dim_organizations.ntd_id
+        END
 )
 
 SELECT
@@ -65,6 +80,7 @@ SELECT
     type_of_service,
     uace_code,
     uza_name,
+    caltrans_district,
     dt,
     execution_ts
 FROM fct_track_and_roadway_by_mode

--- a/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_guideway_age_distribution.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_guideway_age_distribution.sql
@@ -3,9 +3,63 @@ WITH staging_track_and_roadway_guideway_age_distribution AS (
     FROM {{ ref('stg_ntd__track_and_roadway_guideway_age_distribution') }}
 ),
 
-fct_track_and_roadway_guideway_age_distribution AS (
+dim_organizations AS (
     SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+fct_track_and_roadway_guideway_age_distribution AS (
+    SELECT
+        staging_track_and_roadway_guideway_age_distribution.*,
+        dim_organizations.caltrans_district
     FROM staging_track_and_roadway_guideway_age_distribution
+    LEFT JOIN dim_organizations
+        ON CASE
+            WHEN staging_track_and_roadway_guideway_age_distribution.report_year = 2022 THEN
+                staging_track_and_roadway_guideway_age_distribution.ntd_id = dim_organizations.ntd_id_2022
+            ELSE
+                staging_track_and_roadway_guideway_age_distribution.ntd_id = dim_organizations.ntd_id
+        END
 )
 
-SELECT * FROM fct_track_and_roadway_guideway_age_distribution
+SELECT
+    _1940s,
+    _1940s_q,
+    _1950s,
+    _1950s_q,
+    _1960s,
+    _1960s_q,
+    _1970s,
+    _1970s_q,
+    _1980s,
+    _1980s_q,
+    _1990s,
+    _1990s_q,
+    _2000s,
+    _2000s_q,
+    _2010s,
+    _2010s_q,
+    _2020s,
+    _2020s_q,
+    agency,
+    agency_voms,
+    city,
+    guideway_element,
+    mode,
+    mode_name,
+    ntd_id,
+    organization_type,
+    pre1940s,
+    pre1940s_q,
+    primary_uza_population,
+    report_year,
+    reporter_type,
+    state,
+    type_of_service,
+    uace_code,
+    uza_name,
+    caltrans_district,
+    dt,
+    execution_ts
+FROM fct_track_and_roadway_guideway_age_distribution

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__2023_contractual_relationships.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__2023_contractual_relationships.sql
@@ -42,7 +42,7 @@ SELECT
     {{ trim_make_empty_string_null('reporting_module') }} AS reporting_module,
     {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
     {{ trim_make_empty_string_null('other_public_assets_provided_desc') }} AS other_public_assets_provided_desc,
-    SAFE_CAST(ntd_id AS INTEGER) AS ntd_id,
+    SAFE_CAST(ntd_id AS STRING) AS ntd_id,
     dt,
     execution_ts
 FROM stg_ntd__2023_contractual_relationships

--- a/warehouse/models/staging/ntd_safety_and_security/stg_ntd__fra_regulated_mode_major_security_events.sql
+++ b/warehouse/models/staging/ntd_safety_and_security/stg_ntd__fra_regulated_mode_major_security_events.sql
@@ -104,7 +104,7 @@ SELECT
     SAFE_CAST(other_fatalities AS INTEGER) AS other_fatalities,
     SAFE_CAST(pedestrian_not_in_crosswalk AS INTEGER) AS pedestrian_not_in_crosswalk,
     SAFE_CAST(number_of_derailed_cars AS NUMERIC) AS number_of_derailed_cars,
-    SAFE_CAST(ntd_id AS INTEGER) AS ntd_id,
+    SAFE_CAST(ntd_id AS STRING) AS ntd_id,
     dt,
     execution_ts
 FROM stg_ntd__fra_regulated_mode_major_security_events

--- a/warehouse/models/staging/ntd_safety_and_security/stg_ntd__major_safety_events.sql
+++ b/warehouse/models/staging/ntd_safety_and_security/stg_ntd__major_safety_events.sql
@@ -35,7 +35,7 @@ SELECT
     {{ trim_make_empty_string_null('typeofservicecd') }} AS typeofservicecd,
     {{ trim_make_empty_string_null('reportername') }} AS reportername,
     SAFE_CAST(customer AS INTEGER) AS customer,
-    SAFE_CAST(ntdid AS INTEGER) AS ntdid,
+    SAFE_CAST(ntdid AS STRING) AS ntdid,
     dt,
     execution_ts
 FROM stg_ntd__major_safety_events

--- a/warehouse/models/staging/ntd_safety_and_security/stg_ntd__monthly_modal_time_series_safety_and_service.sql
+++ b/warehouse/models/staging/ntd_safety_and_security/stg_ntd__monthly_modal_time_series_safety_and_service.sql
@@ -85,7 +85,7 @@ SELECT
     SAFE_CAST(pedestrian_crossing_tracks_1 AS INTEGER) AS pedestrian_crossing_tracks_1,
     SAFE_CAST(primary_uza_sq_miles AS NUMERIC) AS primary_uza_sq_miles,
     {{ trim_make_empty_string_null('primary_uza_name') }} AS primary_uza_name,
-    SAFE_CAST(_5_digit_ntd_id AS INTEGER) AS _5_digit_ntd_id,
+    SAFE_CAST(_5_digit_ntd_id AS STRING) AS _5_digit_ntd_id,
     SAFE_CAST(total_other_injuries AS INTEGER) AS total_other_injuries,
     SAFE_CAST(other_fatalities AS INTEGER) AS other_fatalities,
     SAFE_CAST(pedestrian_not_in_crosswalk AS INTEGER) AS pedestrian_not_in_crosswalk,

--- a/warehouse/models/staging/ntd_safety_and_security/stg_ntd__nonmajor_safety_and_security_events.sql
+++ b/warehouse/models/staging/ntd_safety_and_security/stg_ntd__nonmajor_safety_and_security_events.sql
@@ -57,7 +57,7 @@ SELECT
     SAFE_CAST(pederstiran_in_crosswalk AS INTEGER) AS pederstiran_in_crosswalk,
     SAFE_CAST(__computed_region_8fe2_rd7y AS NUMERIC) AS __computed_region_8fe2_rd7y,
     SAFE_CAST(bicyclist_injuries AS INTEGER) AS bicyclist_injuries,
-    SAFE_CAST(_5_digit_ntd_id AS INTEGER) AS _5_digit_ntd_id,
+    SAFE_CAST(_5_digit_ntd_id AS STRING) AS _5_digit_ntd_id,
     SAFE_CAST(transit_employee_serious AS INTEGER) AS transit_employee_serious,
     SAFE_CAST(transit_employee_injuries AS INTEGER) AS transit_employee_injuries,
     SAFE_CAST(trespasser_serious_injuries_subtotal_ AS INTEGER) AS trespasser_serious_injuries_subtotal_,


### PR DESCRIPTION
# Description
The PR enriches the newly ingested NTD data tables with caltrans_district to more easily enable analysis by caltrans district in dashboards and elsewhere.

## Type of change
- [x] New feature

## How has this been tested?
<img width="674" alt="Screenshot 2024-12-19 at 4 35 58 PM" src="https://github.com/user-attachments/assets/30945919-e782-4774-bc04-7e15b9ed4b1f" />

## Post-merge follow-ups
- [x] Actions required (specified below)
This enrichment should be further inspected to make sure it's best portraying california agency data