### PR TITLE
Add `mart_gtfs.fct_vehicle_locations_grouped`

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2525,11 +2525,27 @@ models:
           Synthetic primary key constructed from `service_date`, `base64_url`,
           `location_timestamp`, `vehicle_id`, `vehicle_label`,
           `trip_id`, and `trip_start_time`.
-      - *gtfs_dataset_key
+        tests: *almost_unique_rt_key_tests
+      - *gtfs_rt_dt
+      - *rt_service_date
+      - name: gtfs_dataset_key
+        description: *gtfs_dataset_key_desc
+        tests:
+          - dbt_utils.relationships_where:
+              to: ref('dim_gtfs_datasets')
+              field: key
+              to_condition: "type = 'vehicle_positions'"
       - *base64_url
       - *gtfs_rt_name
       - *gtfs_rt_schedule_dataset_key
-      - *trip_instance_key
+      - <<: *trip_instance_key
+        tests:
+          - not_null
+          - unique_proportion:
+              at_least: 0.9999
+          - relationships:
+              to: ref('fct_observed_trips')
+              field: trip_instance_key
       - *rt_location_timestamp
       - name: moving_timestamp
         description: |

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -705,7 +705,8 @@ models:
       - &rt_position_speed
         name: position_speed
         description: '{{ doc("gtfs_position__speed") }}'
-      - name: location_timestamp
+      - &rt_location_timestamp
+        name: location_timestamp
         description: Vehicle timestamp or header timestamp
       - name: vehicle_trip_key
         description: |
@@ -713,7 +714,8 @@ models:
           trip_id, and trip_start_time.
       - name: next_location_key
         description: Location key for the next vehicle timestamp.
-      - name: location
+      - &rt_location
+        name: location
         description: GEOGPOINT created by the position latitute and longitude
       - *trip_instance_key
 
@@ -2511,3 +2513,28 @@ models:
         description: |
           Total scheduled service hours that occurred for the route for this
           month, `day_type`, and `time_of_day`.
+  - name: fct_vehicle_locations_dwell
+    description: |
+      Vehicle positions, grouped by location position. Uses fct_vehicle_locations and
+      calculates a first timestamp at location (location_timestamp) and
+      last timestamp at location (moving_timestamp).
+      Unique at the url/vehicle/trip/location_position level.
+    columns:
+      - name: key
+        description: |
+          Synthetic primary key constructed from `service_date`, `base64_url`,
+          `location_timestamp`, `vehicle_id`, `vehicle_label`,
+          `trip_id`, and `trip_start_time`.
+      - *gtfs_dataset_key
+      - *base64_url
+      - *gtfs_rt_name
+      - *gtfs_rt_schedule_dataset_key
+      - *trip_instance_key
+      - *rt_location_timestamp
+      - name: moving_timestamp
+        description: |
+          The last location_timestamp at this position.
+      - name: n_vp
+        description: |
+          Number of vehicle positions observed at this location.
+      - *rt_location

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2513,7 +2513,7 @@ models:
         description: |
           Total scheduled service hours that occurred for the route for this
           month, `day_type`, and `time_of_day`.
-  - name: fct_vehicle_locations_dwell
+  - name: fct_vehicle_locations_grouped
     description: |
       Vehicle positions, grouped by location position. Uses fct_vehicle_locations and
       calculates a first timestamp at location (location_timestamp) and

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
@@ -59,9 +59,11 @@ direction AS (
         END AS vp_direction,
     FROM same_locations
     WHERE same_locations.new_group = 1
+    -- subset to where new_group is identified so we can fill in unknown
+    -- direction / dwelling points once we group the vp
 ),
 
