### PR TITLE
payments: add seed mapping for new sacrt payments feed v3

### DIFF
--- a/warehouse/seeds/payments_entity_mapping.csv
+++ b/warehouse/seeds/payments_entity_mapping.csv
@@ -1,7 +1,7 @@
 gtfs_dataset_source_record_id,organization_source_record_id,littlepay_participant_id,elavon_customer_name
 recysP9m9kjCJwHZe,receZJ9sEnP9vy3g0,mst,MST TAP TO RIDE
 rectQfIeiKDBeJSAV,recswCrw6a6htmXJ4,sbmtd,SANTA BARBARA MTD
-recbzZQUIdMmFvm1r,recX9lccSE1jmjsmG,sacrt,SACRT TAP TO RIDE
+recbzZQUIdMmFvm1r,recX9lccSE1jmjsmG,sacrt,SACRAMENTO REGIONAL TRANSIT DIST
 recbzZQUIdMmFvm1r,recX9lccSE1jmjsmG,,SACRT MOBILE
 recLhUJUDjFXcmOte,recBiunkSvSVhXa6J,clean-air-express,CLEAN AIR EXPRESS FARE
 recIUAJZhamq51hyM,recvEBkSBc7UxlarC,ccjpa,CAPITOL CORRIDOR TAP2RIDE


### PR DESCRIPTION
# Description
Now that #3854 is merged, we need to set up the organizational/GTFS seed mapping for `sacrt` Littlepay feed v3, to faciliate reconciliation and dashboarding

Resolves #3835 

## Type of change
- [x] New feature

## How has this been tested?
poetry run dbt seed

_Include commands/logs/screenshots as relevant._
<img width="844" alt="Screenshot 2025-04-25 at 10 21 51" src="https://github.com/user-attachments/assets/042a0307-467b-41ed-8aa1-4c426e27ab65" />

## Post-merge follow-ups
- [x] Actions required (specified below)
Finish the dashboarding work in Metabase