### PR TITLE
NTD: create external tables for new endpoints – asset_inventory_time_series and 2022 contractual relationships

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/2022__annual_database_contractual_relationships.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__annual_database_contractual_relationships.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-xlsx-products-clean
+prefix_bucket: false
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__annual_database_contractual_relationships
+  LIMIT 1;
+source_objects:
+  - "annual_database_contractual_relationship/2022/_2022_contractual_relationships/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__annual_reporting.2022__annual_database_contractual_relationships"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "annual_database_contractual_relationship/2022/_2022_contractual_relationships/"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__active_fleet.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__active_fleet.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-xlsx-products-clean
+prefix_bucket: false
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__active_fleet
+  LIMIT 1;
+source_objects:
+  - "asset_inventory_time_series/historical/active_fleet/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__assets.historical__asset_inventory_time_series__active_fleet"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "asset_inventory_time_series/historical/active_fleet/"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__ada_fleet.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__ada_fleet.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-xlsx-products-clean
+prefix_bucket: false
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__ada_fleet
+  LIMIT 1;
+source_objects:
+  - "asset_inventory_time_series/historical/ada_fleet/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__assets.historical__asset_inventory_time_series__ada_fleet"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "asset_inventory_time_series/historical/ada_fleet/"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_fleet_age.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_fleet_age.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-xlsx-products-clean
+prefix_bucket: false
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_fleet_age
+  LIMIT 1;
+source_objects:
+  - "asset_inventory_time_series/historical/avg_fleet_age/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__assets.historical__asset_inventory_time_series__avg_fleet_age"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "asset_inventory_time_series/historical/avg_fleet_age/"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_seating_capacity.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_seating_capacity.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-xlsx-products-clean
+prefix_bucket: false
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_seating_capacity
+  LIMIT 1;
+source_objects:
+  - "asset_inventory_time_series/historical/avg_seating_capacity/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__assets.historical__asset_inventory_time_series__avg_seating_capacity"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "asset_inventory_time_series/historical/avg_seating_capacity/"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_standing_capacity.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_standing_capacity.yml
@@ -1,0 +1,16 @@
+operator: operators.ExternalTable
+bucket: gs://calitp-ntd-xlsx-products-clean
+prefix_bucket: false
+post_hook: |
+  SELECT *
+  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_standing_capacity
+  LIMIT 1;
+source_objects:
+  - "asset_inventory_time_series/historical/avg_standing_capacity/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__assets.historical__asset_inventory_time_series__avg_standing_capacity"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "asset_inventory_time_series/historical/avg_standing_capacity/"


### PR DESCRIPTION
# Description
Following #3853, this PR creates new external tables for our new `asset_inventory_time_series` and `2022__annual_database_contractual_relationships` endopoints.

External tables created:
* create_external_tables/ntd_data_products/2022__annual_database_contractual_relationships.yml
* create_external_tables/ntd_data_products/historical__asset_inventory_time_series__active_fleet.yml
* create_external_tables/ntd_data_products/historical__asset_inventory_time_series__ada_fleet.yml
* create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_fleet_age.yml
* create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_seating_capacity.yml
* create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_standing_capacity.yml

## Type of change
- [x] New feature

## How has this been tested?
local airflow
<img width="1039" alt="Screenshot 2025-04-22 at 16 44 17" src="https://github.com/user-attachments/assets/4771e747-cec6-4d2c-9f89-6b5d8b2b0195" />
<img width="1042" alt="Screenshot 2025-04-22 at 16 44 10" src="https://github.com/user-attachments/assets/3ca613c7-155d-4709-9f0d-7432811d34aa" />
<img width="1053" alt="Screenshot 2025-04-22 at 16 44 04" src="https://github.com/user-attachments/assets/e983941b-6d10-485e-9b85-a3c3c3a72fd6" />
<img width="1039" alt="Screenshot 2025-04-22 at 16 43 57" src="https://github.com/user-attachments/assets/591d5f62-7d40-45d4-9c8d-0e4c81002568" />
<img width="1044" alt="Screenshot 2025-04-22 at 16 43 49" src="https://github.com/user-attachments/assets/89e1d012-4e38-4799-b796-4cd41a5d9f4b" />
<img width="1036" alt="Screenshot 2025-04-22 at 16 43 40" src="https://github.com/user-attachments/assets/684a1f2b-fd63-49c8-8e32-8a42a89bee6a" />


## Post-merge follow-ups
- [x] No action required
