### PR TITLE
payments: sync, parse tasks for new sacrt littlepay feed v3; modify Dockerfile, Dockerfile.composer

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.6.3-python3.11
+FROM apache/airflow:2.5.3-python3.8
 
 # install gcloud as root, then switch back to airflow
 USER root

--- a/airflow/Dockerfile.composer
+++ b/airflow/Dockerfile.composer
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.6.3-python3.11
+FROM apache/airflow:2.5.3-python3.8
 
 # install gcloud as root, then switch back to airflow
 USER root
@@ -15,8 +15,8 @@ RUN gcloud components install gke-gcloud-auth-plugin
 
 USER airflow
 
-COPY requirements-composer-2.8.3-airflow-2.6.3.txt /tmp/requirements-composer-2.8.3-airflow-2.6.3.txt
-RUN pip install --no-cache-dir --user -r /tmp/requirements-composer-2.8.3-airflow-2.6.3.txt
+COPY requirements-composer-2.6.5-airflow-2.5.3.txt /tmp/requirements-composer-2.6.5-airflow-2.5.3.txt
+RUN pip install --no-cache-dir --user -r /tmp/requirements-composer-2.6.5-airflow-2.5.3.txt
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --user -r /tmp/requirements.txt

--- a/airflow/dags/parse_littlepay_v3/sacrt.yml
+++ b/airflow/dags/parse_littlepay_v3/sacrt.yml
@@ -1,0 +1,2 @@
+operator: operators.LittlepayToJSONLV3
+instance: sacrt

--- a/airflow/dags/sync_littlepay_v3/sacrt.yml
+++ b/airflow/dags/sync_littlepay_v3/sacrt.yml
@@ -1,0 +1,4 @@
+operator: operators.LittlepayRawSyncV3
+instance: sacrt
+src_bucket: littlepay-datafeed-prod-sacrt-56af2970
+access_key_secret_name: LITTLEPAY_AWS_IAM_SACRT_ACCESS_KEY_FEED_V3


### PR DESCRIPTION
# Description
Littlepay has generated a new feed v3 for SacRT's recent launch, and this PR sets up the sync and parse tasks necessary to ingest and parse this data.

In this PR, we are also reverting/revising `Dockerfile` and `Dockerfile.composer`
* `Dockerfile` – revising based on the reversion of #3791 
  * revert back to apache/airflow:2.5.3-python3.8
* `Dockerfile.composer`
  * Fix previously existing error,  configure as apache/airflow:2.5.3-python3.8
  * Revert back to Composer 2.6.5

Next:
* Seed mapping for payments organizations
* RBAC for payments users access
* Dashboarding for payments

Partially resolves #3835 

## Type of change
- [x] New feature

## How has this been tested?
local airflow
<img width="439" alt="Screenshot 2025-04-24 at 15 17 54" src="https://github.com/user-attachments/assets/805ce84e-dc73-43f1-a8db-c7c570b626f7" />
<img width="455" alt="Screenshot 2025-04-24 at 15 17 44" src="https://github.com/user-attachments/assets/53ed47ea-7eef-480f-80f0-1ada77856942" />

## Post-merge follow-ups
- [x] No action required
