### PR TITLE
Add new littlepay buckets to Terraform

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -138,8 +138,16 @@ output "google_storage_bucket_acl_tfer--calitp-payments-littlepay-parsed_id" {
   value = google_storage_bucket_acl.tfer--calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_acl_tfer--calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_acl.tfer--calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_acl_tfer--calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_acl.tfer--calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_acl_tfer--calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_acl.tfer--calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_acl_tfer--calitp-prod-gcp-components-tfstate_id" {
@@ -346,8 +354,16 @@ output "google_storage_bucket_acl_tfer--test-calitp-payments-littlepay-parsed_id
   value = google_storage_bucket_acl.tfer--test-calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_acl_tfer--test-calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_acl.tfer--test-calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_acl_tfer--test-calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_acl.tfer--test-calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_acl_tfer--test-calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_acl.tfer--test-calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_acl_tfer--test-calitp-publish-data-analysis_id" {
@@ -534,8 +550,16 @@ output "google_storage_bucket_iam_binding_tfer--calitp-payments-littlepay-parsed
   value = google_storage_bucket_iam_binding.tfer--calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_iam_binding_tfer--calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_iam_binding.tfer--calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_iam_binding_tfer--calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_iam_binding.tfer--calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_iam_binding_tfer--calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_iam_binding.tfer--calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_iam_binding_tfer--calitp-prod-gcp-components-tfstate_id" {
@@ -742,8 +766,16 @@ output "google_storage_bucket_iam_binding_tfer--test-calitp-payments-littlepay-p
   value = google_storage_bucket_iam_binding.tfer--test-calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_iam_binding_tfer--test-calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_iam_binding.tfer--test-calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_iam_binding_tfer--test-calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_iam_binding.tfer--test-calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_iam_binding_tfer--test-calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_iam_binding.tfer--test-calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_iam_binding_tfer--test-calitp-publish-data-analysis_id" {
@@ -930,8 +962,16 @@ output "google_storage_bucket_iam_member_tfer--calitp-payments-littlepay-parsed_
   value = google_storage_bucket_iam_member.tfer--calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_iam_member_tfer--calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_iam_member.tfer--calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_iam_member_tfer--calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_iam_member.tfer--calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_iam_member_tfer--calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_iam_member.tfer--calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_iam_member_tfer--calitp-prod-gcp-components-tfstate_id" {
@@ -1138,8 +1178,16 @@ output "google_storage_bucket_iam_member_tfer--test-calitp-payments-littlepay-pa
   value = google_storage_bucket_iam_member.tfer--test-calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_iam_member_tfer--test-calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_iam_member.tfer--test-calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_iam_member_tfer--test-calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_iam_member.tfer--test-calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_iam_member_tfer--test-calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_iam_member.tfer--test-calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_iam_member_tfer--test-calitp-publish-data-analysis_id" {
@@ -1326,8 +1374,16 @@ output "google_storage_bucket_iam_policy_tfer--calitp-payments-littlepay-parsed_
   value = google_storage_bucket_iam_policy.tfer--calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_iam_policy_tfer--calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_iam_policy.tfer--calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_iam_policy_tfer--calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_iam_policy.tfer--calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_iam_policy_tfer--calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_iam_policy.tfer--calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_iam_policy_tfer--calitp-prod-gcp-components-tfstate_id" {
@@ -1534,8 +1590,16 @@ output "google_storage_bucket_iam_policy_tfer--test-calitp-payments-littlepay-pa
   value = google_storage_bucket_iam_policy.tfer--test-calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_bucket_iam_policy_tfer--test-calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_bucket_iam_policy.tfer--test-calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_bucket_iam_policy_tfer--test-calitp-payments-littlepay-raw_id" {
   value = google_storage_bucket_iam_policy.tfer--test-calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_bucket_iam_policy_tfer--test-calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_bucket_iam_policy.tfer--test-calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_bucket_iam_policy_tfer--test-calitp-publish-data-analysis_id" {
@@ -1858,16 +1922,32 @@ output "google_storage_bucket_tfer--calitp-payments-littlepay-parsed_name" {
   value = google_storage_bucket.tfer--calitp-payments-littlepay-parsed.name
 }
 
+output "google_storage_bucket_tfer--calitp-payments-littlepay-parsed-v3_name" {
+  value = google_storage_bucket.tfer--calitp-payments-littlepay-parsed-v3.name
+}
+
 output "google_storage_bucket_tfer--calitp-payments-littlepay-parsed_self_link" {
   value = google_storage_bucket.tfer--calitp-payments-littlepay-parsed.self_link
+}
+
+output "google_storage_bucket_tfer--calitp-payments-littlepay-parsed-v3_self_link" {
+  value = google_storage_bucket.tfer--calitp-payments-littlepay-parsed-v3.self_link
 }
 
 output "google_storage_bucket_tfer--calitp-payments-littlepay-raw_name" {
   value = google_storage_bucket.tfer--calitp-payments-littlepay-raw.name
 }
 
+output "google_storage_bucket_tfer--calitp-payments-littlepay-raw-v3_name" {
+  value = google_storage_bucket.tfer--calitp-payments-littlepay-raw-v3.name
+}
+
 output "google_storage_bucket_tfer--calitp-payments-littlepay-raw_self_link" {
   value = google_storage_bucket.tfer--calitp-payments-littlepay-raw.self_link
+}
+
+output "google_storage_bucket_tfer--calitp-payments-littlepay-raw-v3_self_link" {
+  value = google_storage_bucket.tfer--calitp-payments-littlepay-raw-v3.self_link
 }
 
 output "google_storage_bucket_tfer--calitp-prod-gcp-components-tfstate_name" {
@@ -2274,16 +2354,32 @@ output "google_storage_bucket_tfer--test-calitp-payments-littlepay-parsed_name" 
   value = google_storage_bucket.tfer--test-calitp-payments-littlepay-parsed.name
 }
 
+output "google_storage_bucket_tfer--test-calitp-payments-littlepay-parsed-v3_name" {
+  value = google_storage_bucket.tfer--test-calitp-payments-littlepay-parsed-v3.name
+}
+
 output "google_storage_bucket_tfer--test-calitp-payments-littlepay-parsed_self_link" {
   value = google_storage_bucket.tfer--test-calitp-payments-littlepay-parsed.self_link
+}
+
+output "google_storage_bucket_tfer--test-calitp-payments-littlepay-parsed-v3_self_link" {
+  value = google_storage_bucket.tfer--test-calitp-payments-littlepay-parsed-v3.self_link
 }
 
 output "google_storage_bucket_tfer--test-calitp-payments-littlepay-raw_name" {
   value = google_storage_bucket.tfer--test-calitp-payments-littlepay-raw.name
 }
 
+output "google_storage_bucket_tfer--test-calitp-payments-littlepay-raw-v3_name" {
+  value = google_storage_bucket.tfer--test-calitp-payments-littlepay-raw-v3.name
+}
+
 output "google_storage_bucket_tfer--test-calitp-payments-littlepay-raw_self_link" {
   value = google_storage_bucket.tfer--test-calitp-payments-littlepay-raw.self_link
+}
+
+output "google_storage_bucket_tfer--test-calitp-payments-littlepay-raw-v3_self_link" {
+  value = google_storage_bucket.tfer--test-calitp-payments-littlepay-raw-v3.self_link
 }
 
 output "google_storage_bucket_tfer--test-calitp-publish-data-analysis_name" {
@@ -2522,8 +2618,16 @@ output "google_storage_default_object_acl_tfer--calitp-payments-littlepay-parsed
   value = google_storage_default_object_acl.tfer--calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_default_object_acl_tfer--calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_default_object_acl.tfer--calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_default_object_acl_tfer--calitp-payments-littlepay-raw_id" {
   value = google_storage_default_object_acl.tfer--calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_default_object_acl_tfer--calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_default_object_acl.tfer--calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_default_object_acl_tfer--calitp-prod-gcp-components-tfstate_id" {
@@ -2730,8 +2834,16 @@ output "google_storage_default_object_acl_tfer--test-calitp-payments-littlepay-p
   value = google_storage_default_object_acl.tfer--test-calitp-payments-littlepay-parsed.id
 }
 
+output "google_storage_default_object_acl_tfer--test-calitp-payments-littlepay-parsed-v3_id" {
+  value = google_storage_default_object_acl.tfer--test-calitp-payments-littlepay-parsed-v3.id
+}
+
 output "google_storage_default_object_acl_tfer--test-calitp-payments-littlepay-raw_id" {
   value = google_storage_default_object_acl.tfer--test-calitp-payments-littlepay-raw.id
+}
+
+output "google_storage_default_object_acl_tfer--test-calitp-payments-littlepay-raw-v3_id" {
+  value = google_storage_default_object_acl.tfer--test-calitp-payments-littlepay-raw-v3.id
 }
 
 output "google_storage_default_object_acl_tfer--test-calitp-publish-data-analysis_id" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -528,6 +528,18 @@ resource "google_storage_bucket" "tfer--calitp-payments-littlepay-parsed" {
   uniform_bucket_level_access = "true"
 }
 
+resource "google_storage_bucket" "tfer--calitp-payments-littlepay-parsed-v3" {
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "calitp-payments-littlepay-parsed-v3"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "enforced"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
 resource "google_storage_bucket" "tfer--calitp-payments-littlepay-raw" {
   default_event_based_hold = "false"
   force_destroy            = "false"
@@ -542,6 +554,18 @@ resource "google_storage_bucket" "tfer--calitp-payments-littlepay-raw" {
     retention_period = "31557600"
   }
 
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
+resource "google_storage_bucket" "tfer--calitp-payments-littlepay-raw-v3" {
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "calitp-payments-littlepay-raw-v3"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "enforced"
+  requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
 }
@@ -1755,11 +1779,65 @@ resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-parsed" {
   }
 }
 
+resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-parsed-v3" {
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "test-calitp-payments-littlepay-parsed-v3"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "enforced"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
+}
+
 resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-raw" {
   default_event_based_hold    = "false"
   force_destroy               = "false"
   location                    = "US-WEST2"
   name                        = "test-calitp-payments-littlepay-raw"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "enforced"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "30"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
