### PR TITLE
Fix Metabase sync errors

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -39,7 +39,7 @@ x-common-fields:
             # occurs prior to that
             error_if: ">20"
   - &gtfs_rt_dataset_key
-    name: &gtfs_rt_dataset_key_desc | #gtfs_dataset_key
+    name: gtfs_rt_dataset_key_desc
     description: |
       Foreign key to the associated GTFS dataset record.
     tests:
@@ -2527,11 +2527,9 @@ models:
           `trip_id`, and `trip_start_time`.
       - *rt_service_date
       - name: gtfs_dataset_key
-        description: *gtfs_rt_dataset_key_desc
+        description: Foreign key to the associated GTFS dataset record.
       - *base64_url
       - *gtfs_rt_name
-      - name: gtfs_rt_schedule_dataset_key
-        description: '{{ doc("column_rt_schedule_dataset_key") }}'
       - <<: *trip_instance_key
         tests:
           - not_null

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -87,11 +87,11 @@ models:
       - name: ntd_id_2022
         description: |
           Pulled from airtable, the 5 digit component of raw_ntd_id
-      - name: rtpa
+      - name: rtpa_name
         description: |
           Regional Transportation Planning Agency. It shows which RTPA each transit agency is headquartered in.
           All transit agencies will be associated with a single RTPA given that there are RTPAs covering the entire state of California.
-      - name: mpo
+      - name: mpo_name
         description: |
           Metropolitan Planning Organization. It shows which MPO each transit agency is headquartered in.
           Not all transit agencies are associated with an MPO, since there are not MPOs covering the entire state.


### PR DESCRIPTION
# Description

Fixed model documentation correcting columns that were removed or changed.

* Removed GTFS_RT_SCHEDULE_DATASET_KEY since the column on MART_GTFS.FCT_VEHICLE_LOCATIONS_GROUPED does not exist anymore
* Renamed columns RTPA to RTPA_NAME and MPO to MPO_NAME from MART_TRANSIT_DATABASE.DIM_ORGANIZATIONS
* Fixed invalid commenting that will fix the empty columns errors

