### PR TITLE
Bump calitp-data-infra version for staging secrets access

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -72,7 +72,7 @@ x-airflow-common:
     AIRFLOW_VAR_EXTRACT_BUCKET: "gs://gtfs-data-test"
     # Corresponds to GCP_PROJECT on composer, but gauth looks for this name.
     # see https://googleapis.dev/python/google-auth/latest/user-guide.html#using-external-identities
-    GOOGLE_CLOUD_PROJECT: cal-itp-data-infra
+    GOOGLE_CLOUD_PROJECT: cal-itp-data-infra-staging
 
     CALITP_BUCKET__AGGREGATOR_SCRAPER: "gs://test-calitp-aggregator-scraper"
     CALITP_BUCKET__AIRTABLE: "gs://test-calitp-airtable"

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-calitp-data-infra==2025.3.25
+calitp-data-infra==2025.5.6
 gusty==0.6.0
 pyairtable==2.2.1
 pydantic>=1.9,<2.0

--- a/packages/calitp-data-infra/pyproject.toml
+++ b/packages/calitp-data-infra/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp-data-infra"
-version = "2025.5.6-rc2"
+version = "2025.5.6"
 description = "Shared code for developing data pipelines that process Cal-ITP data."
 package-mode = true
 authors = ["Andrew Vaccaro"]


### PR DESCRIPTION
# Description

Create a production release of the `calitp-data-infra` package that includes access to the appropriate secrets store based on the configured project.

Resolves #3856

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Verified that the approrpriate secrets store is accessed based on the value of the `GOOGLE_CLOUD_PROJECT` environment variable.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)

This is a prerequisite for testing Cloud Composer upgrades in the staging environment, but no additional actions are required for this issue.