### PR TITLE
Fix dt error on fct_vehicle_locations_grouped

### DIFF
--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
@@ -25,7 +25,8 @@ WITH fct_vehicle_locations AS (
         location,
         -- rather than using next_location_key, use lag to calculate direction from previous
     FROM {{ ref('fct_vehicle_locations') }}
-    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }} AND trip_instance_key IS NOT NULL
+    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START', this_dt_column='service_date') }}
+    AND trip_instance_key IS NOT NULL
 ),
 
 lat_lon AS (
@@ -103,7 +104,7 @@ vp_grouper AS (
     FROM direction
 ),
 
-fct_grouped_locations AS (
+fct_vehicle_locations_grouped AS (
     SELECT
         fct_vehicle_locations.gtfs_dataset_key,
         fct_vehicle_locations.base64_url,
@@ -124,4 +125,4 @@ fct_grouped_locations AS (
     GROUP BY gtfs_dataset_key, base64_url, gtfs_dataset_name, schedule_gtfs_dataset_key, service_date, trip_instance_key, vp_group, ST_ASTEXT(fct_vehicle_locations.location)
 )
 
-SELECT * FROM fct_grouped_locations
+SELECT * FROM fct_vehicle_locations_grouped

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_grouped.sql
@@ -1,17 +1,3 @@
-{{
-    config(
-        materialized='incremental',
-        incremental_strategy='insert_overwrite',
-        partition_by = {
-            'field': 'service_date',
-            'data_type': 'date',
-            'granularity': 'day',
-        },
-        cluster_by=['service_date', 'base64_url'],
-        on_schema_change='append_new_columns'
-    )
-}}
-
 WITH fct_vehicle_locations AS (
    SELECT
         key,


### PR DESCRIPTION
# Description

This PR fixes error `Unrecognized name: dt at [3:17]` on fct_vehicle_locations_grouped by adding the correct column name to macro `incremental_where` = `this_dt_column='service_date'`.

As requested by @vevetron  I removed the materialization of the table.

[#3790]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally.

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/2f9bc99a-c78d-464e-86e2-06f94f363765" />
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/d3db4bce-3be0-45e6-acf8-fb5a43da598f" />

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After merging the code, we need to run a full-refresh to remove the materialization.
Verify if transform_warehouse is running successfully after the full refresh.