### PR TITLE
Fix NTD test errors

### DIFF
--- a/warehouse/models/mart/ntd/_mart_ntd.yml
+++ b/warehouse/models/mart/ntd/_mart_ntd.yml
@@ -474,6 +474,7 @@ models:
           - not_null
           - accepted_values:
               values: [2022, 2023]
+              quote: false
       - *reporter_type
       - name: sales_tax
         description: |
@@ -503,6 +504,7 @@ models:
           - not_null
           - accepted_values:
               values: [2022, 2023]
+              quote: false
       - *ntd_id
       - *agency
       - *reporter_type
@@ -548,6 +550,7 @@ models:
           - not_null
           - accepted_values:
               values: [2022, 2023]
+              quote: false
       - *reporter_type
       - *ntd_id
       - *agency
@@ -729,6 +732,7 @@ models:
           - not_null
           - accepted_values:
               values: [2022, 2023]
+              quote: false
       - *ntd_id
       - *type_of_service
       - *mode

--- a/warehouse/models/staging/ntd_annual_reporting/_src.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_src.yml
@@ -304,7 +304,6 @@ sources:
               The time period for which data was collected.
               This table displays only "Annual Total".
             tests:
-              - not_null
               - accepted_values:
                   values: ["Annual Total"]
           - <<: *time_service_begins

--- a/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
@@ -299,7 +299,6 @@ models:
           The time period for which data was collected.
           This table displays only "Annual Total".
         tests:
-          - not_null
           - accepted_values:
               values: ["Annual Total"]
       - <<: *time_service_begins

--- a/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
@@ -19,6 +19,7 @@ x-common-fields:
       - not_null
       - accepted_values:
           values: [2022, 2023]
+          quote: false
   - &reporter_type
     name: reporter_type
     description: '{{ doc("ntd_reporter_type") }}'


### PR DESCRIPTION
# Description

