### PR TITLE
Add GTFS bucket and CDN

### DIFF
--- a/iac/.gitignore
+++ b/iac/.gitignore
@@ -4,3 +4,4 @@ terraform.tfstate.backup
 terraform.tfstate
 /.terraform.lock.hcl
 /provider.tf
+*.ans

--- a/iac/cal-itp-data-infra/cdn/us/.terraform.lock.hcl
+++ b/iac/cal-itp-data-infra/cdn/us/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.59.0"
+  constraints = "~> 4.59.0"
+  hashes = [
+    "h1:FnhQjRf+Tt0SagED79ryejOd0lqQ42zIbWD2Z9xCNVo=",
+    "zh:057042a29992ee5bddb8b0785ebba5c1455112602760bd88dca2ccab66de714c",
+    "zh:21a0e30a76a9e3e375a374ecd2e82d3240b32913f54017c7b8eca7165ffb2e27",
+    "zh:26cdc960455b335590c5473593d66eddbdb9c60709f416327092a9b4ba8c8b70",
+    "zh:2d8ffb7c150adb43d58fd0057b9a38e9e0435382bb870bf6fe3f13717828a34b",
+    "zh:4c1156babfaffcbb5e91b8a82710a4a33119be416aaee1b85fe5f45162ac37e2",
+    "zh:54de19d1d40fdfa2f9804b64355cac6e6de1bdcdcd193317dd2e24f923cd3007",
+    "zh:9f029f0478458d39cd7255abf8ce32d33111bc6f1ca822718e66344bea61522d",
+    "zh:ac5b8867769921f56e95c95332c6167b73c6b6275f158b762b01a0a8013b67a8",
+    "zh:d010b2b8b0d547fb712c2cc3e0f816c001783fcac072191a3e8ed5e22f826951",
+    "zh:d4e6b5f5aa78b16761c9b47534b631c2d1b6d6ec01f97a15db84dec20be3b8b2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fefbd0cd4cb94ecee0c6d99f079b6cbb56b86cd63609b72395c4f1fa7c2addcb",
+  ]
+}

--- a/iac/cal-itp-data-infra/cdn/us/backend_bucket.tf
+++ b/iac/cal-itp-data-infra/cdn/us/backend_bucket.tf
@@ -1,0 +1,32 @@
+resource "google_compute_backend_bucket" "default" {
+  name        = "calitp-gtfs-backend-bucket"
+  bucket_name = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs_name
+  enable_cdn  = true
+  cdn_policy {
+    cache_mode        = "CACHE_ALL_STATIC"
+    client_ttl        = 3600
+    default_ttl       = 3600
+    max_ttl           = 86400
+    negative_caching  = true
+    serve_while_stale = 86400
+  }
+}
+
+resource "google_compute_url_map" "default" {
+  name            = "http-lb"
+  default_service = google_compute_backend_bucket.default.id
+}
+
+resource "google_compute_target_http_proxy" "default" {
+  name    = "http-lb-proxy"
+  url_map = google_compute_url_map.default.id
+}
+
+resource "google_compute_global_forwarding_rule" "default" {
+  name                  = "http-lb-forwarding-rule"
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.default.id
+  ip_address            = data.terraform_remote_state.networks.outputs.google_compute_network_static-load-balancer-address_id
+}

--- a/iac/cal-itp-data-infra/cdn/us/provider.tf
+++ b/iac/cal-itp-data-infra/cdn/us/provider.tf
@@ -1,0 +1,16 @@
+provider "google" {
+  project = "cal-itp-data-infra"
+}
+
+terraform {
+  required_providers {
+    google = {
+      version = "~> 4.59.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/cdn"
+  }
+}

--- a/iac/cal-itp-data-infra/cdn/us/variables.tf
+++ b/iac/cal-itp-data-infra/cdn/us/variables.tf
@@ -1,0 +1,17 @@
+data "terraform_remote_state" "networks" {
+  backend = "gcs"
+
+  config = {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/networks"
+  }
+}
+
+data "terraform_remote_state" "gcs" {
+  backend = "gcs"
+
+  config = {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/gcs"
+  }
+}

--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2442,6 +2442,10 @@ output "google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket_
   value = google_storage_bucket.tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket.name
 }
 
+output "google_storage_bucket_calitp-gtfs_name" {
+  value = google_storage_bucket.calitp-gtfs.name
+}
+
 output "google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket_self_link" {
   value = google_storage_bucket.tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket.self_link
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -1501,3 +1501,17 @@ resource "google_storage_bucket" "tfer--us-west2-calitp-airflow2-pr-88ca8ec6-buc
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "false"
 }
+
+resource "google_storage_bucket" "calitp-gtfs" {
+  location                    = "US-WEST2"
+  name                        = "calitp-gtfs"
+  project                     = "cal-itp-data-infra"
+  uniform_bucket_level_access = "true"
+  storage_class               = "STANDARD"
+  force_destroy               = "true"
+
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "404.html"
+  }
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -609,3 +609,9 @@ resource "google_storage_bucket_iam_member" "tfer--us-west2-calitp-airflow2-pr-8
   member = "projectViewer:cal-itp-data-infra"
   role   = "roles/storage.legacyBucketReader"
 }
+
+resource "google_storage_bucket_iam_member" "calitp_gtfs_public_web_access" {
+  bucket = google_storage_bucket.calitp-gtfs.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_object.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_object.tf
@@ -1,0 +1,15 @@
+resource "google_storage_bucket_object" "calitp_gtfs_index" {
+  name         = "index.html"
+  bucket       = google_storage_bucket.calitp-gtfs.name
+  content_type = "text/html"
+  content      = <<EOF
+    <!DOCTYPE html>
+    <html lang='en'>
+      <head>
+        <title>Cal-ITP</title>
+        <meta charset='utf-8'>
+      </head>
+      <body>Hello from Cal-ITP.</body>
+    </html>
+  EOF
+}

--- a/iac/cal-itp-data-infra/networks/us/global_address.tf
+++ b/iac/cal-itp-data-infra/networks/us/global_address.tf
@@ -1,0 +1,3 @@
+resource "google_compute_global_address" "static-load-balancer-address" {
+  name = "static-load-balancer-address"
+}

--- a/iac/cal-itp-data-infra/networks/us/outputs.tf
+++ b/iac/cal-itp-data-infra/networks/us/outputs.tf
@@ -1,3 +1,7 @@
 output "google_compute_network_tfer--default_self_link" {
   value = google_compute_network.tfer--default.self_link
 }
+
+output "google_compute_network_static-load-balancer-address_id" {
+  value = google_compute_global_address.static-load-balancer-address.id
+}


### PR DESCRIPTION
# Description

Adds Terraform configuration for:

* GCS Bucket to store GTFS site artifacts
* Load balancer to route inbound requests to the GCS Bucket (future buckets will use this same load balancer)
* External IP address for the load balancer

Resolves #[3812](https://github.com/cal-itp/data-infra/issues/3812)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Visited http://34.8.18.200/
<img width="682" alt="Screenshot 2025-04-10 at 12 22 03" src="https://github.com/user-attachments/assets/a15cf8bf-afdf-4490-81b8-12401f8ec4aa" />

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
