### PR TITLE
Reduce timeout to increase chances of retries

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -6,7 +6,7 @@
 jupyterhub:
   singleuser:
     defaultUrl: "/lab"
-    startTimeout: 2700
+    startTimeout: 300
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
       tag: 2025.1.15


### PR DESCRIPTION
# Description

Reduce timeout to increase chances of retries.

Previously we had issues where node spin up was too long.  But right now the errors are because we are attaching to the wrong node where our hdds are not located.   This should make iterations faster for this error.  A hacky band-aid if you will.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
not tested

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
