### PR TITLE
fix: Prefix secrets version string with "projects/"

### DIFF
--- a/packages/calitp-data-infra/calitp_data_infra/auth.py
+++ b/packages/calitp-data-infra/calitp_data_infra/auth.py
@@ -42,7 +42,7 @@ def get_secret_by_name(
 ) -> str:
     project = project or get_gcp_project_id()
 
-    version = f"{project}/secrets/{name}/versions/latest"
+    version = f"projects/{project}/secrets/{name}/versions/latest"
     response = client.access_secret_version(name=version)
     return response.payload.data.decode("UTF-8").strip()
 

--- a/packages/calitp-data-infra/pyproject.toml
+++ b/packages/calitp-data-infra/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp-data-infra"
-version = "2025.5.6-rc1"
+version = "2025.5.6-rc2"
 description = "Shared code for developing data pipelines that process Cal-ITP data."
 package-mode = true
 authors = ["Andrew Vaccaro"]


### PR DESCRIPTION
# Description

The calitp-data-infra package used an incorrect format for identifying secrets since version `2025.05.06-rc1`. This release candidate version was being used to test Cloud Composer upgrades. This is related to updating the secrets capabilities for staging Airflow. This PR also creates a new release candidate version of calitp-data-infra.

Ref #3856 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Locally ensuring that the format of the secrets ID results in a valid response from the `google.cloud` client library. E.g.:

```py
from google.cloud import secretmanager
client = secretmanager.SecretManagerServiceClient()
project = 'cal-itp-data-infra-staging'
name = 'LITTLEPAY_AWS_IAM_MST_ACCESS_KEY'  # Any secret that exists in the project will do.

version = f'projects/{project}/secrets/{name}/versions/latest'
response = client.access_secret_version(name=version)
```

Previously, with the version set to `f'{project}/secrets/{name}/versions/latest'`, the above code resulted in:
```
google.api_core.exceptions.InvalidArgument: 400 Invalid resource field value in the request. [reason: "RESOURCE_PROJECT_INVALID"
domain: "googleapis.com"
metadata {
  key: "service"
  value: "secretmanager.googleapis.com"
}
metadata {
  key: "method"
  value: "google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion"
}
]
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
