### PR TITLE
NTD: some cleanup and revisions of prior modeling

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
@@ -37,7 +37,6 @@ int_transit_database__organizations_dim AS (
         hubspot_company_record_id,
         alias,
         details,
-        caltrans_district,
         mobility_services_managed,
         parent_organization,
         website,

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt.sql
@@ -3,9 +3,9 @@ WITH staging_calendar_year_upt AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt AS (
     SELECT *
     FROM staging_calendar_year_upt
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm.sql
@@ -3,9 +3,9 @@ WITH staging_calendar_year_vrm AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm AS (
     SELECT *
     FROM staging_calendar_year_vrm
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__master.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__master.sql
@@ -8,4 +8,34 @@ fct_complete_monthly_ridership_with_adjustments_and_estimates__master AS (
     FROM staging_master
 )
 
-SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__master
+SELECT
+    ntd_id,
+    legacy_ntd_id,
+    agency,
+    mode,
+    tos,
+    _3_mode,
+    mode_type_of_service_status,
+    reporter_type,
+    organization_type,
+    hq_city,
+    hq_state,
+    uace_cd,
+    uza_name,
+    uza_sq_miles,
+    uza_population,
+    service_area_population,
+    service_area_sq_miles,
+    last_closed_report_year,
+    last_closed_fy_end_month,
+    last_closed_fy_end_year,
+    passenger_miles_fy,
+    unlinked_passenger_trips_fy,
+    avg_trip_length_fy,
+    fares_fy,
+    operating_expenses_fy,
+    avg_cost_per_trip_fy,
+    avg_fares_per_trip_fy,
+    dt,
+    execution_ts
+FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__master

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__master.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__master.sql
@@ -3,9 +3,9 @@ WITH staging_master AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__master') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__master AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__master AS (
     SELECT *
     FROM staging_master
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__master
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__master

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__upt.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__upt.sql
@@ -3,9 +3,9 @@ WITH staging_upt AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__upt AS (
     SELECT *
     FROM staging_upt
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__upt

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.sql
@@ -8,4 +8,15 @@ fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates AS 
     FROM staging_upt_estimates
 )
 
-SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates
+SELECT
+    top_150,
+    ntd_id,
+    agency,
+    mode,
+    tos,
+    month,
+    year,
+    estimated_upt,
+    dt,
+    execution_ts
+FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.sql
@@ -3,9 +3,9 @@ WITH staging_upt_estimates AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates AS (
     SELECT *
     FROM staging_upt_estimates
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__voms.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__voms.sql
@@ -3,9 +3,9 @@ WITH staging_voms AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__voms') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__voms AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__voms AS (
     SELECT *
     FROM staging_voms
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__voms
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__voms

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrh.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrh.sql
@@ -3,9 +3,9 @@ WITH staging_vrh AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrh') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrh AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__vrh AS (
     SELECT *
     FROM staging_vrh
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrh
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__vrh

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm.sql
@@ -3,9 +3,9 @@ WITH staging_vrm AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm AS (
     SELECT *
     FROM staging_vrm
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.sql
@@ -8,4 +8,15 @@ fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates AS 
     FROM staging_vrm_estimates
 )
 
-SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates
+SELECT
+    top_150,
+    ntd_id,
+    agency,
+    mode,
+    tos,
+    month,
+    year,
+    estimated_vrm,
+    dt,
+    execution_ts
+FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.sql
@@ -3,9 +3,9 @@ WITH staging_vrm_estimates AS (
     FROM {{ ref('stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates') }}
 ),
 
-stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates AS (
+fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates AS (
     SELECT *
     FROM staging_vrm_estimates
 )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates
+SELECT * FROM fct_complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates

--- a/warehouse/models/mart/ntd_safety_and_security/fct_major_safety_events.sql
+++ b/warehouse/models/mart/ntd_safety_and_security/fct_major_safety_events.sql
@@ -28,7 +28,7 @@ SELECT
     typeofservicecd,
     reportername,
     customer,
-    ntdid,
+    ntd_id,
     dt,
     execution_ts
 FROM fct_major_safety_events

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -24,7 +24,6 @@ dim_organizations AS (
         roles,
         itp_id,
         details,
-        caltrans_district,
         website,
         reporting_category,
         hubspot_company_record_id,

--- a/warehouse/models/staging/ntd_ridership/stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__master.sql
+++ b/warehouse/models/staging/ntd_ridership/stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__master.sql
@@ -11,4 +11,34 @@ WITH
         QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
     )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__master
+SELECT
+  ntd_id,
+  legacy_ntd_id,
+  agency,
+  mode,
+  tos,
+  _3_mode,
+  mode_type_of_service_status,
+  reporter_type,
+  organization_type,
+  hq_city,
+  hq_state,
+  uace_cd,
+  uza_name,
+  uza_sq_miles,
+  uza_population,
+  service_area_population,
+  service_area_sq_miles,
+  last_closed_report_year,
+  last_closed_fy_end_month,
+  last_closed_fy_end_year,
+  passenger_miles_fy,
+  unlinked_passenger_trips_fy,
+  avg_trip_length_fy,
+  fares_fy,
+  operating_expenses_fy,
+  avg_cost_per_trip_fy,
+  avg_fares_per_trip_fy,
+  dt,
+  execution_ts
+FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__master

--- a/warehouse/models/staging/ntd_ridership/stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.sql
+++ b/warehouse/models/staging/ntd_ridership/stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.sql
@@ -11,4 +11,15 @@ WITH
         QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
     )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates
+SELECT
+  top_150,
+  ntd_id,
+  agency,
+  mode,
+  tos,
+  month,
+  year,
+  estimated_upt,
+  dt,
+  execution_ts
+FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates

--- a/warehouse/models/staging/ntd_ridership/stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.sql
+++ b/warehouse/models/staging/ntd_ridership/stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.sql
@@ -11,4 +11,15 @@ WITH
         QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
     )
 
-SELECT * FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates
+SELECT
+  top_150,
+  ntd_id,
+  agency,
+  mode,
+  tos,
+  month,
+  year,
+  estimated_vrm,
+  dt,
+  execution_ts
+FROM stg_ntd__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates

--- a/warehouse/models/staging/ntd_safety_and_security/stg_ntd__major_safety_events.sql
+++ b/warehouse/models/staging/ntd_safety_and_security/stg_ntd__major_safety_events.sql
@@ -35,7 +35,7 @@ SELECT
     {{ trim_make_empty_string_null('typeofservicecd') }} AS typeofservicecd,
     {{ trim_make_empty_string_null('reportername') }} AS reportername,
     SAFE_CAST(customer AS INTEGER) AS customer,
-        {{ trim_make_empty_string_null('CAST(ntdid AS STRING)') }} AS ntdid,
+        {{ trim_make_empty_string_null('CAST(ntdid AS STRING)') }} AS ntd_id,
     dt,
     execution_ts
 FROM stg_ntd__major_safety_events

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -26,7 +26,6 @@ stg_transit_database__organizations AS (
         hubspot_company_record_id,
         alias_ as alias,
         details,
-        caltrans_district,
         mobility_services_managed,
         parent_organization,
         website,


### PR DESCRIPTION
# Description
This PR goes back and makes some cleanup/revisions based on prior NTD modeling, in preparation for caltrans_district enrichment in a future PR

* Rename CTEs previous incorrectly named in mart tables
* Add explicit column naming for NTD ridership tables that aren't time-series
* Rename `ntd_id` where used differently than the norm (ex `ntdid`)

Partially resolves #3834 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
`poetry run dbt run -s +mart.ntd_annual_reporting +mart.ntd_funding_and_expenses +mart.ntd_ridership +mart.ntd_safety_and_security`
<img width="797" alt="Screenshot 2025-04-17 at 12 33 31" src="https://github.com/user-attachments/assets/10ba7ff9-b59b-42d7-9c2a-7abbe31c1134" />

## Post-merge follow-ups
- [x] No action required
