### PR TITLE
Add permission to GitHub service account to create payment models

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
@@ -37,6 +37,7 @@ resource "google_project_iam_custom_role" "calitp-dds-analyst" {
     "bigquery.reservations.get",
     "bigquery.reservations.list",
     "bigquery.routines.list",
+    "bigquery.rowAccessPolicies.create",
     "bigquery.savedqueries.get",
     "bigquery.savedqueries.list",
     "bigquery.tables.get",


### PR DESCRIPTION
# Description

Add a new permission to GitHub service account in order to fix access denied when dbt run payment models on sync Metabase Staging.

Part of a sequence of PRs to add permissions nedded: https://github.com/cal-itp/data-infra/pull/3915, https://github.com/cal-itp/data-infra/pull/3910

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running `terraform plan` locally.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
