### PR TITLE
payments: correctly map nevada county organization name to payments data in seed

### DIFF
--- a/warehouse/seeds/payments_entity_mapping.csv
+++ b/warehouse/seeds/payments_entity_mapping.csv
@@ -17,4 +17,4 @@ recGGy7HVkFGILMgO,recZgWVXkpix390of,,SAN JOAQUIN REGIONAL TRANSIT DIS
 recWJJ4dRk4lHXaWX,recOnKhqF25crJt4q,redwood-coast-transit,REDWOOD COAST TRANSIT AUTHORITY
 recWJJ4dRk4lHXaWX,recOnKhqF25crJt4q,,RCTA DIAL A RIDE
 recrxmzfLImgBGwUH,recsrIZdx5Wt6n3ol,atn,ANAHEIM TRANSPORTATION NETWORK
-rec9i3cd99vZ1qdYt,reciLTK7GaEWzeqsY,nevada-county-connects,NEVCO TAP TO PAY
+rec9i3cd99vZ1qdYt,reczUcQgqgtMpkpKC,nevada-county-connects,NEVCO TAP TO PAY


### PR DESCRIPTION
# Description
As flagged by Nevada County, we're currently mapping payments data to the incorrect organization entity name. This PR fixes the organization id found in the seed file. (`Nevada County Transportation Commision` -> `Nevada County`)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
`poetry run dbt run -s +mart.payments`
<img width="859" alt="Screenshot 2025-04-25 at 14 47 37" src="https://github.com/user-attachments/assets/d505c071-2ca1-45da-bee9-668cb498c068" />


## Post-merge follow-ups
- [x] No action required
