### PR TITLE
Adding rtpa and mpo to dim_organizations.

### DIFF
--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -42,6 +42,8 @@ stg_transit_database__organizations AS (
         is_public_entity = "Yes" AS is_public_entity,
         raw_ntd_id,
         ntd_id_2022,
+        rtpa,
+        mpo,
         public_currently_operating = "Yes" AS public_currently_operating,
         public_currently_operating_fixed_route = "Yes" AS public_currently_operating_fixed_route,
     FROM once_daily_organizations


### PR DESCRIPTION
# Description

Adding rtpa and mpo fields to stg, int and mart dim_organizations table/view.

Resolves #\[[3751](https://github.com/cal-itp/data-infra/issues/3751)\]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
```
jovyan@jupyter-fsalemi ~/data-infra/warehouse (rpta_mpo_addition) $ poetry run dbt run -s +dim_organizations
07:34:10  Running with dbt=1.5.1
07:34:13  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.staging.ntd
07:34:14  Found 563 models, 1023 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 206 sources, 4 exposures, 0 metrics, 0 groups
07:34:14  
07:34:17  Concurrency: 8 threads (target='dev')
07:34:17  
07:34:17  1 of 3 START sql view model farhad_staging.stg_transit_database__organizations . [RUN]
07:34:18  1 of 3 OK created sql view model farhad_staging.stg_transit_database__organizations  [CREATE VIEW (0 processed) in 1.13s]
07:34:18  2 of 3 START sql table model farhad_staging.int_transit_database__organizations_dim  [RUN]
07:34:24  2 of 3 OK created sql table model farhad_staging.int_transit_database__organizations_dim  [CREATE TABLE (10.3k rows, 14.2 GiB processed) in 5.35s]
07:34:24  3 of 3 START sql table model farhad_mart_transit_database.dim_organizations .... [RUN]
07:34:26  3 of 3 OK created sql table model farhad_mart_transit_database.dim_organizations  [CREATE TABLE (10.3k rows, 2.2 MiB processed) in 2.37s]
07:34:26  
07:34:26  Finished running 1 view model, 2 table models in 0 hours 0 minutes and 12.24 seconds (12.24s).
07:34:26  
07:34:26  Completed successfully
07:34:26  
07:34:26  Done. PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3
```
## Post-merge follow-ups


- [X] No action required
- [ ] Actions required (specified below)
