### PR TITLE
Add roles/secretmanager.admin permission to DDS Admins

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -288,8 +288,7 @@ resource "google_project_iam_member" "ms-entra-id-DDS_Cloud_Admins" {
     "roles/bigquery.dataEditor",
     "roles/storage.objectAdmin",
     "roles/composer.admin",
-    "roles/secretmanager.secretAccessor",
-    "roles/secretmanager.viewer",
+    "roles/secretmanager.admin",
     google_project_iam_custom_role.calitp-dds-analyst.id
   ])
   role    = each.key

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -589,8 +589,7 @@ resource "google_project_iam_member" "ms-entra-id-DDS_Cloud_Admins" {
     "roles/bigquery.dataEditor",
     "roles/storage.objectAdmin",
     "roles/composer.admin",
-    "roles/secretmanager.secretAccessor",
-    "roles/secretmanager.viewer",
+    "roles/secretmanager.admin",
     google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-DataAnalyst.id
   ])
   role    = each.key


### PR DESCRIPTION
# Description

Add roles/secretmanager.admin permission to DDS Admins in order to allow SSO Admins to edit secret keys.

Resolves [#3966]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running `terraform plan` locally.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
