### PR TITLE
Fix NTD test error

### DIFF
--- a/warehouse/models/mart/ntd/_mart_ntd.yml
+++ b/warehouse/models/mart/ntd/_mart_ntd.yml
@@ -744,6 +744,5 @@ models:
           The time period for which data was collected.
           This table displays only "Annual Total".
         tests:
-          - not_null
           - accepted_values:
               values: ["Annual Total"]


### PR DESCRIPTION
# Description

Fixing failing test from fct_annual_service_modes erroring because of null values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally.

```
❯ poetry run dbt test -s models/mart/ntd
19:19:53  Running with dbt=1.5.1
19:19:57  1 of 33 START test accepted_values_dim_annual_funding_sources_funding_source__federal__state__local  [RUN]
19:19:57  2 of 33 START test accepted_values_dim_annual_funding_sources_report_year__False__2022__2023  [RUN]
19:19:57  3 of 33 START test accepted_values_dim_annual_service_agencies_report_year__False__2022__2023  [RUN]
19:19:57  4 of 33 START test accepted_values_dim_annual_service_mode_time_periods_report_year__False__2022__2023  [RUN]
19:19:57  5 of 33 START test accepted_values_dim_annual_service_mode_time_periods_time_period__Average_Weekday_AM_Peak__Average_Weekday_Midday__Avera19:19:57  5 of 33 START test accepted_values_dim_annual_service_mode_time_periods_time_period__Average_Weekday_AM_Peak__Average_Weekday_Midday__Avera19:19:57  6 of 33 START test accepted_values_fct_annual_service_modes_report_year__False__2022__2023  [RUN]
19:19:57  7 of 33 START test accepted_values_fct_annual_service_modes_time_period__Annual_Total  [RUN]
19:19:57  8 of 33 START test dbt_utils_mutually_exclusive_ranges_dim_annual_agency_information_required___valid_from__CONCAT_year___ntd_id___COALESCE19:19:57  8 of 33 START test dbt_utils_mutually_exclusive_ranges_dim_annual_agency_information_required___valid_from__CONCAT_year___ntd_id___COALESCE19:19:58  3 of 33 PASS accepted_values_dim_annual_service_agencies_report_year__False__2022__2023  [PASS in 1.22s]
19:19:58  9 of 33 START test not_null_dim_annual_agency_information__is_current .......... [RUN]
19:19:58  1 of 33 PASS accepted_values_dim_annual_funding_sources_funding_source__federal__state__local  [PASS in 1.23s]
19:19:58  2 of 33 PASS accepted_values_dim_annual_funding_sources_report_year__False__2022__2023  [PASS in 1.34s]
19:19:58  4 of 33 PASS accepted_values_dim_annual_service_mode_time_periods_report_year__False__2022__2023  [PASS in 1.34s]
19:19:58  10 of 33 START test not_null_dim_annual_agency_information__valid_from ......... [RUN]
19:19:58  7 of 33 PASS accepted_values_fct_annual_service_modes_time_period__Annual_Total  [PASS in 1.33s]
19:19:58  6 of 33 PASS accepted_values_fct_annual_service_modes_report_year__False__2022__2023  [PASS in 1.34s]
19:19:58  5 of 33 PASS accepted_values_dim_annual_service_mode_time_periods_time_period__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Wee19:19:58  5 of 33 PASS accepted_values_dim_annual_service_mode_time_periods_time_period__Average_Weekday_AM_Peak__Average_Weekday_Midday__Average_Wee19:19:58  11 of 33 START test not_null_dim_annual_agency_information__valid_to ........... [RUN]
19:19:58  12 of 33 START test not_null_dim_annual_agency_information_key ................. [RUN]
19:19:58  13 of 33 START test not_null_dim_annual_agency_information_ntd_id .............. [RUN]
19:19:58  14 of 33 START test not_null_dim_annual_agency_information_year ................ [RUN]
19:19:58  15 of 33 START test not_null_dim_annual_funding_sources_funding_source ......... [RUN]
19:19:59  8 of 33 PASS dbt_utils_mutually_exclusive_ranges_dim_annual_agency_information_required___valid_from__CONCAT_year___ntd_id___COALESCE_state19:19:59  8 of 33 PASS dbt_utils_mutually_exclusive_ranges_dim_annual_agency_information_required___valid_from__CONCAT_year___ntd_id___COALESCE_state19:19:59  16 of 33 START test not_null_dim_annual_funding_sources_ntd_id ................. [RUN]
19:19:59  15 of 33 PASS not_null_dim_annual_funding_sources_funding_source ............... [PASS in 0.83s]
19:19:59  17 of 33 START test not_null_dim_annual_funding_sources_report_year ............ [RUN]
19:20:00  11 of 33 PASS not_null_dim_annual_agency_information__valid_to ................. [PASS in 1.72s]
19:20:00  18 of 33 START test not_null_dim_annual_service_agencies_key ................... [RUN]
19:20:00  10 of 33 PASS not_null_dim_annual_agency_information__valid_from ............... [PASS in 1.75s]
19:20:00  9 of 33 PASS not_null_dim_annual_agency_information__is_current ................ [PASS in 1.87s]
19:20:00  19 of 33 START test not_null_dim_annual_service_agencies_ntd_id ................ [RUN]
19:20:00  20 of 33 START test not_null_dim_annual_service_agencies_report_year ........... [RUN]
19:20:00  16 of 33 PASS not_null_dim_annual_funding_sources_ntd_id ....................... [PASS in 0.95s]
19:20:00  21 of 33 START test not_null_dim_annual_service_mode_time_periods_key .......... [RUN]
19:20:00  12 of 33 PASS not_null_dim_annual_agency_information_key ....................... [PASS in 1.95s]
19:20:00  22 of 33 START test not_null_dim_annual_service_mode_time_periods_ntd_id ....... [RUN]
19:20:00  17 of 33 PASS not_null_dim_annual_funding_sources_report_year .................. [PASS in 1.18s]
19:20:00  23 of 33 START test not_null_dim_annual_service_mode_time_periods_report_year .. [RUN]
19:20:00  13 of 33 PASS not_null_dim_annual_agency_information_ntd_id .................... [PASS in 2.06s]
19:20:00  24 of 33 START test not_null_dim_monthly_ridership_with_adjustments_key ........ [RUN]
19:20:00  14 of 33 PASS not_null_dim_annual_agency_information_year ...................... [PASS in 2.11s]
19:20:00  25 of 33 START test not_null_dim_monthly_ridership_with_adjustments_ntd_id ..... [RUN]
19:20:01  18 of 33 PASS not_null_dim_annual_service_agencies_key ......................... [PASS in 0.82s]
19:20:01  26 of 33 START test not_null_fct_annual_service_modes_key ...................... [RUN]
19:20:01  20 of 33 PASS not_null_dim_annual_service_agencies_report_year ................. [PASS in 0.82s]
19:20:01  27 of 33 START test not_null_fct_annual_service_modes_ntd_id ................... [RUN]
19:20:01  19 of 33 PASS not_null_dim_annual_service_agencies_ntd_id ...................... [PASS in 0.90s]
19:20:01  28 of 33 START test not_null_fct_annual_service_modes_report_year .............. [RUN]
19:20:01  22 of 33 PASS not_null_dim_annual_service_mode_time_periods_ntd_id ............. [PASS in 0.83s]
19:20:01  29 of 33 START test unique_dim_annual_agency_information_key ................... [RUN]
19:20:01  23 of 33 PASS not_null_dim_annual_service_mode_time_periods_report_year ........ [PASS in 0.80s]
19:20:01  30 of 33 START test unique_dim_annual_service_agencies_key ..................... [RUN]
19:20:01  24 of 33 PASS not_null_dim_monthly_ridership_with_adjustments_key .............. [PASS in 0.83s]
19:20:01  31 of 33 START test unique_dim_annual_service_mode_time_periods_key ............ [RUN]
19:20:01  25 of 33 PASS not_null_dim_monthly_ridership_with_adjustments_ntd_id ........... [PASS in 0.86s]
19:20:01  32 of 33 START test unique_dim_monthly_ridership_with_adjustments_key .......... [RUN]
19:20:01  21 of 33 PASS not_null_dim_annual_service_mode_time_periods_key ................ [PASS in 1.24s]
19:20:01  33 of 33 START test unique_fct_annual_service_modes_key ........................ [RUN]
19:20:01  26 of 33 PASS not_null_fct_annual_service_modes_key ............................ [PASS in 0.81s]
19:20:01  27 of 33 PASS not_null_fct_annual_service_modes_ntd_id ......................... [PASS in 0.76s]
19:20:02  28 of 33 PASS not_null_fct_annual_service_modes_report_year .................... [PASS in 0.84s]
19:20:02  30 of 33 PASS unique_dim_annual_service_agencies_key ........................... [PASS in 0.78s]
19:20:02  31 of 33 PASS unique_dim_annual_service_mode_time_periods_key .................. [PASS in 0.75s]
19:20:02  32 of 33 PASS unique_dim_monthly_ridership_with_adjustments_key ................ [PASS in 0.78s]
19:20:02  33 of 33 PASS unique_fct_annual_service_modes_key .............................. [PASS in 0.79s]
19:20:03  29 of 33 PASS unique_dim_annual_agency_information_key ......................... [PASS in 1.69s]
19:20:03
19:20:03  Finished running 33 tests in 0 hours 0 minutes and 7.54 seconds (7.54s).
19:20:03
19:20:03  Completed successfully
19:20:03
19:20:03  Done. PASS=33 WARN=0 ERROR=0 SKIP=0 TOTAL=33
```
## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Validate if the error does not happen after next DAG runs.