### PR TITLE
NTD: fix agency field in employees_by_agency tables

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_agency.yml
@@ -12,7 +12,7 @@ destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__e
 prefix_bucket: false
 post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__employees_by_agency LIMIT 1;
 schema_fields:
-  - name: agency
+  - name: max_agency_1
     type: STRING
   - name: avgwagerate
     type: FLOAT

--- a/warehouse/models/mart/ntd_annual_reporting/fct_employees_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_employees_by_agency.sql
@@ -13,7 +13,7 @@ current_dim_organizations AS (
 
 fct_employees_by_agency AS (
     SELECT
-        stg.agency,
+        stg.max_agency_1,
         stg.avgwagerate,
         stg.count_capital_labor_count_q,
         stg.count_capital_labor_hours_q,

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__employees_by_agency.sql
@@ -16,7 +16,7 @@ stg_ntd__employees_by_agency AS (
 )
 
 SELECT
-    {{ trim_make_empty_string_null('agency') }} AS agency,
+    {{ trim_make_empty_string_null('max_agency_1') }} AS max_agency_1,
     SAFE_CAST(avgwagerate AS FLOAT64) AS avgwagerate,
     SAFE_CAST(count_capital_labor_count_q AS NUMERIC) AS count_capital_labor_count_q,
     SAFE_CAST(count_capital_labor_hours_q AS NUMERIC) AS count_capital_labor_hours_q,


### PR DESCRIPTION
# Description
The field for agency name in the employees_by_agency-related NTD tables is misnamed as `agency` through the pipeline, instead of how it is actually found in the source data: `max_agency_1`.

Files changed (column name: `agency` to `max_agency_1`): 
* `dags/create_external_tables/ntd_data_products/multi_year__employees_by_agency`
* `staging/ntd_annual_reporting/stg_ntd__employees_by_agency`
* `mart/ntd_annual_reporting/fct_employees_by_agency`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
In local airflow
<img width="738" alt="Screenshot 2025-04-18 at 18 46 10" src="https://github.com/user-attachments/assets/99694132-eae2-44e7-83bb-26706d791eb5" />

## Post-merge follow-ups
- [x] No action required