### PR TITLE
Adjusted jupyterhub config name to match documentation

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -32,19 +32,17 @@ jupyterhub:
     profileList:
       - display_name: "Default User"
         description: "Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
-        default: True
+        default: true
       - display_name: "Power User"
         description: "Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-      - display_name: "Prototype Image - 2024.5.24"
+      - display_name: "Prototype Image 2024.5.24"
         description: "This is the next image we will deploy."
         kubespawner_override:
-          image:
-            name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
-            tag: 2024.5.24
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2024.5.24
   scheduling:
     userPods:
       nodeAffinity:


### PR DESCRIPTION
# Description

Adjusted the jupyterhub config docker / tag names to match the website

Follows https://z2jh.jupyter.org/en/latest/jupyterhub/customizing/user-environment.html#multiple-profiles

Meant to fix https://github.com/cal-itp/data-infra/pull/3614

Resolves #3615

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Has not been tested

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
Deploy and monitor