### PR TITLE
Populate Metrolink `shape_id` to `fct_scheduled_trips`

### DIFF
--- a/warehouse/seeds/_seeds.yml
+++ b/warehouse/seeds/_seeds.yml
@@ -267,3 +267,31 @@ seeds:
       - name: organization_name
         tests:
           - unique
+
+  - name: gtfs_optional_shapes
+    description: |
+      GTFS shapes is optional, and where it is not provided, it can be
+      constructed based on route_id and direction_id, since shape_id
+      is associated with a trip_id.
+      https://gtfs.org/documentation/schedule/reference/#tripstxt
+    config:
+      labels:
+        domain: seeds
+        dataset: gtfs
+    columns:
+      - name: gtfs_dataset_name
+        description: The GTFS schedule name from dim_gtfs_datasets
+        tests:
+          - not_null
+      - name: route_id
+        description: GTFS trips route_id value
+        tests:
+          - not_null
+      - name: direction_id
+        description: GTFS trips direction_id value (0 or 1)
+        tests:
+          - not_null
+      - name: shape_id
+        description: Derived shape_id based on combination of route_id and direction_id.
+        tests:
+          - not_null

--- a/warehouse/seeds/gtfs_optional_shapes.csv
+++ b/warehouse/seeds/gtfs_optional_shapes.csv
@@ -1,0 +1,17 @@
+gtfs_dataset_name,route_id,direction_id,shape_id
+Metrolink Schedule,Antelope Valley Line,0,AVout
+Metrolink Schedule,Antelope Valley Line,1,AVin
+Metrolink Schedule,Orange County Line,0,OCout
+Metrolink Schedule,Orange County Line,1,OCin
+Metrolink Schedule,LAX FlyAway Bus,0,LAXout
+Metrolink Schedule,LAX FlyAway Bus,1,LAXin
+Metrolink Schedule,San Bernardino Line,0,SBout
+Metrolink Schedule,San Bernardino Line,1,SBin
+Metrolink Schedule,Ventura County Line,0,VTout
+Metrolink Schedule,Ventura County Line,1,VTin
+Metrolink Schedule,91 Line,0,91out
+Metrolink Schedule,91 Line,1,91in
+Metrolink Schedule,Inland Emp.-Orange Co. Line,0,IEOCout
+Metrolink Schedule,Inland Emp.-Orange Co. Line,1,IEOCin
+Metrolink Schedule,Riverside Line,0,RIVERout
+Metrolink Schedule,Riverside Line,1,RIVERin


### PR DESCRIPTION
# Description

Within `mart_gtfs.fct_scheduled_trips`, use `route_id` and `direction_id` to fill in Metrolink's rows to get `shape_id`. 
Resolves #2194 - we've known about this for awhile, and a manual fix seems to be the only way for this to work in downstream analysis.
* The current bug is that `shape_id` is NaN in the trips table, but it's populated in `dim_shapes`. This merge won't link any of Metrolink's shapes in `fct_daily_scheduled_shapes` because of the trips that are counted filter out for null shapes [here](https://github.com/cal-itp/data-infra/blob/6821ffd9cbb07ca9527400278c41964e4b44a74d/warehouse/models/mart/gtfs/fct_daily_scheduled_shapes.sql#L39)

```
trips_counted AS (

    SELECT
        *
    FROM fct_scheduled_trips
    WHERE shape_id IS NOT NULL
    GROUP BY 1, 2, 3, 4, 5
)
```
* **TODO**: A query to check whether there were other missing shape_ids did show some in 2024, for Amtrak, a smattering for San Diego Schedule in May 2024 (but seems like they fixed it after that), and some other operators (~150ish rows for `year-gtfs_dataset_name-route_id-direction_id`. Potentially follow-up with these and add it to the seed table.

**Solution**:
* Added a seed table to populate these for Metrolink. Provides ability for us to add more in the future too, without us writing a super long CASE WHEN statement.
* A full refresh would fill in those missing shape_ids, prevent those from getting dropped, and the query in  `fct_daily_scheduled_shapes` should bring those shapes / shape_geometry in. 



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (add-metrolink) $ poetry run dbt run -s fct_scheduled_trips --full-refresh
20:41:38  Running with dbt=1.5.1
20:41:41  Found 610 models, 1078 tests, 0 snapshots, 0 analyses, 853 macros, 0 operations, 13 seed files, 223 sources, 4 exposures, 0 metrics, 0 groups
20:41:41  
20:41:57  Concurrency: 8 threads (target='dev')
20:41:57  
20:41:57  1 of 1 START sql table model tiffany_mart_gtfs.fct_scheduled_trips ............. [RUN]
20:42:18  1 of 1 OK created sql table model tiffany_mart_gtfs.fct_scheduled_trips ........ [CREATE TABLE (135.2m rows, 57.9 GiB processed) in 21.20s]
20:42:18  
20:42:18  Finished running 1 table model in 0 hours 0 minutes and 36.51 seconds (36.51s).
20:42:18  
20:42:18  Completed successfully
20:42:18  
20:42:18  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

Running `poetry run dbt run -s fct_scheduled_trips+` works, but `+fct_scheduled_trips+` will not, since it hits a query limit. Adjusted up from `2000000000000` and still got `500 Query exceeded limit for bytes billed: 3000000000000. 3003980447744 or higher required.`


## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below) - check this after the weekend's full refresh