+}
+
+resource "google_storage_bucket" "tfer--test-calitp-payments-littlepay-raw-v3" {
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "test-calitp-payments-littlepay-raw-v3"
   project                     = "cal-itp-data-infra"
   public_access_prevention    = "enforced"
   requester_pays              = "false"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
@@ -138,8 +138,16 @@ resource "google_storage_bucket_acl" "tfer--calitp-payments-littlepay-parsed" {
   bucket = "calitp-payments-littlepay-parsed"
 }
 
+resource "google_storage_bucket_acl" "tfer--calitp-payments-littlepay-parsed-v3" {
+  bucket = "calitp-payments-littlepay-parsed-v3"
+}
+
 resource "google_storage_bucket_acl" "tfer--calitp-payments-littlepay-raw" {
   bucket = "calitp-payments-littlepay-raw"
+}
+
+resource "google_storage_bucket_acl" "tfer--calitp-payments-littlepay-raw-v3" {
+  bucket = "calitp-payments-littlepay-raw-v3"
 }
 
 resource "google_storage_bucket_acl" "tfer--calitp-prod-gcp-components-tfstate" {
@@ -346,8 +354,16 @@ resource "google_storage_bucket_acl" "tfer--test-calitp-payments-littlepay-parse
   bucket = "test-calitp-payments-littlepay-parsed"
 }
 
+resource "google_storage_bucket_acl" "tfer--test-calitp-payments-littlepay-parsed-v3" {
+  bucket = "test-calitp-payments-littlepay-parsed-v3"
+}
+
 resource "google_storage_bucket_acl" "tfer--test-calitp-payments-littlepay-raw" {
   bucket = "test-calitp-payments-littlepay-raw"
+}
+
+resource "google_storage_bucket_acl" "tfer--test-calitp-payments-littlepay-raw-v3" {
+  bucket = "test-calitp-payments-littlepay-raw-v3"
 }
 
 resource "google_storage_bucket_acl" "tfer--test-calitp-publish" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -208,8 +208,20 @@ resource "google_storage_bucket_iam_binding" "tfer--calitp-payments-littlepay-pa
   role    = "roles/storage.legacyObjectOwner"
 }
 
