### PR TITLE
payments: create new operators and dags for littlepay feed v3 sync and parse

### DIFF
--- a/airflow/dags/parse_littlepay_v3/METADATA.yml
+++ b/airflow/dags/parse_littlepay_v3/METADATA.yml
@@ -1,0 +1,18 @@
+description: "Parse feed v3 Littlepay files into JSONL"
+schedule_interval: "30 * * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: "2023-03-12"
+    email:
+      - "hello@calitp.org"
+    email_on_failure: False
+    email_on_retry: False
+    max_active_dag_runs: 6
+    retries: 1
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: False

--- a/airflow/dags/parse_littlepay_v3/README.md
+++ b/airflow/dags/parse_littlepay_v3/README.md
@@ -1,5 +1,5 @@
-# `parse_littlepay`
+# `parse_littlepay_v3`
 
 Type: [Data interval processing  / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
 
-This DAG orchestrates the parsing of LittlePay data.
+This DAG orchestrates the parsing of LittlePay feed v3 data.

--- a/airflow/dags/parse_littlepay_v3/README.md
+++ b/airflow/dags/parse_littlepay_v3/README.md
@@ -1,0 +1,5 @@
+# `parse_littlepay`
+
+Type: [Data interval processing  / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
+
+This DAG orchestrates the parsing of LittlePay data.

--- a/airflow/dags/parse_littlepay_v3/nevada_county_connects.yml
+++ b/airflow/dags/parse_littlepay_v3/nevada_county_connects.yml
@@ -1,0 +1,2 @@
+operator: operators.LittlepayToJSONLV3
+instance: nevada-county-connects

--- a/airflow/dags/sync_littlepay_v3/METADATA.yml
+++ b/airflow/dags/sync_littlepay_v3/METADATA.yml
@@ -1,0 +1,17 @@
+description: "Syncs feed V3 Littlepay data from S3 bucket to our buckets"
+schedule_interval: "0 * * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: !days_ago 1
+    email:
+      - "hello@calitp.org"
+    email_on_failure: False
+    email_on_retry: False
+    retries: 0
+    retry_delay: !timedelta 'minutes: 2'
+    concurrency: 50
+    #sla: !timedelta 'hours: 2'
+latest_only: True

--- a/airflow/dags/sync_littlepay_v3/README.md
+++ b/airflow/dags/sync_littlepay_v3/README.md
@@ -1,5 +1,5 @@
-# `sync_littlepay`
+# `sync_littlepay_v3`
 
 Type: [Now / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
 
-This DAG orchestrates the syncing of raw Littlepay data.
+This DAG orchestrates the syncing of raw Littlepay feed v3 data.

--- a/airflow/dags/sync_littlepay_v3/README.md
+++ b/airflow/dags/sync_littlepay_v3/README.md
@@ -1,0 +1,5 @@
+# `sync_littlepay`
+
+Type: [Now / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
+
+This DAG orchestrates the syncing of raw Littlepay data.

--- a/airflow/dags/sync_littlepay_v3/nevada_county_connects.yml
+++ b/airflow/dags/sync_littlepay_v3/nevada_county_connects.yml
@@ -1,0 +1,4 @@
+operator: operators.LittlepayRawSyncV3
+instance: nevada-county-connects
+src_bucket: littlepay-datafeed-prod-nevada-county-connec-7c9479e0
+access_key_secret_name: LITTLEPAY_AWS_IAM_NEVADA_COUNTY_CONNECTS_ACCESS_KEY

--- a/airflow/dags/sync_littlepay_v3/nevada_county_connects.yml
+++ b/airflow/dags/sync_littlepay_v3/nevada_county_connects.yml
@@ -1,4 +1,4 @@
 operator: operators.LittlepayRawSyncV3
 instance: nevada-county-connects
 src_bucket: littlepay-datafeed-prod-nevada-county-connec-7c9479e0
-access_key_secret_name: LITTLEPAY_AWS_IAM_NEVADA_COUNTY_CONNECTS_ACCESS_KEY
+access_key_secret_name: LITTLEPAY_V3_AWS_IAM_NEVADA_COUNTY_CONNECTS_ACCESS_KEY

--- a/airflow/dags/sync_littlepay_v3/nevada_county_connects.yml
+++ b/airflow/dags/sync_littlepay_v3/nevada_county_connects.yml
@@ -1,4 +1,4 @@
 operator: operators.LittlepayRawSyncV3
 instance: nevada-county-connects
 src_bucket: littlepay-datafeed-prod-nevada-county-connec-7c9479e0
-access_key_secret_name: LITTLEPAY_V3_AWS_IAM_NEVADA_COUNTY_CONNECTS_ACCESS_KEY
+access_key_secret_name: LITTLEPAY_AWS_IAM_NEVADA_COUNTY_CONNECTS_ACCESS_KEY_FEED_V3

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -96,7 +96,9 @@ x-airflow-common:
     CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY: "gs://test-calitp-gtfs-schedule-parsed-hourly"
 
     CALITP_BUCKET__LITTLEPAY_PARSED: "gs://test-calitp-payments-littlepay-parsed"
+    CALITP_BUCKET__LITTLEPAY_PARSED_V3: "gs://test-calitp-payments-littlepay-parsed-v3"
     CALITP_BUCKET__LITTLEPAY_RAW: "gs://test-calitp-payments-littlepay-raw"
+    CALITP_BUCKET__LITTLEPAY_RAW_V3: "gs://test-calitp-payments-littlepay-raw-v3"
     CALITP_BUCKET__PUBLISH: "gs://test-calitp-publish"
     CALITP_BUCKET__SENTRY_EVENTS: "gs://test-calitp-sentry"
 

--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -5,7 +5,9 @@ from operators.external_table import ExternalTable
 from operators.gtfs_csv_to_jsonl import GtfsGcsToJsonlOperator
 from operators.gtfs_csv_to_jsonl_hourly import GtfsGcsToJsonlOperatorHourly
 from operators.littlepay_raw_sync import LittlepayRawSync
+from operators.littlepay_raw_sync_feed_v3 import LittlepayRawSyncV3
 from operators.littlepay_to_jsonl import LittlepayToJSONL
+from operators.littlepay_to_jsonl_feed_v3 import LittlepayToJSONLV3
 from operators.pod_operator import PodOperator
 from operators.scrape_ntd_api import NtdDataProductAPIOperator
 from operators.scrape_ntd_xlsx import NtdDataProductXLSXOperator

--- a/airflow/plugins/operators/littlepay_raw_sync_feed_v3.py
+++ b/airflow/plugins/operators/littlepay_raw_sync_feed_v3.py
@@ -48,10 +48,10 @@ class LittlepayFileKey(str):
     def entity(self) -> str:
         return self.split("/")[2]
 
-    # entity is now in location 3 (instead of 2)
+    # filename is now in location 3 (instead of 2)
     @property
     def filename(self) -> str:
-        return self.split("/")[2]
+        return self.split("/")[3]  # Return full filename with extension
 
 
 class LittlepayS3Object(BaseModel):

--- a/airflow/plugins/operators/littlepay_raw_sync_feed_v3.py
+++ b/airflow/plugins/operators/littlepay_raw_sync_feed_v3.py
@@ -156,14 +156,11 @@ class LittlepayRawSyncV3(BaseOperator):
         self,
         *args,
         instance: str,
-        # pull src_bucket from task yml
         src_bucket: str,
         access_key_secret_name: str,
         **kwargs,
     ):
         self.instance = instance
-        # deprecate because source bucket names are not predictable in v3
-        # self.src_bucket = f"littlepay-prod-{instance}-datafeed"
         self.src_bucket = src_bucket
         self.access_key_secret_name = access_key_secret_name
         super().__init__(**kwargs)

--- a/airflow/plugins/operators/littlepay_raw_sync_feed_v3.py
+++ b/airflow/plugins/operators/littlepay_raw_sync_feed_v3.py
@@ -1,0 +1,263 @@
+import concurrent
+import json
+import os
+import traceback
+from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime
+from typing import ClassVar, Dict, List, Optional
+
+import boto3
+import pendulum
+from calitp_data_infra.auth import get_secret_by_name
+from calitp_data_infra.storage import (
+    PARTITIONED_ARTIFACT_METADATA_KEY,
+    PartitionedGCSArtifact,
+    ProcessingOutcome,
+    get_fs,
+    get_latest_file,
+)
+from pydantic.class_validators import validator
+from pydantic.error_wrappers import ValidationError
+from pydantic.main import BaseModel
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+from airflow.models import BaseOperator
+
+# new bucket because of schema changes, need to investigate backfill status with transitions to v3 or handling otherwise
+LITTLEPAY_RAW_BUCKET = os.getenv("CALITP_BUCKET__LITTLEPAY_RAW_V3")
+
+
+class LittlepayFileKey(str):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        # new filename format has 4 parts instead of 3 (with the addition of the feed version in filename)
+        assert len(v.split("/")) == 4 and v.endswith(".psv")
+        return cls(v)
+
+    @property
+    def agency(self) -> str:
+        return self.split("/")[0]
+
+    # entity is now in location 2 (instead of 1) as the feed version is in location 1
+    @property
+    def entity(self) -> str:
+        return self.split("/")[2]
+
+    # entity is now in location 3 (instead of 2)
+    @property
+    def filename(self) -> str:
+        return self.split("/")[2]
+
+
+class LittlepayS3Object(BaseModel):
+    Key: LittlepayFileKey
+    LastModified: pendulum.DateTime
+    ETag: str
+    Size: int
+    StorageClass: str
+
+
+class RawLittlepayFileExtract(PartitionedGCSArtifact):
+    bucket: ClassVar[str] = LITTLEPAY_RAW_BUCKET
+    partition_names: ClassVar[List[str]] = ["instance", "filename", "ts"]
+    instance: str
+    filename: str
+    ts: pendulum.DateTime
+    s3bucket: str
+    s3object: LittlepayS3Object
+
+    @validator("ts", allow_reuse=True)
+    def coerce_ts(cls, v):
+        if isinstance(v, datetime):
+            return pendulum.instance(v)
+        return v
+
+    @property
+    def table(self) -> str:
+        return self.s3object.Key.entity
+
+    # TODO: why does this not override the parent model field?
+    # @property
+    # def filename(self) -> str:
+    #     return self.s3object.Key.filename
+
+
+# We shouldn't save files that we skip since that's an unbounded, increasing list.
+class RawLittlepayFileOutcome(ProcessingOutcome):
+    extract: RawLittlepayFileExtract
+    prior: Optional[
+        RawLittlepayFileExtract
+    ]  # prior existing implies an update to an existing file
+
+
+class RawLittlepaySyncJobResult(PartitionedGCSArtifact):
+    bucket: ClassVar[str] = LITTLEPAY_RAW_BUCKET
+    table: ClassVar[str] = "raw_littlepay_sync_job_result"
+    partition_names: ClassVar[List[str]] = ["instance", "ts"]
+    instance: str
+    ts: pendulum.DateTime
+
+
+def sync_file(
+    src_bucket: str, file: RawLittlepayFileExtract, s3client, fs
+) -> Optional[RawLittlepayFileOutcome]:
+    try:
+        # TODO: this kinda overlaps with get_latest()
+        fileinfo = get_latest_file(
+            bucket=file.bucket,
+            table=file.table,
+            prefix_partitions={
+                "instance": file.instance,
+                "filename": file.filename,
+            },
+            partition_types={
+                "ts": pendulum.DateTime,
+            },
+        )
+        try:
+            metadata_str = fs.getxattr(
+                path=f"gs://{fileinfo.name}",  # noqa: E231
+                attr=PARTITIONED_ARTIFACT_METADATA_KEY,
+            )
+        except KeyError:
+            print(f"metadata missing on {fileinfo.name}")
+            raise
+        prior = RawLittlepayFileExtract(**json.loads(metadata_str))
+        save = (
+            file.s3object.LastModified != prior.s3object.LastModified
+            or file.s3object.ETag != prior.s3object.ETag
+        )
+    except FileNotFoundError:
+        save = True
+        prior = None
+
+    if save:
+        content = s3client.get_object(Bucket=src_bucket, Key=file.s3object.Key)[
+            "Body"
+        ].read()
+        file.save_content(content=content, fs=fs)
+        return RawLittlepayFileOutcome(
+            success=True,
+            extract=file,
+            prior=prior,
+        )
+    return None
+
+
+class LittlepayRawSyncV3(BaseOperator):
+    template_fields = ()
+
+    def __init__(
+        self,
+        *args,
+        instance: str,
+        # pull src_bucket from task yml
+        src_bucket: str,
+        access_key_secret_name: str,
+        **kwargs,
+    ):
+        self.instance = instance
+        # deprecate because source bucket names are not predictable in v3
+        # self.src_bucket = f"littlepay-prod-{instance}-datafeed"
+        self.src_bucket = src_bucket
+        self.access_key_secret_name = access_key_secret_name
+        super().__init__(**kwargs)
+
+    def execute(self, context):
+        assert LITTLEPAY_RAW_BUCKET is not None
+
+        start = pendulum.now()
+        access_key = json.loads(get_secret_by_name(self.access_key_secret_name))
+        print(f"Successfully loaded secret {self.access_key_secret_name}")
+        s3client = boto3.client(
+            "s3",
+            aws_access_key_id=access_key["AccessKey"]["AccessKeyId"],
+            aws_secret_access_key=access_key["AccessKey"]["SecretAccessKey"],
+        )
+
+        list_kwargs = {
+            "Bucket": self.src_bucket,
+        }
+
+        files: List[RawLittlepayFileExtract] = []
+
+        # 1000 objects per page; just stop us from accidentally going forever
+        for _ in tqdm(range(1000)):
+            resp = s3client.list_objects_v2(**list_kwargs)
+
+            for content in resp["Contents"]:
+                if content["Key"] == self.instance:
+                    # Weird 0-length file(s) that seem to get created everywhere
+                    continue
+                try:
+                    obj = LittlepayS3Object(**content)
+                    file = RawLittlepayFileExtract(
+                        instance=self.instance,
+                        ts=start,
+                        s3bucket=self.src_bucket,
+                        s3object=obj,
+                        filename=obj.Key.filename,
+                    )
+                    files.append(file)
+                except ValidationError:
+                    print(content, flush=True)
+                    raise
+
+            if resp["IsTruncated"]:
+                list_kwargs["ContinuationToken"] = resp["NextContinuationToken"]
+            else:
+                break
+        else:
+            raise RuntimeError("failed to page fully through bucket")
+
+        print(
+            f"Found {len(files)} source files in {self.src_bucket}; diffing and copying to {RawLittlepayFileExtract.bucket}."  # noqa: E702
+        )
+
+        fs = get_fs()
+        extracted_files: List[RawLittlepayFileExtract] = []
+        failures = []
+        with logging_redirect_tqdm():
+            pbar = tqdm(total=len(files))
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futures: Dict[Future, RawLittlepayFileExtract] = {
+                    pool.submit(
+                        sync_file,
+                        src_bucket=self.src_bucket,
+                        file=file,
+                        s3client=s3client,
+                        fs=fs,
+                    ): file
+                    for i, file in enumerate(files)
+                }
+                for future in concurrent.futures.as_completed(futures):
+                    pbar.update(1)
+                    try:
+                        ret = future.result()
+                        if ret:
+                            extracted_files.append(ret)
+                    except KeyboardInterrupt:
+                        raise
+                    except Exception as e:
+                        print(
+                            f"exception during processing of {futures[future].s3object.Key} -> {futures[future].path}: {str(e)}"
+                        )
+                        traceback.print_exc()
+                        failures.append(e)
+            del pbar
+
+        RawLittlepaySyncJobResult(
+            instance=self.instance,
+            ts=start,
+            filename="results.jsonl",
+        ).save_content(
+            content="\n".join(e.json() for e in extracted_files).encode(), fs=fs
+        )
+
+        if failures:
+            raise RuntimeError(str(failures))

--- a/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
+++ b/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
@@ -11,7 +11,7 @@ from calitp_data_infra.storage import (
     fetch_all_in_partition,
     get_fs,
 )
-from operators.littlepay_raw_sync import RawLittlepayFileExtract
+from operators.littlepay_raw_sync_feed_v3 import RawLittlepayFileExtract
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 

--- a/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
+++ b/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
@@ -1,0 +1,134 @@
+import csv
+import gzip
+import json
+import os
+from io import StringIO
+from typing import ClassVar, List
+
+import pendulum
+from calitp_data_infra.storage import (
+    PartitionedGCSArtifact,
+    fetch_all_in_partition,
+    get_fs,
+)
+from operators.littlepay_raw_sync import RawLittlepayFileExtract
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+from airflow.models import BaseOperator
+
+LITTLEPAY_RAW_BUCKET = os.getenv("CALITP_BUCKET__LITTLEPAY_RAW_V3")
+LITTLEPAY_PARSED_BUCKET = os.getenv("CALITP_BUCKET__LITTLEPAY_PARSED_V3")
+
+
+class LittlepayFileJSONL(PartitionedGCSArtifact):
+    bucket: ClassVar[str] = LITTLEPAY_PARSED_BUCKET
+    partition_names: ClassVar[List[str]] = ["instance", "extract_filename", "ts"]
+    extract: RawLittlepayFileExtract
+
+    @property
+    def table(self) -> str:
+        return self.extract.table
+
+    @property
+    def instance(self) -> str:
+        return self.extract.instance
+
+    @property
+    def extract_filename(self) -> str:
+        return self.extract.filename
+
+    @property
+    def ts(self) -> pendulum.DateTime:
+        return self.extract.ts
+
+
+def parse_raw_file(file: RawLittlepayFileExtract, fs):
+    # mostly stolen from the Schedule job, we could probably abstract this
+    # assume this is PSV for now, but we could sniff the delimiter
+    filename, extension = os.path.splitext(file.filename)
+    assert extension == ".psv"
+    with fs.open(file.path) as f:
+        reader = csv.DictReader(
+            StringIO(f.read().decode("utf-8-sig")),
+            restkey="calitp_unknown_fields",
+            delimiter="|",
+        )
+    lines = [
+        {**row, "_line_number": line_number}
+        for line_number, row in enumerate(reader, start=1)
+    ]
+    jsonl_file = LittlepayFileJSONL(
+        extract=file,
+        filename=f"{filename}.jsonl.gz",
+    )
+    jsonl_file.save_content(
+        content=gzip.compress("\n".join(json.dumps(line) for line in lines).encode()),
+        fs=fs,
+    )
+
+
+class LittlepayToJSONLV3(BaseOperator):
+    template_fields = ()
+
+    def __init__(
+        self,
+        *args,
+        instance: str,
+        **kwargs,
+    ):
+        self.instance = instance
+        super().__init__(**kwargs)
+
+    def execute(self, context):
+        assert LITTLEPAY_RAW_BUCKET is not None and LITTLEPAY_PARSED_BUCKET is not None
+
+        fs = get_fs()
+
+        # TODO: this could be worth splitting into separate tasks
+        entities = [
+            "authorisations",
+            # renamed based on v3 table name changes
+            "customer-funding-sources",
+            "device-transaction-purchases",
+            # this was already using the new name? verify that this is correct
+            "device-transactions",
+            "micropayment-adjustments",
+            "micropayment-device-transactions",
+            "micropayments",
+            # this was also renamed based on schema changes
+            "products",
+            "refunds",
+            "settlements",
+        ]
+
+        with logging_redirect_tqdm():
+            for entity in tqdm(entities):
+                files_to_process: List[RawLittlepayFileExtract]
+                # This is not very efficient but it should be approximately 1 file per day
+                # since the instance began
+                files_to_process, _, _ = fetch_all_in_partition(
+                    cls=RawLittlepayFileExtract,
+                    table=entity,
+                    partitions={
+                        "instance": self.instance,
+                    },
+                    verbose=True,
+                )
+                print(f"found {len(files_to_process)} files to check")
+
+                # subtract 30 minutes because we run 30 minutes past the hour
+                # in case of late-arriving data
+                period = context["data_interval_end"].subtract(
+                    minutes=30, microseconds=1
+                ) - context["data_interval_start"].subtract(minutes=30)
+
+                print(f"filtering files created in {period}")
+
+                files_to_process = [
+                    file for file in files_to_process if file.ts in period
+                ]
+
+                file: RawLittlepayFileExtract
+                for file in tqdm(files_to_process, desc=entity):
+                    parse_raw_file(file, fs=fs)

--- a/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
+++ b/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
@@ -88,19 +88,15 @@ class LittlepayToJSONLV3(BaseOperator):
         # TODO: this could be worth splitting into separate tasks
         entities = [
             "authorisations",
-            # renamed based on v3 table name changes
             "customer-funding-sources",
             "device-transaction-purchases",
-            # this was already using the new name? verify that this is correct
             "device-transactions",
             "micropayment-adjustments",
             "micropayment-device-transactions",
             "micropayments",
-            # this was also renamed based on schema changes
             "products",
             "refunds",
             "settlements",
-            # this is new? handle in create_external_tables?
             "terminal-device-transactions",
         ]
 

--- a/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
+++ b/airflow/plugins/operators/littlepay_to_jsonl_feed_v3.py
@@ -100,6 +100,8 @@ class LittlepayToJSONLV3(BaseOperator):
             "products",
             "refunds",
             "settlements",
+            # this is new? handle in create_external_tables?
+            "terminal-device-transactions",
         ]
 
         with logging_redirect_tqdm():


### PR DESCRIPTION
# Description
Littlepay has transitioned to their data feed v3, and data for our most recent open loop agency to come online (Nevada County Connects) is being provided in their v3 format.

This PR iterates on our Airflow sync and parse tasks for feed v1 to accommodate the changes found in feed v3: 
* deprecate dynamic creation of source bucket name due to changes in composition in v3
* stand up new raw and parsed buckets, secrets
* updates based on breaking changes in table names, add new tables

Resolves #3705 

## Type of change
- [x] New feature

## How has this been tested?
<img width="427" alt="Screenshot 2025-03-17 at 4 01 30 PM" src="https://github.com/user-attachments/assets/083426d4-a502-46b0-95b3-1ef960a19950" />
<img width="423" alt="Screenshot 2025-03-17 at 4 13 15 PM" src="https://github.com/user-attachments/assets/b23040a7-51a2-494f-9188-d9f618a7e34a" />


## Post-merge follow-ups
- [x] Actions required (specified below)
Turn on dags in GUI, observe for expected behavior