Resolves [#3862]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally.
```
❯ poetry run dbt run -s models/intermediate/gtfs/int_gtfs_schedule__all_scheduled_service.sql
20:17:31  Running with dbt=1.5.1
20:17:32  Unable to do partial parsing because a project config has changed
20:17:39  Found 582 models, 1072 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 217 sources, 4 exposures, 0 metrics, 0 groups
20:17:39
20:17:44  Concurrency: 8 threads (target='dev')
20:17:44
20:17:44  1 of 1 START sql table model erikap_staging.int_gtfs_schedule__all_scheduled_service  [RUN]
20:17:53  1 of 1 OK created sql table model erikap_staging.int_gtfs_schedule__all_scheduled_service  [CREATE TABLE (170.9m rows, 44.1 GiB processed) in 9.04s]
20:17:53
20:17:53  Finished running 1 table model in 0 hours 0 minutes and 14.01 seconds (14.01s).
20:17:53
20:17:53  Completed successfully
20:17:53
20:17:53  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

❯ poetry run dbt test -s models/intermediate/gtfs/int_gtfs_schedule__all_scheduled_service.sql
20:18:03  Running with dbt=1.5.1
20:18:05  Found 582 models, 1072 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 217 sources, 4 exposures, 0 metrics, 0 groups
20:18:05
20:18:07  Concurrency: 8 threads (target='dev')
20:18:07
20:18:07  1 of 9 START test not_null_int_gtfs_schedule__all_scheduled_service__feed_valid_from  [RUN]
20:18:07  2 of 9 START test not_null_int_gtfs_schedule__all_scheduled_service_feed_key ... [RUN]
20:18:07  3 of 9 START test not_null_int_gtfs_schedule__all_scheduled_service_key ........ [RUN]
20:18:07  4 of 9 START test not_null_int_gtfs_schedule__all_scheduled_service_service_date  [RUN]
20:18:07  5 of 9 START test not_null_int_gtfs_schedule__all_scheduled_service_service_id . [RUN]
20:18:07  6 of 9 START test relationships_int_gtfs_schedule__all_scheduled_service_calendar_dates_key__key__ref_dim_calendar_dates_  [RUN]
20:18:07  7 of 9 START test relationships_int_gtfs_schedule__all_scheduled_service_calendar_key__key__ref_dim_calendar_  [RUN]
20:18:07  8 of 9 START test relationships_int_gtfs_schedule__all_scheduled_service_feed_key__key__ref_dim_schedule_feeds_  [RUN]
20:18:08  3 of 9 PASS not_null_int_gtfs_schedule__all_scheduled_service_key .............. [PASS in 1.56s]
20:18:08  9 of 9 START test unique_int_gtfs_schedule__all_scheduled_service_key .......... [RUN]
20:18:08  4 of 9 PASS not_null_int_gtfs_schedule__all_scheduled_service_service_date ..... [PASS in 1.57s]
20:18:08  2 of 9 PASS not_null_int_gtfs_schedule__all_scheduled_service_feed_key ......... [PASS in 1.58s]
20:18:08  1 of 9 PASS not_null_int_gtfs_schedule__all_scheduled_service__feed_valid_from . [PASS in 1.60s]
20:18:08  8 of 9 PASS relationships_int_gtfs_schedule__all_scheduled_service_feed_key__key__ref_dim_schedule_feeds_  [PASS in 1.61s]
20:18:08  5 of 9 PASS not_null_int_gtfs_schedule__all_scheduled_service_service_id ....... [PASS in 1.63s]
20:18:08  6 of 9 PASS relationships_int_gtfs_schedule__all_scheduled_service_calendar_dates_key__key__ref_dim_calendar_dates_  [PASS in 1.87s]
20:18:11  7 of 9 PASS relationships_int_gtfs_schedule__all_scheduled_service_calendar_key__key__ref_dim_calendar_  [PASS in 4.18s]
20:18:12  9 of 9 PASS unique_int_gtfs_schedule__all_scheduled_service_key ................ [PASS in 3.67s]
20:18:12
20:18:12  Finished running 9 tests in 0 hours 0 minutes and 7.13 seconds (7.13s).
20:18:12
20:18:12  Completed successfully
20:18:12
20:18:12  Done. PASS=9 WARN=0 ERROR=0 SKIP=0 TOTAL=9

❯ poetry run dbt run -s models/mart/gtfs/fct_vehicle_locations_grouped.sql
20:18:54  Running with dbt=1.5.1
20:18:56  Found 582 models, 1072 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 217 sources, 4 exposures, 0 metrics, 0 groups
20:18:56
20:18:59  Concurrency: 8 threads (target='dev')
20:18:59
20:18:59  1 of 1 START sql view model erikap_mart_gtfs.fct_vehicle_locations_grouped ..... [RUN]
20:19:01  1 of 1 OK created sql view model erikap_mart_gtfs.fct_vehicle_locations_grouped  [CREATE VIEW (0 processed) in 1.78s]
20:19:01
20:19:01  Finished running 1 view model in 0 hours 0 minutes and 5.09 seconds (5.09s).
20:19:01
20:19:01  Completed successfully
20:19:01
20:19:01  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

❯ poetry run dbt test -s models/mart/gtfs/fct_vehicle_locations_grouped.sql
20:19:10  Running with dbt=1.5.1
20:19:11  Found 582 models, 1072 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 217 sources, 4 exposures, 0 metrics, 0 groups
20:19:11
20:19:13  Concurrency: 8 threads (target='dev')
20:19:13
20:19:13  1 of 1 START test not_null_fct_vehicle_locations_grouped_trip_instance_key ..... [RUN]
20:19:15  1 of 1 PASS not_null_fct_vehicle_locations_grouped_trip_instance_key ........... [PASS in 1.90s]
20:19:15
20:19:15  Finished running 1 test in 0 hours 0 minutes and 3.80 seconds (3.80s).
20:19:15
20:19:15  Completed successfully
20:19:15
20:19:15  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

❯ poetry run dbt run -s models/mart/transit_database/dim_organizations.sql
20:19:31  Running with dbt=1.5.1
20:19:33  Found 582 models, 1072 tests, 0 snapshots, 0 analyses, 852 macros, 0 operations, 12 seed files, 217 sources, 4 exposures, 0 metrics, 0 groups
20:19:33
20:19:37  Concurrency: 8 threads (target='dev')
20:19:37
20:19:37  1 of 1 START sql table model erikap_mart_transit_database.dim_organizations .... [RUN]
20:19:40  1 of 1 OK created sql table model erikap_mart_transit_database.dim_organizations  [CREATE TABLE (10.0k rows, 2.1 MiB processed) in 3.66s]
20:19:40
20:19:40  Finished running 1 table model in 0 hours 0 minutes and 7.50 seconds (7.50s).
20:19:40
20:19:40  Completed successfully
20:19:40
20:19:40  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check next transform_warehouse log to see if it fixed all errors.