+resource "google_storage_bucket_iam_binding" "tfer--calitp-payments-littlepay-parsed-v3" {
+  bucket  = "b/calitp-payments-littlepay-parsed-v3"
+  members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
+  role    = "roles/storage.legacyObjectOwner"
+}
+
 resource "google_storage_bucket_iam_binding" "tfer--calitp-payments-littlepay-raw" {
   bucket  = "b/calitp-payments-littlepay-raw"
+  members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
+  role    = "roles/storage.legacyBucketOwner"
+}
+
+resource "google_storage_bucket_iam_binding" "tfer--calitp-payments-littlepay-raw-v3" {
+  bucket  = "b/calitp-payments-littlepay-raw-v3"
   members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
   role    = "roles/storage.legacyBucketOwner"
 }
@@ -520,8 +532,20 @@ resource "google_storage_bucket_iam_binding" "tfer--test-calitp-payments-littlep
   role    = "roles/storage.legacyBucketReader"
 }
 
+resource "google_storage_bucket_iam_binding" "tfer--test-calitp-payments-littlepay-parsed-v3" {
+  bucket  = "b/test-calitp-payments-littlepay-parsed-v3"
+  members = ["projectViewer:cal-itp-data-infra"]
+  role    = "roles/storage.legacyBucketReader"
+}
+
 resource "google_storage_bucket_iam_binding" "tfer--test-calitp-payments-littlepay-raw" {
   bucket  = "b/test-calitp-payments-littlepay-raw"
+  members = ["projectViewer:cal-itp-data-infra"]
+  role    = "roles/storage.legacyBucketReader"
+}
+
+resource "google_storage_bucket_iam_binding" "tfer--test-calitp-payments-littlepay-raw-v3" {
+  bucket  = "b/test-calitp-payments-littlepay-raw-v3"
   members = ["projectViewer:cal-itp-data-infra"]
   role    = "roles/storage.legacyBucketReader"
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -208,8 +208,20 @@ resource "google_storage_bucket_iam_member" "tfer--calitp-payments-littlepay-par
   role   = "roles/storage.legacyBucketOwner"
 }
 
