### PR TITLE
NTD: create new warehouse tables for new endpoints – asset_inventory_time_series and 2022 contractual relationships

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -211,6 +211,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Authenticate Google Service Account
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: 'true'
+          project_id: ${{ env.PROJECT_ID }}
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Setup GCloud utilities
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
 
@@ -245,7 +256,11 @@ jobs:
 
       - name: Synchronize dbt artifacts output
         working-directory: warehouse
-        run: gsutil cp -r gs://calitp-dbt-artifacts/latest/ .
+        run: gsutil cp -r gs://${{ env.DBT_ARTIFACTS_BUCKET }}/latest/ .
+
+      - name: Install dbt dependencies
+        working-directory: warehouse
+        run: poetry run dbt deps
 
       - name: Create CI report
         working-directory: warehouse

--- a/warehouse/models/mart/ntd_annual_reporting/_mart_ntd_annual_reporting.yml
+++ b/warehouse/models/mart/ntd_annual_reporting/_mart_ntd_annual_reporting.yml
@@ -284,3 +284,4 @@ models:
   - name: fct_vehicles_age_distribution
   - name: fct_vehicles_type_count_by_agency
   - name: fct_2023_contractual_relationships
+  - name: fct_2022_contractual_relationships

--- a/warehouse/models/mart/ntd_annual_reporting/fct_2022_contractual_relationships.sql
+++ b/warehouse/models/mart/ntd_annual_reporting/fct_2022_contractual_relationships.sql
@@ -1,0 +1,53 @@
+WITH staging_contractual_relationships AS (
+    SELECT *
+    FROM {{ ref('stg_ntd__2022_contractual_relationships') }}
+),
+
+current_dim_organizations AS (
+    SELECT
+        ntd_id,
+        caltrans_district AS caltrans_district_current,
+        caltrans_district_name AS caltrans_district_name_current
+    FROM {{ ref('dim_organizations_latest_with_caltrans_district') }}
+),
+
+fct_2022_contractual_relationships AS (
+    SELECT
+        stg.other_reconciling_item_expenses_incurred_by_the_buyer,
+        stg.total_modal_expenses,
+        stg.contract_capital_leasing_expenses,
+        stg.direct_payment_agency_subsidy,
+        stg.months_seller_operated_in_fy,
+        stg.primary_feature,
+        stg.voms_under_contract,
+        stg.service_captured,
+        stg.fares_retained_by,
+        stg.other_party,
+        stg.other_public_assets_provided,
+        stg.buyer_supplies_vehicles_to_seller,
+        stg.contractee_ntd_id,
+        stg.pt_fare_revenues_passenger_fees,
+        stg.agency_name,
+        stg.tos,
+        stg.type_of_contract,
+        stg.reporter_contractual_position,
+        stg.other_operating_expenses_incurred_by_the_buyer,
+        stg.passenger_out_of_pocket_expenses,
+        stg.buyer_provides_maintenance_facility_to_seller,
+        stg.contractee_operator_name,
+        stg.mode,
+        stg.reporting_module,
+        stg.reporter_type,
+        stg.other_public_assets_provided_desc,
+        stg.ntd_id,
+
+        orgs.caltrans_district_current,
+        orgs.caltrans_district_name_current,
+
+        stg.dt,
+        stg.execution_ts
+    FROM staging_contractual_relationships AS stg
+    LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+)
+
+SELECT * FROM fct_2022_contractual_relationships

--- a/warehouse/models/mart/ntd_assets/_mart_assets.yml
+++ b/warehouse/models/mart/ntd_assets/_mart_assets.yml
@@ -1,0 +1,8 @@
+version: 2
+
+models:
+  - name: fct_asset_inventory_time_series_active_fleet
+  - name: fct_asset_inventory_time_series_ada_fleet
+  - name: fct_asset_inventory_time_series_avg_fleet_age
+  - name: fct_asset_inventory_time_series_avg_seating_capacity
+  - name: fct_asset_inventory_time_series_avg_standing_capacity

--- a/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_active_fleet.sql
+++ b/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_active_fleet.sql
@@ -1,0 +1,76 @@
+WITH staging_asset_inventory_time_series_active_fleet AS (
+    SELECT *
+    FROM {{ ref('stg_ntd__asset_inventory_time_series__active_fleet') }}
+),
+
+current_dim_organizations AS (
+    SELECT
+        ntd_id,
+        caltrans_district AS caltrans_district_current,
+        caltrans_district_name AS caltrans_district_name_current
+    FROM {{ ref('dim_organizations_latest_with_caltrans_district') }}
+),
+
+fct_asset_inventory_time_series_active_fleet AS (
+    SELECT
+        stg.state,
+        stg.uza_area_sq_miles,
+        stg.ntd_id,
+        stg.legacy_ntd_id,
+        stg.uace_code,
+        stg.last_report_year,
+        stg.mode_status,
+        stg.service,
+        stg._2023_mode_status,
+        stg.agency_status,
+        stg.uza_population,
+        stg.mode,
+        stg.uza_name,
+        stg.city,
+        stg.census_year,
+        stg.reporting_module,
+        stg.reporter_type,
+        stg.agency_name,
+        stg._2021,
+        stg._2023,
+        stg._1995,
+        stg._2015,
+        stg._2019,
+        stg._2014,
+        stg._2012,
+        stg._2008,
+        stg._2007,
+        stg._2013,
+        stg._2002,
+        stg._2006,
+        stg._2000,
+        stg._2004,
+        stg._2003,
+        stg._1998,
+        stg._2022,
+        stg._1999,
+        stg._1997,
+        stg._2011,
+        stg._2001,
+        stg._1996,
+        stg._2020,
+        stg._2005,
+        stg._2017,
+        stg._1994,
+        stg._1992,
+        stg._2010,
+        stg._2009,
+        stg._2016,
+        stg._2018,
+        stg._1993,
+
+        orgs.caltrans_district_current,
+        orgs.caltrans_district_name_current,
+
+        stg.dt,
+        stg.execution_ts
+    FROM staging_asset_inventory_time_series_active_fleet AS stg
+    LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+)
+
+SELECT * FROM fct_asset_inventory_time_series_active_fleet

