### PR TITLE
Try to change jupyterhub timeout settings

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -6,6 +6,7 @@
 jupyterhub:
   singleuser:
     defaultUrl: "/lab"
+    startTimeout: 3600
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
       tag: 2024.3.27


### PR DESCRIPTION
# Description

Follow the [guide](https://discourse.jupyter.org/t/spawn-failed-timeout-even-when-start-timeout-is-set-to-3600-seconds/8098/7) to increase the timeouts.  Might resolve the issue for the future.

Note these settings aren't in the[ jupyterhub customization guide](https://z2jh.jupyter.org/en/stable/jupyterhub/customizing/user-management.html).

Resolves #3686 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested!

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Check and make sure everything is still working!