### PR TITLE
Add a role to publish from github to buckets

### DIFF
--- a/.github/workflows/composer-apply-files.yml
+++ b/.github/workflows/composer-apply-files.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           create_credentials_file: 'true'
           project_id: cal-itp-data-infra-staging
-          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
           service_account: 'github-actions-terraform@cal-itp-data-infra-staging.iam.gserviceaccount.com'
 
       - name: Terraform Apply

--- a/.github/workflows/composer-plan-files.yml
+++ b/.github/workflows/composer-plan-files.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           create_credentials_file: 'true'
           project_id: cal-itp-data-infra-staging
-          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
           service_account: 'github-actions-terraform@cal-itp-data-infra-staging.iam.gserviceaccount.com'
 
       - name: Terraform Plan

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           create_credentials_file: 'true'
           project_id: cal-itp-data-infra-staging
-          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
           service_account: 'github-actions-terraform@cal-itp-data-infra-staging.iam.gserviceaccount.com'
 
       - uses: google-github-actions/setup-gcloud@v2
@@ -99,7 +99,7 @@ jobs:
         with:
           create_credentials_file: 'true'
           project_id: cal-itp-data-infra
-          workload_identity_provider: 'projects/1005246706141/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          workload_identity_provider: 'projects/1005246706141/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
           service_account: 'github-actions-terraform@cal-itp-data-infra.iam.gserviceaccount.com'
 
       - uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           create_credentials_file: 'true'
           project_id: cal-itp-data-infra-staging
-          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          workload_identity_provider: 'projects/473674835135/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
           service_account: 'github-actions-terraform@cal-itp-data-infra-staging.iam.gserviceaccount.com'
 
       - uses: google-github-actions/setup-gcloud@v2
@@ -105,7 +105,7 @@ jobs:
         with:
           create_credentials_file: 'true'
           project_id: cal-itp-data-infra
-          workload_identity_provider: 'projects/1005246706141/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          workload_identity_provider: 'projects/1005246706141/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
           service_account: 'github-actions-terraform@cal-itp-data-infra.iam.gserviceaccount.com'
 
       - uses: google-github-actions/setup-gcloud@v2

