### PR TITLE
Add a new profile to test a jupyterhub image

### DIFF
--- a/ci/pyproject.toml
+++ b/ci/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.poetry]
 name = "ci"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Andrew Vaccaro"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -39,6 +39,12 @@ jupyterhub:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
+      - display_name: "Prototype Image - 2024.5.24"
+        description: "This is the next image we will deploy."
+        kubespawner_override:
+          image:
+            name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
+            tag: 2024.5.24
   scheduling:
     userPods:
       nodeAffinity:


### PR DESCRIPTION
# Description

With this deployment, when using jupyterhub you should be able to select another image from the list. This image (2024.5.24) was created a while back.

## Type of change

- [x] New feature

## How has this been tested?

Has not been tested!  Will go straight to production.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Make sure jupyterhub is still functional