### PR TITLE
Update external_airtable_transit_tech_stacks_services.yml

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
@@ -14,13 +14,3 @@ hive_options:
   mode: AUTO
   require_partition_filter: false
   source_uri_prefix: "transit_technology_stacks__services/"
-schema_fields:
-  - name: id
-    type: STRING
-    mode: NULLABLE
-  - name: name
-    type: STRING
-    mode: NULLABLE
-  - name: contracts
-    type: STRING
-    mode: REPEATED


### PR DESCRIPTION
# Description
Continuing development of the `Transit Technology Stacks` Airtables and associated schema. At this stage, the schema is intentionally excluded from the YAML file to allow all fields to pass through during testing and iteration. Once the schema is finalized, it will be added to the YAML to enforce structure and validation.
Also correcting the error introduced as a result of wrong existing/old `contracts` field type:
```
Error while reading table: cal-itp-data-infra.external_airtable.transit_technology_stacks__services, error message: JSON parsing error in row starting at position 634952: Repeated field must be imported as a JSON array. Field: contracts. File: gs://calitp-airtable/transit_technology_stacks__services/dt=2025-04-10/ts=2025-04-10T02:08:01.991582+00:00/services.jsonl.gz
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

