### PR TITLE
Update calitp_data_infra to pull project from environment variable

### DIFF
--- a/packages/calitp-data-infra/calitp_data_infra/auth.py
+++ b/packages/calitp-data-infra/calitp_data_infra/auth.py
@@ -37,7 +37,7 @@ def get_gcp_project_id() -> str:
 
 def get_secret_by_name(
     name: str,
-    project: str = None,
+    project: str = "",
     client=secretmanager.SecretManagerServiceClient(),
 ) -> str:
     project = project or get_gcp_project_id()
@@ -49,7 +49,7 @@ def get_secret_by_name(
 
 def get_secrets_by_label(
     label: str,
-    project: str = None,
+    project: str = "",
     client=secretmanager.SecretManagerServiceClient(),
 ) -> Mapping[str, str]:
     secret_values = {}

--- a/packages/calitp-data-infra/calitp_data_infra/auth.py
+++ b/packages/calitp-data-infra/calitp_data_infra/auth.py
@@ -1,14 +1,43 @@
 from typing import Mapping
 
+import os
 from google.cloud import secretmanager  # type: ignore
 
-project = "projects/cal-itp-data-infra"
+
+def get_gcp_project() -> str:
+    """
+    Get the GCP project ID from the environment variable. Try the following
+    environment variables in order:
+    1. GCP_PROJECT
+    2. GOOGLE_CLOUD_PROJECT
+    3. PROJECT_ID
+
+    Cloud Composer should set at least one of these environment variables. See
+    https://cloud.google.com/composer/docs/composer-3/set-environment-variables
+    """
+    try:
+        return os.getenv(
+            "GCP_PROJECT",
+            os.getenv(
+                "GOOGLE_CLOUD_PROJECT",
+                os.environ["PROJECT_ID"]
+            ),
+        )
+    except KeyError:
+        raise ValueError(
+            "GCP project not set in environment variables. "
+            "Please set GCP_PROJECT, GOOGLE_CLOUD_PROJECT, "
+            "or PROJECT_ID."
+        )
 
 
 def get_secret_by_name(
     name: str,
+    project: str = None,
     client=secretmanager.SecretManagerServiceClient(),
 ) -> str:
+    project = project or get_gcp_project()
+
     version = f"{project}/secrets/{name}/versions/latest"
     response = client.access_secret_version(name=version)
     return response.payload.data.decode("UTF-8").strip()
@@ -16,9 +45,11 @@ def get_secret_by_name(
 
 def get_secrets_by_label(
     label: str,
+    project: str = None,
     client=secretmanager.SecretManagerServiceClient(),
 ) -> Mapping[str, str]:
     secret_values = {}
+    project = project or get_gcp_project()
 
     # once we get on at least 2.0.0 of secret manager, we can filter server-side
     for secret in client.list_secrets(parent=project):

--- a/packages/calitp-data-infra/pyproject.toml
+++ b/packages/calitp-data-infra/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp-data-infra"
-version = "2025.3.25"
+version = "2025.5.6-rc1"
 description = "Shared code for developing data pipelines that process Cal-ITP data."
 package-mode = true
 authors = ["Andrew Vaccaro"]

--- a/packages/calitp-data-infra/tests/test_auth.py
+++ b/packages/calitp-data-infra/tests/test_auth.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch
+
+import pytest
+from calitp_data_infra.auth import get_gcp_project_id
+
+
+def test_get_gcp_project_id() -> None:
+    """
+    Test the get_gcp_project_id function.
+    """
+    import os
+
+    with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"}):
+        project_id = get_gcp_project_id()
+
+    assert project_id == "test-project"
+
+
+def test_get_gcp_project_id_no_env() -> None:
+    """
+    Test the get_gcp_project_id function when no environment variable is set.
+    """
+    # Remove the environment variable for testing
+    import os
+
+    with patch.dict("os.environ"):
+        os.environ.pop("GOOGLE_CLOUD_PROJECT", None)
+        os.environ.pop("GCP_PROJECT", None)
+        os.environ.pop("PROJECT_ID", None)
+
+        with pytest.raises(ValueError):
+            get_gcp_project_id()


### PR DESCRIPTION
# Description

Rather than hard-coding the project ID in the `calitp_data_infra` package code, use an environment variable.

Rel #3856 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Ran included unit tests; added unit tests for getting project ID.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

1. Locally update version dependency for images to `2025.5.6-rc1` and test
2. If tests are successful, update version to `2025.5.6`
