### PR TITLE
Add lifecyle rule to delete old data on dev and test buckets

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -110,10 +110,6 @@ output "google_storage_bucket_acl_tfer--calitp-gtfs-schedule-validation_id" {
   value = google_storage_bucket_acl.tfer--calitp-gtfs-schedule-validation.id
 }
 
-output "google_storage_bucket_acl_tfer--calitp-jamesl-gcp-components-tfstate_id" {
-  value = google_storage_bucket_acl.tfer--calitp-jamesl-gcp-components-tfstate.id
-}
-
 output "google_storage_bucket_acl_tfer--calitp-map-tiles_id" {
   value = google_storage_bucket_acl.tfer--calitp-map-tiles.id
 }
@@ -168,14 +164,6 @@ output "google_storage_bucket_acl_tfer--calitp-state-geoportal-scrape_id" {
 
 output "google_storage_bucket_acl_tfer--calitp-state-highway-network-stops_id" {
   value = google_storage_bucket_acl.tfer--calitp-state-highway-network-stops.id
-}
-
-output "google_storage_bucket_acl_tfer--cold-storage-outputs-gtfs-data-test-charlie-test_id" {
-  value = google_storage_bucket_acl.tfer--cold-storage-outputs-gtfs-data-test-charlie-test.id
-}
-
-output "google_storage_bucket_acl_tfer--cold-storage-outputs-gtfs-data-test_id" {
-  value = google_storage_bucket_acl.tfer--cold-storage-outputs-gtfs-data-test.id
 }
 
 output "google_storage_bucket_acl_tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp_id" {
@@ -518,10 +506,6 @@ output "google_storage_bucket_iam_binding_tfer--calitp-gtfs-schedule-validation_
   value = google_storage_bucket_iam_binding.tfer--calitp-gtfs-schedule-validation.id
 }
 
-output "google_storage_bucket_iam_binding_tfer--calitp-jamesl-gcp-components-tfstate_id" {
-  value = google_storage_bucket_iam_binding.tfer--calitp-jamesl-gcp-components-tfstate.id
-}
-
 output "google_storage_bucket_iam_binding_tfer--calitp-map-tiles_id" {
   value = google_storage_bucket_iam_binding.tfer--calitp-map-tiles.id
 }
@@ -576,14 +560,6 @@ output "google_storage_bucket_iam_binding_tfer--calitp-state-geoportal-scrape_id
 
 output "google_storage_bucket_iam_binding_tfer--calitp-state-highway-network-stops_id" {
   value = google_storage_bucket_iam_binding.tfer--calitp-state-highway-network-stops.id
-}
-
-output "google_storage_bucket_iam_binding_tfer--cold-storage-outputs-gtfs-data-test-charlie-test_id" {
-  value = google_storage_bucket_iam_binding.tfer--cold-storage-outputs-gtfs-data-test-charlie-test.id
-}
-
-output "google_storage_bucket_iam_binding_tfer--cold-storage-outputs-gtfs-data-test_id" {
-  value = google_storage_bucket_iam_binding.tfer--cold-storage-outputs-gtfs-data-test.id
 }
 
 output "google_storage_bucket_iam_binding_tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp_id" {
@@ -926,10 +902,6 @@ output "google_storage_bucket_iam_member_tfer--calitp-gtfs-schedule-validation_i
   value = google_storage_bucket_iam_member.tfer--calitp-gtfs-schedule-validation.id
 }
 
-output "google_storage_bucket_iam_member_tfer--calitp-jamesl-gcp-components-tfstate_id" {
-  value = google_storage_bucket_iam_member.tfer--calitp-jamesl-gcp-components-tfstate.id
-}
-
 output "google_storage_bucket_iam_member_tfer--calitp-map-tiles_id" {
   value = google_storage_bucket_iam_member.tfer--calitp-map-tiles.id
 }
@@ -984,14 +956,6 @@ output "google_storage_bucket_iam_member_tfer--calitp-state-geoportal-scrape_id"
 
 output "google_storage_bucket_iam_member_tfer--calitp-state-highway-network-stops_id" {
   value = google_storage_bucket_iam_member.tfer--calitp-state-highway-network-stops.id
-}
-
-output "google_storage_bucket_iam_member_tfer--cold-storage-outputs-gtfs-data-test-charlie-test_id" {
-  value = google_storage_bucket_iam_member.tfer--cold-storage-outputs-gtfs-data-test-charlie-test.id
-}
-
-output "google_storage_bucket_iam_member_tfer--cold-storage-outputs-gtfs-data-test_id" {
-  value = google_storage_bucket_iam_member.tfer--cold-storage-outputs-gtfs-data-test.id
 }
 
 output "google_storage_bucket_iam_member_tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp_id" {
@@ -1334,10 +1298,6 @@ output "google_storage_bucket_iam_policy_tfer--calitp-gtfs-schedule-validation_i
   value = google_storage_bucket_iam_policy.tfer--calitp-gtfs-schedule-validation.id
 }
 
-output "google_storage_bucket_iam_policy_tfer--calitp-jamesl-gcp-components-tfstate_id" {
-  value = google_storage_bucket_iam_policy.tfer--calitp-jamesl-gcp-components-tfstate.id
-}
-
 output "google_storage_bucket_iam_policy_tfer--calitp-map-tiles_id" {
   value = google_storage_bucket_iam_policy.tfer--calitp-map-tiles.id
 }
@@ -1392,14 +1352,6 @@ output "google_storage_bucket_iam_policy_tfer--calitp-state-geoportal-scrape_id"
 
 output "google_storage_bucket_iam_policy_tfer--calitp-state-highway-network-stops_id" {
   value = google_storage_bucket_iam_policy.tfer--calitp-state-highway-network-stops.id
-}
-
-output "google_storage_bucket_iam_policy_tfer--cold-storage-outputs-gtfs-data-test-charlie-test_id" {
-  value = google_storage_bucket_iam_policy.tfer--cold-storage-outputs-gtfs-data-test-charlie-test.id
-}
-
-output "google_storage_bucket_iam_policy_tfer--cold-storage-outputs-gtfs-data-test_id" {
-  value = google_storage_bucket_iam_policy.tfer--cold-storage-outputs-gtfs-data-test.id
 }
 
 output "google_storage_bucket_iam_policy_tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp_id" {
@@ -1854,14 +1806,6 @@ output "google_storage_bucket_tfer--calitp-gtfs-schedule-validation_self_link" {
   value = google_storage_bucket.tfer--calitp-gtfs-schedule-validation.self_link
 }
 
-output "google_storage_bucket_tfer--calitp-jamesl-gcp-components-tfstate_name" {
-  value = google_storage_bucket.tfer--calitp-jamesl-gcp-components-tfstate.name
-}
-
-output "google_storage_bucket_tfer--calitp-jamesl-gcp-components-tfstate_self_link" {
-  value = google_storage_bucket.tfer--calitp-jamesl-gcp-components-tfstate.self_link
-}
-
 output "google_storage_bucket_tfer--calitp-map-tiles_name" {
   value = google_storage_bucket.tfer--calitp-map-tiles.name
 }
@@ -1972,22 +1916,6 @@ output "google_storage_bucket_tfer--calitp-state-highway-network-stops_name" {
 
 output "google_storage_bucket_tfer--calitp-state-highway-network-stops_self_link" {
   value = google_storage_bucket.tfer--calitp-state-highway-network-stops.self_link
-}
-
-output "google_storage_bucket_tfer--cold-storage-outputs-gtfs-data-test-charlie-test_name" {
-  value = google_storage_bucket.tfer--cold-storage-outputs-gtfs-data-test-charlie-test.name
-}
-
-output "google_storage_bucket_tfer--cold-storage-outputs-gtfs-data-test-charlie-test_self_link" {
-  value = google_storage_bucket.tfer--cold-storage-outputs-gtfs-data-test-charlie-test.self_link
-}
-
-output "google_storage_bucket_tfer--cold-storage-outputs-gtfs-data-test_name" {
-  value = google_storage_bucket.tfer--cold-storage-outputs-gtfs-data-test.name
-}
-
-output "google_storage_bucket_tfer--cold-storage-outputs-gtfs-data-test_self_link" {
-  value = google_storage_bucket.tfer--cold-storage-outputs-gtfs-data-test.self_link
 }
 
 output "google_storage_bucket_tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp_name" {
@@ -2562,10 +2490,6 @@ output "google_storage_default_object_acl_tfer--calitp-gtfs-schedule-validation_
   value = google_storage_default_object_acl.tfer--calitp-gtfs-schedule-validation.id
 }
 
-output "google_storage_default_object_acl_tfer--calitp-jamesl-gcp-components-tfstate_id" {
-  value = google_storage_default_object_acl.tfer--calitp-jamesl-gcp-components-tfstate.id
-}
-
 output "google_storage_default_object_acl_tfer--calitp-map-tiles_id" {
   value = google_storage_default_object_acl.tfer--calitp-map-tiles.id
 }
@@ -2620,14 +2544,6 @@ output "google_storage_default_object_acl_tfer--calitp-state-geoportal-scrape_id
 
 output "google_storage_default_object_acl_tfer--calitp-state-highway-network-stops_id" {
   value = google_storage_default_object_acl.tfer--calitp-state-highway-network-stops.id
-}
-
-output "google_storage_default_object_acl_tfer--cold-storage-outputs-gtfs-data-test-charlie-test_id" {
-  value = google_storage_default_object_acl.tfer--cold-storage-outputs-gtfs-data-test-charlie-test.id
-}
-
-output "google_storage_default_object_acl_tfer--cold-storage-outputs-gtfs-data-test_id" {
-  value = google_storage_default_object_acl.tfer--cold-storage-outputs-gtfs-data-test.id
 }
 
 output "google_storage_default_object_acl_tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp_id" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -672,6 +672,21 @@ resource "google_storage_bucket" "tfer--dev-calitp-aggregator-scraper" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--dev-calitp-gtfs-rt-raw" {
@@ -684,6 +699,21 @@ resource "google_storage_bucket" "tfer--dev-calitp-gtfs-rt-raw" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--dev-calitp-test-sandbox" {
@@ -764,6 +794,21 @@ resource "google_storage_bucket" "tfer--gtfs-data-test" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--gtfs-data-test-reports" {
@@ -780,6 +825,21 @@ resource "google_storage_bucket" "tfer--gtfs-data-test-reports" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--gtfs-schedule-backfill-test" {
@@ -917,6 +977,21 @@ resource "google_storage_bucket" "tfer--test-calitp-aggregator-scraper" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-airtable" {
@@ -929,6 +1004,21 @@ resource "google_storage_bucket" "tfer--test-calitp-airtable" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-dbt-artifacts" {
@@ -941,6 +1031,21 @@ resource "google_storage_bucket" "tfer--test-calitp-dbt-artifacts" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-dbt-python-models" {
@@ -953,6 +1058,21 @@ resource "google_storage_bucket" "tfer--test-calitp-dbt-python-models" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-elavon" {
@@ -965,25 +1085,10 @@ resource "google_storage_bucket" "tfer--test-calitp-elavon" {
     }
 
     condition {
-      age                        = "0"
+      age                        = "30"
       created_before             = ""
       days_since_custom_time     = "0"
       days_since_noncurrent_time = "0"
-      num_newer_versions         = "1"
-      with_state                 = "ARCHIVED"
-    }
-  }
-
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-
-    condition {
-      age                        = "0"
-      created_before             = ""
-      days_since_custom_time     = "0"
-      days_since_noncurrent_time = "7"
       num_newer_versions         = "0"
       with_state                 = "ANY"
     }
@@ -998,7 +1103,7 @@ resource "google_storage_bucket" "tfer--test-calitp-elavon" {
   uniform_bucket_level_access = "true"
 
   versioning {
-    enabled = "true"
+    enabled = "false"
   }
 }
 
@@ -1012,6 +1117,21 @@ resource "google_storage_bucket" "tfer--test-calitp-elavon-parsed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-elavon-raw" {
@@ -1024,6 +1144,21 @@ resource "google_storage_bucket" "tfer--test-calitp-elavon-raw" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-config" {
@@ -1036,6 +1171,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-config" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-download-config" {
@@ -1048,6 +1198,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-download-config" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-raw" {
@@ -1060,6 +1225,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-raw" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-parsed" {
@@ -1072,6 +1252,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-parsed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-raw" {
@@ -1084,6 +1279,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-raw" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-raw-v2" {
@@ -1096,6 +1306,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-raw-v2" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-validation" {
@@ -1108,6 +1333,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-rt-validation" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-parsed" {
@@ -1120,6 +1360,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-parsed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-parsed-hourly" {
@@ -1132,6 +1387,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-parsed-hourly"
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-processed" {
@@ -1144,24 +1414,48 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-processed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-raw" {
-  default_event_based_hold = "false"
-  force_destroy            = "false"
-  location                 = "US-WEST2"
-  name                     = "test-calitp-gtfs-schedule-raw"
-  project                  = "cal-itp-data-infra"
-  public_access_prevention = "inherited"
-  requester_pays           = "false"
-
-  retention_policy {
-    is_locked        = "false"
-    retention_period = "2678400"
-  }
-
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "test-calitp-gtfs-schedule-raw"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-raw-v2" {
@@ -1174,6 +1468,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-raw-v2" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-raw-v2-backfill-test" {
@@ -1186,6 +1495,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-raw-v2-backfil
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-unzipped" {
@@ -1198,6 +1522,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-unzipped" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-unzipped-hourly" {
@@ -1210,6 +1549,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-unzipped-hourl
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-validation" {
@@ -1222,6 +1576,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-validation" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-validation-hourly" {
@@ -1234,6 +1603,21 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-validation-hou
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-ntd-api-products" {
@@ -1246,6 +1630,21 @@ resource "google_storage_bucket" "tfer--test-calitp-ntd-api-products" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-ntd-report-validation" {
@@ -1258,6 +1657,21 @@ resource "google_storage_bucket" "tfer--test-calitp-ntd-report-validation" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-ntd-xlsx-products-clean" {
@@ -1270,6 +1684,21 @@ resource "google_storage_bucket" "tfer--test-calitp-ntd-xlsx-products-clean" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-ntd-xlsx-products-raw" {
@@ -1282,6 +1711,21 @@ resource "google_storage_bucket" "tfer--test-calitp-ntd-xlsx-products-raw" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-parsed" {
@@ -1294,6 +1738,21 @@ resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-parsed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-raw" {
@@ -1306,6 +1765,21 @@ resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-raw" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-publish" {
@@ -1318,6 +1792,21 @@ resource "google_storage_bucket" "tfer--test-calitp-publish" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-publish-data-analysis" {
@@ -1330,6 +1819,21 @@ resource "google_storage_bucket" "tfer--test-calitp-publish-data-analysis" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-reports-data" {
@@ -1342,6 +1846,21 @@ resource "google_storage_bucket" "tfer--test-calitp-reports-data" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-sentry" {
@@ -1354,6 +1873,21 @@ resource "google_storage_bucket" "tfer--test-calitp-sentry" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-calitp-state-geoportal-scrape" {
@@ -1366,6 +1900,21 @@ resource "google_storage_bucket" "tfer--test-calitp-state-geoportal-scrape" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-rt-parsed" {
@@ -1378,6 +1927,21 @@ resource "google_storage_bucket" "tfer--test-rt-parsed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--test-rt-validations" {
@@ -1390,6 +1954,21 @@ resource "google_storage_bucket" "tfer--test-rt-validations" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--us-002E-artifacts-002E-cal-itp-data-infra-002E-appspot-002E-com" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -437,18 +437,6 @@ resource "google_storage_bucket" "tfer--calitp-gtfs-schedule-validation-hourly" 
   uniform_bucket_level_access = "true"
 }
 
-resource "google_storage_bucket" "tfer--calitp-jamesl-gcp-components-tfstate" {
-  default_event_based_hold    = "false"
-  force_destroy               = "false"
-  location                    = "US-WEST1"
-  name                        = "calitp-jamesl-gcp-components-tfstate"
-  project                     = "cal-itp-data-infra"
-  public_access_prevention    = "enforced"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "true"
-}
-
 resource "google_storage_bucket" "tfer--calitp-map-tiles" {
   cors {
     max_age_seconds = "300"
@@ -628,30 +616,6 @@ resource "google_storage_bucket" "tfer--calitp-state-highway-network-stops" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
-}
-
-resource "google_storage_bucket" "tfer--cold-storage-outputs-gtfs-data-test" {
-  default_event_based_hold    = "false"
-  force_destroy               = "false"
-  location                    = "US"
-  name                        = "cold-storage-outputs-gtfs-data-test"
-  project                     = "cal-itp-data-infra"
-  public_access_prevention    = "inherited"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "false"
-}
-
-resource "google_storage_bucket" "tfer--cold-storage-outputs-gtfs-data-test-charlie-test" {
-  default_event_based_hold    = "false"
-  force_destroy               = "false"
-  location                    = "US"
-  name                        = "cold-storage-outputs-gtfs-data-test-charlie-test"
-  project                     = "cal-itp-data-infra"
-  public_access_prevention    = "inherited"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "false"
 }
 
 resource "google_storage_bucket" "tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
@@ -110,10 +110,6 @@ resource "google_storage_bucket_acl" "tfer--calitp-gtfs-schedule-validation-hour
   bucket = "calitp-gtfs-schedule-validation-hourly"
 }
 
-resource "google_storage_bucket_acl" "tfer--calitp-jamesl-gcp-components-tfstate" {
-  bucket = "calitp-jamesl-gcp-components-tfstate"
-}
-
 resource "google_storage_bucket_acl" "tfer--calitp-map-tiles" {
   bucket = "calitp-map-tiles"
 }
@@ -168,14 +164,6 @@ resource "google_storage_bucket_acl" "tfer--calitp-state-geoportal-scrape" {
 
 resource "google_storage_bucket_acl" "tfer--calitp-state-highway-network-stops" {
   bucket = "calitp-state-highway-network-stops"
-}
-
-resource "google_storage_bucket_acl" "tfer--cold-storage-outputs-gtfs-data-test" {
-  bucket = "cold-storage-outputs-gtfs-data-test"
-}
-
-resource "google_storage_bucket_acl" "tfer--cold-storage-outputs-gtfs-data-test-charlie-test" {
-  bucket = "cold-storage-outputs-gtfs-data-test-charlie-test"
 }
 
 resource "google_storage_bucket_acl" "tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -166,12 +166,6 @@ resource "google_storage_bucket_iam_binding" "tfer--calitp-gtfs-schedule-validat
   role    = "roles/storage.legacyObjectOwner"
 }
 
-resource "google_storage_bucket_iam_binding" "tfer--calitp-jamesl-gcp-components-tfstate" {
-  bucket  = "b/calitp-jamesl-gcp-components-tfstate"
-  members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
-  role    = "roles/storage.legacyObjectOwner"
-}
-
 resource "google_storage_bucket_iam_binding" "tfer--calitp-map-tiles" {
   bucket  = "b/calitp-map-tiles"
   members = ["allUsers"]
@@ -252,18 +246,6 @@ resource "google_storage_bucket_iam_binding" "tfer--calitp-state-geoportal-scrap
 
 resource "google_storage_bucket_iam_binding" "tfer--calitp-state-highway-network-stops" {
   bucket  = "b/calitp-state-highway-network-stops"
-  members = ["projectViewer:cal-itp-data-infra"]
-  role    = "roles/storage.legacyBucketReader"
-}
-
-resource "google_storage_bucket_iam_binding" "tfer--cold-storage-outputs-gtfs-data-test" {
-  bucket  = "b/cold-storage-outputs-gtfs-data-test"
-  members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
-  role    = "roles/storage.legacyBucketOwner"
-}
-
-resource "google_storage_bucket_iam_binding" "tfer--cold-storage-outputs-gtfs-data-test-charlie-test" {
-  bucket  = "b/cold-storage-outputs-gtfs-data-test-charlie-test"
   members = ["projectViewer:cal-itp-data-infra"]
   role    = "roles/storage.legacyBucketReader"
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -166,12 +166,6 @@ resource "google_storage_bucket_iam_member" "tfer--calitp-gtfs-schedule-validati
   role   = "roles/storage.legacyObjectOwner"
 }
 
-resource "google_storage_bucket_iam_member" "tfer--calitp-jamesl-gcp-components-tfstate" {
-  bucket = "b/calitp-jamesl-gcp-components-tfstate"
-  member = "projectViewer:cal-itp-data-infra"
-  role   = "roles/storage.legacyObjectReader"
-}
-
 resource "google_storage_bucket_iam_member" "tfer--calitp-map-tiles" {
   bucket = "b/calitp-map-tiles"
   member = "projectEditor:cal-itp-data-infra"
@@ -254,18 +248,6 @@ resource "google_storage_bucket_iam_member" "tfer--calitp-state-highway-network-
   bucket = "b/calitp-state-highway-network-stops"
   member = "projectViewer:cal-itp-data-infra"
   role   = "roles/storage.legacyObjectReader"
-}
-
-resource "google_storage_bucket_iam_member" "tfer--cold-storage-outputs-gtfs-data-test" {
-  bucket = "b/cold-storage-outputs-gtfs-data-test"
-  member = "projectViewer:cal-itp-data-infra"
-  role   = "roles/storage.legacyBucketReader"
-}
-
-resource "google_storage_bucket_iam_member" "tfer--cold-storage-outputs-gtfs-data-test-charlie-test" {
-  bucket = "b/cold-storage-outputs-gtfs-data-test-charlie-test"
-  member = "projectEditor:cal-itp-data-infra"
-  role   = "roles/storage.legacyBucketOwner"
 }
 
 resource "google_storage_bucket_iam_member" "tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -1092,43 +1092,6 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-gtfs-schedule-validati
 POLICY
 }
 
-resource "google_storage_bucket_iam_policy" "tfer--calitp-jamesl-gcp-components-tfstate" {
-  bucket = "b/calitp-jamesl-gcp-components-tfstate"
-
-  policy_data = <<POLICY
-{
-  "bindings": [
-    {
-      "members": [
-        "projectEditor:cal-itp-data-infra",
-        "projectOwner:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyBucketOwner"
-    },
-    {
-      "members": [
-        "projectViewer:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyBucketReader"
-    },
-    {
-      "members": [
-        "projectEditor:cal-itp-data-infra",
-        "projectOwner:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyObjectOwner"
-    },
-    {
-      "members": [
-        "projectViewer:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyObjectReader"
-    }
-  ]
-}
-POLICY
-}
-
 resource "google_storage_bucket_iam_policy" "tfer--calitp-map-tiles" {
   bucket = "b/calitp-map-tiles"
 
@@ -1665,54 +1628,6 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-state-highway-network-
         "projectViewer:cal-itp-data-infra"
       ],
       "role": "roles/storage.legacyObjectReader"
-    }
-  ]
-}
-POLICY
-}
-
-resource "google_storage_bucket_iam_policy" "tfer--cold-storage-outputs-gtfs-data-test" {
-  bucket = "b/cold-storage-outputs-gtfs-data-test"
-
-  policy_data = <<POLICY
-{
-  "bindings": [
-    {
-      "members": [
-        "projectEditor:cal-itp-data-infra",
-        "projectOwner:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyBucketOwner"
-    },
-    {
-      "members": [
-        "projectViewer:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyBucketReader"
-    }
-  ]
-}
-POLICY
-}
-
-resource "google_storage_bucket_iam_policy" "tfer--cold-storage-outputs-gtfs-data-test-charlie-test" {
-  bucket = "b/cold-storage-outputs-gtfs-data-test-charlie-test"
-
-  policy_data = <<POLICY
-{
-  "bindings": [
-    {
-      "members": [
-        "projectEditor:cal-itp-data-infra",
-        "projectOwner:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyBucketOwner"
-    },
-    {
-      "members": [
-        "projectViewer:cal-itp-data-infra"
-      ],
-      "role": "roles/storage.legacyBucketReader"
     }
   ]
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
@@ -112,10 +112,6 @@ resource "google_storage_default_object_acl" "tfer--calitp-gtfs-schedule-validat
   bucket = "calitp-gtfs-schedule-validation-hourly"
 }
 
-resource "google_storage_default_object_acl" "tfer--calitp-jamesl-gcp-components-tfstate" {
-  bucket = "calitp-jamesl-gcp-components-tfstate"
-}
-
 resource "google_storage_default_object_acl" "tfer--calitp-map-tiles" {
   bucket = "calitp-map-tiles"
 }
@@ -170,16 +166,6 @@ resource "google_storage_default_object_acl" "tfer--calitp-state-geoportal-scrap
 
 resource "google_storage_default_object_acl" "tfer--calitp-state-highway-network-stops" {
   bucket = "calitp-state-highway-network-stops"
-}
-
-resource "google_storage_default_object_acl" "tfer--cold-storage-outputs-gtfs-data-test" {
-  bucket      = "cold-storage-outputs-gtfs-data-test"
-  role_entity = ["OWNER:project-editors-1005246706141", "OWNER:project-owners-1005246706141", "READER:project-viewers-1005246706141"]
-}
-
-resource "google_storage_default_object_acl" "tfer--cold-storage-outputs-gtfs-data-test-charlie-test" {
-  bucket      = "cold-storage-outputs-gtfs-data-test-charlie-test"
-  role_entity = ["OWNER:project-editors-1005246706141", "OWNER:project-owners-1005246706141", "READER:project-viewers-1005246706141"]
 }
 
 resource "google_storage_default_object_acl" "tfer--dataproc-staging-us-west2-1005246706141-sfgmtgyp" {


### PR DESCRIPTION
# Description

This PR adds lifecyle rule to delete data older than 30 days on dev and test buckets (using Terraform).

I am deleting these three obsolete buckets instead of adding the rule since they are old and not in use anymore: `cold-storage-outputs-gtfs-data-test-charlie-test`, `cold-storage-outputs-gtfs-data-test` and `calitp-jamesl-gcp-components-tfstate`.

Resolves [#3666]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running `Terraform plan` locally

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check if data older than 30 days were deleted from dev and test buckets.