### PR TITLE
new section in Saving Code doc to address failing pre-commit checks. 

### DIFF
--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -121,7 +121,7 @@ If you discover merge conflicts and they are within a single notebook that only 
 
 ### Options for Resolving Pre-commit issues
 
-Pre-commit checks are used to ensure our code meets our quality standards and fix fomatting issues before being commited to the remote repo. If your Pull Request or files are failing the pre-commit checks, try these steps to resolve them.
+Pre-commit checks are used to ensure our code meets our quality standards and fix formatting issues before being committed to the remote repo. If your Pull Request or files are failing the pre-commit checks, try these steps to resolve them.
 
 - In the root repo, run `pip install pre-commit` and `pre-commit install`. Speifically, if you are in the root of the `data-analyses` repo you can run `make add_precommit` to run the same commands.
 - Run `git add` and `git commit` like normal. The pre-commit checks will run and identify any errors it finds, automatically correct errors it can do, and identify errors that need manual changes.

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -119,16 +119,23 @@ If you discover merge conflicts and they are within a single notebook that only 
 
 (resolve-pre-commit-hook-issues)=
 
-### Options for Resolving Pre-commit issues
+### Options for Resolving Pre-commit Issues
 
 Pre-commit checks are used to ensure our code meets our quality standards and fix formatting issues before being committed to the remote repo. If your Pull Request or files are failing the pre-commit checks, try these steps to resolve them.
 
-- In the root repo, run `pip install pre-commit` and `pre-commit install`. Speifically, if you are in the root of the `data-analyses` repo you can run `make add_precommit` to run the same commands.
+- In the root repo, run `pip install pre-commit` and `pre-commit install`. Specifically, if you are in the root of the `data-analyses` repo you can run `make add_precommit` to run the same commands.
 - Run `git add` and `git commit` like normal. The pre-commit checks will run and identify any errors it finds, automatically correct errors it can do, and identify errors that need manual changes.
-- If you are not able to `git push` your commit and get a `Everything up-to-date` message, or if your PR is failing the pre-commit check, then run `pre-commit run --all-files`. This will run the pre-commit check on all files.
+- If you are not able to `git push` your commit and get a `Everything up-to-date` message, or if your PR is failing the pre-commit check, then run `pre-commit run --all-files`. Running `pre-commit run --all-files` will run the pre-commit checks again on all files.
 - Address any manual changes the check identifies ("E402 module level import not at top of file", "\<> imported but unused", "expected 2 blank lines, found 1", etc.)
-- Run `pre-commit run --all-files`, address manual changes again until all checks are passing,
-- Then you can `git add` the adjusted files,`git commit`, `git push` again.
+- Repeat `pre-commit run --all-files` and make manual changes until all checks are passing.
+- Finally you can `git add` the adjusted files, `git commit`, `git push` again.
+
+If you are importing a module from a different directory with `import sys`, `sys.path.append()` and `from ... import...` into your script, you may receive the `E402 module level import not at top of file` pre-commit error. This error occurs because of the placement of the `sys.path.append()` line and the `import...` line that follows. To satisfy  the pre-commit checks and still have your script run, please do the following:
+
+- include `import importlib`, `import os` and `import sys` at the beginning of your script with the other dependencies.
+- include a line for `sys.path.append(os.path.abspath("../path_to_module"))`
+- followed by a line for `module_name = importlib.import_module("module_name")`
+- [See this script for an exmaple](https://github.com/cal-itp/data-analyses/blob/main/_shared_utils/shared_utils/schedule_gtfs_keys_multi_orgs.py#L9-L17)
 
 (other-common-github-issues-encountered-during-saving-codes)=
 

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -135,7 +135,7 @@ If you are importing a module from a different directory with `import sys`, `sys
 - include `import importlib`, `import os` and `import sys` at the beginning of your script with the other dependencies.
 - include a line for `sys.path.append(os.path.abspath("../path_to_module"))`
 - followed by a line for `module_name = importlib.import_module("module_name")`
-- [See this script for an exmaple](https://github.com/cal-itp/data-analyses/blob/main/_shared_utils/shared_utils/schedule_gtfs_keys_multi_orgs.py#L9-L17)
+- [See this script for an example](https://github.com/cal-itp/data-analyses/blob/main/_shared_utils/shared_utils/schedule_gtfs_keys_multi_orgs.py#L9-L17)
 
 (other-common-github-issues-encountered-during-saving-codes)=
 

--- a/docs/analytics_tools/saving_code.md
+++ b/docs/analytics_tools/saving_code.md
@@ -15,6 +15,7 @@ Doing work locally and pushing directly from the command line is a similar workf
    - The `main` branch is ahead, and I want to [sync my branch with `main`](#rebase-and-merge)
    - [Rebase](#rebase) or [merge](#merge)
    - Options to [Resolve Merge Conflicts](#resolve-merge-conflicts)
+   - Options to [Resolve pre-commit issues](#resolve-pre-commit-hook-issues)
    - [Other Common Issues](#other-common-github-issues-encountered-during-saving-codes)
 
 3. [Other Common GitHub Commands](#other-common-github-commands)
@@ -115,6 +116,19 @@ If you discover merge conflicts and they are within a single notebook that only 
   - To keep the remote version, run:<br/>
     `git checkout --theirs path/to/notebook.ipynb`
 - From here, just add the file and commit with a message as you normally would and the conflict should be fixed in your Pull Request.
+
+(resolve-pre-commit-hook-issues)=
+
+### Options for Resolving Pre-commit issues
+
+Pre-commit checks are used to ensure our code meets our quality standards and fix fomatting issues before being commited to the remote repo. If your Pull Request or files are failing the pre-commit checks, try these steps to resolve them.
+
+- In the root repo, run `pip install pre-commit` and `pre-commit install`. Speifically, if you are in the root of the `data-analyses` repo you can run `make add_precommit` to run the same commands.
+- Run `git add` and `git commit` like normal. The pre-commit checks will run and identify any errors it finds, automatically correct errors it can do, and identify errors that need manual changes.
+- If you are not able to `git push` your commit and get a `Everything up-to-date` message, or if your PR is failing the pre-commit check, then run `pre-commit run --all-files`. This will run the pre-commit check on all files.
+- Address any manual changes the check identifies ("E402 module level import not at top of file", "\<> imported but unused", "expected 2 blank lines, found 1", etc.)
+- Run `pre-commit run --all-files`, address manual changes again until all checks are passing,
+- Then you can `git add` the adjusted files,`git commit`, `git push` again.
 
 (other-common-github-issues-encountered-during-saving-codes)=
 


### PR DESCRIPTION
# Description

Adding a new section to the Cal-ITP, Saving Code doc page about resolving pre-commit check failures.

For now, creating a new section called `Options for Resolving Pre-commit issues` inbetween the `Options for Resolving Merge Conflicts... Other Common Issues` section (same heading level). Similar language to the `Installing and Using pre-commit hooks` of the `Submitting Changes` doc page, but more in-depth.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?



## Post-merge follow-ups


- [x] No action required
- [ ] Actions required (specified below)
