### PR TITLE
Add roles/secretmanager.secretAccessor and roles/secretmanager.viewer…

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -272,6 +272,8 @@ resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Ware
     "roles/bigquery.dataEditor",
     "roles/bigquery.filteredDataViewer",
     "roles/storage.objectUser",
+    "roles/secretmanager.secretAccessor",
+    "roles/secretmanager.viewer",
     google_project_iam_custom_role.calitp-dds-analyst.id
   ])
   role    = each.key
@@ -286,6 +288,8 @@ resource "google_project_iam_member" "ms-entra-id-DDS_Cloud_Admins" {
     "roles/bigquery.dataEditor",
     "roles/storage.objectAdmin",
     "roles/composer.admin",
+    "roles/secretmanager.secretAccessor",
+    "roles/secretmanager.viewer",
     google_project_iam_custom_role.calitp-dds-analyst.id
   ])
   role    = each.key

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -573,6 +573,8 @@ resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Ware
     "roles/bigquery.filteredDataViewer",
     "roles/bigquery.metadataViewer",
     "roles/storage.objectUser",
+    "roles/secretmanager.secretAccessor",
+    "roles/secretmanager.viewer",
     google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-DataAnalyst.id
   ])
   role    = each.key
@@ -587,6 +589,8 @@ resource "google_project_iam_member" "ms-entra-id-DDS_Cloud_Admins" {
     "roles/bigquery.dataEditor",
     "roles/storage.objectAdmin",
     "roles/composer.admin",
+    "roles/secretmanager.secretAccessor",
+    "roles/secretmanager.viewer",
     google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-DataAnalyst.id
   ])
   role    = each.key


### PR DESCRIPTION
# Description

Add `roles/secretmanager.secretAccessor` and `roles/secretmanager.viewer` permissions to DDS analysts and DDS Admins in order to run airflow using SSO logins.

Resolves [#3965]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Run `terraform plan` locally and through PR.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