--- a/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
@@ -1,10 +1,10 @@
-resource "google_iam_workload_identity_pool" "github-actions--pool" {
-  workload_identity_pool_id = "github-actions-pool"
+resource "google_iam_workload_identity_pool" "github-actions" {
+  workload_identity_pool_id = "github-actions"
 }
 
-resource "google_iam_workload_identity_pool_provider" "github-actions--provider" {
-  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions--pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "github-actions-provider"
+resource "google_iam_workload_identity_pool_provider" "data-infra" {
+  workload_identity_pool_provider_id = "data-infra"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
   attribute_mapping = {
     "google.subject"       = "assertion.sub"
     "attribute.actor"      = "assertion.actor"
@@ -12,7 +12,7 @@ resource "google_iam_workload_identity_pool_provider" "github-actions--provider"
     "attribute.repository" = "assertion.repository"
   }
   attribute_condition = <<EOT
-    attribute.repository == "cal-itp/data-infra"
+    attribute.repository == "${local.data-infra_github_repository_name}"
   EOT
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"

--- a/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
@@ -166,10 +166,6 @@ output "google_service_account_tfer--111881979116192190399_id" {
   value = google_service_account.tfer--111881979116192190399.id
 }
 
-output "google_iam_workload_identity_pool_provider_github-actions--provider_name" {
-  value = google_iam_workload_identity_pool_provider.github-actions--provider.name
-}
-
 output "google_service_account_composer-service-account_id" {
   value = google_service_account.composer-service-account.id
 }

--- a/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
@@ -1,18 +1,13 @@
-locals {
-  project_id             = "473674835135"
-  github_repository_name = "cal-itp/data-infra"
-}
-
 resource "google_service_account_iam_member" "github-actions-terraform" {
   service_account_id = google_service_account.github-actions-terraform.id
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
 }
 
 resource "google_service_account_iam_member" "github-actions-service-account" {
   service_account_id = google_service_account.github-actions-service-account.id
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
 }
 
 resource "google_service_account_iam_member" "custom_service_account" {

--- a/iac/cal-itp-data-infra-staging/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  project_id                        = "473674835135"
+  data-infra_github_repository_name = "cal-itp/data-infra"
+}

--- a/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
@@ -40,3 +40,14 @@ resource "google_service_account_iam_member" "github-actions--github-actions-ser
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
 }
+
+resource "google_service_account" "github_action_sa" {
+  account_id   = "github-action-sa"
+  display_name = "GitHub Action Service Account"
+}
+
+resource "google_project_iam_member" "github_action_sa_binding" {
+  project = "cal-itp-data-infra"
+  role    = "roles/google_project_iam_custom_role.github_action_role.name"
+  member  = "serviceAccount:${google_service_account.github_action_sa.email}"
+}

--- a/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
@@ -1,14 +1,10 @@
-locals {
-  github_repository_name = "cal-itp/data-infra"
+resource "google_iam_workload_identity_pool" "github-actions" {
+  workload_identity_pool_id = "github-actions"
 }
 
-resource "google_iam_workload_identity_pool" "github-actions--pool" {
-  workload_identity_pool_id = "github-actions-pool"
-}
-
-resource "google_iam_workload_identity_pool_provider" "github-actions--provider" {
-  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions--pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "github-actions-provider"
+resource "google_iam_workload_identity_pool_provider" "data-infra" {
+  workload_identity_pool_provider_id = "data-infra"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
   attribute_mapping = {
     "google.subject"       = "assertion.sub"
     "attribute.actor"      = "assertion.actor"
@@ -16,38 +12,26 @@ resource "google_iam_workload_identity_pool_provider" "github-actions--provider"
     "attribute.repository" = "assertion.repository"
   }
   attribute_condition = <<EOT
-    attribute.repository == "cal-itp/data-infra"
+    attribute.repository == "${local.data-infra_github_repository_name}"
   EOT
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
 
-resource "google_service_account_iam_member" "github-actions-terraform" {
-  service_account_id = google_service_account.github-actions-terraform.id
-  role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
-}
-
-resource "google_service_account_iam_member" "github-actions-service-account" {
-  service_account_id = google_service_account.github-actions-service-account.id
-  role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
-}
-
-resource "google_service_account_iam_member" "github-actions--github-actions-services-accoun" {
-  service_account_id = "projects/cal-itp-data-infra/serviceAccounts/github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com"
-  role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions--pool.name}/attribute.repository/${local.github_repository_name}"
-}
-
-resource "google_service_account" "github_action_sa" {
-  account_id   = "github-action-sa"
-  display_name = "GitHub Action Service Account"
-}
-
-resource "google_project_iam_member" "github_action_sa_binding" {
-  project = "cal-itp-data-infra"
-  role    = "roles/google_project_iam_custom_role.github_action_role.name"
-  member  = "serviceAccount:${google_service_account.github_action_sa.email}"
+resource "google_iam_workload_identity_pool_provider" "gtfs-calitp-org" {
+  workload_identity_pool_provider_id = "gtfs-calitp-org"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.gtfs-calitp-org_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
 }

--- a/iac/cal-itp-data-infra/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra/iam/us/outputs.tf
@@ -505,11 +505,3 @@ output "google_service_account_tfer--117956330948086473326_id" {
 output "google_service_account_tfer--118350215382382143206_id" {
   value = google_service_account.tfer--118350215382382143206.id
 }
-
-output "google_iam_workload_identity_pool_provider_github-actions--provider_name" {
-  value = google_iam_workload_identity_pool_provider.github-actions--provider.name
-}
-
-output "service_account_email" {
-  value = google_service_account.github_action_sa.email
-}

--- a/iac/cal-itp-data-infra/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra/iam/us/outputs.tf
@@ -509,3 +509,7 @@ output "google_service_account_tfer--118350215382382143206_id" {
 output "google_iam_workload_identity_pool_provider_github-actions--provider_name" {
   value = google_iam_workload_identity_pool_provider.github-actions--provider.name
 }
+
+output "service_account_email" {
+  value = google_service_account.github_action_sa.email
+}

--- a/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
@@ -15,3 +15,17 @@ resource "google_project_iam_custom_role" "tfer--projects-002F-cal-itp-data-infr
   stage       = "ALPHA"
   title       = "Data Analyst"
 }
+
+resource "google_project_iam_custom_role" "github_publish_website_action_role" {
+  role_id     = "github_action_role"
+  title       = "GitHub Publish Website to GCS Bucket Action Role"
+  description = "Role for GitHub Actions to deploy to GCS"
+  permissions = [
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+    "storage.objects.list",
+    "storage.buckets.get"
+  ]
+  project     = "cal-itp-data-infra"
+}

--- a/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
@@ -27,5 +27,5 @@ resource "google_project_iam_custom_role" "github_publish_website_action_role" {
     "storage.objects.list",
     "storage.buckets.get"
   ]
-  project     = "cal-itp-data-infra"
+  project = "cal-itp-data-infra"
 }

--- a/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
@@ -15,17 +15,3 @@ resource "google_project_iam_custom_role" "tfer--projects-002F-cal-itp-data-infr
   stage       = "ALPHA"
   title       = "Data Analyst"
 }
-
-resource "google_project_iam_custom_role" "github_publish_website_action_role" {
-  role_id     = "github_action_role"
-  title       = "GitHub Publish Website to GCS Bucket Action Role"
-  description = "Role for GitHub Actions to deploy to GCS"
-  permissions = [
-    "storage.objects.create",
-    "storage.objects.delete",
-    "storage.objects.get",
-    "storage.objects.list",
-    "storage.buckets.get"
-  ]
-  project = "cal-itp-data-infra"
-}

--- a/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
@@ -1,0 +1,23 @@
+resource "google_service_account_iam_member" "github-actions-terraform" {
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
+  service_account_id = google_service_account.github-actions-terraform.id
+  role               = "roles/iam.workloadIdentityUser"
+}
+
+resource "google_service_account_iam_member" "github-actions-service-account_data-infra" {
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+}
+
+resource "google_service_account_iam_member" "github-actions-service-account_gtfs-calitp-org" {
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.gtfs-calitp-org_github_repository_name}"
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+}
+
+resource "google_service_account_iam_member" "github-actions--github-actions-services-accoun" {
+  service_account_id = "projects/cal-itp-data-infra/serviceAccounts/github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
+}

--- a/iac/cal-itp-data-infra/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra/iam/us/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  data-infra_github_repository_name      = "cal-itp/data-infra"
+  gtfs-calitp-org_github_repository_name = "cal-itp/gtfs.calitp.org"
+}


### PR DESCRIPTION
# Description

Adds a role that should allow us to publish from a github repo directly to a bucket. 

Continues work on #3812

## Type of change

- [x] New feature

## How has this been tested?

Has Not

## Post-merge follow-ups

- [x] Actions required (specified below)
Capture output with
```gcloud iam service-accounts keys create key.json \
  --iam-account <service-account-email>```
  Then test in calitp.gtfs.org repo