### PR TITLE
Add permissions to GitHub service account to deploy to dbt

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -551,11 +551,11 @@ resource "google_project_iam_member" "github-actions-terraform" {
 
 resource "google_project_iam_member" "github-actions-service-account" {
   for_each = toset([
-    "roles/bigquery.dataViewer",
-    "roles/bigquery.jobUser",
-    "roles/bigquery.readSessionUser",
+    "roles/bigquery.filteredDataViewer",
+    "roles/bigquery.metadataViewer",
     "roles/composer.admin",
-    "roles/storage.admin"
+    "roles/storage.objectAdmin",
+    google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-DataAnalyst.id
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.github-actions-service-account.email}"


### PR DESCRIPTION
# Description

This PR adds permission to Github service account through Terraform to be able to run deploy dbt.

Resolves #3862

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally running `Terraform plan`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
