### PR TITLE
Use airflow deps that resolve cleanly with current and next Cloud Composer images

### DIFF
--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,10 +1,10 @@
-calitp-data-infra==2025.3.24
+calitp-data-infra==2025.3.25
 gusty==0.6.0
 pyairtable==2.2.1
 pydantic>=1.9,<2.0
 typer==0.4.1
 sentry-sdk==1.17.0
-platformdirs<3,>=2.5
-boto3==1.26.87
+platformdirs>=2.5
+boto3>=1.26.87,<2
 openpyxl==3.1.5
 beautifulsoup4==4.12.3


### PR DESCRIPTION
# Description

Includes dependencies compatible with `composer-2.6.5-airflow-2.5.3` and `composer-2.8.3-airflow-2.6.3`

Resolves #3765
Supersedes #3791 
**Merge _after_ #3792**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

In addition to building the image, explicitly resolved dependencies by running the following in a Python 3.8 environment:

```bash
uv pip install -r requirements-composer-2.6.5-airflow-2.5.3.txt -r requirements.txt --dry-run
```

... and the following in a Python 3.11 environment:

```bash
uv pip install -r requirements-composer-2.8.3-airflow-2.6.3.txt -r requirements.txt --dry-run
```

Both commands were successful with the new version pins.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

This new set of requirements will be deployed to Cloud Composer. After that is done we should verify that Google thinks we're good to upgrade:

```bash
gcloud beta composer environments check-upgrade \
  calitp-airflow2-prod-composer2-patch \
  --location us-west2 \
  --project cal-itp-data-infra \
  --image-version composer-2.8.3-airflow-2.6.3
```

... pause all DAGs in the environment, create a snapshot:

```bash
gcloud composer environments snapshots save \
  calitp-airflow2-prod-composer2-patch \
  --location us-west2 \
  --project cal-itp-data-infra
```

... run the upgrade:

```bash
gcloud composer environments update \
  calitp-airflow2-prod-composer2-patch \
  --location us-west2 \
  --project cal-itp-data-infra \
  --image-version composer-2.6.5-airflow-2.5.3
```

... and then unpause the DAGs one-by-one.

These steps are documented in https://docs.google.com/document/d/1ZajlwMGpbH_Gc3gLvcIISDwJ7rVghF8eEw7Y1aKFOQc/edit?pli=1&tab=t.0#heading=h.kcefhx2vr74p.