### PR TITLE
Adding RTPA and MPO to external_airtable_california_transit_organizations.yml

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -262,4 +262,4 @@ schema_fields:
     mode: REPEATED
   - name: mpo
     type: STRING
-    mode: NULLABLE
+    mode: REPEATED

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -57,9 +57,9 @@ schema_fields:
   - name: gtfs_schedule_status
     type: STRING
     mode: REPEATED
-  - name: mpo_rtpa
-    type: STRING
-    mode: REPEATED
+  # - name: mpo_rtpa
+  #   type: STRING
+  #   mode: REPEATED
   - name: ntp_id
     type: STRING
     mode: REPEATED
@@ -255,5 +255,11 @@ schema_fields:
     type: STRING
     mode: NULLABLE
   - name: ntd_id_2022
+    type: STRING
+    mode: NULLABLE
+  - name: rtpa
+    type: STRING
+    mode: REPEATED
+  - name: mpo
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION

# Description

Adding RTPA and MPO to external_airtable_california_transit_organizations.yml in order to eventually add these fields to the dim_organizations in the GBC warehouse.

Resolves #\[[3751](https://github.com/cal-itp/data-infra/issues/3751)\]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
<!--
## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and `poetry run dbt test -s CHANGED_MODEL`, then include the output in this section of the PR._
-->
## Post-merge follow-ups


- [ ] No action required
- [X] Actions required (specified below)

Once this step is completed, Staging, Intermediate and Marts models will be updated to include these fields in the dim_organizations.
