### PR TITLE
use service_date for fct_vp_grouped table settings

### DIFF
--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
@@ -3,11 +3,11 @@
         materialized='incremental',
         incremental_strategy='insert_overwrite',
         partition_by = {
-            'field': 'dt',
+            'field': 'service_date',
             'data_type': 'date',
             'granularity': 'day',
         },
-        cluster_by=['dt', 'base64_url'],
+        cluster_by=['service_date', 'base64_url'],
         on_schema_change='append_new_columns'
     )
 }}
@@ -25,7 +25,7 @@ WITH fct_vehicle_locations AS (
         location,
         -- rather than using next_location_key, use lag to calculate direction from previous
     FROM {{ ref('fct_vehicle_locations') }}
-    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }}
+    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }} AND trip_instance_key IS NOT NULL
 ),
 
 lat_lon AS (


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Fix all the dbt errors related to creating `mart_gtfs.fct_vehicle_positions_grouped`. Erika diagnosed this was due to table settings. We can remove `dt` and use `service_date`, since `dt` was needed in `fct_vehicle_locations`, but once we make this table downstream, we'll use `service_date`. [Slack discussion](https://cal-itp.slack.com/archives/C01FNDG1ZPA/p1742490672202539)

Part of #3645

Related to #3660, #3672, #3771

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (vp-grouped-table-settings) $ poetry run dbt run -s fct_vehicle_locations_grouped --full-refresh
17:56:49  Running with dbt=1.5.1
17:56:52  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.staging.ntd
17:56:53  Found 582 models, 1061 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 217 sources, 4 exposures, 0 metrics, 0 groups
17:56:53  
17:56:56  Concurrency: 8 threads (target='dev')
17:56:56  
17:56:56  1 of 1 START sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [RUN]
17:57:14  1 of 1 OK created sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_grouped  [CREATE TABLE (73.2m rows, 30.7 GiB processed) in 17.78s]
17:57:14  
17:57:14  Finished running 1 incremental model in 0 hours 0 minutes and 21.02 seconds (21.02s).
17:57:15  
17:57:15  Completed successfully
17:57:15  
17:57:15  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (vp-grouped-table-settings) $ poetry run dbt test -s fct_vehicle_locations_grouped
17:57:33  Running with dbt=1.5.1
17:57:36  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.calitp_warehouse.staging.ntd
17:57:37  Found 582 models, 1061 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 217 sources, 4 exposures, 0 metrics, 0 groups
17:57:37  
17:57:45  Concurrency: 8 threads (target='dev')
17:57:45  
17:57:45  1 of 1 START test not_null_fct_vehicle_locations_grouped_trip_instance_key ..... [RUN]
17:57:46  1 of 1 PASS not_null_fct_vehicle_locations_grouped_trip_instance_key ........... [PASS in 0.98s]
17:57:46  
17:57:46  Finished running 1 test in 0 hours 0 minutes and 9.19 seconds (9.19s).
17:57:46  
17:57:46  Completed successfully
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required - wait for Sunday's full refresh
- [ ] Actions required (specified below)
