### PR TITLE
Upgrade to pydantic 2.0

### DIFF
--- a/airflow/dags/airtable_loader_v2/generate_gtfs_download_configs.py
+++ b/airflow/dags/airtable_loader_v2/generate_gtfs_download_configs.py
@@ -19,7 +19,7 @@ from calitp_data_infra.storage import (
     GTFSDownloadConfigExtract,
     get_fs,
 )
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 def gtfs_datasets_to_extract_configs(

--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -24,7 +24,7 @@ from calitp_data_infra.storage import (
     get_fs,
     get_latest,
 )
-from pydantic import validator
+from pydantic.v1 import validator
 from requests.exceptions import HTTPError
 
 GTFS_FEED_LIST_ERROR_THRESHOLD = 0.95

--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -6,7 +6,7 @@ import logging
 
 import requests
 from bs4 import BeautifulSoup
-from pydantic import HttpUrl, ValidationError, parse_obj_as
+from pydantic.v1 import HttpUrl, ValidationError, parse_obj_as
 
 from airflow.exceptions import AirflowException
 

--- a/airflow/plugins/operators/littlepay_raw_sync.py
+++ b/airflow/plugins/operators/littlepay_raw_sync.py
@@ -14,9 +14,9 @@ from calitp_data_infra.storage import (
     get_fs,
     get_latest_file,
 )
-from pydantic.class_validators import validator
-from pydantic.error_wrappers import ValidationError
-from pydantic.main import BaseModel
+from pydantic.v1.class_validators import validator
+from pydantic.v1.error_wrappers import ValidationError
+from pydantic.v1.main import BaseModel
 
 from airflow.models import BaseOperator
 

--- a/airflow/plugins/operators/scrape_ntd_xlsx.py
+++ b/airflow/plugins/operators/scrape_ntd_xlsx.py
@@ -12,7 +12,7 @@ from calitp_data_infra.storage import (  # type: ignore
     get_fs,
     make_name_bq_safe,
 )
-from pydantic import HttpUrl, parse_obj_as
+from pydantic.v1 import HttpUrl, parse_obj_as
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator  # type: ignore

--- a/airflow/plugins/operators/scrape_state_geoportal.py
+++ b/airflow/plugins/operators/scrape_state_geoportal.py
@@ -7,7 +7,7 @@ import pandas as pd  # type: ignore
 import pendulum
 import requests
 from calitp_data_infra.storage import PartitionedGCSArtifact, get_fs  # type: ignore
-from pydantic import HttpUrl, parse_obj_as
+from pydantic.v1 import HttpUrl, parse_obj_as
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator  # type: ignore

--- a/airflow/plugins/utils.py
+++ b/airflow/plugins/utils.py
@@ -11,7 +11,7 @@ from calitp_data_infra.storage import (
     PartitionedGCSArtifact,
     fetch_all_in_partition,
 )
-from pydantic import validator
+from pydantic.v1 import validator
 
 SCHEDULE_UNZIPPED_BUCKET = os.environ["CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED"]
 SCHEDULE_UNZIPPED_BUCKET_HOURLY = os.environ[

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,11 +1,11 @@
 calitp-data-infra==2025.6.5
 gusty==0.6.0
 pyairtable==2.2.1
-pydantic>=1.9,<2.0
+pydantic>=1.9  # 2.10.5 for latest composer
 typer==0.4.1
 sentry-sdk==1.17.0
-platformdirs>=2.5
-boto3>=1.26.87,<2
+platformdirs>=2.5  # 4.3.6 for latest composer
+boto3>=1.26.87  # 1.36.15 for latest composer
 openpyxl==3.1.5
 beautifulsoup4==4.12.3
 astronomer-cosmos

--- a/packages/calitp-data-infra/calitp_data_infra/storage.py
+++ b/packages/calitp-data-infra/calitp_data_infra/storage.py
@@ -33,7 +33,7 @@ import gcsfs  # type: ignore
 import humanize
 import pendulum
 from google.cloud import storage  # type: ignore
-from pydantic import (
+from pydantic.v1 import (
     BaseModel,
     ConstrainedStr,
     Extra,
@@ -42,8 +42,8 @@ from pydantic import (
     ValidationError,
     validator,
 )
-from pydantic.class_validators import root_validator
-from pydantic.tools import parse_obj_as
+from pydantic.v1.class_validators import root_validator
+from pydantic.v1.tools import parse_obj_as
 from requests import Request, Session
 from typing_extensions import Annotated, Literal
 

--- a/packages/calitp-data-infra/pyproject.toml
+++ b/packages/calitp-data-infra/pyproject.toml
@@ -8,12 +8,13 @@ authors = ["Andrew Vaccaro"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 # Some of these are pinned oddly to play nicely with Composer
-pydantic = ">=1.9,<2.0"
+pydantic = ">1.9"
 tqdm = "^4.64.1"
-pendulum = "^2.1.2"
+pendulum = ">2.1.2"
 humanize = "^4.6.0"
 backoff = "^2.2.1"
 typing-extensions = ">=3.10.0.2"
+google-cloud-secret-manager = ">2.16.4"
 gcsfs = "!=2022.7.1"
 google-api-core = "^2.24.1"
 google-cloud-secret-manager = "^2.23.1"

--- a/packages/calitp-data-infra/tests/test_storage.py
+++ b/packages/calitp-data-infra/tests/test_storage.py
@@ -1,7 +1,7 @@
 import pendulum
 import pytest
 from calitp_data_infra.storage import GTFSDownloadConfig, make_name_bq_safe
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 def test_gtfs_download_config() -> None:


### PR DESCRIPTION
# Description

- Update Dockerfile and Dockerfile.composer to use `apache/airflow:2.10.2-python3.11`
- Create a `requirements-composer-2.11.1-airflow-2.10.2.txt` file with the appropriate dependencies
- Create a Python 3.11 environment and install the dependencies
  ```bash
  pip install -r requirements-composer-2.11.1-airflow-2.10.2.txt -r requirements.txt
  ```
- Verify that the docker image builds at all. Useful to do this as a separate step for better visibility into errors:
  ```bash
  docker build . -t calitp-airflow-test
  ```
- Follow other testing instructions in the airflow/README.md file.

As of 2025 Feb 6, the following packages in requirements.txt of the airflow image need to be updated to work with Python 3.11:
- boto3 -- our Airflow image was pinned to `boto3==1.36.15`, which requires botocore 1.29.165, requires urllib3<1.27, which is too old for the newer Composer images.
- platformdirs -- our image was pinned to `platformdirs<3,>=2.5`, whereas the current Composer image requires 4.3.6. Oddly, the previous Composer image we were using required `platformdirs==3.2.0`, so I'm not actually sure how that was working without conflict (except that our requirements were installed _after_ the Composer requirements).
- pydantic -- We had pinned `pydantic==1.9` because of typing extension conflicts, which should no longer be an issue, as we are using Python 3.11 in the new Composer image.

Additionally, the following package version requirements have been loosened in calitp-data-infra:
- `pydantic = ">1.9"`
- `pendulum = ">2.1.2"`
- `google-cloud-secret-manager = ">2.16.4"`

Replaced all imports from `pydantic` to use `pydantic.v1` compatibility layer within Pydantic 2+ (found with `pydantic(?!\.v1)`).

In order to test the updated calitp-data-infra package, I had to copy the packages folder into the airflow folder, add `COPY ./packages/calitp-data-infra/ /tmp/calitp-data-infra/` to the airflow Dockerfile, and then use `calitp-data-infra @ file:///tmp/calitp-data-infra` in the requirements file.

As a follow-on, we should consider upgrading our use of Pydantic to the latest version. The `bump-pydantic` tool should help with that.

Resolves #3767

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and `poetry run dbt test -s CHANGED_MODEL`, then include the output in this section of the PR._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [ ] Actions required (specified below)