--- a/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_ada_fleet.sql
+++ b/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_ada_fleet.sql
@@ -1,0 +1,76 @@
+WITH staging_asset_inventory_time_series_ada_fleet AS (
+    SELECT *
+    FROM {{ ref('stg_ntd__asset_inventory_time_series__ada_fleet') }}
+),
+
+current_dim_organizations AS (
+    SELECT
+        ntd_id,
+        caltrans_district AS caltrans_district_current,
+        caltrans_district_name AS caltrans_district_name_current
+    FROM {{ ref('dim_organizations_latest_with_caltrans_district') }}
+),
+
+fct_asset_inventory_time_series_ada_fleet AS (
+    SELECT
+        stg.state,
+        stg.uza_area_sq_miles,
+        stg.ntd_id,
+        stg.legacy_ntd_id,
+        stg.uace_code,
+        stg.last_report_year,
+        stg.mode_status,
+        stg.service,
+        stg._2023_mode_status,
+        stg.agency_status,
+        stg.uza_population,
+        stg.mode,
+        stg.uza_name,
+        stg.city,
+        stg.census_year,
+        stg.reporting_module,
+        stg.reporter_type,
+        stg.agency_name,
+        stg._2021,
+        stg._2023,
+        stg._1995,
+        stg._2015,
+        stg._2019,
+        stg._2014,
+        stg._2012,
+        stg._2008,
+        stg._2007,
+        stg._2013,
+        stg._2002,
+        stg._2006,
+        stg._2000,
+        stg._2004,
+        stg._2003,
+        stg._1998,
+        stg._2022,
+        stg._1999,
+        stg._1997,
+        stg._2011,
+        stg._2001,
+        stg._1996,
+        stg._2020,
+        stg._2005,
+        stg._2017,
+        stg._1994,
+        stg._1992,
+        stg._2010,
+        stg._2009,
+        stg._2016,
+        stg._2018,
+        stg._1993,
+
+        orgs.caltrans_district_current,
+        orgs.caltrans_district_name_current,
+
+        stg.dt,
+        stg.execution_ts
+    FROM staging_asset_inventory_time_series_ada_fleet AS stg
+    LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+)
+
+SELECT * FROM fct_asset_inventory_time_series_ada_fleet

--- a/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_avg_fleet_age.sql
+++ b/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_avg_fleet_age.sql
@@ -1,0 +1,76 @@
+WITH staging_asset_inventory_time_series_avg_fleet_age AS (
+    SELECT *
+    FROM {{ ref('stg_ntd__asset_inventory_time_series__avg_fleet_age') }}
+),
+
+current_dim_organizations AS (
+    SELECT
+        ntd_id,
+        caltrans_district AS caltrans_district_current,
+        caltrans_district_name AS caltrans_district_name_current
+    FROM {{ ref('dim_organizations_latest_with_caltrans_district') }}
+),
+
+fct_asset_inventory_time_series_avg_fleet_age AS (
+    SELECT
+        stg.state,
+        stg.uza_area_sq_miles,
+        stg.ntd_id,
+        stg.legacy_ntd_id,
+        stg.uace_code,
+        stg.last_report_year,
+        stg.mode_status,
+        stg.service,
+        stg._2023_mode_status,
+        stg.agency_status,
+        stg.uza_population,
+        stg.mode,
+        stg.uza_name,
+        stg.city,
+        stg.census_year,
+        stg.reporting_module,
+        stg.reporter_type,
+        stg.agency_name,
+        stg._2021,
+        stg._2023,
+        stg._1995,
+        stg._2015,
+        stg._2019,
+        stg._2014,
+        stg._2012,
+        stg._2008,
+        stg._2007,
+        stg._2013,
+        stg._2002,
+        stg._2006,
+        stg._2000,
+        stg._2004,
+        stg._2003,
+        stg._1998,
+        stg._2022,
+        stg._1999,
+        stg._1997,
+        stg._2011,
+        stg._2001,
+        stg._1996,
+        stg._2020,
+        stg._2005,
+        stg._2017,
+        stg._1994,
+        stg._1992,
+        stg._2010,
+        stg._2009,
+        stg._2016,
+        stg._2018,
+        stg._1993,
+
+        orgs.caltrans_district_current,
+        orgs.caltrans_district_name_current,
+
+        stg.dt,
+        stg.execution_ts
+    FROM staging_asset_inventory_time_series_avg_fleet_age AS stg
+    LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+)
+
+SELECT * FROM fct_asset_inventory_time_series_avg_fleet_age

