### PR TITLE
Properly attach Metrolink's shape_array_key

### DIFF
--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -109,8 +109,6 @@ gtfs_joins AS (
         shapes.key AS shape_array_key,
         shapes.pt_array --# this attaches now
         
- 
-
     FROM int_gtfs_schedule__daily_scheduled_service_index AS service_index
     INNER JOIN dim_trips2 AS trips
         ON service_index.feed_key = trips.feed_key
@@ -121,7 +119,20 @@ gtfs_joins AS (
     LEFT JOIN dim_routes AS routes
         ON service_index.feed_key = routes.feed_key
             AND trips.route_id = routes.route_id
+),
 
+gtfs_joins2 AS (
+    SELECT
+        
+        gtfs_joins.*,
+        stop_times_grouped.iteration_num,
+        stop_times_grouped.frequencies_defined_trip,
+    FROM gtfs_joins
+    LEFT JOIN stop_times_grouped
+        ON gtfs_joins.feed_key = stop_times_grouped.feed_key
+            AND gtfs_joins.trip_id = stop_times_grouped.trip_id
+    -- drop trips with no stops
+    --WHERE stop_times_grouped.feed_key IS NOT NULL
 )
 
-SELECT * FROM gtfs_joins
+SELECT * FROM gtfs_joins2

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -18,13 +18,11 @@ dim_routes AS (
 ),
 
 fct_daily_schedule_feeds AS (
-    SELECT *
-    FROM {{ ref('fct_daily_schedule_feeds') }}
+    SELECT * FROM {{ ref('fct_daily_schedule_feeds') }}
 ),
 
 dim_shapes_arrays AS (
-    SELECT *
-    FROM {{ ref('dim_shapes_arrays') }}
+    SELECT * FROM {{ ref('dim_shapes_arrays') }}
 ),
 
 dim_gtfs_datasets AS (
@@ -33,9 +31,7 @@ dim_gtfs_datasets AS (
 ),
 
 stop_times_grouped AS (
-    SELECT *
-    FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index')
-    }}
+    SELECT * FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index') }}
 ),
 
 -- use seed to fill in where shape_ids are missing

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -59,8 +59,7 @@ derived_shapes_with_feed AS (
 
 dim_trips_fixed AS (
     SELECT
-        * EXCEPT(feed_key, route_id, direction_id, shape_id, key),
-        dim_trips.key, --the key in dim_trips will have null shape_id, so somehow it's not carrying over in the join later
+        * EXCEPT(feed_key, route_id, direction_id, shape_id),
         dim_trips.feed_key,
         dim_trips.route_id,
         dim_trips.direction_id,

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -31,7 +31,8 @@ dim_gtfs_datasets AS (
 ),
 
 stop_times_grouped AS (
-    SELECT * FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index') }}
+    SELECT * FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
+
 ),
 
 -- use seed to fill in where shape_ids are missing

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -132,7 +132,7 @@ gtfs_joins2 AS (
         ON gtfs_joins.feed_key = stop_times_grouped.feed_key
             AND gtfs_joins.trip_id = stop_times_grouped.trip_id
     -- drop trips with no stops
-    --WHERE stop_times_grouped.feed_key IS NOT NULL
+    WHERE stop_times_grouped.feed_key IS NOT NULL
 )
 
 SELECT * FROM gtfs_joins2

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -4,32 +4,29 @@
 WITH int_gtfs_schedule__daily_scheduled_service_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
-
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
 ),
 
 dim_trips AS (
     SELECT *
     FROM {{ ref('dim_trips') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
-
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
 ),
 
 dim_routes AS (
     SELECT *
     FROM {{ ref('dim_routes') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
 ),
 
 fct_daily_schedule_feeds AS (
     SELECT * FROM {{ ref('fct_daily_schedule_feeds') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
 ),
 
 dim_shapes_arrays AS (
     SELECT * FROM {{ ref('dim_shapes_arrays') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
-
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
 ),
 
 dim_gtfs_datasets AS (
@@ -39,7 +36,7 @@ dim_gtfs_datasets AS (
 
 stop_times_grouped AS (
     SELECT * FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
 ),
 
 -- use seed to fill in where shape_ids are missing
@@ -63,7 +60,8 @@ derived_shapes_with_feed AS (
 
 dim_trips2 AS (
     SELECT
-        * EXCEPT(feed_key, route_id, direction_id, shape_id),
+        * EXCEPT(feed_key, route_id, direction_id, shape_id, key),
+        dim_trips.key, --the key in dim_trips will have null shape_id, so somehow it's not carrying over in the join later
         dim_trips.feed_key,
         dim_trips.route_id,
         dim_trips.direction_id,
@@ -74,5 +72,6 @@ dim_trips2 AS (
             AND derived_shapes_with_feed.route_id = dim_trips.route_id
             AND derived_shapes_with_feed.direction_id = dim_trips.direction_id
 )
+
 
 SELECT * FROM dim_trips2

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -107,7 +107,7 @@ gtfs_joins AS (
         trips.warning_duplicate_gtfs_key AS contains_warning_duplicate_trip_primary_key,
         
         shapes.key AS shape_array_key,
-        --shapes.pt_array # this attaches now
+        shapes.pt_array --# this attaches now
         
  
 
@@ -121,12 +121,7 @@ gtfs_joins AS (
     LEFT JOIN dim_routes AS routes
         ON service_index.feed_key = routes.feed_key
             AND trips.route_id = routes.route_id
-    --LEFT JOIN stop_times_grouped
-    --   ON service_index.feed_key = stop_times_grouped.feed_key
-    --        AND trips.trip_id = stop_times_grouped.trip_id
-    -- drop trips with no stops
-    --WHERE stop_times_grouped.feed_key IS NOT NULL
-)
 
+)
 
 SELECT * FROM gtfs_joins

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -1,40 +1,30 @@
 {{ config(
-    materialized='table') }}
---fix config
+    materialized='table',
+    cluster_by='service_date') }}
+
 WITH int_gtfs_schedule__daily_scheduled_service_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
-        AND {{ incremental_where(
-            default_start_var='GTFS_SCHEDULE_START',
-            this_dt_column='service_date',
-            filter_dt_column='service_date',
-            dev_lookback_days = 60) 
-    }}
 ),
 
 dim_trips AS (
     SELECT *
     FROM {{ ref('dim_trips') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
-    
 ),
 
 dim_routes AS (
     SELECT *
     FROM {{ ref('dim_routes') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
-
 ),
 
 fct_daily_schedule_feeds AS (
-    SELECT * FROM {{ ref('fct_daily_schedule_feeds') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
+    SELECT *
+    FROM {{ ref('fct_daily_schedule_feeds') }}
 ),
 
 dim_shapes_arrays AS (
-    SELECT * FROM {{ ref('dim_shapes_arrays') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
+    SELECT *
+    FROM {{ ref('dim_shapes_arrays') }}
 ),
 
 dim_gtfs_datasets AS (
@@ -43,8 +33,9 @@ dim_gtfs_datasets AS (
 ),
 
 stop_times_grouped AS (
-    SELECT * FROM `cal-itp-data-infra-staging.tiffany_mart_gtfs.test_st_groups`
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
+    SELECT *
+    FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index')
+    }}
 ),
 
 -- use seed to fill in where shape_ids are missing
@@ -66,15 +57,15 @@ derived_shapes_with_feed AS (
         ON derived_shapes.gtfs_dataset_name = fct_daily_schedule_feeds.gtfs_dataset_name
 ),
 
-dim_trips2 AS (
-    SELECT 
+dim_trips_fixed AS (
+    SELECT
         * EXCEPT(feed_key, route_id, direction_id, shape_id, key),
         dim_trips.key, --the key in dim_trips will have null shape_id, so somehow it's not carrying over in the join later
         dim_trips.feed_key,
         dim_trips.route_id,
         dim_trips.direction_id,
         COALESCE(dim_trips.shape_id, derived_shapes_with_feed.shape_id) AS shape_id,
-    FROM dim_trips 
+    FROM dim_trips
     LEFT JOIN derived_shapes_with_feed
         ON derived_shapes_with_feed.feed_key = dim_trips.feed_key
             AND derived_shapes_with_feed.route_id = dim_trips.route_id
@@ -111,15 +102,56 @@ gtfs_joins AS (
         routes.continuous_drop_off AS route_continuous_drop_off,
         routes.route_color,
         routes.route_text_color,
-        
+
         trips.shape_id,
         trips.warning_duplicate_gtfs_key AS contains_warning_duplicate_trip_primary_key,
-        
+
         shapes.key AS shape_array_key,
-        shapes.pt_array --# this attaches now
-        
+
+        stop_times_grouped.num_distinct_stops_served,
+        stop_times_grouped.num_stop_times,
+        stop_times_grouped.trip_first_departure_sec,
+        stop_times_grouped.trip_last_arrival_sec,
+        stop_times_grouped.service_hours,
+        stop_times_grouped.flex_service_hours,
+        stop_times_grouped.contains_warning_duplicate_gtfs_key AS contains_warning_duplicate_stop_times_primary_key,
+        stop_times_grouped.contains_warning_missing_foreign_key_stop_id,
+        stop_times_grouped.trip_start_timezone,
+        stop_times_grouped.trip_end_timezone,
+        stop_times_grouped.is_gtfs_flex_trip,
+        stop_times_grouped.num_gtfs_flex_stop_times,
+        stop_times_grouped.is_entirely_demand_responsive_trip,
+        stop_times_grouped.has_rider_service,
+        stop_times_grouped.first_start_pickup_drop_off_window_sec,
+        stop_times_grouped.last_end_pickup_drop_off_window_sec,
+        stop_times_grouped.num_approximate_timepoint_stop_times,
+        stop_times_grouped.num_exact_timepoint_stop_times,
+        stop_times_grouped.num_arrival_times_populated_stop_times,
+        stop_times_grouped.num_departure_times_populated_stop_times,
+        -- spec is explicit: all stop times are relative to midnight in the feed time zone (from agency.txt)
+        -- see: https://gtfs.org/schedule/reference/#stopstxt
+        -- so to make a timestamp, we use the feed timezone from agency.txt
+        TIMESTAMP_ADD(
+            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
+            INTERVAL stop_times_grouped.trip_first_departure_sec SECOND
+            ) AS trip_first_departure_ts,
+
+        TIMESTAMP_ADD(
+            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
+            INTERVAL stop_times_grouped.trip_last_arrival_sec SECOND
+            ) AS trip_last_arrival_ts,
+
+        TIMESTAMP_ADD(
+            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
+            INTERVAL stop_times_grouped.first_start_pickup_drop_off_window_sec SECOND
+            ) AS trip_first_start_pickup_drop_off_window_ts,
+
+        TIMESTAMP_ADD(
+            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
+            INTERVAL stop_times_grouped.last_end_pickup_drop_off_window_sec SECOND
+            ) AS trip_last_end_pickup_drop_off_window_ts,
     FROM int_gtfs_schedule__daily_scheduled_service_index AS service_index
-    INNER JOIN dim_trips2 AS trips
+    INNER JOIN dim_trips_fixed AS trips
         ON service_index.feed_key = trips.feed_key
             AND service_index.service_id = trips.service_id
     LEFT JOIN dim_shapes_arrays as shapes
@@ -133,6 +165,88 @@ gtfs_joins AS (
             AND trips.trip_id = stop_times_grouped.trip_id
     -- drop trips with no stops
     WHERE stop_times_grouped.feed_key IS NOT NULL
+),
+
+fct_scheduled_trips AS (
+    SELECT
+        gtfs_joins.key,
+        {{ dbt_utils.generate_surrogate_key(['gtfs_joins.service_date', 'gtfs_joins.base64_url', 'gtfs_joins.trip_id', 'gtfs_joins.iteration_num']) }} AS trip_instance_key,
+        gtfs_joins.feed_timezone,
+        gtfs_joins.base64_url,
+
+        dim_gtfs_datasets.name,
+        dim_gtfs_datasets.regional_feed_type,
+
+        daily_feeds.gtfs_dataset_key AS gtfs_dataset_key,
+
+        gtfs_joins.service_date,
+        gtfs_joins.feed_key,
+        gtfs_joins.service_id,
+        gtfs_joins.trip_key,
+        gtfs_joins.trip_id,
+        -- if it's not a frequency based trip, it should be unique on its given date
+        -- so simply coalesce
+        COALESCE(gtfs_joins.iteration_num, 1) AS iteration_num,
+        gtfs_joins.frequencies_defined_trip,
+        gtfs_joins.trip_short_name,
+        gtfs_joins.direction_id,
+        gtfs_joins.block_id,
+        gtfs_joins.route_key,
+        gtfs_joins.route_id,
+        gtfs_joins.route_type,
+        gtfs_joins.route_short_name,
+        gtfs_joins.route_long_name,
+        gtfs_joins.route_continuous_pickup,
+        gtfs_joins.route_continuous_drop_off,
+        gtfs_joins.route_desc,
+        gtfs_joins.agency_id,
+        gtfs_joins.network_id,
+        gtfs_joins.shape_array_key,
+        gtfs_joins.shape_id,
+        gtfs_joins.contains_warning_duplicate_trip_primary_key,
+        gtfs_joins.num_distinct_stops_served,
+        gtfs_joins.num_stop_times,
+        gtfs_joins.trip_first_departure_sec,
+        gtfs_joins.trip_last_arrival_sec,
+        gtfs_joins.trip_start_timezone,
+        gtfs_joins.trip_end_timezone,
+        gtfs_joins.service_hours,
+        gtfs_joins.flex_service_hours,
+        gtfs_joins.contains_warning_duplicate_stop_times_primary_key,
+        gtfs_joins.contains_warning_missing_foreign_key_stop_id,
+        gtfs_joins.trip_first_departure_ts,
+        gtfs_joins.trip_last_arrival_ts,
+        gtfs_joins.first_start_pickup_drop_off_window_sec,
+        gtfs_joins.last_end_pickup_drop_off_window_sec,
+        gtfs_joins.is_gtfs_flex_trip,
+        gtfs_joins.is_entirely_demand_responsive_trip,
+        gtfs_joins.num_gtfs_flex_stop_times,
+        gtfs_joins.num_approximate_timepoint_stop_times,
+        gtfs_joins.num_exact_timepoint_stop_times,
+        gtfs_joins.num_arrival_times_populated_stop_times,
+        gtfs_joins.num_departure_times_populated_stop_times,
+        gtfs_joins.trip_first_start_pickup_drop_off_window_ts,
+        gtfs_joins.trip_last_end_pickup_drop_off_window_ts,
+        DATE(trip_first_departure_ts, "America/Los_Angeles") AS trip_start_date_pacific,
+        DATETIME(trip_first_departure_ts, "America/Los_Angeles") AS trip_first_departure_datetime_pacific,
+        DATETIME(trip_last_arrival_ts, "America/Los_Angeles") AS trip_last_arrival_datetime_pacific,
+        DATE(trip_first_departure_ts, trip_start_timezone) AS trip_start_date_local_tz,
+        DATETIME(trip_first_departure_ts, trip_start_timezone) AS trip_first_departure_datetime_local_tz,
+        DATETIME(trip_last_arrival_ts, trip_end_timezone) AS trip_last_arrival_datetime_local_tz,
+        DATE(trip_first_start_pickup_drop_off_window_ts, "America/Los_Angeles") AS trip_first_start_pickup_drop_off_window_date_pacific,
+        DATETIME(trip_first_start_pickup_drop_off_window_ts, "America/Los_Angeles") AS trip_first_start_pickup_drop_off_window_datetime_pacific,
+        DATETIME(trip_last_end_pickup_drop_off_window_ts, "America/Los_Angeles") AS trip_last_end_pickup_drop_off_window_pacific,
+        DATE(trip_first_start_pickup_drop_off_window_ts, trip_start_timezone) AS trip_first_start_pickup_drop_off_window_date_local_tz,
+        DATETIME(trip_first_start_pickup_drop_off_window_ts, trip_start_timezone) AS trip_first_start_pickup_drop_off_window_datetime_local_tz,
+        DATETIME(trip_last_end_pickup_drop_off_window_ts, trip_end_timezone) AS trip_last_end_pickup_drop_off_window_datetime_local_tz,
+    FROM gtfs_joins
+    LEFT JOIN fct_daily_schedule_feeds AS daily_feeds
+        ON gtfs_joins.feed_key = daily_feeds.feed_key
+        AND gtfs_joins.service_date = daily_feeds.date
+    LEFT JOIN dim_gtfs_datasets
+        ON daily_feeds.gtfs_dataset_key = dim_gtfs_datasets.key
+    -- drop trips that no one can actually ride
+    WHERE has_rider_service
 )
 
-SELECT * FROM gtfs_joins
+SELECT * FROM fct_scheduled_trips

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -1,28 +1,35 @@
 {{ config(
-    materialized='table',
-    cluster_by='service_date') }}
-
+    materialized='table') }}
+--fix config
 WITH int_gtfs_schedule__daily_scheduled_service_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index') }}
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
+
 ),
 
 dim_trips AS (
     SELECT *
     FROM {{ ref('dim_trips') }}
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
+
 ),
 
 dim_routes AS (
     SELECT *
     FROM {{ ref('dim_routes') }}
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
 ),
 
 fct_daily_schedule_feeds AS (
     SELECT * FROM {{ ref('fct_daily_schedule_feeds') }}
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
 ),
 
 dim_shapes_arrays AS (
     SELECT * FROM {{ ref('dim_shapes_arrays') }}
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
+
 ),
 
 dim_gtfs_datasets AS (
@@ -32,6 +39,7 @@ dim_gtfs_datasets AS (
 
 stop_times_grouped AS (
     SELECT * FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602", "0f80473907c7613e9fefbb71220e9e56", "5dc8e10aaf365db19377d6a89d287497", "c38789e6ea2280c459f71931e0333e00", "df3f70652f80ec0199607a3ec6b1f371")
 ),
 
 -- use seed to fill in where shape_ids are missing
@@ -40,184 +48,31 @@ derived_shapes AS (
     FROM {{ ref('gtfs_optional_shapes') }}
 ),
 
-gtfs_joins AS (
-    SELECT
-        {{ dbt_utils.generate_surrogate_key(['service_index.service_date', 'trips.key', 'stop_times_grouped.iteration_num']) }} AS key,
+derived_shapes_with_feed AS (
+    SELECT DISTINCT
+        fct_daily_schedule_feeds.feed_key,
+        derived_shapes.gtfs_dataset_name,
+        derived_shapes.route_id,
+        derived_shapes.direction_id,
+        derived_shapes.shape_id
 
-        service_index.service_date,
-        service_index.feed_key,
-        trips.base64_url,
-        service_index.service_id,
-        service_index.feed_timezone,
-
-        trips.key AS trip_key,
-        trips.trip_id AS trip_id,
-        trips.trip_short_name,
-        trips.direction_id,
-        trips.block_id,
-        stop_times_grouped.iteration_num,
-        stop_times_grouped.frequencies_defined_trip,
-
-        routes.key AS route_key,
-        routes.route_id AS route_id,
-        routes.route_type,
-        routes.route_short_name,
-        routes.route_long_name,
-        routes.route_desc,
-        routes.agency_id AS agency_id,
-        routes.network_id AS network_id,
-        routes.continuous_pickup AS route_continuous_pickup,
-        routes.continuous_drop_off AS route_continuous_drop_off,
-
-        shapes.key AS shape_array_key,
-
-        trips.shape_id,
-        trips.warning_duplicate_gtfs_key AS contains_warning_duplicate_trip_primary_key,
-
-        stop_times_grouped.num_distinct_stops_served,
-        stop_times_grouped.num_stop_times,
-        stop_times_grouped.trip_first_departure_sec,
-        stop_times_grouped.trip_last_arrival_sec,
-        stop_times_grouped.service_hours,
-        stop_times_grouped.flex_service_hours,
-        stop_times_grouped.contains_warning_duplicate_gtfs_key AS contains_warning_duplicate_stop_times_primary_key,
-        stop_times_grouped.contains_warning_missing_foreign_key_stop_id,
-        stop_times_grouped.trip_start_timezone,
-        stop_times_grouped.trip_end_timezone,
-        stop_times_grouped.is_gtfs_flex_trip,
-        stop_times_grouped.num_gtfs_flex_stop_times,
-        stop_times_grouped.is_entirely_demand_responsive_trip,
-        stop_times_grouped.has_rider_service,
-        stop_times_grouped.first_start_pickup_drop_off_window_sec,
-        stop_times_grouped.last_end_pickup_drop_off_window_sec,
-        stop_times_grouped.num_approximate_timepoint_stop_times,
-        stop_times_grouped.num_exact_timepoint_stop_times,
-        stop_times_grouped.num_arrival_times_populated_stop_times,
-        stop_times_grouped.num_departure_times_populated_stop_times,
-        -- spec is explicit: all stop times are relative to midnight in the feed time zone (from agency.txt)
-        -- see: https://gtfs.org/schedule/reference/#stopstxt
-        -- so to make a timestamp, we use the feed timezone from agency.txt
-        TIMESTAMP_ADD(
-            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
-            INTERVAL stop_times_grouped.trip_first_departure_sec SECOND
-            ) AS trip_first_departure_ts,
-
-        TIMESTAMP_ADD(
-            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
-            INTERVAL stop_times_grouped.trip_last_arrival_sec SECOND
-            ) AS trip_last_arrival_ts,
-
-        TIMESTAMP_ADD(
-            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
-            INTERVAL stop_times_grouped.first_start_pickup_drop_off_window_sec SECOND
-            ) AS trip_first_start_pickup_drop_off_window_ts,
-
-        TIMESTAMP_ADD(
-            {{ gtfs_noon_minus_twelve_hours('service_date', 'service_index.feed_timezone') }},
-            INTERVAL stop_times_grouped.last_end_pickup_drop_off_window_sec SECOND
-            ) AS trip_last_end_pickup_drop_off_window_ts,
-
-    FROM int_gtfs_schedule__daily_scheduled_service_index AS service_index
-    INNER JOIN dim_trips AS trips
-        ON service_index.feed_key = trips.feed_key
-            AND service_index.service_id = trips.service_id
-    LEFT JOIN dim_routes AS routes
-        ON service_index.feed_key = routes.feed_key
-            AND trips.route_id = routes.route_id
-    LEFT JOIN dim_shapes_arrays AS shapes
-        ON service_index.feed_key = shapes.feed_key
-            AND trips.shape_id = shapes.shape_id
-    LEFT JOIN stop_times_grouped
-        ON service_index.feed_key = stop_times_grouped.feed_key
-            AND trips.trip_id = stop_times_grouped.trip_id
-    -- drop trips with no stops
-    WHERE stop_times_grouped.feed_key IS NOT NULL
+    FROM derived_shapes
+    INNER JOIN fct_daily_schedule_feeds
+        ON derived_shapes.gtfs_dataset_name = fct_daily_schedule_feeds.gtfs_dataset_name
 ),
 
-fct_scheduled_trips AS (
+dim_trips2 AS (
     SELECT
-        gtfs_joins.key,
-        {{ dbt_utils.generate_surrogate_key(['gtfs_joins.service_date', 'gtfs_joins.base64_url', 'gtfs_joins.trip_id', 'gtfs_joins.iteration_num']) }} AS trip_instance_key,
-        gtfs_joins.feed_timezone,
-        gtfs_joins.base64_url,
-
-        dim_gtfs_datasets.name,
-        dim_gtfs_datasets.regional_feed_type,
-
-        daily_feeds.gtfs_dataset_key AS gtfs_dataset_key,
-
-        gtfs_joins.service_date,
-        gtfs_joins.feed_key,
-        gtfs_joins.service_id,
-        gtfs_joins.trip_key,
-        gtfs_joins.trip_id,
-        -- if it's not a frequency based trip, it should be unique on its given date
-        -- so simply coalesce
-        COALESCE(gtfs_joins.iteration_num, 1) AS iteration_num,
-        gtfs_joins.frequencies_defined_trip,
-        gtfs_joins.trip_short_name,
-        gtfs_joins.direction_id,
-        gtfs_joins.block_id,
-        gtfs_joins.route_key,
-        gtfs_joins.route_id,
-        gtfs_joins.route_type,
-        gtfs_joins.route_short_name,
-        gtfs_joins.route_long_name,
-        gtfs_joins.route_continuous_pickup,
-        gtfs_joins.route_continuous_drop_off,
-        gtfs_joins.route_desc,
-        gtfs_joins.agency_id,
-        gtfs_joins.network_id,
-        gtfs_joins.shape_array_key,
-        COALESCE(gtfs_joins.shape_id, derived_shapes.shape_id) AS shape_id,
-        gtfs_joins.contains_warning_duplicate_trip_primary_key,
-        gtfs_joins.num_distinct_stops_served,
-        gtfs_joins.num_stop_times,
-        gtfs_joins.trip_first_departure_sec,
-        gtfs_joins.trip_last_arrival_sec,
-        gtfs_joins.trip_start_timezone,
-        gtfs_joins.trip_end_timezone,
-        gtfs_joins.service_hours,
-        gtfs_joins.flex_service_hours,
-        gtfs_joins.contains_warning_duplicate_stop_times_primary_key,
-        gtfs_joins.contains_warning_missing_foreign_key_stop_id,
-        gtfs_joins.trip_first_departure_ts,
-        gtfs_joins.trip_last_arrival_ts,
-        gtfs_joins.first_start_pickup_drop_off_window_sec,
-        gtfs_joins.last_end_pickup_drop_off_window_sec,
-        gtfs_joins.is_gtfs_flex_trip,
-        gtfs_joins.is_entirely_demand_responsive_trip,
-        gtfs_joins.num_gtfs_flex_stop_times,
-        gtfs_joins.num_approximate_timepoint_stop_times,
-        gtfs_joins.num_exact_timepoint_stop_times,
-        gtfs_joins.num_arrival_times_populated_stop_times,
-        gtfs_joins.num_departure_times_populated_stop_times,
-        gtfs_joins.trip_first_start_pickup_drop_off_window_ts,
-        gtfs_joins.trip_last_end_pickup_drop_off_window_ts,
-        DATE(trip_first_departure_ts, "America/Los_Angeles") AS trip_start_date_pacific,
-        DATETIME(trip_first_departure_ts, "America/Los_Angeles") AS trip_first_departure_datetime_pacific,
-        DATETIME(trip_last_arrival_ts, "America/Los_Angeles") AS trip_last_arrival_datetime_pacific,
-        DATE(trip_first_departure_ts, trip_start_timezone) AS trip_start_date_local_tz,
-        DATETIME(trip_first_departure_ts, trip_start_timezone) AS trip_first_departure_datetime_local_tz,
-        DATETIME(trip_last_arrival_ts, trip_end_timezone) AS trip_last_arrival_datetime_local_tz,
-        DATE(trip_first_start_pickup_drop_off_window_ts, "America/Los_Angeles") AS trip_first_start_pickup_drop_off_window_date_pacific,
-        DATETIME(trip_first_start_pickup_drop_off_window_ts, "America/Los_Angeles") AS trip_first_start_pickup_drop_off_window_datetime_pacific,
-        DATETIME(trip_last_end_pickup_drop_off_window_ts, "America/Los_Angeles") AS trip_last_end_pickup_drop_off_window_pacific,
-        DATE(trip_first_start_pickup_drop_off_window_ts, trip_start_timezone) AS trip_first_start_pickup_drop_off_window_date_local_tz,
-        DATETIME(trip_first_start_pickup_drop_off_window_ts, trip_start_timezone) AS trip_first_start_pickup_drop_off_window_datetime_local_tz,
-        DATETIME(trip_last_end_pickup_drop_off_window_ts, trip_end_timezone) AS trip_last_end_pickup_drop_off_window_datetime_local_tz,
-    FROM gtfs_joins
-    LEFT JOIN fct_daily_schedule_feeds AS daily_feeds
-        ON gtfs_joins.feed_key = daily_feeds.feed_key
-        AND gtfs_joins.service_date = daily_feeds.date
-    LEFT JOIN dim_gtfs_datasets
-        ON daily_feeds.gtfs_dataset_key = dim_gtfs_datasets.key
-    LEFT JOIN derived_shapes
-    ON dim_gtfs_datasets.name = derived_shapes.gtfs_dataset_name
-        AND gtfs_joins.route_id = derived_shapes.route_id
-        AND gtfs_joins.direction_id = derived_shapes.direction_id
-    -- drop trips that no one can actually ride
-    WHERE has_rider_service
+        * EXCEPT(feed_key, route_id, direction_id, shape_id),
+        dim_trips.feed_key,
+        dim_trips.route_id,
+        dim_trips.direction_id,
+        COALESCE(dim_trips.shape_id, derived_shapes_with_feed.shape_id) AS shape_id
+    FROM dim_trips
+    LEFT JOIN derived_shapes_with_feed
+        ON derived_shapes_with_feed.feed_key = dim_trips.feed_key
+            AND derived_shapes_with_feed.route_id = dim_trips.route_id
+            AND derived_shapes_with_feed.direction_id = dim_trips.direction_id
 )
 
-SELECT * FROM fct_scheduled_trips
+SELECT * FROM dim_trips2

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -32,7 +32,6 @@ dim_gtfs_datasets AS (
 
 stop_times_grouped AS (
     SELECT * FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
-
 ),
 
 -- use seed to fill in where shape_ids are missing

--- a/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_scheduled_trips.sql
@@ -4,29 +4,29 @@
 WITH int_gtfs_schedule__daily_scheduled_service_index AS (
     SELECT *
     FROM {{ ref('int_gtfs_schedule__daily_scheduled_service_index') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
 ),
 
 dim_trips AS (
     SELECT *
     FROM {{ ref('dim_trips') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
 ),
 
 dim_routes AS (
     SELECT *
     FROM {{ ref('dim_routes') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
 ),
 
 fct_daily_schedule_feeds AS (
     SELECT * FROM {{ ref('fct_daily_schedule_feeds') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
 ),
 
 dim_shapes_arrays AS (
     SELECT * FROM {{ ref('dim_shapes_arrays') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
 ),
 
 dim_gtfs_datasets AS (
@@ -36,7 +36,7 @@ dim_gtfs_datasets AS (
 
 stop_times_grouped AS (
     SELECT * FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
-    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602")
+    WHERE feed_key in ("c8c998ed5280bd8afe6229f41075d602") 
 ),
 
 -- use seed to fill in where shape_ids are missing
@@ -59,19 +59,74 @@ derived_shapes_with_feed AS (
 ),
 
 dim_trips2 AS (
-    SELECT
+    SELECT 
         * EXCEPT(feed_key, route_id, direction_id, shape_id, key),
         dim_trips.key, --the key in dim_trips will have null shape_id, so somehow it's not carrying over in the join later
         dim_trips.feed_key,
         dim_trips.route_id,
         dim_trips.direction_id,
-        COALESCE(dim_trips.shape_id, derived_shapes_with_feed.shape_id) AS shape_id
-    FROM dim_trips
+        COALESCE(dim_trips.shape_id, derived_shapes_with_feed.shape_id) AS shape_id,
+    FROM dim_trips 
     LEFT JOIN derived_shapes_with_feed
         ON derived_shapes_with_feed.feed_key = dim_trips.feed_key
             AND derived_shapes_with_feed.route_id = dim_trips.route_id
             AND derived_shapes_with_feed.direction_id = dim_trips.direction_id
+),
+
+gtfs_joins AS (
+    SELECT
+
+        service_index.service_date,
+        service_index.feed_key,
+        trips.base64_url,
+        service_index.service_id,
+        service_index.feed_timezone,
+
+        trips.key AS trip_key,
+        trips.trip_id AS trip_id,
+        trips.trip_short_name,
+        trips.direction_id,
+        trips.block_id,
+        --stop_times_grouped.iteration_num,
+        --stop_times_grouped.frequencies_defined_trip,
+
+        routes.key AS route_key,
+        routes.route_id AS route_id,
+        routes.route_type,
+        routes.route_short_name,
+        routes.route_long_name,
+        routes.route_desc,
+        routes.agency_id AS agency_id,
+        routes.network_id AS network_id,
+        routes.continuous_pickup AS route_continuous_pickup,
+        routes.continuous_drop_off AS route_continuous_drop_off,
+        routes.route_color,
+        routes.route_text_color,
+        
+        trips.shape_id,
+        trips.warning_duplicate_gtfs_key AS contains_warning_duplicate_trip_primary_key,
+        
+        shapes.key AS shape_array_key,
+        --shapes.pt_array # this attaches now
+        
+ 
+
+    FROM int_gtfs_schedule__daily_scheduled_service_index AS service_index
+    INNER JOIN dim_trips2 AS trips
+        ON service_index.feed_key = trips.feed_key
+            AND service_index.service_id = trips.service_id
+    LEFT JOIN dim_shapes_arrays as shapes
+        ON service_index.feed_key = shapes.feed_key
+            AND trips.shape_id = shapes.shape_id
+    LEFT JOIN dim_routes AS routes
+        ON service_index.feed_key = routes.feed_key
+            AND trips.route_id = routes.route_id
+    --LEFT JOIN stop_times_grouped
+    --   ON service_index.feed_key = stop_times_grouped.feed_key
+    --        AND trips.trip_id = stop_times_grouped.trip_id
+    -- drop trips with no stops
+    --WHERE stop_times_grouped.feed_key IS NOT NULL
 )
 
 
-SELECT * FROM dim_trips2
+SELECT * FROM gtfs_joins


### PR DESCRIPTION
# Description

* Metrolink's `shape_array_key` still doesn't join in.
* Move the order of where the seed table is up and fix `dim_trips` instead. Doing it later means the left join with `dim_shapes_arrays` still misses Metrolink.
* Follow-up to #3928 to resolve #2194.
* Also add `route_color` to this table because we once wanted it. https://github.com/cal-itp/data-analyses/issues/1107

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (find-metrolink-shapes) $ poetry run dbt run -s fct_scheduled_trips+ --full-refresh
00:01:54  Running with dbt=1.5.1
00:02:20  Found 612 models, 1078 tests, 0 snapshots, 0 analyses, 853 macros, 0 operations, 13 seed files, 223 sources, 4 exposures, 0 metrics, 0 groups
00:02:20  
00:02:44  Concurrency: 8 threads (target='dev')
00:02:44  
00:02:45  1 of 21 START sql table model tiffany_mart_gtfs.fct_scheduled_trips ............ [RUN]
00:03:07  1 of 21 OK created sql table model tiffany_mart_gtfs.fct_scheduled_trips ....... [CREATE TABLE (135.2m rows, 58.1 GiB processed) in 22.39s]
00:03:07  2 of 21 START sql table model tiffany_mart_gtfs.fct_daily_feed_scheduled_service_summary  [RUN]
00:03:07  3 of 21 START sql table model tiffany_mart_gtfs.fct_daily_scheduled_shapes ..... [RUN]
00:03:07  4 of 21 START sql incremental model tiffany_mart_gtfs.fct_daily_scheduled_stops  [RUN]
00:03:07  6 of 21 START sql table model tiffany_mart_gtfs.fct_monthly_route_service_by_timeofday  [RUN]
00:03:07  5 of 21 START sql table model tiffany_mart_gtfs_quality.fct_daily_trip_updates_vehicle_positions_completeness  [RUN]
00:03:07  7 of 21 START sql table model tiffany_mart_gtfs.fct_monthly_routes ............. [RUN]
00:03:07  8 of 21 START sql table model tiffany_staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [RUN]
00:03:07  9 of 21 START sql incremental model tiffany_mart_gtfs.test_monthly_stop_times .. [RUN]
00:03:13  6 of 21 OK created sql table model tiffany_mart_gtfs.fct_monthly_route_service_by_timeofday  [CREATE TABLE (2.9m rows, 11.9 GiB processed) in 5.94s]
00:03:19  2 of 21 OK created sql table model tiffany_mart_gtfs.fct_daily_feed_scheduled_service_summary  [CREATE TABLE (336.4k rows, 17.0 GiB processed) in 11.98s]
00:03:19  10 of 21 START sql table model tiffany_mart_gtfs_quality.fct_daily_reports_site_organization_scheduled_service_summary  [RUN]
00:03:24  10 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_daily_reports_site_organization_scheduled_service_summary  [CREATE TABLE (188.0k rows, 214.4 MiB processed) in 4.61s]
00:03:24  11 of 21 START sql table model tiffany_mart_gtfs_quality.idx_monthly_reports_site  [RUN]
00:03:26  8 of 21 OK created sql table model tiffany_staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [CREATE TABLE (2.3m rows, 16.9 GiB processed) in 18.93s]
00:03:26  12 of 21 START sql table model tiffany_staging.int_gtfs_quality__guideline_checks_long  [RUN]
00:03:27  11 of 21 OK created sql table model tiffany_mart_gtfs_quality.idx_monthly_reports_site  [CREATE TABLE (6.2k rows, 1.8 GiB processed) in 3.10s]
00:03:27  13 of 21 START sql table model tiffany_mart_gtfs_quality.fct_monthly_reports_site_organization_file_checks  [RUN]
00:03:27  14 of 21 START sql table model tiffany_mart_gtfs_quality.fct_monthly_reports_site_organization_validation_codes  [RUN]
00:03:30  14 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_monthly_reports_site_organization_validation_codes  [CREATE TABLE (34.1k rows, 3.0 GiB processed) in 2.89s]
00:03:30  15 of 21 START sql view model tiffany_mart_gtfs_quality.fct_monthly_route_id_changes  [RUN]
00:03:30  13 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_monthly_reports_site_organization_file_checks  [CREATE TABLE (74.2k rows, 364.2 MiB processed) in 3.20s]
00:03:30  16 of 21 START sql view model tiffany_mart_gtfs_quality.fct_monthly_stop_id_changes  [RUN]
00:03:30  15 of 21 OK created sql view model tiffany_mart_gtfs_quality.fct_monthly_route_id_changes  [CREATE VIEW (0 processed) in 0.67s]
00:03:31  16 of 21 OK created sql view model tiffany_mart_gtfs_quality.fct_monthly_stop_id_changes  [CREATE VIEW (0 processed) in 0.85s]
00:03:35  5 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_daily_trip_updates_vehicle_positions_completeness  [CREATE TABLE (116.6k rows, 9.7 GiB processed) in 27.51s]
00:03:53  12 of 21 OK created sql table model tiffany_staging.int_gtfs_quality__guideline_checks_long  [CREATE TABLE (168.5m rows, 92.9 GiB processed) in 27.02s]
00:03:53  17 of 21 START sql table model tiffany_mart_gtfs_quality.fct_daily_organization_combined_guideline_checks  [RUN]
00:03:53  18 of 21 START sql table model tiffany_mart_gtfs_quality.fct_daily_service_combined_guideline_checks  [RUN]
00:03:53  19 of 21 START sql table model tiffany_mart_gtfs_quality.fct_implemented_checks  [RUN]
00:03:55  7 of 21 OK created sql table model tiffany_mart_gtfs.fct_monthly_routes ........ [CREATE TABLE (138.0k rows, 135.9 GiB processed) in 47.82s]
00:03:56  19 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_implemented_checks  [CREATE TABLE (75.0 rows, 15.6 GiB processed) in 2.64s]
00:04:24  18 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_daily_service_combined_guideline_checks  [CREATE TABLE (18.1m rows, 49.6 GiB processed) in 30.95s]
00:04:25  17 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_daily_organization_combined_guideline_checks  [CREATE TABLE (15.1m rows, 52.4 GiB processed) in 31.84s]
00:04:25  20 of 21 START sql table model tiffany_mart_gtfs_quality.fct_monthly_reports_site_organization_guideline_checks  [RUN]
00:04:30  20 of 21 OK created sql table model tiffany_mart_gtfs_quality.fct_monthly_reports_site_organization_guideline_checks  [CREATE TABLE (884.8k rows, 2.1 GiB processed) in 5.64s]
00:05:26  3 of 21 OK created sql table model tiffany_mart_gtfs.fct_daily_scheduled_shapes  [CREATE TABLE (8.6m rows, 142.6 GiB processed) in 138.67s]
```

* Needed to materialize one the incremental table `int_gtfs_schedule__stop_times_grouped` for Metrolink in order for this to test whether it would work or not. Once this worked, reverted back to `{{ref('int_gtfs_schedule__stop_times_grouped')}}` 

![metrolink_shape_attached](https://github.com/user-attachments/assets/7d4758dc-130d-4719-afe0-7d45bcf9a801)

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required - use Airflow's warehouse full transform for this - `int_gtfs_schedule__stop_times_grouped, fct_daily_scheduled_stops` are both incremental tables and would need a full refresh
