### PR TITLE
modify organization tables for enrichment

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
@@ -10,6 +10,21 @@ WITH dim AS (
         ) }}
 ),
 
+agency_info AS (
+    SELECT
+        id AS agency_info_id,
+        ntd_id
+    FROM {{ ref('stg_transit_database__ntd_agency_info') }}
+),
+
+join_for_ntd_id AS (
+    SELECT
+        dim.*,
+        agency_info.ntd_id
+    FROM dim
+    LEFT JOIN join_for_ntd_id ON dim.ntd_agency_info_key = agency_info.agency_info_id
+)
+
 int_transit_database__organizations_dim AS (
     SELECT
         {{ dbt_utils.generate_surrogate_key(['id', '_valid_from']) }} AS key,
@@ -35,6 +50,7 @@ int_transit_database__organizations_dim AS (
         manual_check__contact_on_website,
         hq_county_geography,
         is_public_entity,
+        ntd_id,
         raw_ntd_id,
         ntd_id_2022,
         rtpa,
@@ -44,6 +60,6 @@ int_transit_database__organizations_dim AS (
         _is_current,
         _valid_from,
         _valid_to
-    FROM dim
+    FROM join_for_ntd_id
 )
 SELECT * FROM int_transit_database__organizations_dim

--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
@@ -12,9 +12,9 @@ WITH dim AS (
 
 agency_info AS (
     SELECT
-        id AS agency_info_id,
+        source_record_id,
         ntd_id
-    FROM {{ ref('stg_transit_database__ntd_agency_info') }}
+    FROM {{ ref('int_transit_database__ntd_agency_info_dim') }}
 ),
 
 join_for_ntd_id AS (
@@ -22,8 +22,8 @@ join_for_ntd_id AS (
         dim.*,
         agency_info.ntd_id
     FROM dim
-    LEFT JOIN join_for_ntd_id ON dim.ntd_agency_info_key = agency_info.agency_info_id
-)
+    LEFT JOIN agency_info ON dim.ntd_agency_info_key = agency_info.source_record_id
+),
 
 int_transit_database__organizations_dim AS (
     SELECT

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -37,9 +37,7 @@ dim_organizations AS (
         -- use same May 23, 2023 cutover date as `assessment_status` --> `public_currently_operating` in downstream models for consistency
         CASE
             WHEN _valid_from >= '2023-05-23' THEN raw_ntd_id
-            -- is this substitution appropriate?
             ELSE ntd_id
-            -- previously: ELSE ntd_to_org.ntd_id
         END AS ntd_id,
         ntd_agency_info_key,
         ntd_id_2022,

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -4,10 +4,6 @@ WITH dim AS (
     SELECT * FROM {{ ref('int_transit_database__organizations_dim') }}
 ),
 
--- ntd_agency_to_organization AS (
---     SELECT * FROM {{ ref('_deprecated__ntd_agency_to_organization') }}
--- ),
-
 mpo_rtpa AS (
     SELECT
         key,
@@ -59,8 +55,6 @@ dim_organizations AS (
         _valid_to
 
     FROM dim
-    -- LEFT JOIN ntd_agency_to_organization ntd_to_org
-    --     ON source_record_id = ntd_to_org.organization_record_id
     LEFT JOIN mpo_rtpa mr_rtpa ON dim.rtpa = mr_rtpa.source_record_id
     LEFT JOIN mpo_rtpa mr_mpo ON dim.mpo = mr_mpo.source_record_id
 

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -39,9 +39,8 @@ dim_organizations AS (
             WHEN _valid_from >= '2023-05-23' THEN raw_ntd_id
             -- is this substitution appropriate?
             ELSE ntd_id
-            -- ELSE ntd_to_org.ntd_id
+            -- previously: ELSE ntd_to_org.ntd_id
         END AS ntd_id,
-        -- how to appropriately use ntd_agency_info_key?
         ntd_agency_info_key,
         ntd_id_2022,
         mr_rtpa.key AS rtpa_key,

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -38,7 +38,7 @@ dim_organizations AS (
         CASE
             WHEN _valid_from >= '2023-05-23' THEN raw_ntd_id
             -- is this substitution appropriate?
-            ELSE ntd_id_2022
+            ELSE ntd_id
             -- ELSE ntd_to_org.ntd_id
         END AS ntd_id,
         -- how to appropriately use ntd_agency_info_key?

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -4,9 +4,9 @@ WITH dim AS (
     SELECT * FROM {{ ref('int_transit_database__organizations_dim') }}
 ),
 
-ntd_agency_to_organization AS (
-    SELECT * FROM {{ ref('_deprecated__ntd_agency_to_organization') }}
-),
+-- ntd_agency_to_organization AS (
+--     SELECT * FROM {{ ref('_deprecated__ntd_agency_to_organization') }}
+-- ),
 
 mpo_rtpa AS (
     SELECT
@@ -41,8 +41,12 @@ dim_organizations AS (
         -- use same May 23, 2023 cutover date as `assessment_status` --> `public_currently_operating` in downstream models for consistency
         CASE
             WHEN _valid_from >= '2023-05-23' THEN raw_ntd_id
-            ELSE ntd_to_org.ntd_id
+            -- is this substitution appropriate?
+            ELSE ntd_id_2022
+            -- ELSE ntd_to_org.ntd_id
         END AS ntd_id,
+        -- how to appropriately use ntd_agency_info_key?
+        ntd_agency_info_key,
         ntd_id_2022,
         mr_rtpa.key AS rtpa_key,
         mr_rtpa.name AS rtpa_name,
@@ -55,8 +59,8 @@ dim_organizations AS (
         _valid_to
 
     FROM dim
-    LEFT JOIN ntd_agency_to_organization ntd_to_org
-        ON source_record_id = ntd_to_org.organization_record_id
+    -- LEFT JOIN ntd_agency_to_organization ntd_to_org
+    --     ON source_record_id = ntd_to_org.organization_record_id
     LEFT JOIN mpo_rtpa mr_rtpa ON dim.rtpa = mr_rtpa.source_record_id
     LEFT JOIN mpo_rtpa mr_mpo ON dim.mpo = mr_mpo.source_record_id
 

--- a/warehouse/models/mart/transit_database_latest/dim_organizations_latest_with_caltrans_district.sql
+++ b/warehouse/models/mart/transit_database_latest/dim_organizations_latest_with_caltrans_district.sql
@@ -1,0 +1,56 @@
+WITH
+current_organizations AS (
+    SELECT * FROM {{ ref('dim_organizations') }}
+    WHERE _is_current
+),
+
+bridge_organizations_x_headquarters_county_geography_latest AS (
+    SELECT * FROM {{ ref('bridge_organizations_x_headquarters_county_geography') }}
+    WHERE _is_current
+),
+
+dim_county_geography_latest AS (
+    SELECT * FROM {{ ref('dim_county_geography') }}
+    WHERE _is_current
+),
+
+dim_organizations_latest_with_caltrans_district AS (
+    SELECT
+        co.key,
+        co.source_record_id,
+        co.name,
+        co.organization_type,
+        co.roles,
+        co.itp_id,
+        co.ntd_agency_info_key,
+        co.details,
+        co.website,
+        co.reporting_category,
+        co.hubspot_company_record_id,
+        co.gtfs_static_status,
+        co.gtfs_realtime_status,
+        co._deprecated__assessment_status,
+        co.manual_check__contact_on_website,
+        co.alias,
+        co.is_public_entity,
+        co.public_currently_operating,
+        co.public_currently_operating_fixed_route,
+        co.ntd_id,
+        co.ntd_id_2022,
+        co.rtpa_key,
+        co.rtpa_name,
+        co.mpo_key,
+        co.mpo_name,
+
+        dcgl.caltrans_district,
+        dcgl.caltrans_district_name,
+
+        co._is_current,
+        co._valid_from,
+        co._valid_to
+    FROM current_organizations AS co
+        LEFT JOIN bridge_organizations_x_headquarters_county_geography_latest ON co.key = bridge_organizations_x_headquarters_county_geography_latest.organization_key
+        LEFT JOIN dim_county_geography_latest AS dcgl ON bridge_organizations_x_headquarters_county_geography_latest.county_geography_key = dcgl.key
+)
+
+SELECT * FROM dim_organizations_latest_with_caltrans_district

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -22,7 +22,7 @@ stg_transit_database__organizations AS (
             WHEN id = 'rec2DteW2sfmBJRsH' AND itp_id = 188 THEN 187
             ELSE CAST(itp_id AS INTEGER)
         END AS itp_id,
-        {{ trim_make_empty_string_null(unnested_ntd_records) }} AS ntd_agency_info_key,
+        {{ trim_make_empty_string_null('unnested_ntd_records') }} AS ntd_agency_info_key,
         hubspot_company_record_id,
         alias_ as alias,
         details,

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -22,7 +22,7 @@ stg_transit_database__organizations AS (
             WHEN id = 'rec2DteW2sfmBJRsH' AND itp_id = 188 THEN 187
             ELSE CAST(itp_id AS INTEGER)
         END AS itp_id,
-        unnested_ntd_records AS ntd_agency_info_key,
+        {{ trim_make_empty_string_null(unnested_ntd_records) }} AS ntd_agency_info_key,
         hubspot_company_record_id,
         alias_ as alias,
         details,


### PR DESCRIPTION
# Description

This PR seeks to replace the deprecated use of `_deprecated__ntd_agency_to_organization` in `dim_organizations` with the appropriate alternative to determine ntd_id, as well as create a `dim_organizations_latest_with_caltrans_district` which is latest only and enriched with `caltrans_district`, and perform some other cleanup tasks as outlined below:

Refactor mart_transit_database.dim_organizations:
* remove deprecated use of `_deprecated__ntd_agency_to_organization`
* instead, utilize `ntd_id` via `ntd_agency_info_key` from `int_transit_database__ntd_agency_info_dim`
* **Remaining Questions**
  * Is this an appropriate substitution and use of ntd_id?
  * Should we be incorporating versioned use of ntd_id/caltrans district

create mart_transit_database_latest.dim_organizations_latest_with_caltrans_district
* latest only
* enriched with caltrans district and name

Data type handling in stg_transit_database__organizations:
* Cast unnested_ntd_records/ntd_agency_info_key as string appropriately

Partially resolves: #3709 

Replaces: #3608, #3710 

## Type of change
- [x] New feature

## How has this been tested?
poetry run dbt run +dim_organizations_latest_with_caltrans_district
<img width="1120" alt="Screenshot 2025-04-08 at 13 28 07" src="https://github.com/user-attachments/assets/8def1e58-f34c-4bba-94bc-f3230e9e58aa" />


## Post-merge follow-ups
- [x] No action required
