### PR TITLE
Loosen the version of google-cloud-secret-manager

### DIFF
--- a/packages/calitp-data-infra/poetry.lock
+++ b/packages/calitp-data-infra/poetry.lock
@@ -1544,4 +1544,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.12"
-content-hash = "4443e7e65a08db09c116371cbfaae5bfea544a588975faabe1978609a3e171c4"
+content-hash = "8dd6a7c3e72eb9213a36458af6ee6ddff1db6498438c711e0bb8ffaad022c7c2"

--- a/packages/calitp-data-infra/pyproject.toml
+++ b/packages/calitp-data-infra/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp-data-infra"
-version = "2025.3.24"
+version = "2025.3.25"
 description = "Shared code for developing data pipelines that process Cal-ITP data."
 package-mode = true
 authors = ["Andrew Vaccaro"]
@@ -15,7 +15,7 @@ humanize = "^4.6.0"
 backoff = "^2.2.1"
 google-api-core = ">=1.31.4"
 typing-extensions = ">=3.10.0.2"
-google-cloud-secret-manager = "2.16.4"
+google-cloud-secret-manager = ">=2.16.4,<2.23"
 gcsfs = "!=2022.7.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

The new version of `google-cloud-secret-manager` (>=2.16.4,<2.23) covers the versions pinned in Cloud Composer images from the current image at least up through the latest extended support version (composer-2.10.2-airflow-2.10.2).

Related to #3765 and #3791 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Locally ran tests and linter in Python 3.8 and 3.11 environments using:

```bash
pytest
mypy .
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Merge #3793 
