### PR TITLE
ntd: define mart schema in dbt project for funding and expenses tables

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -157,6 +157,12 @@ models:
           domain: mart
           dataset: ntd_annual_reporting
         schema: mart_ntd_annual_reporting
+      ntd_funding_and_expenses:
+        +materialized: table
+        +labels:
+          domain: mart
+          dataset: ntd_funding_and_expenses
+        schema: mart_ntd_funding_and_expenses
       ntd_ridership:
         +materialized: table
         +labels:


### PR DESCRIPTION
# Description
We created warehouse tables for the NTD funding and expenses endpoints in #3665 but neglected to define the mart schema in the dbt_project.yml file, so by default they populated in the staging schema, as noticed by @evansiroky. This PR defines the schema for these tables as `mart_ntd_funding_and_expenses` and they will now appear in Bigquery as such.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
<img width="1031" alt="Screenshot 2025-02-12 at 12 53 15 PM" src="https://github.com/user-attachments/assets/c2067fc3-e4f7-463c-9669-397f0767cc3d" />

<img width="424" alt="Screenshot 2025-02-12 at 12 53 43 PM" src="https://github.com/user-attachments/assets/2a3c4146-29f5-4e6c-bcfe-e7c9de65752c" />


## Post-merge follow-ups
- [x] No action required
