### PR TITLE
Revert "fix(jupyterhub): adjusted timeouts to be way higher"

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -6,8 +6,6 @@
 jupyterhub:
   singleuser:
     defaultUrl: "/lab"
-    startTimeout: 3600
-    http_timeout: 3600
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
       tag: 2024.3.27


### PR DESCRIPTION
This reverts commit 96395c69796434179ea71e18de94d546ed6f278f.

# Description
Accidentally pushed directly to main with my last commit