### PR TITLE
Add additional ntd time series datasources to pipeline

### DIFF
--- a/airflow/dags/sync_ntd_data_xlsx/funding_and_expenses/capital_expenditures_time_series.yml
+++ b/airflow/dags/sync_ntd_data_xlsx/funding_and_expenses/capital_expenditures_time_series.yml
@@ -1,0 +1,7 @@
+operator: operators.NtdDataProductXLSXOperator
+
+product: 'capital_expenditures_time_series'
+xlsx_file_url: 'https://www.transit.dot.gov/ntd/data-product/ts31-capital-expenditures-time-series-2' # placeholder for scraped url from scrape_ntd_xlsx_urls task
+year: 'historical' # one of: 'historical' (long history), 'mutli-year' (select history), or a specific year (ex: 2022)
+dependencies:
+  - scrape_ntd_xlsx_urls

--- a/airflow/dags/sync_ntd_data_xlsx/funding_and_expenses/operating_and_capital_funding_time_series.yml
+++ b/airflow/dags/sync_ntd_data_xlsx/funding_and_expenses/operating_and_capital_funding_time_series.yml
@@ -1,0 +1,7 @@
+operator: operators.NtdDataProductXLSXOperator
+
+product: 'operating_and_capital_funding_time_series'
+xlsx_file_url: 'https://www.transit.dot.gov/ntd/data-product/ts12-operating-funding-time-series-3' # placeholder for scraped url from scrape_ntd_xlsx_urls task
+year: 'historical' # one of: 'historical' (long history), 'mutli-year' (select history), or a specific year (ex: 2022)
+dependencies:
+  - scrape_ntd_xlsx_urls

--- a/airflow/dags/sync_ntd_data_xlsx/funding_and_expenses/service_data_and_operating_expenses_time_series_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_xlsx/funding_and_expenses/service_data_and_operating_expenses_time_series_by_mode.yml
@@ -1,0 +1,7 @@
+operator: operators.NtdDataProductXLSXOperator
+
+product: 'service_data_and_operating_expenses_time_series_by_mode'
+xlsx_file_url: 'https://www.transit.dot.gov/ntd/data-product/ts21-service-data-and-operating-expenses-time-series-mode-2' # placeholder for scraped url from scrape_ntd_xlsx_urls task
+year: 'historical' # one of: 'historical' (long history), 'mutli-year' (select history), or a specific year (ex: 2022)
+dependencies:
+  - scrape_ntd_xlsx_urls

--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -15,7 +15,7 @@ xlsx_urls = {
     "contractual_relationship_url": "https://www.transit.dot.gov/ntd/data-product/2023-annual-database-contractual-relationship",
     "operating_and_capital_funding_url": "https://www.transit.dot.gov/ntd/data-product/ts12-operating-funding-time-series-3",
     "service_data_and_operating_expenses_time_series_by_mode_url": "https://www.transit.dot.gov/ntd/data-product/ts21-service-data-and-operating-expenses-time-series-mode-2",
-    "operating_and_capital_funding_url": "https://www.transit.dot.gov/ntd/data-product/ts12-operating-funding-time-series-3",
+    "capital_expenditures_time_series_url": "https://www.transit.dot.gov/ntd/data-product/ts31-capital-expenditures-time-series-2",
 }
 
 

--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -14,6 +14,8 @@ xlsx_urls = {
     "2023_agency_url": "https://www.transit.dot.gov/ntd/data-product/2023-annual-database-agency-information",
     "contractual_relationship_url": "https://www.transit.dot.gov/ntd/data-product/2023-annual-database-contractual-relationship",
     "operating_and_capital_funding_url": "https://www.transit.dot.gov/ntd/data-product/ts12-operating-funding-time-series-3",
+    "service_data_and_operating_expenses_time_series_by_mode_url": "https://www.transit.dot.gov/ntd/data-product/ts21-service-data-and-operating-expenses-time-series-mode-2",
+    "operating_and_capital_funding_url": "https://www.transit.dot.gov/ntd/data-product/ts12-operating-funding-time-series-3",
 }
 
 

--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -13,6 +13,7 @@ xlsx_urls = {
     "2022_agency_url": "https://www.transit.dot.gov/ntd/data-product/2022-annual-database-agency-information",
     "2023_agency_url": "https://www.transit.dot.gov/ntd/data-product/2023-annual-database-agency-information",
     "contractual_relationship_url": "https://www.transit.dot.gov/ntd/data-product/2023-annual-database-contractual-relationship",
+    "operating_and_capital_funding_url": "https://www.transit.dot.gov/ntd/data-product/ts12-operating-funding-time-series-3",
 }
 
 

--- a/airflow/plugins/operators/scrape_ntd_xlsx.py
+++ b/airflow/plugins/operators/scrape_ntd_xlsx.py
@@ -32,9 +32,13 @@ xcom_keys = {
         "2023",
     ): "contractual_relationship_url",
     (
-        "operating_and_capital_funding",
+        "operating_and_capital_funding_time_series",
         "historical",
     ): "operating_and_capital_funding_url",
+    (
+        "service_data_and_operating_expenses_time_series_by_mode",
+        "historical",
+    ): "service_data_and_operating_expenses_time_series_by_mode_url",
 }
 
 

--- a/airflow/plugins/operators/scrape_ntd_xlsx.py
+++ b/airflow/plugins/operators/scrape_ntd_xlsx.py
@@ -31,6 +31,10 @@ xcom_keys = {
         "annual_database_contractual_relationship",
         "2023",
     ): "contractual_relationship_url",
+    (
+        "operating_and_capital_funding",
+        "historical",
+    ): "operating_and_capital_funding_url",
 }
 
 

--- a/airflow/plugins/operators/scrape_ntd_xlsx.py
+++ b/airflow/plugins/operators/scrape_ntd_xlsx.py
@@ -39,6 +39,10 @@ xcom_keys = {
         "service_data_and_operating_expenses_time_series_by_mode",
         "historical",
     ): "service_data_and_operating_expenses_time_series_by_mode_url",
+    (
+        "capital_expenditures_time_series",
+        "historical",
+    ): "capital_expenditures_time_series_url",
 }
 
 


### PR DESCRIPTION
# Description
This PR scrapes the following NTD time series excel spreadsheet endpoints and writes the contents to GCS buckets, following the patterns developed in #3604, others

* capital_expenditures_time_series
* operating_and_capital_funding_time_series
* service_data_and_operating_expenses_time_series_by_mode

Referenced in #3562

## Type of change

- [x] New feature

## How has this been tested?
<img width="684" alt="Screenshot 2025-01-16 at 1 21 20 PM" src="https://github.com/user-attachments/assets/d8b992fa-0e42-41b0-bde3-64f131e3c5b7" />

## Post-merge follow-ups
- [x] Actions required (specified below)
Monitor for expected behavior, create external tables and warehouse tables in follow-on PRs