--- a/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_avg_seating_capacity.sql
+++ b/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_avg_seating_capacity.sql
@@ -1,0 +1,76 @@
+WITH staging_asset_inventory_time_series_avg_seating_capacity AS (
+    SELECT *
+    FROM {{ ref('stg_ntd__asset_inventory_time_series__avg_seating_capacity') }}
+),
+
+current_dim_organizations AS (
+    SELECT
+        ntd_id,
+        caltrans_district AS caltrans_district_current,
+        caltrans_district_name AS caltrans_district_name_current
+    FROM {{ ref('dim_organizations_latest_with_caltrans_district') }}
+),
+
+fct_asset_inventory_time_series_avg_seating_capacity AS (
+    SELECT
+        stg.state,
+        stg.uza_area_sq_miles,
+        stg.ntd_id,
+        stg.legacy_ntd_id,
+        stg.uace_code,
+        stg.last_report_year,
+        stg.mode_status,
+        stg.service,
+        stg._2023_mode_status,
+        stg.agency_status,
+        stg.uza_population,
+        stg.mode,
+        stg.uza_name,
+        stg.city,
+        stg.census_year,
+        stg.reporting_module,
+        stg.reporter_type,
+        stg.agency_name,
+        stg._2021,
+        stg._2023,
+        stg._1995,
+        stg._2015,
+        stg._2019,
+        stg._2014,
+        stg._2012,
+        stg._2008,
+        stg._2007,
+        stg._2013,
+        stg._2002,
+        stg._2006,
+        stg._2000,
+        stg._2004,
+        stg._2003,
+        stg._1998,
+        stg._2022,
+        stg._1999,
+        stg._1997,
+        stg._2011,
+        stg._2001,
+        stg._1996,
+        stg._2020,
+        stg._2005,
+        stg._2017,
+        stg._1994,
+        stg._1992,
+        stg._2010,
+        stg._2009,
+        stg._2016,
+        stg._2018,
+        stg._1993,
+
+        orgs.caltrans_district_current,
+        orgs.caltrans_district_name_current,
+
+        stg.dt,
+        stg.execution_ts
+    FROM staging_asset_inventory_time_series_avg_seating_capacity AS stg
+    LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+)
+
+SELECT * FROM fct_asset_inventory_time_series_avg_seating_capacity

--- a/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_avg_standing_capacity.sql
+++ b/warehouse/models/mart/ntd_assets/fct_asset_inventory_time_series_avg_standing_capacity.sql
@@ -1,0 +1,76 @@
+WITH staging_asset_inventory_time_series_avg_standing_capacity AS (
+    SELECT *
+    FROM {{ ref('stg_ntd__asset_inventory_time_series__avg_standing_capacity') }}
+),
+
+current_dim_organizations AS (
+    SELECT
+        ntd_id,
+        caltrans_district AS caltrans_district_current,
+        caltrans_district_name AS caltrans_district_name_current
+    FROM {{ ref('dim_organizations_latest_with_caltrans_district') }}
+),
+
+fct_asset_inventory_time_series_avg_standing_capacity AS (
+    SELECT
+        stg.state,
+        stg.uza_area_sq_miles,
+        stg.ntd_id,
+        stg.legacy_ntd_id,
+        stg.uace_code,
+        stg.last_report_year,
+        stg.mode_status,
+        stg.service,
+        stg._2023_mode_status,
+        stg.agency_status,
+        stg.uza_population,
+        stg.mode,
+        stg.uza_name,
+        stg.city,
+        stg.census_year,
+        stg.reporting_module,
+        stg.reporter_type,
+        stg.agency_name,
+        stg._2021,
+        stg._2023,
+        stg._1995,
+        stg._2015,
+        stg._2019,
+        stg._2014,
+        stg._2012,
+        stg._2008,
+        stg._2007,
+        stg._2013,
+        stg._2002,
+        stg._2006,
+        stg._2000,
+        stg._2004,
+        stg._2003,
+        stg._1998,
+        stg._2022,
+        stg._1999,
+        stg._1997,
+        stg._2011,
+        stg._2001,
+        stg._1996,
+        stg._2020,
+        stg._2005,
+        stg._2017,
+        stg._1994,
+        stg._1992,
+        stg._2010,
+        stg._2009,
+        stg._2016,
+        stg._2018,
+        stg._1993,
+
+        orgs.caltrans_district_current,
+        orgs.caltrans_district_name_current,
+
+        stg.dt,
+        stg.execution_ts
+    FROM staging_asset_inventory_time_series_avg_standing_capacity AS stg
+    LEFT JOIN current_dim_organizations AS orgs USING (ntd_id)
+)
+
+SELECT * FROM fct_asset_inventory_time_series_avg_standing_capacity

--- a/warehouse/models/staging/ntd_annual_reporting/_src.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_src.yml
@@ -387,6 +387,7 @@ sources:
           - *dt
           - *execution_ts
 
+      - name: 2022__annual_database_contractual_relationships
       - name: 2023__annual_database_contractual_relationships
       - name: multi_year__breakdowns
       - name: multi_year__breakdowns_by_agency

--- a/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
@@ -383,6 +383,7 @@ models:
       - *dt
       - *execution_ts
 