+resource "google_storage_bucket_iam_member" "tfer--calitp-payments-littlepay-parsed-v3" {
+  bucket = "b/calitp-payments-littlepay-parsed-v3"
+  member = "projectEditor:cal-itp-data-infra"
+  role   = "roles/storage.legacyBucketOwner"
+}
+
 resource "google_storage_bucket_iam_member" "tfer--calitp-payments-littlepay-raw" {
   bucket = "b/calitp-payments-littlepay-raw"
+  member = "projectViewer:cal-itp-data-infra"
+  role   = "roles/storage.legacyBucketReader"
+}
+
+resource "google_storage_bucket_iam_member" "tfer--calitp-payments-littlepay-raw-v3" {
+  bucket = "b/calitp-payments-littlepay-raw-v3"
   member = "projectViewer:cal-itp-data-infra"
   role   = "roles/storage.legacyBucketReader"
 }
@@ -520,8 +532,20 @@ resource "google_storage_bucket_iam_member" "tfer--test-calitp-payments-littlepa
   role   = "roles/storage.legacyObjectOwner"
 }
 
+resource "google_storage_bucket_iam_member" "tfer--test-calitp-payments-littlepay-parsed-v3" {
+  bucket = "b/test-calitp-payments-littlepay-parsed-v3"
+  member = "projectEditor:cal-itp-data-infra"
+  role   = "roles/storage.legacyObjectOwner"
+}
+
 resource "google_storage_bucket_iam_member" "tfer--test-calitp-payments-littlepay-raw" {
   bucket = "b/test-calitp-payments-littlepay-raw"
+  member = "projectOwner:cal-itp-data-infra"
+  role   = "roles/storage.legacyBucketOwner"
+}
+
+resource "google_storage_bucket_iam_member" "tfer--test-calitp-payments-littlepay-raw-v3" {
+  bucket = "b/test-calitp-payments-littlepay-raw-v3"
   member = "projectOwner:cal-itp-data-infra"
   role   = "roles/storage.legacyBucketOwner"
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -1363,8 +1363,83 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-payments-littlepay-par
 POLICY
 }
 
