### PR TITLE
NTD: modeling and other cleanup to facilitate dashboarding

### DIFF
--- a/warehouse/models/mart/ntd_annual_reporting/dim_2022_agency_information.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/dim_2022_agency_information.sql
@@ -63,6 +63,7 @@ dim_2022_agency_information AS (
         stg.execution_ts
     FROM staging_agency_information AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM dim_2022_agency_information

--- a/warehouse/models/mart/ntd_annual_reporting/dim_2023_agency_information.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/dim_2023_agency_information.sql
@@ -64,6 +64,8 @@ dim_2023_agency_information AS (
         stg.execution_ts
     FROM staging_agency_information AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
+
 )
 
 SELECT * FROM dim_2023_agency_information

--- a/warehouse/models/mart/ntd_annual_reporting/fct_2023_contractual_relationships.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_2023_contractual_relationships.sql
@@ -44,6 +44,8 @@ fct_2023_contractual_relationships AS (
         orgs.caltrans_district_current,
         orgs.caltrans_district_name_current,
 
+        2023 AS report_year,
+
         stg.dt,
         stg.execution_ts
     FROM staging_contractual_relationships AS stg

--- a/warehouse/models/mart/ntd_annual_reporting/fct_breakdowns.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_breakdowns.sql
@@ -50,6 +50,7 @@ fct_breakdowns AS (
         stg.execution_ts
     FROM staging_breakdowns AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_breakdowns

--- a/warehouse/models/mart/ntd_annual_reporting/fct_breakdowns_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_breakdowns_by_agency.sql
@@ -45,6 +45,7 @@ fct_breakdowns_by_agency AS (
         stg.execution_ts
     FROM staging_breakdowns_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_breakdowns_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_by_capital_use.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_by_capital_use.sql
@@ -59,6 +59,7 @@ fct_capital_expenses_by_capital_use AS (
         stg.execution_ts
     FROM staging_capital_expenses_by_capital_use AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenses_by_capital_use

--- a/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_by_mode.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_by_mode.sql
@@ -55,6 +55,7 @@ fct_capital_expenses_by_mode AS (
         stg.execution_ts
     FROM staging_capital_expenses_by_mode AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenses_by_mode

--- a/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_for_existing_service.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_for_existing_service.sql
@@ -44,6 +44,7 @@ fct_capital_expenses_for_existing_service AS (
         stg.execution_ts
     FROM staging_capital_expenses_for_existing_service AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenses_for_existing_service

--- a/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_for_expansion_of_service.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_capital_expenses_for_expansion_of_service.sql
@@ -44,6 +44,7 @@ fct_capital_expenses_for_expansion_of_service AS (
         stg.execution_ts
     FROM staging_capital_expenses_for_expansion_of_service AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenses_for_expansion_of_service

--- a/warehouse/models/mart/ntd_annual_reporting/fct_employees_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_employees_by_agency.sql
@@ -47,6 +47,8 @@ fct_employees_by_agency AS (
         stg.execution_ts
     FROM staging_employees_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs ON stg.max_ntd_id = orgs.ntd_id
+    WHERE stg.max_state_1 = 'CA'
+
 )
 
 SELECT * FROM fct_employees_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_employees_by_mode_and_employee_type.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_employees_by_mode_and_employee_type.sql
@@ -60,6 +60,7 @@ fct_employees_by_mode_and_employee_type AS (
         stg.execution_ts
     FROM staging_employees_by_mode_and_employee_type AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_employees_by_mode_and_employee_type

--- a/warehouse/models/mart/ntd_annual_reporting/fct_fuel_and_energy.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_fuel_and_energy.sql
@@ -86,6 +86,7 @@ fct_fuel_and_energy AS (
         stg.execution_ts
     FROM staging_fuel_and_energy AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_fuel_and_energy

--- a/warehouse/models/mart/ntd_annual_reporting/fct_fuel_and_energy_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_fuel_and_energy_by_agency.sql
@@ -51,6 +51,7 @@ fct_fuel_and_energy_by_agency AS (
         stg.execution_ts
     FROM staging_fuel_and_energy_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_fuel_and_energy_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_by_expense_type.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_by_expense_type.sql
@@ -45,6 +45,7 @@ fct_funding_sources_by_expense_type AS (
         stg.execution_ts
     FROM staging_funding_sources_by_expense_type AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_funding_sources_by_expense_type

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_directly_generated.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_directly_generated.sql
@@ -46,6 +46,7 @@ fct_funding_sources_directly_generated AS (
         stg.execution_ts
     FROM staging_funding_sources_directly_generated AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_funding_sources_directly_generated

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_federal.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_federal.sql
@@ -39,6 +39,7 @@ fct_funding_sources_federal AS (
         stg.execution_ts
     FROM staging_funding_sources_federal AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_funding_sources_federal

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_local.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_local.sql
@@ -42,6 +42,7 @@ fct_funding_sources_local AS (
         stg.execution_ts
     FROM staging_funding_sources_local AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_funding_sources_local

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_state.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_state.sql
@@ -37,6 +37,7 @@ fct_funding_sources_state AS (
         stg.execution_ts
     FROM staging_funding_sources_state AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_funding_sources_state

--- a/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_taxes_levied_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_funding_sources_taxes_levied_by_agency.sql
@@ -40,6 +40,7 @@ fct_funding_sources_taxes_levied_by_agency AS (
         stg.execution_ts
     FROM staging_funding_sources_taxes_levied_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_funding_sources_taxes_levied_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_maintenance_facilities.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_maintenance_facilities.sql
@@ -60,6 +60,7 @@ fct_maintenance_facilities AS (
         stg.execution_ts
     FROM staging_maintenance_facilities AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_maintenance_facilities

--- a/warehouse/models/mart/ntd_annual_reporting/fct_maintenance_facilities_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_maintenance_facilities_by_agency.sql
@@ -44,6 +44,7 @@ fct_maintenance_facilities_by_agency AS (
         stg.execution_ts
     FROM staging_maintenance_facilities_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_maintenance_facilities_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_metrics.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_metrics.sql
@@ -60,6 +60,7 @@ fct_metrics AS (
         stg.execution_ts
     FROM staging_metrics AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_metrics

--- a/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_function.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_function.sql
@@ -50,6 +50,7 @@ fct_operating_expenses_by_function AS (
         stg.execution_ts
     FROM staging_operating_expenses_by_function AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_operating_expenses_by_function

--- a/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_function_and_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_function_and_agency.sql
@@ -39,6 +39,7 @@ fct_operating_expenses_by_function_and_agency AS (
         stg.execution_ts
     FROM staging_operating_expenses_by_function_and_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_operating_expenses_by_function_and_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type.sql
@@ -70,6 +70,8 @@ fct_operating_expenses_by_type AS (
         stg.execution_ts
     FROM staging_operating_expenses_by_type AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
+
 )
 
 SELECT * FROM fct_operating_expenses_by_type

--- a/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type_and_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_operating_expenses_by_type_and_agency.sql
@@ -49,6 +49,7 @@ fct_operating_expenses_by_type_and_agency AS (
         stg.execution_ts
     FROM staging_operating_expenses_by_type_and_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_operating_expenses_by_type_and_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_service_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_service_by_agency.sql
@@ -56,6 +56,7 @@ fct_service_by_agency AS (
         stg.execution_ts
     FROM staging_service_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs ON stg._5_digit_ntd_id = orgs.ntd_id
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_service_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_service_by_mode.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_service_by_mode.sql
@@ -67,6 +67,7 @@ fct_service_by_mode AS (
         stg.execution_ts
     FROM staging_service_by_mode AS stg
     LEFT JOIN current_dim_organizations AS orgs ON stg._5_digit_ntd_id = orgs.ntd_id
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_service_by_mode

--- a/warehouse/models/mart/ntd_annual_reporting/fct_service_by_mode_and_time_period.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_service_by_mode_and_time_period.sql
@@ -90,6 +90,8 @@ fct_service_by_mode_and_time_period AS (
         stg.execution_ts
     FROM staging_service_by_mode_and_time_period AS stg
     LEFT JOIN current_dim_organizations AS orgs ON stg._5_digit_ntd_id = orgs.ntd_id
+    WHERE stg.state = 'CA'
+
 )
 
 SELECT * FROM fct_service_by_mode_and_time_period

--- a/warehouse/models/mart/ntd_annual_reporting/fct_stations_and_facilities_by_agency_and_facility_type.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_stations_and_facilities_by_agency_and_facility_type.sql
@@ -58,6 +58,7 @@ fct_stations_and_facilities_by_agency_and_facility_type AS (
         stg.execution_ts
     FROM staging_stations_and_facilities_by_agency_and_facility_type AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_stations_and_facilities_by_agency_and_facility_type

--- a/warehouse/models/mart/ntd_annual_reporting/fct_stations_by_mode_and_age.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_stations_by_mode_and_age.sql
@@ -46,6 +46,7 @@ fct_stations_by_mode_and_age AS (
         stg.execution_ts
     FROM staging_stations_by_mode_and_age AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_stations_by_mode_and_age

--- a/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_agency.sql
@@ -53,6 +53,7 @@ fct_track_and_roadway_by_agency AS (
         stg.execution_ts
     FROM staging_track_and_roadway_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.max_state = 'CA'
 )
 
 SELECT * FROM fct_track_and_roadway_by_agency

--- a/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_mode.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_by_mode.sql
@@ -77,6 +77,7 @@ fct_track_and_roadway_by_mode AS (
         stg.execution_ts
     FROM staging_track_and_roadway_by_mode AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_track_and_roadway_by_mode

--- a/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_guideway_age_distribution.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_track_and_roadway_guideway_age_distribution.sql
@@ -56,6 +56,7 @@ fct_track_and_roadway_guideway_age_distribution AS (
         stg.execution_ts
     FROM staging_track_and_roadway_guideway_age_distribution AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_track_and_roadway_guideway_age_distribution

--- a/warehouse/models/mart/ntd_annual_reporting/fct_vehicles_age_distribution.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_vehicles_age_distribution.sql
@@ -55,6 +55,7 @@ fct_vehicles_age_distribution AS (
         stg.execution_ts
     FROM staging_vehicles_age_distribution AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_vehicles_age_distribution

--- a/warehouse/models/mart/ntd_annual_reporting/fct_vehicles_type_count_by_agency.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_vehicles_type_count_by_agency.sql
@@ -117,6 +117,7 @@ fct_vehicles_type_count_by_agency AS (
         stg.execution_ts
     FROM staging_vehicles_type_count_by_agency AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_vehicles_type_count_by_agency

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_facilities.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_facilities.sql
@@ -39,6 +39,7 @@ fct_capital_expenditures_time_series_facilities AS (
         int.execution_ts
     FROM int_ntd__capital_expenditures_time_series_facilities AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenditures_time_series_facilities

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_other.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_other.sql
@@ -39,6 +39,7 @@ fct_capital_expenditures_time_series_other AS (
         int.execution_ts
     FROM int_ntd__capital_expenditures_time_series_other AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenditures_time_series_other

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_rolling_stock.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_rolling_stock.sql
@@ -39,6 +39,7 @@ fct_capital_expenditures_time_series_rolling_stock AS (
         int.execution_ts
     FROM int_ntd__capital_expenditures_time_series_rolling_stock AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenditures_time_series_rolling_stock

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_total.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_capital_expenditures_time_series_total.sql
@@ -39,6 +39,7 @@ fct_capital_expenditures_time_series_total AS (
         int.execution_ts
     FROM int_ntd__capital_expenditures_time_series_total AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_capital_expenditures_time_series_total

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_federal.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_federal.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_capital_federal AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_capital_federal AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_capital_federal

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_local.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_local.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_capital_local AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_capital_local AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_capital_local

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_other.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_other.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_capital_other AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_capital_other AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_capital_other

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_state.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_state.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_capital_state AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_capital_state AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_capital_state

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_total.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_capital_total.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_capital_total AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_capital_total AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_capital_total

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_decommissioned_operatingfares.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_decommissioned_operatingfares.sql
@@ -63,6 +63,7 @@ fct_operating_and_capital_funding_time_series_decommissioned_operatingfares AS (
         stg.execution_ts
     FROM staging_operating_and_capital_funding_time_series_decommissioned_operatingfares AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_decommissioned_operatingfares

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_decommissioned_operatingother.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_decommissioned_operatingother.sql
@@ -63,6 +63,7 @@ fct_operating_and_capital_funding_time_series_decommissioned_operatingother AS (
         stg.execution_ts
     FROM staging_operating_and_capital_funding_time_series_decommissioned_operatingother AS stg
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_decommissioned_operatingother

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_federal.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_federal.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_operating_federal AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_operating_federal AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_operating_federal

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_local.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_local.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_operating_local AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_operating_local AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_operating_local

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_other.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_other.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_operating_other AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_operating_other AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_operating_other

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_state.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_state.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_operating_state AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_operating_state AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_operating_state

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_total.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_operating_total.sql
@@ -38,6 +38,7 @@ fct_operating_and_capital_funding_time_series_operating_total AS (
         int.execution_ts
     FROM int_ntd__operating_and_capital_funding_time_series_operating_total AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_operating_total

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_summary_total.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_summary_total.sql
@@ -24,6 +24,7 @@ fct_operating_and_capital_funding_time_series_summary_total AS (
         stg.dt,
         stg.execution_ts
     FROM staging_operating_and_capital_funding_time_series_summary_total AS stg
+    WHERE stg.state = 'CA'
 )
 
 SELECT * FROM fct_operating_and_capital_funding_time_series_summary_total

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_drm.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_drm.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_drm AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_drm AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_drm

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_fares.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_fares.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_fares AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_fares AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_fares

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_ga.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_ga.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_opexp_ga AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_ga AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_opexp_ga

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_nvm.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_nvm.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_opexp_nvm AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_nvm AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_opexp_nvm

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_total.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_total.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_opexp_total AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_total AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_opexp_total

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vm.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vm.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vm AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_vm AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vm

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vo.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vo.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vo AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_opexp_vo AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vo

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_pmt.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_pmt.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_pmt AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_pmt AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_pmt

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_upt.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_upt.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_upt AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_upt AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_upt

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_voms.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_voms.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_voms AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_voms AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_voms

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_vrh.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_vrh.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_vrh AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrh AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_vrh

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_vrm.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_service_data_and_operating_expenses_time_series_by_mode_vrm.sql
@@ -41,6 +41,7 @@ fct_service_data_and_operating_expenses_time_series_by_mode_vrm AS (
         int.execution_ts
     FROM int_ntd__service_data_and_operating_expenses_time_series_by_mode_vrm AS int
     LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+    WHERE int.state = 'CA'
 )
 
 SELECT * FROM fct_service_data_and_operating_expenses_time_series_by_mode_vrm


### PR DESCRIPTION
# Description
After ingesting our new NTD endpoints and performing preliminary dashboarding, we are going to perform another round of modeling and cleanup to facilitate dashboarding in Metabase based on learnings and needs.

Changes:
* Enrich tables with source dimension information for organizations
* Normalize commonly used fields in mart tables (ex `max_state` -> `state`, `_5_digit_ntd_id` -> `ntd_id`)
* Pre-filter mart tables for state = 'CA'
* Adding `report_year` field where necessary

Resolves #\[issue\]

## Type of change
- [x] New feature

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and `poetry run dbt test -s CHANGED_MODEL`, then include the output in this section of the PR._

## Post-merge follow-ups
- [x] Actions required (specified below)
Reverse temporary solutions/modeling within Metabase that this new modeling and cleanup will better faciliate