### PR TITLE
Add other permission requested to calitp-dds-analyst role to run dbt models

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
@@ -44,6 +44,7 @@ resource "google_project_iam_custom_role" "calitp-dds-analyst" {
     "bigquery.tables.list",
     "bigquery.tables.create",
     "bigquery.tables.update",
+    "bigquery.tables.updateData",
     "resourcemanager.projects.get",
     "storage.buckets.get",
     "storage.buckets.list",


### PR DESCRIPTION
…alyst role in order to run dbt models on staging

# Description

This PR is a continuation of permissions requested in order to run dbt models on staging: `bigquery.tables.updateData` to [calitp-dds-analyst](https://github.com/cal-itp/data-infra/blob/5ee76444f3d624fb41a6255d522b4eaef472dc63/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf#L19)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally using `terraform plan`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