Fixing some failing tests for new NTD models [#3475].
- Report Year was updated from string to integer: tests that validates the year are failing because need to add a param to remove quotes
- Service by Mode: I added not null test last week, but the table contains null values for `max_time_period`, so removing the test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally, creating tables and running tests.

```
 ❯ poetry run dbt test -s +models/staging/ntd_annual_reporting/
21:14:43  1 of 22 START test accepted_values_stg_ntd__service_by_agency_report_year__False__2022__2023  [RUN]
21:14:43  2 of 22 START test accepted_values_stg_ntd__service_by_mode_and_time_period_report_year__False__2022__2023  [RUN]
21:14:43  3 of 22 START test accepted_values_stg_ntd__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [RUN]
21:14:43  4 of 22 START test accepted_values_stg_ntd__service_by_mode_max_time_period__Annual_Total  [RUN]
21:14:43  5 of 22 START test accepted_values_stg_ntd__service_by_mode_report_year__False__2022__2023  [RUN]
21:14:43  6 of 22 START test not_null_stg_ntd__service_by_agency__5_digit_ntd_id ......... [RUN]
21:14:43  7 of 22 START test not_null_stg_ntd__service_by_agency_report_year ............. [RUN]
21:14:43  8 of 22 START test not_null_stg_ntd__service_by_mode__5_digit_ntd_id ........... [RUN]
21:14:44  7 of 22 PASS not_null_stg_ntd__service_by_agency_report_year ................... [PASS in 1.11s]
21:14:44  1 of 22 PASS accepted_values_stg_ntd__service_by_agency_report_year__False__2022__2023  [PASS in 1.13s]
21:14:44  9 of 22 START test not_null_stg_ntd__service_by_mode_and_time_period__5_digit_ntd_id  [RUN]
21:14:44  10 of 22 START test not_null_stg_ntd__service_by_mode_and_time_period_report_year  [RUN]
21:14:44  8 of 22 PASS not_null_stg_ntd__service_by_mode__5_digit_ntd_id ................. [PASS in 1.10s]
21:14:44  11 of 22 START test not_null_stg_ntd__service_by_mode_report_year .............. [RUN]
21:14:44  3 of 22 PASS accepted_values_stg_ntd__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [PASS in 1.15s]
21:14:44  4 of 22 PASS accepted_values_stg_ntd__service_by_mode_max_time_period__Annual_Total  [PASS in 1.15s]
21:14:44  2 of 22 PASS accepted_values_stg_ntd__service_by_mode_and_time_period_report_year__False__2022__2023  [PASS in 1.15s]
21:14:44  5 of 22 PASS accepted_values_stg_ntd__service_by_mode_report_year__False__2022__2023  [PASS in 1.15s]
21:14:44  6 of 22 PASS not_null_stg_ntd__service_by_agency__5_digit_ntd_id ............... [PASS in 1.15s]
21:14:44  12 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_agency_report_year__2022__2023  [RUN]
21:14:44  13 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year__2022__2023  [RUN]
21:14:44  14 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [RUN]
21:14:44  15 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_max_time_period__Annual_Total  [RUN]
21:14:44  16 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_report_year__2022__2023  [RUN]
21:14:44  13 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year__2022__2023  [PASS in 0.72s]
21:14:44  17 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency__5_digit_ntd_id  [RUN]
21:14:44  16 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_report_year__2022__2023  [PASS in 0.73s]
21:14:44  18 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency_report_year  [RUN]
21:14:44  14 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [PASS in 0.76s]
21:14:44  15 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_max_time_period__Annual_Total  [PASS in 0.76s]
21:14:44  12 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_agency_report_year__2022__2023  [PASS in 0.77s]
21:14:44  19 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode__5_digit_ntd_id  [RUN]
21:14:45  20 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period__5_digit_ntd_id  [RUN]
21:14:45  21 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year  [RUN]
21:14:45  10 of 22 PASS not_null_stg_ntd__service_by_mode_and_time_period_report_year .... [PASS in 0.91s]
21:14:45  22 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_report_year  [RUN]
21:14:45  11 of 22 PASS not_null_stg_ntd__service_by_mode_report_year .................... [PASS in 0.90s]
21:14:45  9 of 22 PASS not_null_stg_ntd__service_by_mode_and_time_period__5_digit_ntd_id . [PASS in 0.95s]
21:14:45  17 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency__5_digit_ntd_id  [PASS in 0.66s]
21:14:45  18 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency_report_year  [PASS in 0.63s]
21:14:45  20 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period__5_digit_ntd_id  [PASS in 0.67s]
21:14:45  21 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year  [PASS in 0.68s]
21:14:45  19 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode__5_digit_ntd_id  [PASS in 0.69s]
21:14:45  22 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_report_year  [PASS in 0.72s]
21:14:45
21:14:45  Finished running 22 tests in 0 hours 0 minutes and 4.11 seconds (4.11s).
21:14:46
21:14:46  Completed successfully
21:14:46
21:14:46  Done. PASS=22 WARN=0 ERROR=0 SKIP=0 TOTAL=22
```

```
❯ poetry run dbt test -s +models/mart/ntd_annual_reporting/
21:16:54  Running with dbt=1.5.1
21:16:58  1 of 22 START test accepted_values_stg_ntd__service_by_agency_report_year__False__2022__2023  [RUN]
21:16:58  2 of 22 START test accepted_values_stg_ntd__service_by_mode_and_time_period_report_year__False__2022__2023  [RUN]
21:16:58  3 of 22 START test accepted_values_stg_ntd__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [RUN]
21:16:58  4 of 22 START test accepted_values_stg_ntd__service_by_mode_max_time_period__Annual_Total  [RUN]
21:16:58  5 of 22 START test accepted_values_stg_ntd__service_by_mode_report_year__False__2022__2023  [RUN]
21:16:58  6 of 22 START test not_null_stg_ntd__service_by_agency__5_digit_ntd_id ......... [RUN]
21:16:58  7 of 22 START test not_null_stg_ntd__service_by_agency_report_year ............. [RUN]
21:16:58  8 of 22 START test not_null_stg_ntd__service_by_mode__5_digit_ntd_id ........... [RUN]
21:17:00  3 of 22 PASS accepted_values_stg_ntd__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [PASS in 1.36s]
21:17:00  9 of 22 START test not_null_stg_ntd__service_by_mode_and_time_period__5_digit_ntd_id  [RUN]
21:17:00  5 of 22 PASS accepted_values_stg_ntd__service_by_mode_report_year__False__2022__2023  [PASS in 1.39s]
21:17:00  2 of 22 PASS accepted_values_stg_ntd__service_by_mode_and_time_period_report_year__False__2022__2023  [PASS in 1.39s]
21:17:00  6 of 22 PASS not_null_stg_ntd__service_by_agency__5_digit_ntd_id ............... [PASS in 1.39s]
21:17:00  10 of 22 START test not_null_stg_ntd__service_by_mode_and_time_period_report_year  [RUN]
21:17:00  11 of 22 START test not_null_stg_ntd__service_by_mode_report_year .............. [RUN]
21:17:00  12 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_agency_report_year__2022__2023  [RUN]
21:17:00  7 of 22 PASS not_null_stg_ntd__service_by_agency_report_year ................... [PASS in 1.51s]
21:17:00  1 of 22 PASS accepted_values_stg_ntd__service_by_agency_report_year__False__2022__2023  [PASS in 1.55s]
21:17:00  4 of 22 PASS accepted_values_stg_ntd__service_by_mode_max_time_period__Annual_Total  [PASS in 1.51s]
21:17:00  8 of 22 PASS not_null_stg_ntd__service_by_mode__5_digit_ntd_id ................. [PASS in 1.51s]
21:17:00  13 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year__2022__2023  [RUN]
21:17:00  14 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [RUN]
21:17:00  15 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_max_time_period__Annual_Total  [RUN]
21:17:00  16 of 22 START test source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_report_year__2022__2023  [RUN]
21:17:01  14 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_time_period__Annual_Total__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Weekday_PM_Peak__Average_Weekday_Other__Average_Typical_Weekday__Average_Typical_Saturday__Average_Typical_Sunday  [PASS in 1.02s]
21:17:01  12 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_agency_report_year__2022__2023  [PASS in 1.15s]
21:17:01  17 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency__5_digit_ntd_id  [RUN]
21:17:01  18 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency_report_year  [RUN]
21:17:01  16 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_report_year__2022__2023  [PASS in 1.05s]
21:17:01  19 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode__5_digit_ntd_id  [RUN]
21:17:01  15 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_max_time_period__Annual_Total  [PASS in 1.08s]
21:17:01  20 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period__5_digit_ntd_id  [RUN]
21:17:01  11 of 22 PASS not_null_stg_ntd__service_by_mode_report_year .................... [PASS in 1.22s]
21:17:01  21 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year  [RUN]
21:17:01  13 of 22 PASS source_accepted_values_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year__2022__2023  [PASS in 1.14s]
21:17:01  22 of 22 START test source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_report_year  [RUN]
21:17:01  9 of 22 PASS not_null_stg_ntd__service_by_mode_and_time_period__5_digit_ntd_id . [PASS in 1.30s]
21:17:01  10 of 22 PASS not_null_stg_ntd__service_by_mode_and_time_period_report_year .... [PASS in 1.36s]
21:17:02  18 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency_report_year  [PASS in 1.02s]
21:17:02  21 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period_report_year  [PASS in 1.01s]
21:17:02  17 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_agency__5_digit_ntd_id  [PASS in 1.08s]
21:17:02  19 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode__5_digit_ntd_id  [PASS in 1.06s]
21:17:02  20 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_and_time_period__5_digit_ntd_id  [PASS in 1.07s]
21:17:02  22 of 22 PASS source_not_null_external_ntd__annual_reporting_multi_year__service_by_mode_report_year  [PASS in 1.05s]
21:17:02
21:17:02  Finished running 22 tests in 0 hours 0 minutes and 5.62 seconds (5.62s).
21:17:02
21:17:02  Completed successfully
21:17:02
21:17:02  Done. PASS=22 WARN=0 ERROR=0 SKIP=0 TOTAL=22
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm no errors next time the tests run.
