### PR TITLE
Push a newer image with a more updated node version

### DIFF
--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -1,5 +1,4 @@
-FROM jupyter/datascience-notebook:python-3.11.6
-
+FROM quay.io/jupyter/datascience-notebook:python-3.11.10
 LABEL org.opencontainers.image.source=https://github.com/cal-itp/data-infra
 
 USER root
@@ -7,7 +6,8 @@ RUN apt-get update
 RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+# I don't think this nodejs gets used.
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update \
     && apt-get install -y keychain nodejs git-lfs libspatialindex-dev graphviz libgraphviz-dev
 # GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md
@@ -16,7 +16,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/g
 RUN apt update \
     && apt install -y gh
 RUN apt-get install -y gdal-bin libgdal-dev # for rasterio
-# create these ahead of time, then chown to to the notebook user
+# create these ahead of time, then chown to the notebook user
 ENV GCLOUD_HOME=/gcloud
 ENV POETRY_HOME="/poetry"
 RUN mkdir $POETRY_HOME \
@@ -29,13 +29,11 @@ USER $NB_UID
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="$POETRY_HOME/bin:$PATH"
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
-# RUN npm install -g --unsafe-perm=true --allow-root vega-cli # Can't get these to work
-# RUN npm install -g --unsafe-perm=true --allow-root vega-lite
 RUN npm install -g --unsafe-perm=true --allow-root sql-language-server
 # gcloud CLI https://cloud.google.com/sdk/docs/install#deb
 RUN cd $GCLOUD_HOME \
-    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-506.0.0-linux-x86_64.tar.gz \
-    && tar -zxvf google-cloud-cli-506.0.0-linux-x86_64.tar.gz \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-512.0.0-linux-x86_64.tar.gz \
+    && tar -zxvf google-cloud-cli-512.0.0-linux-x86_64.tar.gz \
     && ./google-cloud-sdk/install.sh
 ENV PATH="$GCLOUD_HOME/google-cloud-sdk/bin:$PATH"
 
@@ -46,7 +44,6 @@ RUN poetry config virtualenvs.create false
 RUN cd /reqs && poetry install --with=shared_utils --with=portfolio
 RUN cd /reqs && poetry show # print out the package versions for documentation
 RUN poetry config virtualenvs.create true
-
 ENV DBT_PROFILES_DIR=/home/jovyan/.dbt/
 COPY ./overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 COPY ./dask_config.yml /opt/conda/etc/dask/dask_config.yml

--- a/images/jupyter-singleuser/README.md
+++ b/images/jupyter-singleuser/README.md
@@ -21,8 +21,7 @@ docker build  -t envs-hurt . 2>&1 | tee build.log
 
 You can go into the docker image and do tests:
 ```
-docker images
-docker exec -it upbeat_bhaskara /bin/bash
+docker run -it envs-hurt bash
 ```
 
 ## Deploying Changes to Production

--- a/images/jupyter-singleuser/pyproject.toml
+++ b/images/jupyter-singleuser/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jupyter-singleuser"
-version = "2025.2.20"
+version = "2025.2.26"
 description = ""
 package-mode = false
 authors = ["Vevetron"]
@@ -15,8 +15,7 @@ intake-parquet = ">=0.2.3"
 ipyleaflet = "0.15.0"
 jupytext = ">=1.13.5"
 jupyterlab-code-formatter = ">=1.4.10"
-lxml_html_clean = ">=0.4.1" #To stop some background error messages
-# voila = "0.5.8"
+lxml_html_clean = ">=0.4.1"
 plotnine = ">=0.8.0"
 plotly = "5.5.0"
 folium = ">=0.12.1.post1"

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -9,7 +9,7 @@ jupyterhub:
     startTimeout: 300
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
-      tag: 2025.2.20
+      tag: 2025.2.26
     memory:
       # Much more than 10 and we risk bumping up against the actual capacity of e2-highmem-2
       limit: 10G
@@ -31,10 +31,10 @@ jupyterhub:
               mkdir -p -- /home/jovyan/.jupyter;
               cp /tmp/jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py;
     profileList:
-      - display_name: "Default User - 2025.2.20, Python 3.11"
+      - display_name: "Default User - 2025.2.26, Python 3.11"
         description: "Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         default: true
-      - display_name: "Power User - 2025.2.20, Python 3.11"
+      - display_name: "Power User - 2025.2.26, Python 3.11"
         description: "Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"


### PR DESCRIPTION
# Description

The jupyter images are having serious issues with the node version in the current jupyter notebook.

This switched to a newer image on the same version of python. It also uses something like node ~22, while the old used node ~20.

Resolves #(https://github.com/cal-itp/data-analyses/issues/1388)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Can't test locally, but the build.log looks good!

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Test in prod