+resource "google_storage_bucket_iam_policy" "tfer--calitp-payments-littlepay-parsed-v3" {
+  bucket = "b/calitp-payments-littlepay-parsed-v3"
+
+  policy_data = <<POLICY
+{
+  "bindings": [
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectReader"
+    }
+  ]
+}
+POLICY
+}
+
 resource "google_storage_bucket_iam_policy" "tfer--calitp-payments-littlepay-raw" {
   bucket = "b/calitp-payments-littlepay-raw"
+
+  policy_data = <<POLICY
+{
+  "bindings": [
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectReader"
+    }
+  ]
+}
+POLICY
+}
+
+
+resource "google_storage_bucket_iam_policy" "tfer--calitp-payments-littlepay-raw-v3" {
+  bucket = "b/calitp-payments-littlepay-raw-v3"
 
   policy_data = <<POLICY
 {
@@ -3316,8 +3391,83 @@ resource "google_storage_bucket_iam_policy" "tfer--test-calitp-payments-littlepa
 POLICY
 }
 
+resource "google_storage_bucket_iam_policy" "tfer--test-calitp-payments-littlepay-parsed-v3" {
+  bucket = "b/test-calitp-payments-littlepay-parsed-v3"
+
+  policy_data = <<POLICY
+{
+  "bindings": [
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectReader"
+    }
+  ]
+}
+POLICY
+}
+
 resource "google_storage_bucket_iam_policy" "tfer--test-calitp-payments-littlepay-raw" {
   bucket = "b/test-calitp-payments-littlepay-raw"
+
+  policy_data = <<POLICY
+{
+  "bindings": [
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectReader"
+    }
+  ]
+}
+POLICY
+}
+
+
+resource "google_storage_bucket_iam_policy" "tfer--test-calitp-payments-littlepay-raw-v3" {
+  bucket = "b/test-calitp-payments-littlepay-raw-v3"
 
   policy_data = <<POLICY
 {

--- a/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
@@ -140,8 +140,16 @@ resource "google_storage_default_object_acl" "tfer--calitp-payments-littlepay-pa
   bucket = "calitp-payments-littlepay-parsed"
 }
 
+resource "google_storage_default_object_acl" "tfer--calitp-payments-littlepay-parsed-v3" {
+  bucket = "calitp-payments-littlepay-parsed-v3"
+}
+
 resource "google_storage_default_object_acl" "tfer--calitp-payments-littlepay-raw" {
   bucket = "calitp-payments-littlepay-raw"
+}
+
+resource "google_storage_default_object_acl" "tfer--calitp-payments-littlepay-raw-v3" {
+  bucket = "calitp-payments-littlepay-raw-v3"
 }
 
 resource "google_storage_default_object_acl" "tfer--calitp-prod-gcp-components-tfstate" {
@@ -353,8 +361,16 @@ resource "google_storage_default_object_acl" "tfer--test-calitp-payments-littlep
   bucket = "test-calitp-payments-littlepay-parsed"
 }
 
+resource "google_storage_default_object_acl" "tfer--test-calitp-payments-littlepay-parsed-v3" {
+  bucket = "test-calitp-payments-littlepay-parsed-v3"
+}
+
 resource "google_storage_default_object_acl" "tfer--test-calitp-payments-littlepay-raw" {
   bucket = "test-calitp-payments-littlepay-raw"
+}
+
+resource "google_storage_default_object_acl" "tfer--test-calitp-payments-littlepay-raw-v3" {
+  bucket = "test-calitp-payments-littlepay-raw-v3"
 }
 
 resource "google_storage_default_object_acl" "tfer--test-calitp-publish" {


### PR DESCRIPTION
# Description

Some Littlepay buckets created in March are not in Terraform: `calitp-payments-littlepay-parsed-v3`, `calitp-payments-littlepay-raw-v3`, `test-calitp-payments-littlepay-parsed-v3`, and `test-calitp-payments-littlepay-raw-v3`.

This PR adds those four buckets and creates a lifecycle rule to `test-calitp-payments-littlepay-parsed-v3` and `test-calitp-payments-littlepay-raw-v3`.

Resolves #3666

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally with `Terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)