+  - name: stg_ntd__2022_contractual_relationships
   - name: stg_ntd__2023_contractual_relationships
   - name: stg_ntd__breakdowns
   - name: stg_ntd__breakdowns_by_agency

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__2022_contractual_relationships.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__2022_contractual_relationships.sql
@@ -1,0 +1,48 @@
+WITH external_contractual_relationships AS (
+    SELECT *
+    FROM {{ source('external_ntd__annual_reporting', '2022__annual_database_contractual_relationships') }}
+),
+
+get_latest_extract AS(
+    SELECT *
+    FROM external_contractual_relationships
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd__2022_contractual_relationships AS (
+    SELECT *
+    FROM get_latest_extract
+)
+
+SELECT
+    SAFE_CAST(other_reconciling_item_expenses_incurred_by_the_buyer AS INTEGER) AS other_reconciling_item_expenses_incurred_by_the_buyer,
+    SAFE_CAST(total_modal_expenses AS INTEGER) AS total_modal_expenses,
+    SAFE_CAST(contract_capital_leasing_expenses AS INTEGER) AS contract_capital_leasing_expenses,
+    SAFE_CAST(direct_payment_agency_subsidy AS INTEGER) AS direct_payment_agency_subsidy,
+    SAFE_CAST(months_seller_operated_in_fy AS INTEGER) AS months_seller_operated_in_fy,
+    {{ trim_make_empty_string_null('primary_feature') }} AS primary_feature,
+    SAFE_CAST(voms_under_contract AS INTEGER) AS voms_under_contract,
+    {{ trim_make_empty_string_null('service_captured') }} AS service_captured,
+    {{ trim_make_empty_string_null('fares_retained_by') }} AS fares_retained_by,
+    {{ trim_make_empty_string_null('other_party') }} AS other_party,
+    SAFE_CAST(other_public_assets_provided AS BOOLEAN) AS other_public_assets_provided,
+    SAFE_CAST(buyer_supplies_vehicles_to_seller AS BOOLEAN) AS buyer_supplies_vehicles_to_seller,
+    {{ trim_make_empty_string_null('contractee_ntd_id') }} AS contractee_ntd_id,
+    SAFE_CAST(pt_fare_revenues_passenger_fees AS INTEGER) AS pt_fare_revenues_passenger_fees,
+    {{ trim_make_empty_string_null('agency_name') }} AS agency_name,
+    {{ trim_make_empty_string_null('tos') }} AS tos,
+    {{ trim_make_empty_string_null('type_of_contract') }} AS type_of_contract,
+    {{ trim_make_empty_string_null('reporter_contractual_position') }} AS reporter_contractual_position,
+    SAFE_CAST(other_operating_expenses_incurred_by_the_buyer AS INTEGER) AS other_operating_expenses_incurred_by_the_buyer,
+    SAFE_CAST(passenger_out_of_pocket_expenses AS INTEGER) AS passenger_out_of_pocket_expenses,
+    SAFE_CAST(buyer_provides_maintenance_facility_to_seller AS BOOLEAN) AS buyer_provides_maintenance_facility_to_seller,
+    {{ trim_make_empty_string_null('contractee_operator_name') }} AS contractee_operator_name,
+    {{ trim_make_empty_string_null('mode') }} AS mode,
+    {{ trim_make_empty_string_null('reporting_module') }} AS reporting_module,
+    {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
+    {{ trim_make_empty_string_null('other_public_assets_provided_desc') }} AS other_public_assets_provided_desc,
+    {{ trim_make_empty_string_null('CAST(ntd_id AS STRING)') }} AS ntd_id,
+    dt,
+    execution_ts
+FROM stg_ntd__2022_contractual_relationships

--- a/warehouse/models/staging/ntd_assets/_src.yml
+++ b/warehouse/models/staging/ntd_assets/_src.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sources:
+  - name: external_ntd__assets
+    description: Historical assets data tables, loaded from DOT NTD API https://www.transit.dot.gov/ntd/ntd-data.
+    database: "{{ env_var('DBT_SOURCE_DATABASE', var('SOURCE_DATABASE')) }}"
+    schema: external_ntd__assets
+    tables:
+      - name: historical__asset_inventory_time_series__active_fleet
+      - name: historical__asset_inventory_time_series__ada_fleet
+      - name: historical__asset_inventory_time_series__avg_fleet_age
+      - name: historical__asset_inventory_time_series__avg_seating_capacity
+      - name: historical__asset_inventory_time_series__avg_standing_capacity

--- a/warehouse/models/staging/ntd_assets/_stg_ntd_assets.yml
+++ b/warehouse/models/staging/ntd_assets/_stg_ntd_assets.yml
@@ -1,0 +1,8 @@
+version: 2
+
+models:
+  - name: stg_ntd__asset_inventory_time_series__active_fleet
+  - name: stg_ntd__asset_inventory_time_series__ada_fleet
+  - name: stg_ntd__asset_inventory_time_series__avg_fleet_age
+  - name: stg_ntd__asset_inventory_time_series__avg_seating_capacity
+  - name: stg_ntd__asset_inventory_time_series__avg_standing_capacity

--- a/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__active_fleet.sql
+++ b/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__active_fleet.sql
@@ -1,0 +1,70 @@
+WITH external_active_fleet AS (
+    SELECT *
+    FROM {{ source('external_ntd__assets', 'historical__asset_inventory_time_series__active_fleet') }}
+),
+
+get_latest_extract AS(
+    SELECT *
+    FROM external_active_fleet
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd__asset_inventory_time_series__active_fleet AS (
+    SELECT
+        {{ trim_make_empty_string_null('state') }} AS state,
+        SAFE_CAST(uza_area_sq_miles AS NUMERIC) AS uza_area_sq_miles,
+        {{ trim_make_empty_string_null('CAST(ntd_id AS STRING)') }} AS ntd_id,
+        {{ trim_make_empty_string_null('legacy_ntd_id') }} AS legacy_ntd_id,
+        SAFE_CAST(uace_code AS INTEGER) AS uace_code,
+        SAFE_CAST(last_report_year AS INTEGER) AS last_report_year,
+        {{ trim_make_empty_string_null('mode_status') }} AS mode_status,
+        {{ trim_make_empty_string_null('service') }} AS service,
+        {{ trim_make_empty_string_null('_2023_mode_status') }} AS _2023_mode_status,
+        {{ trim_make_empty_string_null('agency_status') }} AS agency_status,
+        SAFE_CAST(uza_population AS INTEGER) AS uza_population,
+        {{ trim_make_empty_string_null('mode') }} AS mode,
+        {{ trim_make_empty_string_null('uza_name') }} AS uza_name,
+        {{ trim_make_empty_string_null('city') }} AS city,
+        SAFE_CAST(census_year AS INTEGER) AS census_year,
+        {{ trim_make_empty_string_null('reporting_module') }} AS reporting_module,
+        {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
+        {{ trim_make_empty_string_null('agency_name') }} AS agency_name,
+        SAFE_CAST(_2021 AS NUMERIC) AS _2021,
+        SAFE_CAST(_2023 AS NUMERIC) AS _2023,
+        SAFE_CAST(_1995 AS NUMERIC) AS _1995,
+        SAFE_CAST(_2015 AS NUMERIC) AS _2015,
+        SAFE_CAST(_2019 AS NUMERIC) AS _2019,
+        SAFE_CAST(_2014 AS NUMERIC) AS _2014,
+        SAFE_CAST(_2012 AS NUMERIC) AS _2012,
+        SAFE_CAST(_2008 AS NUMERIC) AS _2008,
+        SAFE_CAST(_2007 AS NUMERIC) AS _2007,
+        SAFE_CAST(_2013 AS NUMERIC) AS _2013,
+        SAFE_CAST(_2002 AS NUMERIC) AS _2002,
+        SAFE_CAST(_2006 AS NUMERIC) AS _2006,
+        SAFE_CAST(_2000 AS NUMERIC) AS _2000,
+        SAFE_CAST(_2004 AS NUMERIC) AS _2004,
+        SAFE_CAST(_1998 AS NUMERIC) AS _1998,
+        SAFE_CAST(_2003 AS NUMERIC) AS _2003,
+        SAFE_CAST(_2022 AS NUMERIC) AS _2022,
+        SAFE_CAST(_1999 AS NUMERIC) AS _1999,
+        SAFE_CAST(_1997 AS NUMERIC) AS _1997,
+        SAFE_CAST(_2011 AS NUMERIC) AS _2011,
+        SAFE_CAST(_2001 AS NUMERIC) AS _2001,
+        SAFE_CAST(_1996 AS NUMERIC) AS _1996,
+        SAFE_CAST(_2020 AS NUMERIC) AS _2020,
+        SAFE_CAST(_2005 AS NUMERIC) AS _2005,
+        SAFE_CAST(_2017 AS NUMERIC) AS _2017,
+        SAFE_CAST(_1994 AS NUMERIC) AS _1994,
+        SAFE_CAST(_1992 AS NUMERIC) AS _1992,
+        SAFE_CAST(_2010 AS NUMERIC) AS _2010,
+        SAFE_CAST(_2009 AS NUMERIC) AS _2009,
+        SAFE_CAST(_2016 AS NUMERIC) AS _2016,
+        SAFE_CAST(_2018 AS NUMERIC) AS _2018,
+        SAFE_CAST(_1993 AS NUMERIC) AS _1993,
+        dt,
+        execution_ts
+    FROM get_latest_extract
+)
+
+SELECT * FROM stg_ntd__asset_inventory_time_series__active_fleet

--- a/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__ada_fleet.sql
+++ b/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__ada_fleet.sql
@@ -1,0 +1,70 @@
+WITH external_ada_fleet AS (
+    SELECT *
+    FROM {{ source('external_ntd__assets', 'historical__asset_inventory_time_series__ada_fleet') }}
+),
+
+get_latest_extract AS(
+    SELECT *
+    FROM external_ada_fleet
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd__asset_inventory_time_series__ada_fleet AS (
+    SELECT
+        {{ trim_make_empty_string_null('state') }} AS state,
+        SAFE_CAST(uza_area_sq_miles AS NUMERIC) AS uza_area_sq_miles,
+        {{ trim_make_empty_string_null('CAST(ntd_id AS STRING)') }} AS ntd_id,
+        {{ trim_make_empty_string_null('legacy_ntd_id') }} AS legacy_ntd_id,
+        SAFE_CAST(uace_code AS INTEGER) AS uace_code,
+        SAFE_CAST(last_report_year AS INTEGER) AS last_report_year,
+        {{ trim_make_empty_string_null('mode_status') }} AS mode_status,
+        {{ trim_make_empty_string_null('service') }} AS service,
+        {{ trim_make_empty_string_null('_2023_mode_status') }} AS _2023_mode_status,
+        {{ trim_make_empty_string_null('agency_status') }} AS agency_status,
+        SAFE_CAST(uza_population AS INTEGER) AS uza_population,
+        {{ trim_make_empty_string_null('mode') }} AS mode,
+        {{ trim_make_empty_string_null('uza_name') }} AS uza_name,
+        {{ trim_make_empty_string_null('city') }} AS city,
+        SAFE_CAST(census_year AS INTEGER) AS census_year,
+        {{ trim_make_empty_string_null('reporting_module') }} AS reporting_module,
+        {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
+        {{ trim_make_empty_string_null('agency_name') }} AS agency_name,
+        SAFE_CAST(_2021 AS NUMERIC) AS _2021,
+        SAFE_CAST(_2023 AS NUMERIC) AS _2023,
+        SAFE_CAST(_1995 AS NUMERIC) AS _1995,
+        SAFE_CAST(_2015 AS NUMERIC) AS _2015,
+        SAFE_CAST(_2019 AS NUMERIC) AS _2019,
+        SAFE_CAST(_2014 AS NUMERIC) AS _2014,
+        SAFE_CAST(_2012 AS NUMERIC) AS _2012,
+        SAFE_CAST(_2008 AS NUMERIC) AS _2008,
+        SAFE_CAST(_2007 AS NUMERIC) AS _2007,
+        SAFE_CAST(_2013 AS NUMERIC) AS _2013,
+        SAFE_CAST(_2002 AS NUMERIC) AS _2002,
+        SAFE_CAST(_2006 AS NUMERIC) AS _2006,
+        SAFE_CAST(_2000 AS NUMERIC) AS _2000,
+        SAFE_CAST(_2004 AS NUMERIC) AS _2004,
+        SAFE_CAST(_1998 AS NUMERIC) AS _1998,
+        SAFE_CAST(_2003 AS NUMERIC) AS _2003,
+        SAFE_CAST(_2022 AS NUMERIC) AS _2022,
+        SAFE_CAST(_1999 AS NUMERIC) AS _1999,
+        SAFE_CAST(_1997 AS NUMERIC) AS _1997,
+        SAFE_CAST(_2011 AS NUMERIC) AS _2011,
+        SAFE_CAST(_2001 AS NUMERIC) AS _2001,
+        SAFE_CAST(_1996 AS NUMERIC) AS _1996,
+        SAFE_CAST(_2020 AS NUMERIC) AS _2020,
+        SAFE_CAST(_2005 AS NUMERIC) AS _2005,
+        SAFE_CAST(_2017 AS NUMERIC) AS _2017,
+        SAFE_CAST(_1994 AS NUMERIC) AS _1994,
+        SAFE_CAST(_1992 AS NUMERIC) AS _1992,
+        SAFE_CAST(_2010 AS NUMERIC) AS _2010,
+        SAFE_CAST(_2009 AS NUMERIC) AS _2009,
+        SAFE_CAST(_2016 AS NUMERIC) AS _2016,
+        SAFE_CAST(_2018 AS NUMERIC) AS _2018,
+        SAFE_CAST(_1993 AS NUMERIC) AS _1993,
+        dt,
+        execution_ts
+    FROM get_latest_extract
+)
+
+SELECT * FROM stg_ntd__asset_inventory_time_series__ada_fleet

--- a/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_fleet_age.sql
+++ b/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_fleet_age.sql
@@ -1,0 +1,70 @@
+WITH external_avg_fleet_age AS (
+    SELECT *
+    FROM {{ source('external_ntd__assets', 'historical__asset_inventory_time_series__avg_fleet_age') }}
+),
+
+get_latest_extract AS(
+    SELECT *
+    FROM external_avg_fleet_age
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd__asset_inventory_time_series__avg_fleet_age AS (
+    SELECT
+        {{ trim_make_empty_string_null('state') }} AS state,
+        SAFE_CAST(uza_area_sq_miles AS NUMERIC) AS uza_area_sq_miles,
+        {{ trim_make_empty_string_null('CAST(ntd_id AS STRING)') }} AS ntd_id,
+        {{ trim_make_empty_string_null('legacy_ntd_id') }} AS legacy_ntd_id,
+        SAFE_CAST(uace_code AS INTEGER) AS uace_code,
+        SAFE_CAST(last_report_year AS INTEGER) AS last_report_year,
+        {{ trim_make_empty_string_null('mode_status') }} AS mode_status,
+        {{ trim_make_empty_string_null('service') }} AS service,
+        {{ trim_make_empty_string_null('_2023_mode_status') }} AS _2023_mode_status,
+        {{ trim_make_empty_string_null('agency_status') }} AS agency_status,
+        SAFE_CAST(uza_population AS INTEGER) AS uza_population,
+        {{ trim_make_empty_string_null('mode') }} AS mode,
+        {{ trim_make_empty_string_null('uza_name') }} AS uza_name,
+        {{ trim_make_empty_string_null('city') }} AS city,
+        SAFE_CAST(census_year AS INTEGER) AS census_year,
+        {{ trim_make_empty_string_null('reporting_module') }} AS reporting_module,
+        {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
+        {{ trim_make_empty_string_null('agency_name') }} AS agency_name,
+        SAFE_CAST(_2021 AS NUMERIC) AS _2021,
+        SAFE_CAST(_2023 AS NUMERIC) AS _2023,
+        SAFE_CAST(_1995 AS NUMERIC) AS _1995,
+        SAFE_CAST(_2015 AS NUMERIC) AS _2015,
+        SAFE_CAST(_2019 AS NUMERIC) AS _2019,
+        SAFE_CAST(_2014 AS NUMERIC) AS _2014,
+        SAFE_CAST(_2012 AS NUMERIC) AS _2012,
+        SAFE_CAST(_2008 AS NUMERIC) AS _2008,
+        SAFE_CAST(_2007 AS NUMERIC) AS _2007,
+        SAFE_CAST(_2013 AS NUMERIC) AS _2013,
+        SAFE_CAST(_2002 AS NUMERIC) AS _2002,
+        SAFE_CAST(_2006 AS NUMERIC) AS _2006,
+        SAFE_CAST(_2000 AS NUMERIC) AS _2000,
+        SAFE_CAST(_2004 AS NUMERIC) AS _2004,
+        SAFE_CAST(_1998 AS NUMERIC) AS _1998,
+        SAFE_CAST(_2003 AS NUMERIC) AS _2003,
+        SAFE_CAST(_2022 AS NUMERIC) AS _2022,
+        SAFE_CAST(_1999 AS NUMERIC) AS _1999,
+        SAFE_CAST(_1997 AS NUMERIC) AS _1997,
+        SAFE_CAST(_2011 AS NUMERIC) AS _2011,
+        SAFE_CAST(_2001 AS NUMERIC) AS _2001,
+        SAFE_CAST(_1996 AS NUMERIC) AS _1996,
+        SAFE_CAST(_2020 AS NUMERIC) AS _2020,
+        SAFE_CAST(_2005 AS NUMERIC) AS _2005,
+        SAFE_CAST(_2017 AS NUMERIC) AS _2017,
+        SAFE_CAST(_1994 AS NUMERIC) AS _1994,
+        SAFE_CAST(_1992 AS NUMERIC) AS _1992,
+        SAFE_CAST(_2010 AS NUMERIC) AS _2010,
+        SAFE_CAST(_2009 AS NUMERIC) AS _2009,
+        SAFE_CAST(_2016 AS NUMERIC) AS _2016,
+        SAFE_CAST(_2018 AS NUMERIC) AS _2018,
+        SAFE_CAST(_1993 AS NUMERIC) AS _1993,
+        dt,
+        execution_ts
+    FROM get_latest_extract
+)
+
+SELECT * FROM stg_ntd__asset_inventory_time_series__avg_fleet_age

--- a/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_seating_capacity.sql
+++ b/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_seating_capacity.sql
@@ -1,0 +1,70 @@
+WITH external_avg_seating_capacity AS (
+    SELECT *
+    FROM {{ source('external_ntd__assets', 'historical__asset_inventory_time_series__avg_seating_capacity') }}
+),
+
+get_latest_extract AS(
+    SELECT *
+    FROM external_avg_seating_capacity
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd__asset_inventory_time_series__avg_seating_capacity AS (
+    SELECT
+        {{ trim_make_empty_string_null('state') }} AS state,
+        SAFE_CAST(uza_area_sq_miles AS NUMERIC) AS uza_area_sq_miles,
+        {{ trim_make_empty_string_null('CAST(ntd_id AS STRING)') }} AS ntd_id,
+        {{ trim_make_empty_string_null('legacy_ntd_id') }} AS legacy_ntd_id,
+        SAFE_CAST(uace_code AS INTEGER) AS uace_code,
+        SAFE_CAST(last_report_year AS INTEGER) AS last_report_year,
+        {{ trim_make_empty_string_null('mode_status') }} AS mode_status,
+        {{ trim_make_empty_string_null('service') }} AS service,
+        {{ trim_make_empty_string_null('_2023_mode_status') }} AS _2023_mode_status,
+        {{ trim_make_empty_string_null('agency_status') }} AS agency_status,
+        SAFE_CAST(uza_population AS INTEGER) AS uza_population,
+        {{ trim_make_empty_string_null('mode') }} AS mode,
+        {{ trim_make_empty_string_null('uza_name') }} AS uza_name,
+        {{ trim_make_empty_string_null('city') }} AS city,
+        SAFE_CAST(census_year AS INTEGER) AS census_year,
+        {{ trim_make_empty_string_null('reporting_module') }} AS reporting_module,
+        {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
+        {{ trim_make_empty_string_null('agency_name') }} AS agency_name,
+        SAFE_CAST(_2021 AS NUMERIC) AS _2021,
+        SAFE_CAST(_2023 AS NUMERIC) AS _2023,
+        SAFE_CAST(_1995 AS NUMERIC) AS _1995,
+        SAFE_CAST(_2015 AS NUMERIC) AS _2015,
+        SAFE_CAST(_2019 AS NUMERIC) AS _2019,
+        SAFE_CAST(_2014 AS NUMERIC) AS _2014,
+        SAFE_CAST(_2012 AS NUMERIC) AS _2012,
+        SAFE_CAST(_2008 AS NUMERIC) AS _2008,
+        SAFE_CAST(_2007 AS NUMERIC) AS _2007,
+        SAFE_CAST(_2013 AS NUMERIC) AS _2013,
+        SAFE_CAST(_2002 AS NUMERIC) AS _2002,
+        SAFE_CAST(_2006 AS NUMERIC) AS _2006,
+        SAFE_CAST(_2000 AS NUMERIC) AS _2000,
+        SAFE_CAST(_2004 AS NUMERIC) AS _2004,
+        SAFE_CAST(_1998 AS NUMERIC) AS _1998,
+        SAFE_CAST(_2003 AS NUMERIC) AS _2003,
+        SAFE_CAST(_2022 AS NUMERIC) AS _2022,
+        SAFE_CAST(_1999 AS NUMERIC) AS _1999,
+        SAFE_CAST(_1997 AS NUMERIC) AS _1997,
+        SAFE_CAST(_2011 AS NUMERIC) AS _2011,
+        SAFE_CAST(_2001 AS NUMERIC) AS _2001,
+        SAFE_CAST(_1996 AS NUMERIC) AS _1996,
+        SAFE_CAST(_2020 AS NUMERIC) AS _2020,
+        SAFE_CAST(_2005 AS NUMERIC) AS _2005,
+        SAFE_CAST(_2017 AS NUMERIC) AS _2017,
+        SAFE_CAST(_1994 AS NUMERIC) AS _1994,
+        SAFE_CAST(_1992 AS NUMERIC) AS _1992,
+        SAFE_CAST(_2010 AS NUMERIC) AS _2010,
+        SAFE_CAST(_2009 AS NUMERIC) AS _2009,
+        SAFE_CAST(_2016 AS NUMERIC) AS _2016,
+        SAFE_CAST(_2018 AS NUMERIC) AS _2018,
+        SAFE_CAST(_1993 AS NUMERIC) AS _1993,
+        dt,
+        execution_ts
+    FROM get_latest_extract
+)
+
+SELECT * FROM stg_ntd__asset_inventory_time_series__avg_seating_capacity

--- a/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_standing_capacity.sql
+++ b/warehouse/models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_standing_capacity.sql
@@ -1,0 +1,70 @@
+WITH external_avg_standing_capacity AS (
+    SELECT *
+    FROM {{ source('external_ntd__assets', 'historical__asset_inventory_time_series__avg_standing_capacity') }}
+),
+
+get_latest_extract AS(
+    SELECT *
+    FROM external_avg_standing_capacity
+    -- we pull the whole table every month in the pipeline, so this gets only the latest extract
+    QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1
+),
+
+stg_ntd__asset_inventory_time_series__avg_standing_capacity AS (
+    SELECT
+        {{ trim_make_empty_string_null('state') }} AS state,
+        SAFE_CAST(uza_area_sq_miles AS NUMERIC) AS uza_area_sq_miles,
+        {{ trim_make_empty_string_null('CAST(ntd_id AS STRING)') }} AS ntd_id,
+        {{ trim_make_empty_string_null('legacy_ntd_id') }} AS legacy_ntd_id,
+        SAFE_CAST(uace_code AS INTEGER) AS uace_code,
+        SAFE_CAST(last_report_year AS INTEGER) AS last_report_year,
+        {{ trim_make_empty_string_null('mode_status') }} AS mode_status,
+        {{ trim_make_empty_string_null('service') }} AS service,
+        {{ trim_make_empty_string_null('_2023_mode_status') }} AS _2023_mode_status,
+        {{ trim_make_empty_string_null('agency_status') }} AS agency_status,
+        SAFE_CAST(uza_population AS INTEGER) AS uza_population,
+        {{ trim_make_empty_string_null('mode') }} AS mode,
+        {{ trim_make_empty_string_null('uza_name') }} AS uza_name,
+        {{ trim_make_empty_string_null('city') }} AS city,
+        SAFE_CAST(census_year AS INTEGER) AS census_year,
+        {{ trim_make_empty_string_null('reporting_module') }} AS reporting_module,
+        {{ trim_make_empty_string_null('reporter_type') }} AS reporter_type,
+        {{ trim_make_empty_string_null('agency_name') }} AS agency_name,
+        SAFE_CAST(_2021 AS NUMERIC) AS _2021,
+        SAFE_CAST(_2023 AS NUMERIC) AS _2023,
+        SAFE_CAST(_1995 AS NUMERIC) AS _1995,
+        SAFE_CAST(_2015 AS NUMERIC) AS _2015,
+        SAFE_CAST(_2019 AS NUMERIC) AS _2019,
+        SAFE_CAST(_2014 AS NUMERIC) AS _2014,
+        SAFE_CAST(_2012 AS NUMERIC) AS _2012,
+        SAFE_CAST(_2008 AS NUMERIC) AS _2008,
+        SAFE_CAST(_2007 AS NUMERIC) AS _2007,
+        SAFE_CAST(_2013 AS NUMERIC) AS _2013,
+        SAFE_CAST(_2002 AS NUMERIC) AS _2002,
+        SAFE_CAST(_2006 AS NUMERIC) AS _2006,
+        SAFE_CAST(_2000 AS NUMERIC) AS _2000,
+        SAFE_CAST(_2004 AS NUMERIC) AS _2004,
+        SAFE_CAST(_1998 AS NUMERIC) AS _1998,
+        SAFE_CAST(_2003 AS NUMERIC) AS _2003,
+        SAFE_CAST(_2022 AS NUMERIC) AS _2022,
+        SAFE_CAST(_1999 AS NUMERIC) AS _1999,
+        SAFE_CAST(_1997 AS NUMERIC) AS _1997,
+        SAFE_CAST(_2011 AS NUMERIC) AS _2011,
+        SAFE_CAST(_2001 AS NUMERIC) AS _2001,
+        SAFE_CAST(_1996 AS NUMERIC) AS _1996,
+        SAFE_CAST(_2020 AS NUMERIC) AS _2020,
+        SAFE_CAST(_2005 AS NUMERIC) AS _2005,
+        SAFE_CAST(_2017 AS NUMERIC) AS _2017,
+        SAFE_CAST(_1994 AS NUMERIC) AS _1994,
+        SAFE_CAST(_1992 AS NUMERIC) AS _1992,
+        SAFE_CAST(_2010 AS NUMERIC) AS _2010,
+        SAFE_CAST(_2009 AS NUMERIC) AS _2009,
+        SAFE_CAST(_2016 AS NUMERIC) AS _2016,
+        SAFE_CAST(_2018 AS NUMERIC) AS _2018,
+        SAFE_CAST(_1993 AS NUMERIC) AS _1993,
+        dt,
+        execution_ts
+    FROM get_latest_extract
+)
+
+SELECT * FROM stg_ntd__asset_inventory_time_series__avg_standing_capacity


### PR DESCRIPTION
# Description
Following #3857, this PR creates staging, mart tables and their accompanying yml files for our two new NTD data endpoint areas – asset_inventory_time_series and 2022 contractual relationships.

Asset inventory staging tables created:
* models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__active_fleet
* models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__ada_fleet
* models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_fleet_age
* models/staging/ntd_assets/stg_ntd__asset_inventory_time_series__avg_seating_capacity
* models/staging/ntd_assetsstg_ntd__asset_inventory_time_series__avg_standing_capacity

Asset inventory mart tables created:
* models/mart/ntd_assets/fct_asset_inventory_time_series_active_fleet
* models/mart/ntd_assets/fct_asset_inventory_time_series_ada_fleet
* models/mart/ntd_assets/fct_asset_inventory_time_series_avg_fleet_age
* models/mart/ntd_assets/fct_asset_inventory_time_series_avg_seating_capacity
* models/mart/ntd_assets/fct_asset_inventory_time_series_avg_standing_capacity

Contractual relationships staging table created:
* models/staging/ntd_annual_reporting/stg_ntd__2022_contractual_relationships.sql

Contractual relationships mart table created:
* models/mart/ntd_annual_reporting/fct_2022_contractual_relationships.sql

ntd annual reporting yml files modified:
* models/staging/ntd_annual_reporting/_src.yml
* models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
* mart/ntd_annual_reporting/_mart_ntd_annual_reporting.yml

ntd asset inventory yml files added:
* models/staging/ntd_assets/_src.yml
* models/staging/ntd_assets/_stg_ntd_assets.yml
* models/mart/ntd_assets/_mart_assets.yml

## Type of change
- [x] New feature

## How has this been tested?
`poetry run dbt run -s +mart.ntd_annual_reporting +mart.ntd_assets`
<img width="750" alt="Screenshot 2025-04-25 at 13 58 01" src="https://github.com/user-attachments/assets/7a29ada0-15f7-4396-8fac-bd55a53eb312" />

## Post-merge follow-ups
- [x] No action required
