### PR TITLE
Adds gcs editor role to terraform service account

### DIFF
--- a/iac/README.md
+++ b/iac/README.md
@@ -4,15 +4,20 @@ This subdirectory contains the Terraform configuration for Google Cloud.
 
 
 ## Local Development Setup
+You will need to do these steps.
 
 Install Terraform via ASDF:
 
 ```bash
+$ brew install asdf
 $ asdf plugin add terraform https://github.com/asdf-community/asdf-hashicorp.git
 $ asdf install terraform 1.10.5
 $ asdf set terraform 1.10.5
 $ asdf reshim
 ```
+
+You may need to add this to your ~/.bashrc
+```export PATH="$HOME/.asdf/bin:$HOME/.asdf/shims:$PATH"```
 
 Create the `iac/provider.tf` file containing the following provider definition:
 
@@ -48,6 +53,7 @@ $ make plan
 
 
 ## Importing Resources
+This is what we did to first derive the terraform environment.  You will not need to do this ever again (heaven forbid).
 
 To install Terraformer:
 
@@ -70,7 +76,7 @@ You'll need to move the imported resources to the correct directory:
 $ mv generated/google/cal-itp-data-infra-staging/gcs cal-itp-data-infra-staging/gcs
 ```
 
-Then, you'll need to run `terraform init` in the new directory. See below for a common error and resolution.
+Then, you'll need to run `terraform init` in the new directory, `cal-itp-data-infra-staging/gcs`. See below for a common error and resolution.
 
 Once that completes, modify the `provider.tf` file to add the storage bucket:
 

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -541,7 +541,8 @@ resource "google_project_iam_member" "tfer--roles-002F-viewerserviceAccount-003A
 resource "google_project_iam_member" "tfer--terraform-membership" {
   for_each = toset([
     "roles/resourcemanager.projectIamAdmin",
-    "roles/editor"
+    "roles/editor",
+    "roles/storage.admin"
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.tfer--terraform.email}"


### PR DESCRIPTION
# Description
Terraform was unable to manage storage buckets.  This should give the terraform service account an additional role for more powar!!


Resolves #3775 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Nope.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Monitor Terraform Plan / Apply