-vp_keys_grouped AS (
+keys_grouped AS (
     SELECT
         fct_vehicle_locations.key,
         direction.new_group,
@@ -78,7 +80,7 @@ vp_grouper AS (
         fct_vehicle_locations.trip_instance_key,
         fct_vehicle_locations.location,
         fct_vehicle_locations.location_timestamp,
-        SUM(vp_keys_grouped.new_group)
+        SUM(keys_grouped.new_group)
             OVER (
                 PARTITION BY service_date, trip_instance_key
                 ORDER BY location_timestamp
@@ -86,8 +88,8 @@ vp_grouper AS (
             )  AS vp_group,
         vp_keys_grouped.vp_direction
     FROM fct_vehicle_locations
-    INNER JOIN vp_keys_grouped
-        ON fct_vehicle_locations.key = vp_keys_grouped.key
+    INNER JOIN keys_grouped
+        ON fct_vehicle_locations.key = keys_grouped.key
 ),
 
 fct_dwelling_locations AS (

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
@@ -1,0 +1,88 @@
+{{ config(materialized='table') }}
+
+WITH fct_vehicle_locations AS (
+    SELECT
+        key,
+        --gtfs_dataset_key,
+        --dt,
+        service_date,
+        --base64_url,
+        --gtfs_dataset_name,
+        --schedule_gtfs_dataset_key,
+        trip_instance_key,
+        location_timestamp,
+        location,
+        next_location_key,
+
+    FROM {{ ref('fct_vehicle_locations') }}
+    WHERE gtfs_dataset_name="LA DOT VehiclePositions" AND trip_instance_key="0000a63ce280462e6eed4f3ae92df16d" AND service_date = "2025-01-07"
+    ORDER by service_date, trip_instance_key, location_timestamp
+    ),
+
+current_vp AS (
+    SELECT
+        service_date,
+        trip_instance_key,
+        key,
+        location,
+        location_timestamp,
+        next_location_key,
+    FROM fct_vehicle_locations
+),
+
+get_next AS (
+    SELECT
+        key AS next_location_key,
+        location,
+        location_timestamp
+    FROM current_vp
+),
+
+vp_groupings AS (
+    SELECT
+        current_vp.service_date,
+        current_vp.trip_instance_key,
+        current_vp.key,
+        current_vp.location_timestamp,
+        get_next.location_timestamp AS next_location_timestamp,
+        ST_X(current_vp.location) AS current_longitude,
+        ST_Y(current_vp.location) AS current_latitude,
+        ST_X(get_next.location) AS next_longitude,
+        ST_Y(get_next.location) AS next_latitude,
+    FROM current_vp
+    LEFT JOIN get_next
+        ON current_vp.next_location_key = get_next.next_location_key
+),
+
+vp_grouping_agg AS (
+    SELECT
+        vp_groupings.service_date,
+        vp_groupings.trip_instance_key,
+        vp_groupings.key,
+        vp_groupings.location_timestamp,
+        vp_groupings.current_longitude,
+        vp_groupings.next_longitude,
+        vp_groupings.current_latitude,
+        vp_groupings.next_latitude,
+        CASE
+            WHEN current_longitude = next_longitude AND current_latitude = next_latitude
+            THEN 0
+            ELSE 1
+        END AS new_group,
+    FROM vp_groupings
+),
+
+vp_grouping_agg2 AS (
+    SELECT
+        key,
+        SUM(new_group)
+            OVER (
+                PARTITION BY service_date, trip_instance_key
+                ORDER BY location_timestamp
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            )  AS vp_group,
+    FROM vp_grouping_agg
+)
+
+
+SELECT * FROM vp_grouping_agg2

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
@@ -3,14 +3,17 @@
 WITH fct_vehicle_locations AS (
     SELECT
         key,
+        gtfs_dataset_key,
+        base64_url,
+        gtfs_dataset_name,
+        schedule_gtfs_dataset_key,
         service_date,
         trip_instance_key,
         location_timestamp,
         location,
         next_location_key,
-
     FROM {{ ref('fct_vehicle_locations') }}
-    WHERE gtfs_dataset_name="LA DOT VehiclePositions" AND service_date = "2025-01-07" AND (trip_instance_key="0000a63ce280462e6eed4f3ae92df16d" OR trip_instance_key="ec14aa25e209f90ed025450c18519814")
+    WHERE gtfs_dataset_name="LA DOT VehiclePositions" AND service_date = "2025-01-07" --AND (trip_instance_key="0000a63ce280462e6eed4f3ae92df16d" OR trip_instance_key="ec14aa25e209f90ed025450c18519814")
     ORDER by service_date, trip_instance_key, location_timestamp
     ),
 
@@ -56,9 +59,13 @@ merged AS (
 fct_vp_dwell AS (
     SELECT
         MIN(fct_vehicle_locations.key) as key,
+        fct_vehicle_locations.gtfs_dataset_key,
+        fct_vehicle_locations.base64_url,
+        fct_vehicle_locations.gtfs_dataset_name,
+        fct_vehicle_locations.schedule_gtfs_dataset_key,
         fct_vehicle_locations.trip_instance_key as trip_instance_key,
         fct_vehicle_locations.service_date as service_date,
-        merged.vp_group AS vp_group,
+        --merged.vp_group AS vp_group,
         MIN(fct_vehicle_locations.location_timestamp) AS location_timestamp,
         MAX(fct_vehicle_locations.location_timestamp) AS moving_timestamp,
         COUNT(*) AS n_vp,
@@ -68,7 +75,7 @@ fct_vp_dwell AS (
     FROM fct_vehicle_locations
     LEFT JOIN merged
         ON fct_vehicle_locations.key = merged.key
-    GROUP BY service_date, trip_instance_key, vp_group
+    GROUP BY service_date, gtfs_dataset_key, base64_url, gtfs_dataset_name, schedule_gtfs_dataset_key, trip_instance_key, vp_group
 )
 
 -- can we roll in n_vp + location into merged

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_dwell.sql
@@ -10,92 +10,82 @@ WITH fct_vehicle_locations AS (
         next_location_key,
 
     FROM {{ ref('fct_vehicle_locations') }}
-    WHERE gtfs_dataset_name="LA DOT VehiclePositions" AND service_date = "2025-01-07" --AND trip_instance_key="0000a63ce280462e6eed4f3ae92df16d"
+    WHERE gtfs_dataset_name="LA DOT VehiclePositions" AND service_date = "2025-01-07" AND (trip_instance_key="0000a63ce280462e6eed4f3ae92df16d" OR trip_instance_key="ec14aa25e209f90ed025450c18519814")
     ORDER by service_date, trip_instance_key, location_timestamp
     ),
 
-current_vp AS (
-    SELECT
-        service_date,
-        trip_instance_key,
-        key,
-        location,
-        location_timestamp,
-        next_location_key,
-    FROM fct_vehicle_locations
-),
 
 get_next AS (
     SELECT
         key AS next_location_key,
         location,
         location_timestamp
-    FROM current_vp
+    FROM fct_vehicle_locations
 ),
 
 vp_groupings AS (
     SELECT
-        current_vp.service_date,
-        current_vp.trip_instance_key,
-        current_vp.key,
-        current_vp.location_timestamp,
+        fct_vehicle_locations.service_date,
+        fct_vehicle_locations.trip_instance_key,
+        fct_vehicle_locations.key,
+        --fct_vehicle_locations.location,
+        fct_vehicle_locations.location_timestamp,
         get_next.location_timestamp AS next_location_timestamp,
-        ST_X(current_vp.location) AS current_longitude,
-        ST_Y(current_vp.location) AS current_latitude,
-        ST_X(get_next.location) AS next_longitude,
-        ST_Y(get_next.location) AS next_latitude,
-    FROM current_vp
-    LEFT JOIN get_next
-        ON current_vp.next_location_key = get_next.next_location_key
-),
-
-vp_grouping_agg AS (
-    SELECT
-        vp_groupings.service_date,
-        vp_groupings.trip_instance_key,
-        vp_groupings.key,
-        vp_groupings.location_timestamp,
-        vp_groupings.current_longitude,
-        vp_groupings.next_longitude,
-        vp_groupings.current_latitude,
-        vp_groupings.next_latitude,
+        --get_next.location AS next_location,
         CASE
-            WHEN vp_groupings.current_longitude = vp_groupings.next_longitude AND vp_groupings.current_latitude = vp_groupings.next_latitude
+            WHEN ST_EQUALS(fct_vehicle_locations.location, get_next.location)
             THEN 0
             ELSE 1
         END AS new_group,
-    FROM vp_groupings
+    FROM fct_vehicle_locations
+    LEFT JOIN get_next
+        ON fct_vehicle_locations.next_location_key = get_next.next_location_key
 ),
 
 grouped AS (
     SELECT
         key,
-        vp_grouping_agg.current_longitude,
-        vp_grouping_agg.current_latitude,
         SUM(new_group)
             OVER (
                 PARTITION BY service_date, trip_instance_key
                 ORDER BY location_timestamp
                 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
             )  AS vp_group,
-    FROM vp_grouping_agg
+    FROM vp_groupings
 ),
 
 merged AS (
     SELECT
-        current_vp.trip_instance_key AS trip_instance_key,
-        current_vp.service_date AS service_date,
-        MIN(current_vp.key) AS key,
+        fct_vehicle_locations.trip_instance_key AS trip_instance_key,
+        fct_vehicle_locations.service_date AS service_date,
+        MIN(fct_vehicle_locations.key) AS key,
         grouped.vp_group AS vp_group,
-        COUNT(current_vp.key) AS n_vp,
-        MIN(current_vp.location_timestamp) AS location_timestamp,
-        MAX(current_vp.location_timestamp) AS moving_timestamp,
-        ST_GEOGPOINT(grouped.current_longitude, grouped.current_latitude) AS location,
-    FROM current_vp
-    INNER JOIN grouped
-        ON current_vp.key = grouped.key
-    GROUP BY service_date, trip_instance_key, vp_group, current_longitude, current_latitude
-    ORDER BY service_date, trip_instance_key, vp_group, location_timestamp
+        COUNT(*) AS n_vp,
+        MIN(fct_vehicle_locations.location_timestamp) AS location_timestamp,
+        MAX(fct_vehicle_locations.location_timestamp) AS moving_timestamp,
+    FROM fct_vehicle_locations
+    LEFT JOIN grouped
+        ON fct_vehicle_locations.key = grouped.key
+    GROUP BY service_date, trip_instance_key, vp_group
+),
+
+fct_vehicle_locations_dwell AS (
+    SELECT
+        merged.trip_instance_key AS trip_instance_key,
+        merged.service_date AS service_date,
+        merged.key AS key,
+        merged.vp_group as vp_group, -- this column can be deleted, but use this to check, because vp_group=11 should have 2, but sometimes has count of 1.
+        merged.n_vp as n_vp,
+        merged.location_timestamp AS location_timestamp,
+        merged.moving_timestamp AS moving_timestamp,
+        fct_vehicle_locations.location AS location
+    FROM merged
+    LEFT JOIN fct_vehicle_locations
+        ON merged.key = fct_vehicle_locations.key
 )
 
-SELECT * FROM merged
+-- can we roll in n_vp + location into merged
+-- without the last merge? how to group with location (geography) type?
+-- expect to see n_vp have values 1, 2, 3 for these 2 trips
+
+SELECT * FROM fct_vehicle_locations_dwell

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
@@ -15,7 +15,6 @@
 WITH fct_vehicle_locations AS (
     SELECT
         key,
-        dt,
         gtfs_dataset_key,
         base64_url,
         gtfs_dataset_name,
@@ -89,7 +88,6 @@ keys_grouped AS (
 vp_grouper AS (
     SELECT
         fct_vehicle_locations.key,
-        fct_vehicle_locations.dt,
         fct_vehicle_locations.gtfs_dataset_key,
         fct_vehicle_locations.base64_url,
         fct_vehicle_locations.gtfs_dataset_name,
@@ -113,7 +111,6 @@ vp_grouper AS (
 fct_grouped_locations AS (
     SELECT
         MIN(vp_grouper.key) AS key,
-        vp_grouper.dt,
         vp_grouper.gtfs_dataset_key,
         vp_grouper.base64_url,
         vp_grouper.gtfs_dataset_name,
@@ -130,7 +127,7 @@ fct_grouped_locations AS (
             ELSE MIN(vp_grouper.vp_direction)
         END AS vp_direction,
     FROM vp_grouper
-    GROUP BY gtfs_dataset_key, base64_url, gtfs_dataset_name, schedule_gtfs_dataset_key, dt, service_date, trip_instance_key, vp_group
+    GROUP BY gtfs_dataset_key, base64_url, gtfs_dataset_name, schedule_gtfs_dataset_key, service_date, trip_instance_key, vp_group
 )
 
 SELECT * FROM fct_grouped_locations

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
@@ -26,8 +26,8 @@ WITH fct_vehicle_locations AS (
         location,
         next_location_key,
     FROM {{ ref('fct_vehicle_locations') }}
-    ORDER by service_date, trip_instance_key, location_timestamp
     WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }}
+    ORDER by service_date, trip_instance_key, location_timestamp
     ),
 
 

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
@@ -98,7 +98,7 @@ vp_grouper AS (
         ON fct_vehicle_locations.key = keys_grouped.key
 ),
 
-fct_dwelling_locations AS (
+fct_grouped_locations AS (
     SELECT
         MIN(vp_grouper.key) AS key,
         vp_grouper.dt,
@@ -121,4 +121,4 @@ fct_dwelling_locations AS (
     GROUP BY gtfs_dataset_key, base64_url, gtfs_dataset_name, schedule_gtfs_dataset_key, dt, service_date, trip_instance_key, vp_group
 )
 
-SELECT * FROM fct_dwelling_locations
+SELECT * FROM fct_grouped_locations


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

* Part of https://github.com/cal-itp/data-infra/issues/3645
* Redo #3646 with new image 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (fct_vehicle_locations_grouped) $ poetry run dbt run -s fct_vehicle_locations_grouped+
19:18:18  Running with dbt=1.5.1
19:18:30  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
19:18:31  Found 477 models, 1013 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 178 sources, 4 exposures, 0 metrics, 0 groups
19:18:31  
19:18:49  Concurrency: 8 threads (target='dev')
19:18:49  
19:18:49  1 of 1 START sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [RUN]
19:19:18  1 of 1 OK created sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [SCRIPT (24.6 GiB processed) in 28.27s]
19:19:18  
19:19:18  Finished running 1 incremental model in 0 hours 0 minutes and 46.22 seconds (46.22s).
19:19:18  
19:19:18  Completed successfully
19:19:18  
19:19:18  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (fct_vehicle_locations_grouped) $ poetry run dbt run -s +fct_vehicle_locations_grouped+
19:21:47  Running with dbt=1.5.1
19:21:50  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
19:21:51  Found 477 models, 1013 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 178 sources, 4 exposures, 0 metrics, 0 groups
19:21:51  
19:21:55  Concurrency: 8 threads (target='dev')
19:21:55  
19:21:55  1 of 19 START sql view model tiffany_staging.stg_gtfs_rt__vehicle_positions .... [RUN]
19:21:55  2 of 19 START sql view model tiffany_staging.stg_gtfs_schedule__agency ......... [RUN]
19:21:55  3 of 19 START sql view model tiffany_staging.stg_gtfs_schedule__download_outcomes  [RUN]
19:21:55  4 of 19 START sql view model tiffany_staging.stg_gtfs_schedule__file_parse_outcomes  [RUN]
19:21:55  5 of 19 START sql view model tiffany_staging.stg_gtfs_schedule__unzip_outcomes . [RUN]
19:21:55  6 of 19 START sql view model tiffany_staging.stg_transit_database__gtfs_datasets  [RUN]
19:21:56  6 of 19 OK created sql view model tiffany_staging.stg_transit_database__gtfs_datasets  [CREATE VIEW (0 processed) in 1.13s]
19:21:56  7 of 19 START sql table model tiffany_staging.int_transit_database__gtfs_datasets_dim  [RUN]
19:21:56  1 of 19 OK created sql view model tiffany_staging.stg_gtfs_rt__vehicle_positions  [CREATE VIEW (0 processed) in 1.16s]
19:21:56  3 of 19 OK created sql view model tiffany_staging.stg_gtfs_schedule__download_outcomes  [CREATE VIEW (0 processed) in 1.17s]
19:21:56  2 of 19 OK created sql view model tiffany_staging.stg_gtfs_schedule__agency .... [CREATE VIEW (0 processed) in 1.21s]
19:21:56  5 of 19 OK created sql view model tiffany_staging.stg_gtfs_schedule__unzip_outcomes  [CREATE VIEW (0 processed) in 1.33s]
19:21:56  4 of 19 OK created sql view model tiffany_staging.stg_gtfs_schedule__file_parse_outcomes  [CREATE VIEW (0 processed) in 1.34s]
19:21:56  8 of 19 START sql view model tiffany_staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [RUN]
19:21:58  8 of 19 OK created sql view model tiffany_staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [CREATE VIEW (0 processed) in 1.40s]
19:21:58  9 of 19 START sql view model tiffany_staging.int_gtfs_schedule__joined_feed_outcomes  [RUN]
19:21:59  9 of 19 OK created sql view model tiffany_staging.int_gtfs_schedule__joined_feed_outcomes  [CREATE VIEW (0 processed) in 1.38s]
19:21:59  10 of 19 START sql table model tiffany_mart_gtfs.dim_schedule_feeds ............ [RUN]
19:22:01  7 of 19 OK created sql table model tiffany_staging.int_transit_database__gtfs_datasets_dim  [CREATE TABLE (5.0k rows, 5.7 GiB processed) in 4.66s]
19:22:01  11 of 19 START sql table model tiffany_mart_transit_database.bridge_schedule_dataset_for_validation  [RUN]
19:22:01  12 of 19 START sql table model tiffany_mart_transit_database.dim_gtfs_datasets . [RUN]
19:22:03  11 of 19 OK created sql table model tiffany_mart_transit_database.bridge_schedule_dataset_for_validation  [CREATE TABLE (2.9k rows, 517.7 KiB processed) in 2.29s]
19:22:03  12 of 19 OK created sql table model tiffany_mart_transit_database.dim_gtfs_datasets  [CREATE TABLE (5.0k rows, 1.6 MiB processed) in 2.55s]
19:22:03  13 of 19 START sql table model tiffany_staging.int_transit_database__urls_to_gtfs_datasets  [RUN]
19:22:06  13 of 19 OK created sql table model tiffany_staging.int_transit_database__urls_to_gtfs_datasets  [CREATE TABLE (4.9k rows, 879.3 KiB processed) in 2.18s]
19:23:13  10 of 19 OK created sql table model tiffany_mart_gtfs.dim_schedule_feeds ....... [CREATE TABLE (15.9k rows, 12.3 GiB processed) in 73.82s]
19:23:13  14 of 19 START sql table model tiffany_mart_gtfs.fct_daily_schedule_feeds ...... [RUN]
19:23:17  14 of 19 OK created sql table model tiffany_mart_gtfs.fct_daily_schedule_feeds . [CREATE TABLE (303.1k rows, 3.1 MiB processed) in 4.27s]
19:23:17  15 of 19 START sql view model tiffany_mart_gtfs.fct_vehicle_positions_messages . [RUN]
19:23:18  15 of 19 OK created sql view model tiffany_mart_gtfs.fct_vehicle_positions_messages  [CREATE VIEW (0 processed) in 1.05s]
19:23:18  16 of 19 START sql incremental model tiffany_staging.int_gtfs_rt__vehicle_positions_trip_day_map_grouping  [RUN]
19:26:10  16 of 19 OK created sql incremental model tiffany_staging.int_gtfs_rt__vehicle_positions_trip_day_map_grouping  [SCRIPT (15.9 GiB processed) in 171.41s]
19:26:10  17 of 19 START sql table model tiffany_mart_gtfs.fct_vehicle_positions_trip_summaries  [RUN]
19:26:30  17 of 19 OK created sql table model tiffany_mart_gtfs.fct_vehicle_positions_trip_summaries  [CREATE TABLE (2.4m rows, 24.5 GiB processed) in 20.00s]
19:26:30  18 of 19 START sql incremental model tiffany_mart_gtfs.fct_vehicle_locations ... [RUN]
19:28:57  18 of 19 OK created sql incremental model tiffany_mart_gtfs.fct_vehicle_locations  [SCRIPT (10.7 GiB processed) in 147.27s]
19:28:57  19 of 19 START sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [RUN]
19:29:15  19 of 19 OK created sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [SCRIPT (25.9 GiB processed) in 17.37s]
19:29:15  
19:29:15  Finished running 9 view models, 7 table models, 3 incremental models in 0 hours 7 minutes and 23.76 seconds (443.76s).
19:29:15  
19:29:15  Completed successfully
19:29:15  
19:29:15  Done. PASS=19 WARN=0 ERROR=0 SKIP=0 TOTAL=19
```

Tests: No tests? Is this right?
```
poetry run dbt test -s fct_vehicle_locations_grouped
19:47:21  Running with dbt=1.5.1
19:47:24  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
19:47:25  Found 477 models, 1013 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 178 sources, 4 exposures, 0 metrics, 0 groups
19:47:25  
19:47:25  Nothing to do. Try checking your model configs and model specification args
```

Docs: 
```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (fct_vehicle_locations_grouped) $ poetry run dbt docs generate
19:38:45  Running with dbt=1.5.1
19:38:48  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
19:38:49  Found 477 models, 1013 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 178 sources, 4 exposures, 0 metrics, 0 groups
19:38:49  
19:39:08  Concurrency: 8 threads (target='dev')
19:39:08  
19:39:52  Building catalog
19:40:19  Catalog written to /home/jovyan/data-infra/warehouse/target/catalog.json
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
