### PR TITLE
ntd: revise requests headers to fix failing xlxs scrape

### DIFF
--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -22,6 +22,13 @@ xlsx_urls = {
     "asset_inventory_time_series_url": "https://www.transit.dot.gov/ntd/data-product/ts41-asset-inventory-time-series-4",
 }
 
+headers = {
+    "User-Agent": "CalITP/1.0.0",
+    "sec-ch-ua": '"CalITP";v="1"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+}
+
 
 def push_url_to_xcom(key, scraped_url, context):
     """Push the scraped URL value to XCom with proper error handling."""
@@ -46,7 +53,7 @@ def href_matcher(href):
 def make_http_request(url, key):
     """Make HTTP request with proper error handling."""
     try:
-        response = requests.get(url)
+        response = requests.get(url, headers=headers)
         response.raise_for_status()
         return response
     except requests.exceptions.HTTPError as e:

--- a/airflow/plugins/operators/scrape_ntd_xlsx.py
+++ b/airflow/plugins/operators/scrape_ntd_xlsx.py
@@ -20,6 +20,13 @@ from airflow.models import BaseOperator  # type: ignore
 RAW_XLSX_BUCKET = os.environ["CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__RAW"]
 CLEAN_XLSX_BUCKET = os.environ["CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN"]
 
+headers = {
+    "User-Agent": "CalITP/1.0.0",
+    "sec-ch-ua": '"CalITP";v="1"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+}
+
 # Map product and year combinations to their xcom keys for dynamic url scraping
 xcom_keys = {
     (
@@ -96,7 +103,7 @@ class NtdDataProductXLSXExtract(PartitionedGCSArtifact):
     def _make_request(self, url: str) -> bytes:
         """Make HTTP request with proper error handling."""
         try:
-            response = requests.get(url)
+            response = requests.get(url, headers=headers)
             response.raise_for_status()
             return response.content
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
# Description
The NTD data portal recently began blocking our Python requests calls. By modifying the User Agent in the headers, we are able to make our request calls successfully.

Modified request code:
```
headers = {
    "User-Agent": "CalITP/1.0.0",
    "sec-ch-ua": '"CalITP";v="1"',
    "sec-ch-ua-mobile": "?0",
    "sec-ch-ua-platform": '"macOS"',
}
```

` response = requests.get(url, headers=headers)`

Resolves #3900 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
<img width="721" alt="Screenshot 2025-06-02 at 11 40 41" src="https://github.com/user-attachments/assets/44e16bce-2ade-4b39-bec0-dfb2bf5ba158" />


## Post-merge follow-ups
- [x] Actions required (specified below)
Monitor for expected behavior in production