### PR TITLE
Review Staging and Production gh service account and Entra ID permissions

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
@@ -17,6 +17,11 @@ resource "google_project_iam_custom_role" "tfer--projects-002F-cal-itp-data-infr
 }
 
 resource "google_project_iam_custom_role" "calitp-dds-analyst" {
+  # Contain some permissions from the following roles:
+  # - roles/viewer
+  # - roles/bigquery.user
+  # - roles/bigquery.metadataViewer
+  # - roles/bigquery.filteredDataViewer
   description = "Custom role for DDS Analysts"
   permissions = [
     "bigquery.bireservations.get",
@@ -29,6 +34,7 @@ resource "google_project_iam_custom_role" "calitp-dds-analyst" {
     "bigquery.jobs.create",
     "bigquery.jobs.list",
     "bigquery.models.list",
+    "bigquery.models.getMetadata",
     "bigquery.readsessions.create",
     "bigquery.readsessions.getData",
     "bigquery.readsessions.update",
@@ -36,16 +42,25 @@ resource "google_project_iam_custom_role" "calitp-dds-analyst" {
     "bigquery.reservationAssignments.search",
     "bigquery.reservations.get",
     "bigquery.reservations.list",
+    "bigquery.routines.get",
     "bigquery.routines.list",
     "bigquery.rowAccessPolicies.create",
+    "bigquery.rowAccessPolicies.getFilteredData",
     "bigquery.savedqueries.get",
     "bigquery.savedqueries.list",
     "bigquery.tables.get",
     "bigquery.tables.getData",
+    "bigquery.tables.getIamPolicy",
     "bigquery.tables.list",
     "bigquery.tables.create",
     "bigquery.tables.update",
     "bigquery.tables.updateData",
+    "dataform.locations.get",
+    "dataform.locations.list",
+    "dataform.repositories.create",
+    "dataform.repositories.list",
+    "dataplex.projects.search",
+    "resourcemanager.projects.list",
     "resourcemanager.projects.get",
     "storage.buckets.get",
     "storage.buckets.list",

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -234,8 +234,13 @@ resource "google_project_iam_member" "github-actions-terraform" {
 
 resource "google_project_iam_member" "github-actions-service-account" {
   for_each = toset([
+    "roles/viewer",
+    "roles/bigquery.user",
+    "roles/bigquery.dataOwner",
     "roles/bigquery.filteredDataViewer",
     "roles/bigquery.metadataViewer",
+    "roles/composer.admin",
+    "roles/storage.objectAdmin",
     google_project_iam_custom_role.calitp-dds-analyst.id,
     google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-staging-002F-roles-002F-CustomGCSPublisher.id
   ])
@@ -256,6 +261,10 @@ resource "google_project_iam_member" "custom_service_account" {
 resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Warehouse_Users" {
   for_each = toset([
     "roles/viewer",
+    "roles/bigquery.user",
+    "roles/bigquery.dataEditor",
+    "roles/bigquery.filteredDataViewer",
+    "roles/storage.objectUser",
     google_project_iam_custom_role.calitp-dds-analyst.id
   ])
   role    = each.key
@@ -266,6 +275,10 @@ resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Ware
 resource "google_project_iam_member" "ms-entra-id-DDS_Cloud_Admins" {
   for_each = toset([
     "roles/editor",
+    "roles/bigquery.admin",
+    "roles/bigquery.dataEditor",
+    "roles/storage.objectAdmin",
+    "roles/composer.admin",
     google_project_iam_custom_role.calitp-dds-analyst.id
   ])
   role    = each.key

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -541,6 +541,7 @@ resource "google_project_iam_member" "tfer--roles-002F-viewerserviceAccount-003A
 resource "google_project_iam_member" "github-actions-terraform" {
   for_each = toset([
     "roles/resourcemanager.projectIamAdmin",
+    "roles/iam.roleAdmin",
     "roles/editor",
     "roles/storage.admin"
   ])
@@ -551,6 +552,9 @@ resource "google_project_iam_member" "github-actions-terraform" {
 
 resource "google_project_iam_member" "github-actions-service-account" {
   for_each = toset([
+    "roles/viewer",
+    "roles/bigquery.user",
+    "roles/bigquery.dataOwner",
     "roles/bigquery.filteredDataViewer",
     "roles/bigquery.metadataViewer",
     "roles/composer.admin",
@@ -565,6 +569,10 @@ resource "google_project_iam_member" "github-actions-service-account" {
 resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Warehouse_Users" {
   for_each = toset([
     "roles/viewer",
+    "roles/bigquery.user",
+    "roles/bigquery.filteredDataViewer",
+    "roles/bigquery.metadataViewer",
+    "roles/storage.objectUser",
     google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-DataAnalyst.id
   ])
   role    = each.key
@@ -575,6 +583,10 @@ resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Ware
 resource "google_project_iam_member" "ms-entra-id-DDS_Cloud_Admins" {
   for_each = toset([
     "roles/editor",
+    "roles/bigquery.admin",
+    "roles/bigquery.dataEditor",
+    "roles/storage.objectAdmin",
+    "roles/composer.admin",
     google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-DataAnalyst.id
   ])
   role    = each.key


### PR DESCRIPTION
# Description

Added permissions that are missing for MS Entra ID users on production and staging.
Also as deploy dbt has been requesting many permissions to sync Metabase (https://github.com/cal-itp/data-infra/pull/3910, https://github.com/cal-itp/data-infra/pull/3915, https://github.com/cal-itp/data-infra/pull/3925), I reviewed roles needed and added instead of only individual permissions on the custom `calitp-dds-analyst` role.

Resolves #3920

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally with `terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check is MS Entra Id users can save queries in the bigquery console.