### PR TITLE
Create staging service account, dbt buckets and CDN

### DIFF
--- a/iac/cal-itp-data-infra-staging/cdn/us/backend_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/cdn/us/backend_bucket.tf
@@ -1,20 +1,6 @@
-resource "google_compute_backend_bucket" "calitp-gtfs" {
-  name        = "calitp-gtfs-backend-bucket"
-  bucket_name = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs_name
-  enable_cdn  = true
-  cdn_policy {
-    cache_mode        = "CACHE_ALL_STATIC"
-    client_ttl        = 3600
-    default_ttl       = 3600
-    max_ttl           = 86400
-    negative_caching  = true
-    serve_while_stale = 86400
-  }
-}
-
-resource "google_compute_backend_bucket" "calitp-dbt-docs" {
-  name        = "calitp-dbt-docs-backend-bucket"
-  bucket_name = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-dbt-docs_name
+resource "google_compute_backend_bucket" "calitp-staging-dbt-docs" {
+  name        = "calitp-staging-dbt-docs-backend-bucket"
+  bucket_name = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-dbt-docs_name
   enable_cdn  = true
   cdn_policy {
     cache_mode        = "CACHE_ALL_STATIC"
@@ -28,7 +14,7 @@ resource "google_compute_backend_bucket" "calitp-dbt-docs" {
 
 resource "google_compute_url_map" "default" {
   name            = "http-lb"
-  default_service = google_compute_backend_bucket.calitp-gtfs.id
+  default_service = google_compute_backend_bucket.calitp-staging-dbt-docs.id
 }
 
 resource "google_compute_target_http_proxy" "default" {

--- a/iac/cal-itp-data-infra-staging/cdn/us/provider.tf
+++ b/iac/cal-itp-data-infra-staging/cdn/us/provider.tf
@@ -1,0 +1,16 @@
+provider "google" {
+  project = "cal-itp-data-infra-staging"
+}
+
+terraform {
+  required_providers {
+    google = {
+      version = "~> 4.59.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "calitp-staging-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra-staging/cdn"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/cdn/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/cdn/us/variables.tf
@@ -1,0 +1,17 @@
+data "terraform_remote_state" "networks" {
+  backend = "gcs"
+
+  config = {
+    bucket = "calitp-staging-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra-staging/networks"
+  }
+}
+
+data "terraform_remote_state" "gcs" {
+  backend = "gcs"
+
+  config = {
+    bucket = "calitp-staging-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra-staging/gcs"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -118,6 +118,10 @@ output "google_storage_bucket_tfer--test-calitp-amplitude-benefits-events_self_l
   value = google_storage_bucket.tfer--test-calitp-amplitude-benefits-events.self_link
 }
 
+output "google_storage_bucket_calitp-staging-dbt-docs_name" {
+  value = google_storage_bucket.calitp-staging-dbt-docs.name
+}
+
 output "google_storage_default_object_acl_tfer--calitp-staging-data-analyses-portfolio-draft_id" {
   value = google_storage_default_object_acl.tfer--calitp-staging-data-analyses-portfolio-draft.id
 }

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -104,3 +104,31 @@ resource "google_storage_bucket" "tfer--calitp-staging-gcp-components-tfstate" {
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
 }
+
+resource "google_storage_bucket" "calitp-staging-dbt-artifacts" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-staging-dbt-artifacts"
+  project                     = "cal-itp-data-infra-staging"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
+resource "google_storage_bucket" "calitp-staging-dbt-docs" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-staging-dbt-docs"
+  project                     = "cal-itp-data-infra-staging"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+
+  website {
+    main_page_suffix = "index.html"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
@@ -33,3 +33,9 @@ resource "google_storage_bucket_iam_member" "tfer--calitp-staging-gcp-components
   member = "projectViewer:cal-itp-data-infra-staging"
   role   = "roles/storage.legacyBucketReader"
 }
+
+resource "google_storage_bucket_iam_member" "calitp-staging-dbt-docs" {
+  bucket = google_storage_bucket.calitp-staging-dbt-docs.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}

--- a/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
@@ -23,8 +23,14 @@ resource "google_iam_workload_identity_pool_provider" "github-actions--provider"
   }
 }
 
-resource "google_service_account_iam_member" "github-actions--service-account" {
-  service_account_id = google_service_account.tfer--terraform.id
+resource "google_service_account_iam_member" "github-actions-terraform" {
+  service_account_id = google_service_account.github-actions-terraform.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
+}
+
+resource "google_service_account_iam_member" "github-actions-service-account" {
+  service_account_id = google_service_account.github-actions-service-account.id
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
 }

--- a/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
@@ -166,10 +166,6 @@ output "google_service_account_tfer--111881979116192190399_id" {
   value = google_service_account.tfer--111881979116192190399.id
 }
 
-output "google_service_account_tfer--terraform_email" {
-  value = google_service_account.tfer--terraform.email
-}
-
 output "google_iam_workload_identity_pool_provider_github-actions--provider_name" {
   value = google_iam_workload_identity_pool_provider.github-actions--provider.name
 }

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -220,19 +220,22 @@ resource "google_project_iam_member" "tfer--roles-002F-storage-002E-objectViewer
   role    = "roles/storage.objectViewer"
 }
 
-resource "google_project_iam_member" "tfer--terraform-membership" {
+resource "google_project_iam_member" "github-actions-terraform" {
   for_each = toset([
     "roles/resourcemanager.projectIamAdmin",
     "roles/editor",
     "roles/storage.admin"
   ])
   role    = each.key
-  member  = "serviceAccount:${google_service_account.tfer--terraform.email}"
+  member  = "serviceAccount:${google_service_account.github-actions-terraform.email}"
   project = "cal-itp-data-infra-staging"
 }
 
-resource "google_project_iam_member" "tfer--pytest-membership" {
-  member  = "serviceAccount:${google_service_account.tfer--pytest.email}"
+resource "google_project_iam_member" "github-actions-service-account" {
+  for_each = toset([
+    "roles/storage.admin"
+  ])
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.github-actions-service-account.email}"
   project = "cal-itp-data-infra-staging"
-  role    = "roles/storage.objectViewer"
 }

--- a/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
@@ -26,7 +26,7 @@ resource "google_service_account" "tfer--111881979116192190399" {
   project      = "cal-itp-data-infra-staging"
 }
 
-resource "google_service_account" "tfer--terraform" {
+resource "google_service_account" "github-actions-terraform" {
   account_id   = "github-actions-terraform"
   description  = "Service account for Github Actions to run Terraform"
   disabled     = "false"
@@ -34,10 +34,10 @@ resource "google_service_account" "tfer--terraform" {
   project      = "cal-itp-data-infra-staging"
 }
 
-resource "google_service_account" "tfer--pytest" {
-  account_id   = "github-actions-pytest"
-  description  = "Service account for Github Actions to run tests"
+resource "google_service_account" "github-actions-service-account" {
+  account_id   = "github-actions-service-account"
+  description  = "Service account for general Github Actions"
   disabled     = "false"
-  display_name = "pytest"
+  display_name = "github_actions_services_account"
   project      = "cal-itp-data-infra-staging"
 }

--- a/iac/cal-itp-data-infra-staging/networks/us/global_address.tf
+++ b/iac/cal-itp-data-infra-staging/networks/us/global_address.tf
@@ -1,0 +1,3 @@
+resource "google_compute_global_address" "static-load-balancer-address" {
+  name = "static-load-balancer-address"
+}

--- a/iac/cal-itp-data-infra-staging/networks/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/networks/us/outputs.tf
@@ -1,3 +1,7 @@
 output "google_compute_network_tfer--default_self_link" {
   value = google_compute_network.tfer--default.self_link
 }
+
+output "google_compute_network_static-load-balancer-address_id" {
+  value = google_compute_global_address.static-load-balancer-address.id
+}

--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2374,6 +2374,10 @@ output "google_storage_bucket_calitp-gtfs_name" {
   value = google_storage_bucket.calitp-gtfs.name
 }
 
+output "google_storage_bucket_calitp-dbt-docs_name" {
+  value = google_storage_bucket.calitp-dbt-docs.name
+}
+
 output "google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket_self_link" {
   value = google_storage_bucket.tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket.self_link
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -2058,3 +2058,19 @@ resource "google_storage_bucket" "calitp-gtfs" {
     not_found_page   = "404.html"
   }
 }
+
+resource "google_storage_bucket" "calitp-dbt-docs" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-dbt-docs"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+
+  website {
+    main_page_suffix = "index.html"
+  }
+}

--- a/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
@@ -23,13 +23,19 @@ resource "google_iam_workload_identity_pool_provider" "github-actions--provider"
   }
 }
 
-resource "google_service_account_iam_member" "github-actions--service-account" {
-  service_account_id = google_service_account.tfer--terraform.id
+resource "google_service_account_iam_member" "github-actions-terraform" {
+  service_account_id = google_service_account.github-actions-terraform.id
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
 }
 
-resource "google_service_account_iam_member" "github-actions--github-actions-service-accoun" {
+resource "google_service_account_iam_member" "github-actions-service-account" {
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
+}
+
+resource "google_service_account_iam_member" "github-actions--github-actions-services-accoun" {
   service_account_id = "projects/cal-itp-data-infra/serviceAccounts/github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com"
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"

--- a/iac/cal-itp-data-infra/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra/iam/us/outputs.tf
@@ -506,10 +506,6 @@ output "google_service_account_tfer--118350215382382143206_id" {
   value = google_service_account.tfer--118350215382382143206.id
 }
 
-output "google_service_account_terraform_email" {
-  value = google_service_account.tfer--terraform.email
-}
-
 output "google_iam_workload_identity_pool_provider_github-actions--provider_name" {
   value = google_iam_workload_identity_pool_provider.github-actions--provider.name
 }

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -538,13 +538,26 @@ resource "google_project_iam_member" "tfer--roles-002F-viewerserviceAccount-003A
   role    = "roles/viewer"
 }
 
-resource "google_project_iam_member" "tfer--terraform-membership" {
+resource "google_project_iam_member" "github-actions-terraform" {
   for_each = toset([
     "roles/resourcemanager.projectIamAdmin",
     "roles/editor",
     "roles/storage.admin"
   ])
   role    = each.key
-  member  = "serviceAccount:${google_service_account.tfer--terraform.email}"
+  member  = "serviceAccount:${google_service_account.github-actions-terraform.email}"
+  project = "cal-itp-data-infra"
+}
+
+resource "google_project_iam_member" "github-actions-service-account" {
+  for_each = toset([
+    "roles/bigquery.dataViewer",
+    "roles/bigquery.jobUser",
+    "roles/bigquery.readSessionUser",
+    "roles/composer.admin",
+    "roles/storage.admin"
+  ])
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.github-actions-service-account.email}"
   project = "cal-itp-data-infra"
 }

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -248,10 +248,18 @@ resource "google_service_account" "tfer--118350215382382143206" {
   project      = "cal-itp-data-infra"
 }
 
-resource "google_service_account" "tfer--terraform" {
+resource "google_service_account" "github-actions-terraform" {
   account_id   = "github-actions-terraform"
   description  = "Service account for Github Actions to run Terraform"
   disabled     = "false"
-  display_name = "Terraform"
+  display_name = "github-actions-terraform"
+  project      = "cal-itp-data-infra"
+}
+
+resource "google_service_account" "github-actions-service-account" {
+  account_id   = "github-actions-service-account"
+  description  = "Service account for general Github Actions tasks"
+  disabled     = "false"
+  display_name = "github-actions"
   project      = "cal-itp-data-infra"
 }


### PR DESCRIPTION
# Description

Creates the following buckets:

- calitp-dbt-docs (in cal-itp-data-infra)
- calitp-staging-dbt-docs (in cal-itp-data-infra-staging)
- calitp-staging-dbt-artifacts (in cal-itp-data-infra-staging)

Also creates a service account for staging.

Part of #3783

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan` runs cleanly

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Observe production build output