### PR TITLE
`mart_gtfs.fct_vehicle_locations_grouped` - incremental settings like `fct_vehicle_locations`

### DIFF
--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
@@ -3,11 +3,11 @@
         materialized='incremental',
         incremental_strategy='insert_overwrite',
         partition_by = {
-            'field': 'service_date',
+            'field': 'dt',
             'data_type': 'date',
             'granularity': 'day',
         },
-        cluster_by=['service_date', 'base64_url'],
+        cluster_by=['dt', 'base64_url'],
         on_schema_change='append_new_columns'
     )
 }}
@@ -15,6 +15,7 @@
 WITH fct_vehicle_locations AS (
     SELECT
         key,
+        dt,
         gtfs_dataset_key,
         base64_url,
         gtfs_dataset_name,
@@ -88,6 +89,7 @@ keys_grouped AS (
 vp_grouper AS (
     SELECT
         fct_vehicle_locations.key,
+        fct_vehicle_locations.dt,
         fct_vehicle_locations.gtfs_dataset_key,
         fct_vehicle_locations.base64_url,
         fct_vehicle_locations.gtfs_dataset_name,
@@ -111,6 +113,7 @@ vp_grouper AS (
 fct_grouped_locations AS (
     SELECT
         MIN(vp_grouper.key) AS key,
+        vp_grouper.dt,
         vp_grouper.gtfs_dataset_key,
         vp_grouper.base64_url,
         vp_grouper.gtfs_dataset_name,
@@ -127,7 +130,7 @@ fct_grouped_locations AS (
             ELSE MIN(vp_grouper.vp_direction)
         END AS vp_direction,
     FROM vp_grouper
-    GROUP BY gtfs_dataset_key, base64_url, gtfs_dataset_name, schedule_gtfs_dataset_key, service_date, trip_instance_key, vp_group
+    GROUP BY dt, gtfs_dataset_key, base64_url, gtfs_dataset_name, schedule_gtfs_dataset_key, service_date, trip_instance_key, vp_group
 )
 
 SELECT * FROM fct_grouped_locations


### PR DESCRIPTION
# Description

Airflow DAG error showed missing `dt`. Instead of using partitions of `service_date`, we'll grab `dt` from `mart_gtfs.fct_vehicle_locations` and pass it through so source table and downstream derived table are partitioned the same way. 

``` 
Runtime Error
[2025-02-04, 00:26:15 UTC] {pod_manager.py:435} INFO - [base]   Database Error in model fct_vehicle_locations_grouped (models/mart/gtfs/fct_vehicle_locations_grouped.sql)
[2025-02-04, 00:26:17 UTC] {pod_manager.py:435} INFO - [base]     Unrecognized name: dt at [3:17]
```

Follow-up to #3660 

[Slack thread](https://cal-itp.slack.com/archives/C0332307HKM/p1738628781207819) -- are there implications for data duplication, data storage, since vehicle locations is probably some of the biggest tables

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

#### run table
```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (fix-fct-vehicle-locations-grouped) $ poetry run dbt run -s fct_vehicle_locations_grouped+
17:07:06  Running with dbt=1.5.1
17:07:09  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
17:07:10  Found 561 models, 1013 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 207 sources, 4 exposures, 0 metrics, 0 groups
17:07:10  
17:07:13  Concurrency: 8 threads (target='dev')
17:07:13  
17:07:13  1 of 1 START sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [RUN]
17:07:39  1 of 1 OK created sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [SCRIPT (36.0 GiB processed) in 25.90s]
17:07:39  
17:07:39  Finished running 1 incremental model in 0 hours 0 minutes and 28.48 seconds (28.48s).
17:07:39  
17:07:39  Completed successfully
17:07:39  
17:07:39  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

#### test table
```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (fix-fct-vehicle-locations-grouped) $ poetry run dbt test -s fct_vehicle_locations_grouped
17:08:38  Running with dbt=1.5.1
17:08:41  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
17:08:42  Found 561 models, 1013 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 207 sources, 4 exposures, 0 metrics, 0 groups
17:08:42  
17:08:42  Nothing to do. Try checking your model configs and model specification args
```

#### generate docs for new table

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (fix-fct-vehicle-locations-grouped) $ poetry run dbt docs generate
17:09:06  Running with dbt=1.5.1
17:09:09  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.mart.ad_hoc
17:09:10  Found 561 models, 1013 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 207 sources, 4 exposures, 0 metrics, 0 groups
17:09:10  
17:09:17  Concurrency: 8 threads (target='dev')
17:09:17  
17:10:02  Building catalog
17:10:27  Catalog written to /home/jovyan/data-infra/warehouse/target/catalog.json
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
