### PR TITLE
Add Admin login instructions for @dot.ca.gov emails

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -26,13 +26,13 @@ To test any changes you've made to DAGs, operators, etc., you'll need to follow 
 Ensure you have a default authentication file by [installing Google SDK](https://cloud.google.com/sdk/docs/install) and running
 
 ```console
-unset GOOGLE_APPLICATION_CREDENTIALS
-gcloud init
+gcloud auth login --login-config=iac/login.json
+gcloud config set project cal-itp-data-infra-staging
 
 # When selecting the project, pick `cal-itp-data-infra`
 
 # may also need to run...
-# gcloud auth application-default login
+gcloud auth application-default login --login-config=iac/login.json
 ```
 
 Next, run the initial database migration (which also creates a default local Airflow user named `airflow`).

--- a/docs/analytics_tools/jupyterhub.md
+++ b/docs/analytics_tools/jupyterhub.md
@@ -67,19 +67,11 @@ See the screencast below for a full walkthrough.
 
 <div style="position: relative; padding-bottom: 62.5%; height: 0;"><iframe src="https://www.loom.com/embed/6883b0bf9c8b4547a93d00bc6ba45b6d" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
-The commands required:
+The commands required (assuming you're in the root directory):
 
 ```bash
-# init will both authenticate and do basic configuration
-# You do not have to set a default compute region/zone
-gcloud init
-
-# Optionally, you can auth and set the project separately
-gcloud auth login
-gcloud config set project cal-itp-data-infra
-
-# Regardless, set up application default credentials
-gcloud auth application-default login
+gcloud auth login --login-config=iac/login.json
+gcloud config set project cal-itp-data-infra-staging
 ```
 
 If you are still not able to connect, make sure you have the suite of permissions associated with other analysts.

--- a/iac/login.json
+++ b/iac/login.json
@@ -1,0 +1,9 @@
+{
+  "universe_domain": "googleapis.com",
+  "universe_cloud_web_domain": "cloud.google",
+  "type": "external_account_authorized_user_login_config",
+  "audience": "//iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/providers/dot-gcp",
+  "auth_url": "https://auth.cloud.google/authorize",
+  "token_url": "https://sts.googleapis.com/v1/oauthtoken",
+  "token_info_url": "https://sts.googleapis.com/v1/introspect"
+}

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -28,7 +28,8 @@ We do not currently use Terraform to manage our cluster, nodepools, etc. and maj
 First, verify you are logged in and gcloud is pointed at `cal-itp-data-infra` and the `us-west1` region.
 
 ```bash
-gcloud auth list
+gcloud auth login --login-config=iac/login.json
+gcloud config set project cal-itp-data-infra
 gcloud config get-value project
 gcloud config get-value compute/region
 ```

--- a/runbooks/workflow/upgrade-metabase.md
+++ b/runbooks/workflow/upgrade-metabase.md
@@ -14,7 +14,7 @@ When Metabase detects a version change, it runs a set of database migrations. In
 
 ### Service Credentials
 
-1. Log into GCloud: `gcloud auth login`
+1. Log into GCloud from the repository directory: `gcloud auth login --login-config=iac/login.json`
 2. List the clusters you can access: `gcloud container clusters list`
 3. Pull Kubernetes credentials for the `data-infra-apps` cluster to your local machine: `gcloud container clusters get-credentials data-infra-apps --location us-west1`
 

--- a/warehouse/README.md
+++ b/warehouse/README.md
@@ -223,17 +223,14 @@ You can enable [displaying hidden folders/files in macOS Finder](https://www.mac
          export PATH="$HOME/google-cloud-sdk/bin:$PATH"
          ```
 
-2. Restart your terminal, and run `gcloud init`
+2. Restart your terminal and run `gcloud auth login --login-config=iac/login.json`
 
-3. Step through the prompts and select the Google account associated with GCP
-
-   - Set `cal-itp-data-infra` as the default project
-   - Do not set a region
+3. Set the default project with `gcloud config set project cal-itp-data-infra-staging`
 
 4. You should also [set the application default](https://cloud.google.com/sdk/gcloud/reference/auth/application-default) so that `dbt` can access your Google Cloud credentials.
 
    ```bash
-   gcloud auth application-default login
+   gcloud auth application-default login --login-config=iac/login.json
    ```
 
 5. If `bq ls` shows output, you are good to go.


### PR DESCRIPTION
# Description

Admins can use the CLI to log in and perform various administrative functions. Most major changes will be performed via Terraform.

Resolves #3748

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

`gcloud auth login` locally

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
