### PR TITLE
payments: revise elavon row access policy for nevada county after correcting organization seed mapping

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -163,7 +163,7 @@ filter using (
 
 {{ create_row_access_policy(
     filter_column = 'organization_name',
-    filter_value = 'Nevada County Transportation Commission',
+    filter_value = 'Nevada County',
     principals = ['serviceAccount:nevada-county-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
 ) }};
 


### PR DESCRIPTION
# Description
After correcting the payments organization name seed mapping for Nevada County in #3868, we also need to replace the organization name in the filter for the Elavon row access policy

File modified:
* macros/create_row_access_policy.sql

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
`poetry run dbt run -s +mart.payments`
<img width="830" alt="Screenshot 2025-04-25 at 15 36 18" src="https://github.com/user-attachments/assets/640a9f95-3667-4b3d-be5c-80cdf435497c" />

## Post-merge follow-ups
- [x] No action required
