### PR TITLE
Do not modify manual staging composer service membership

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
@@ -10,7 +10,7 @@ resource "google_service_account_iam_member" "github-actions-service-account" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
 }
 
-resource "google_service_account_iam_member" "composer-service-account" {
+resource "google_service_account_iam_member" "custom_service_account" {
   service_account_id = google_service_account.composer-service-account.id
   role               = "roles/composer.ServiceAgentV2Ext"
   member             = "serviceAccount:service-${local.project_id}@cloudcomposer-accounts.iam.gserviceaccount.com"


### PR DESCRIPTION
# Description

This commit does not attempt to modify the manually-authorized service account IAM binding for the staging Composer service account.

Relates to #3780 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform apply` locally

## Post-merge follow-ups


- [x] No action required
- [ ] Actions required (specified below)
