### PR TITLE
Add and update wheelchair accessibility models and macros

### DIFF
--- a/warehouse/macros/define_gtfs_guidelines.sql
+++ b/warehouse/macros/define_gtfs_guidelines.sql
@@ -80,6 +80,14 @@
 "Includes complete wheelchair accessibility data in both stops.txt and trips.txt"
 {% endmacro %}
 
+{% macro wheelchair_accessible_trips() %}
+"Includes wheelchair_accessible in trips.txt"
+{% endmacro %}
+
+{% macro wheelchair_boarding_stops() %}
+"Includes wheelchair_boarding in stops.txt"
+{% endmacro %}
+
 {% macro shapes_file_present() %}
 "Shapes.txt file is present"
 {% endmacro %}

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__wheelchair_accessible_trips.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__wheelchair_accessible_trips.sql
@@ -1,0 +1,47 @@
+WITH guideline_index AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ wheelchair_accessible_trips() }}
+),
+
+dim_trips AS (
+    SELECT * FROM {{ ref('dim_trips') }}
+),
+
+feed_trips_summary AS (
+   SELECT
+       feed_key,
+       COUNTIF(wheelchair_accessible IS NOT NULL AND CAST(wheelchair_accessible AS STRING) != "0") AS ct_trips_accessibility_info,
+       COUNT(*) AS ct_trips,
+       ROUND(COUNTIF(wheelchair_accessible IS NOT NULL AND CAST(wheelchair_accessible AS STRING) != "0")/COUNT(*)*100) AS wheelchair_accessible_trips_percentage
+    FROM dim_trips
+   GROUP BY feed_key
+),
+
+check_start AS (
+    SELECT MIN(_feed_valid_from) AS first_check_date
+    FROM dim_trips
+),
+
+int_gtfs_quality__wheelchair_accessible_trips AS (
+    SELECT
+        idx.* EXCEPT(status),
+        CASE
+            WHEN has_schedule_feed
+                THEN
+                    CASE
+                        WHEN trips.ct_trips_accessibility_info = trips.ct_trips
+                            THEN {{ guidelines_pass_status() }}
+                        WHEN CAST(idx.date AS TIMESTAMP) < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        ELSE {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+        wheelchair_accessible_trips_percentage
+    FROM guideline_index AS idx
+    CROSS JOIN check_start
+    LEFT JOIN feed_trips_summary AS trips
+            ON idx.schedule_feed_key = trips.feed_key
+)
+
+SELECT * FROM int_gtfs_quality__wheelchair_accessible_trips

--- a/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__wheelchair_boarding_stops.sql
+++ b/warehouse/models/intermediate/gtfs_quality/guidelines_checks/int_gtfs_quality__wheelchair_boarding_stops.sql
@@ -1,0 +1,47 @@
+WITH guideline_index AS (
+    SELECT *
+    FROM {{ ref('int_gtfs_quality__guideline_checks_index') }}
+    WHERE check = {{ wheelchair_boarding_stops() }}
+),
+
+dim_stops AS (
+    SELECT * FROM {{ ref('dim_stops') }}
+),
+
+feed_stops_summary AS (
+   SELECT
+       feed_key,
+       COUNTIF(wheelchair_boarding IS NOT NULL AND CAST(wheelchair_boarding AS STRING) != "0") AS ct_stops_accessibility_info,
+       COUNT(*) AS ct_stops,
+       ROUND(COUNTIF(wheelchair_boarding IS NOT NULL AND CAST(wheelchair_boarding AS STRING) != "0")/COUNT(*) *100) AS wheelchair_boarding_stops_percentage
+    FROM dim_stops
+   GROUP BY feed_key
+),
+
+check_start AS (
+    SELECT MIN(_feed_valid_from) AS first_check_date
+    FROM dim_stops
+),
+
+int_gtfs_quality__wheelchair_boarding_stops AS (
+    SELECT
+        idx.* EXCEPT(status),
+        CASE
+            WHEN has_schedule_feed
+                THEN
+                    CASE
+                        WHEN stops.ct_stops_accessibility_info = stops.ct_stops
+                             THEN {{ guidelines_pass_status() }}
+                        WHEN CAST(idx.date AS TIMESTAMP) < first_check_date THEN {{ guidelines_na_too_early_status() }}
+                        ELSE {{ guidelines_fail_status() }}
+                    END
+            ELSE idx.status
+        END AS status,
+        wheelchair_boarding_stops_percentage
+    FROM guideline_index AS idx
+    CROSS JOIN check_start
+    LEFT JOIN feed_stops_summary AS stops
+            ON idx.schedule_feed_key = stops.feed_key
+)
+
+SELECT * FROM int_gtfs_quality__wheelchair_boarding_stops

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__guideline_checks_long.sql
@@ -51,7 +51,9 @@ unioned AS (
             ref('int_gtfs_quality__modification_date_present'),
             ref('int_gtfs_quality__grading_scheme_v1'),
             ref('int_gtfs_quality__feed_listed'),
-            ref('int_gtfs_quality__lead_time')
+            ref('int_gtfs_quality__lead_time'),
+            ref('int_gtfs_quality__wheelchair_accessible_trips'),
+            ref('int_gtfs_quality__wheelchair_boarding_stops')
         ],
         include = ['date', 'key', 'check', 'status']
     ) }}

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_quality__intended_checks.sql
@@ -10,13 +10,17 @@ WITH stg_gtfs_quality__intended_checks AS (
     UNION ALL
     SELECT {{ complete_wheelchair_accessibility_data() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}, false, null
     UNION ALL
+    SELECT {{ wheelchair_accessible_trips() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}, false, 0
+    UNION ALL
+    SELECT {{ wheelchair_boarding_stops() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}, false, 1
+    UNION ALL
     SELECT {{ shapes_for_all_trips() }}, {{ accurate_service_data() }}, {{ schedule_feed() }}, false, null
     UNION ALL
-    SELECT {{ include_tts() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}, false, null
+    SELECT {{ include_tts() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}, false, 2
     UNION ALL
     SELECT {{ shapes_valid() }}, {{ accurate_service_data() }}, {{ schedule_feed() }}, false, null
     UNION ALL
-    SELECT {{ pathways_valid() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}, false, null
+    SELECT {{ pathways_valid() }}, {{ accurate_accessibility_data() }}, {{ schedule_feed() }}, false, 3
     UNION ALL
     SELECT {{ technical_contact_listed() }}, {{ technical_contact_availability() }}, {{ schedule_feed() }}, false, null
     UNION ALL


### PR DESCRIPTION
# Description

Adding **_Beyond Compliance_** section to the report website. This PR is the phase one of this project. In this phase, the necessary models and macros where built and modified. They will be used in the report website code. This is a new feature.   



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
```
jovyan@jupyter-fsalemi:~/data-infra/warehouse$ poetry run dbt run -s +stg_gtfs_quality__intended_checks
09:19:13  Running with dbt=1.5.1
09:19:17  Found 612 models, 1224 tests, 0 snapshots, 0 analyses, 854 macros, 0 operations, 13 seed files, 223 sources, 4 exposures, 0 metrics, 0 groups
09:19:17  
09:19:25  Concurrency: 8 threads (target='dev')
09:19:25  
09:19:25  
09:19:25  Finished running  in 0 hours 0 minutes and 7.80 seconds (7.80s).
jovyan@jupyter-fsalemi:~/data-infra/warehouse$ poetry run dbt run -s +int_gtfs_quality__wheelchair_accessible_trips
09:20:23  Running with dbt=1.5.1
09:20:27  Found 612 models, 1224 tests, 0 snapshots, 0 analyses, 854 macros, 0 operations, 13 seed files, 223 sources, 4 exposures, 0 metrics, 0 groups
09:20:27  
09:20:31  Concurrency: 8 threads (target='dev')
09:20:31  
09:20:31  1 of 37 START sql view model farhad_staging.stg_gtfs_rt__service_alerts_outcomes  [RUN]
09:20:31  2 of 37 START sql view model farhad_staging.stg_gtfs_rt__trip_updates_outcomes . [RUN]
09:20:31  3 of 37 START sql view model farhad_staging.stg_gtfs_rt__vehicle_positions_outcomes  [RUN]
09:20:31  4 of 37 START sql view model farhad_staging.stg_gtfs_schedule__agency .......... [RUN]
09:20:31  6 of 37 START sql view model farhad_staging.stg_gtfs_schedule__file_parse_outcomes  [RUN]
09:20:31  5 of 37 START sql view model farhad_staging.stg_gtfs_schedule__download_outcomes  [RUN]
09:20:31  7 of 37 START sql view model farhad_staging.stg_gtfs_schedule__trips ........... [RUN]
09:20:32  8 of 37 START sql view model farhad_staging.stg_gtfs_schedule__unzip_outcomes .. [RUN]
09:20:33  1 of 37 OK created sql view model farhad_staging.stg_gtfs_rt__service_alerts_outcomes  [CREATE VIEW (0 processed) in 1.19s]
09:20:33  9 of 37 START sql view model farhad_staging.stg_transit_database__gtfs_datasets  [RUN]
09:20:33  5 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__download_outcomes  [CREATE VIEW (0 processed) in 0.98s]
09:20:33  3 of 37 OK created sql view model farhad_staging.stg_gtfs_rt__vehicle_positions_outcomes  [CREATE VIEW (0 processed) in 1.19s]
09:20:33  10 of 37 START sql view model farhad_staging.stg_transit_database__gtfs_service_data  [RUN]
09:20:33  11 of 37 START sql view model farhad_staging.stg_transit_database__ntd_agency_info  [RUN]
09:20:33  6 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__file_parse_outcomes  [CREATE VIEW (0 processed) in 1.04s]
09:20:33  7 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__trips ...... [CREATE VIEW (0 processed) in 1.04s]
09:20:33  8 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__unzip_outcomes  [CREATE VIEW (0 processed) in 0.89s]
09:20:33  4 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__agency ..... [CREATE VIEW (0 processed) in 1.09s]
09:20:33  2 of 37 OK created sql view model farhad_staging.stg_gtfs_rt__trip_updates_outcomes  [CREATE VIEW (0 processed) in 1.23s]
09:20:33  12 of 37 START sql view model farhad_staging.stg_transit_database__organizations  [RUN]
09:20:33  13 of 37 START sql view model farhad_staging.stg_transit_database__services .... [RUN]
09:20:33  14 of 37 START sql view model farhad_staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [RUN]
09:20:33  15 of 37 START sql incremental model farhad_staging.int_gtfs_rt__unioned_parse_outcomes  [RUN]
09:20:33  9 of 37 OK created sql view model farhad_staging.stg_transit_database__gtfs_datasets  [CREATE VIEW (0 processed) in 0.82s]
09:20:33  16 of 37 START sql table model farhad_staging.int_transit_database__gtfs_datasets_dim  [RUN]
09:20:33  12 of 37 OK created sql view model farhad_staging.stg_transit_database__organizations  [CREATE VIEW (0 processed) in 0.83s]
09:20:33  13 of 37 OK created sql view model farhad_staging.stg_transit_database__services  [CREATE VIEW (0 processed) in 0.79s]
09:20:33  17 of 37 START sql table model farhad_staging.int_transit_database__services_dim  [RUN]
09:20:34  10 of 37 OK created sql view model farhad_staging.stg_transit_database__gtfs_service_data  [CREATE VIEW (0 processed) in 0.95s]
09:20:34  11 of 37 OK created sql view model farhad_staging.stg_transit_database__ntd_agency_info  [CREATE VIEW (0 processed) in 0.96s]
09:20:34  18 of 37 START sql table model farhad_staging.int_transit_database__ntd_agency_info_dim  [RUN]
09:20:34  14 of 37 OK created sql view model farhad_staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [CREATE VIEW (0 processed) in 1.24s]
09:20:34  19 of 37 START sql view model farhad_staging.int_gtfs_schedule__joined_feed_outcomes  [RUN]
09:20:35  19 of 37 OK created sql view model farhad_staging.int_gtfs_schedule__joined_feed_outcomes  [CREATE VIEW (0 processed) in 1.00s]
09:20:35  20 of 37 START sql table model farhad_mart_gtfs.dim_schedule_feeds ............. [RUN]
09:20:37  18 of 37 OK created sql table model farhad_staging.int_transit_database__ntd_agency_info_dim  [CREATE TABLE (230.0 rows, 266.9 MiB processed) in 3.07s]
09:20:37  21 of 37 START sql table model farhad_staging.int_transit_database__organizations_dim  [RUN]
09:20:38  16 of 37 OK created sql table model farhad_staging.int_transit_database__gtfs_datasets_dim  [CREATE TABLE (5.1k rows, 6.9 GiB processed) in 4.18s]
09:20:38  22 of 37 START sql table model farhad_mart_transit_database.bridge_schedule_dataset_for_validation  [RUN]
09:20:38  23 of 37 START sql table model farhad_mart_transit_database.dim_gtfs_datasets .. [RUN]
09:20:38  17 of 37 OK created sql table model farhad_staging.int_transit_database__services_dim  [CREATE TABLE (8.9k rows, 10.4 GiB processed) in 4.38s]
09:20:38  24 of 37 START sql table model farhad_mart_transit_database.dim_services ....... [RUN]
09:20:38  25 of 37 START sql table model farhad_staging.int_transit_database__gtfs_service_data_dim  [RUN]
09:20:40  22 of 37 OK created sql table model farhad_mart_transit_database.bridge_schedule_dataset_for_validation  [CREATE TABLE (3.0k rows, 530.3 KiB processed) in 2.22s]
09:20:40  23 of 37 OK created sql table model farhad_mart_transit_database.dim_gtfs_datasets  [CREATE TABLE (5.1k rows, 1.6 MiB processed) in 2.24s]
09:20:40  26 of 37 START sql table model farhad_staging.int_transit_database__urls_to_gtfs_datasets  [RUN]
09:20:40  24 of 37 OK created sql table model farhad_mart_transit_database.dim_services .. [CREATE TABLE (8.9k rows, 1.6 MiB processed) in 2.21s]
09:20:41  21 of 37 OK created sql table model farhad_staging.int_transit_database__organizations_dim  [CREATE TABLE (10.1k rows, 16.1 GiB processed) in 4.62s]
09:20:41  27 of 37 START sql table model farhad_mart_transit_database.bridge_organizations_x_services_managed  [RUN]
09:20:41  28 of 37 START sql table model farhad_mart_transit_database.dim_organizations .. [RUN]
09:20:42  26 of 37 OK created sql table model farhad_staging.int_transit_database__urls_to_gtfs_datasets  [CREATE TABLE (5.1k rows, 901.4 KiB processed) in 2.19s]
09:20:43  25 of 37 OK created sql table model farhad_staging.int_transit_database__gtfs_service_data_dim  [CREATE TABLE (23.4k rows, 6.6 GiB processed) in 5.24s]
09:20:43  29 of 37 START sql table model farhad_mart_transit_database.dim_gtfs_service_data  [RUN]
09:20:43  27 of 37 OK created sql table model farhad_mart_transit_database.bridge_organizations_x_services_managed  [CREATE TABLE (17.4k rows, 2.1 MiB processed) in 2.13s]
09:20:44  28 of 37 OK created sql table model farhad_mart_transit_database.dim_organizations  [CREATE TABLE (10.1k rows, 2.2 MiB processed) in 2.73s]
09:20:46  29 of 37 OK created sql table model farhad_mart_transit_database.dim_gtfs_service_data  [CREATE TABLE (23.4k rows, 5.1 MiB processed) in 2.47s]
09:20:56  15 of 37 OK created sql incremental model farhad_staging.int_gtfs_rt__unioned_parse_outcomes  [SCRIPT (1.7 GiB processed) in 22.41s]
09:21:53  20 of 37 OK created sql table model farhad_mart_gtfs.dim_schedule_feeds ........ [CREATE TABLE (19.0k rows, 13.8 GiB processed) in 77.80s]
09:21:53  30 of 37 START sql incremental model farhad_mart_gtfs.dim_trips ................ [RUN]
09:21:53  31 of 37 START sql table model farhad_mart_gtfs.fct_daily_schedule_feeds ....... [RUN]
09:21:53  32 of 37 START sql table model farhad_mart_gtfs.fct_schedule_feed_downloads .... [RUN]
09:21:57  31 of 37 OK created sql table model farhad_mart_gtfs.fct_daily_schedule_feeds .. [CREATE TABLE (339.9k rows, 3.5 MiB processed) in 4.65s]
09:21:57  33 of 37 START sql incremental model farhad_mart_gtfs.fct_daily_rt_feed_files .. [RUN]
09:22:01  33 of 37 OK created sql incremental model farhad_mart_gtfs.fct_daily_rt_feed_files  [MERGE (428.0 rows, 95.1 MiB processed) in 3.66s]
09:22:05  32 of 37 OK created sql table model farhad_mart_gtfs.fct_schedule_feed_downloads  [CREATE TABLE (346.3k rows, 7.3 GiB processed) in 12.27s]
09:22:05  34 of 37 START sql table model farhad_staging.int_gtfs_quality__naive_organization_service_dataset_full_join  [RUN]
09:22:15  34 of 37 OK created sql table model farhad_staging.int_gtfs_quality__naive_organization_service_dataset_full_join  [CREATE TABLE (2.3m rows, 83.6 MiB processed) in 9.72s]
09:22:15  35 of 37 START sql table model farhad_staging.int_gtfs_quality__daily_assessment_candidate_entities  [RUN]
09:22:19  35 of 37 OK created sql table model farhad_staging.int_gtfs_quality__daily_assessment_candidate_entities  [CREATE TABLE (2.3m rows, 652.2 MiB processed) in 4.39s]
09:22:19  36 of 37 START sql table model farhad_staging.int_gtfs_quality__guideline_checks_index  [RUN]
09:22:33  30 of 37 OK created sql incremental model farhad_mart_gtfs.dim_trips ........... [MERGE (152.3k rows, 7.2 GiB processed) in 39.86s]
09:22:35  36 of 37 OK created sql table model farhad_staging.int_gtfs_quality__guideline_checks_index  [CREATE TABLE (177.3m rows, 698.3 MiB processed) in 15.64s]
09:22:35  37 of 37 START sql table model farhad_staging.int_gtfs_quality__wheelchair_accessible_trips  [RUN]
09:22:38  37 of 37 OK created sql table model farhad_staging.int_gtfs_quality__wheelchair_accessible_trips  [CREATE TABLE (2.3m rows, 9.6 GiB processed) in 3.45s]
09:22:38  
09:22:38  Finished running 15 view models, 19 table models, 3 incremental models in 0 hours 2 minutes and 11.50 seconds (131.50s).
09:22:39  
09:22:39  Completed successfully
09:22:39  
09:22:39  Done. PASS=37 WARN=0 ERROR=0 SKIP=0 TOTAL=37


jovyan@jupyter-fsalemi:~/data-infra/warehouse$ poetry run dbt run -s +int_gtfs_quality__wheelchair_boarding_stops
09:23:50  Running with dbt=1.5.1
09:23:54  Found 612 models, 1224 tests, 0 snapshots, 0 analyses, 854 macros, 0 operations, 13 seed files, 223 sources, 4 exposures, 0 metrics, 0 groups
09:23:54  
09:23:58  Concurrency: 8 threads (target='dev')
09:23:58  
09:23:58  1 of 37 START sql view model farhad_staging.stg_gtfs_rt__service_alerts_outcomes  [RUN]
09:23:58  2 of 37 START sql view model farhad_staging.stg_gtfs_rt__trip_updates_outcomes . [RUN]
09:23:58  3 of 37 START sql view model farhad_staging.stg_gtfs_rt__vehicle_positions_outcomes  [RUN]
09:23:58  4 of 37 START sql view model farhad_staging.stg_gtfs_schedule__agency .......... [RUN]
09:23:58  5 of 37 START sql view model farhad_staging.stg_gtfs_schedule__download_outcomes  [RUN]
09:23:58  6 of 37 START sql view model farhad_staging.stg_gtfs_schedule__file_parse_outcomes  [RUN]
09:23:58  7 of 37 START sql view model farhad_staging.stg_gtfs_schedule__stops ........... [RUN]
09:23:59  8 of 37 START sql view model farhad_staging.stg_gtfs_schedule__unzip_outcomes .. [RUN]
09:23:59  5 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__download_outcomes  [CREATE VIEW (0 processed) in 1.06s]
09:23:59  3 of 37 OK created sql view model farhad_staging.stg_gtfs_rt__vehicle_positions_outcomes  [CREATE VIEW (0 processed) in 1.14s]
09:23:59  6 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__file_parse_outcomes  [CREATE VIEW (0 processed) in 1.04s]
09:23:59  9 of 37 START sql view model farhad_staging.stg_transit_database__gtfs_datasets  [RUN]
09:23:59  4 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__agency ..... [CREATE VIEW (0 processed) in 1.14s]
09:23:59  1 of 37 OK created sql view model farhad_staging.stg_gtfs_rt__service_alerts_outcomes  [CREATE VIEW (0 processed) in 1.23s]
09:23:59  10 of 37 START sql view model farhad_staging.stg_transit_database__gtfs_service_data  [RUN]
09:23:59  11 of 37 START sql view model farhad_staging.stg_transit_database__ntd_agency_info  [RUN]
09:23:59  8 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__unzip_outcomes  [CREATE VIEW (0 processed) in 0.88s]
09:23:59  7 of 37 OK created sql view model farhad_staging.stg_gtfs_schedule__stops ...... [CREATE VIEW (0 processed) in 1.07s]
09:23:59  13 of 37 START sql view model farhad_staging.stg_transit_database__services .... [RUN]
09:23:59  12 of 37 START sql view model farhad_staging.stg_transit_database__organizations  [RUN]
09:24:00  2 of 37 OK created sql view model farhad_staging.stg_gtfs_rt__trip_updates_outcomes  [CREATE VIEW (0 processed) in 1.29s]
09:24:00  14 of 37 START sql view model farhad_staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [RUN]
09:24:00  15 of 37 START sql incremental model farhad_staging.int_gtfs_rt__unioned_parse_outcomes  [RUN]
09:24:00  10 of 37 OK created sql view model farhad_staging.stg_transit_database__gtfs_service_data  [CREATE VIEW (0 processed) in 0.95s]
09:24:00  12 of 37 OK created sql view model farhad_staging.stg_transit_database__organizations  [CREATE VIEW (0 processed) in 0.91s]
09:24:00  13 of 37 OK created sql view model farhad_staging.stg_transit_database__services  [CREATE VIEW (0 processed) in 0.93s]
09:24:00  16 of 37 START sql table model farhad_staging.int_transit_database__services_dim  [RUN]
09:24:00  9 of 37 OK created sql view model farhad_staging.stg_transit_database__gtfs_datasets  [CREATE VIEW (0 processed) in 1.04s]
09:24:00  11 of 37 OK created sql view model farhad_staging.stg_transit_database__ntd_agency_info  [CREATE VIEW (0 processed) in 1.00s]
09:24:00  17 of 37 START sql table model farhad_staging.int_transit_database__gtfs_datasets_dim  [RUN]
09:24:00  18 of 37 START sql table model farhad_staging.int_transit_database__ntd_agency_info_dim  [RUN]
09:24:01  14 of 37 OK created sql view model farhad_staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [CREATE VIEW (0 processed) in 1.13s]
09:24:01  19 of 37 START sql view model farhad_staging.int_gtfs_schedule__joined_feed_outcomes  [RUN]
09:24:02  19 of 37 OK created sql view model farhad_staging.int_gtfs_schedule__joined_feed_outcomes  [CREATE VIEW (0 processed) in 1.04s]
09:24:02  20 of 37 START sql table model farhad_mart_gtfs.dim_schedule_feeds ............. [RUN]
09:24:04  18 of 37 OK created sql table model farhad_staging.int_transit_database__ntd_agency_info_dim  [CREATE TABLE (230.0 rows, 266.9 MiB processed) in 3.10s]
09:24:04  21 of 37 START sql table model farhad_staging.int_transit_database__organizations_dim  [RUN]
09:24:05  17 of 37 OK created sql table model farhad_staging.int_transit_database__gtfs_datasets_dim  [CREATE TABLE (5.1k rows, 6.9 GiB processed) in 4.12s]
09:24:05  22 of 37 START sql table model farhad_mart_transit_database.bridge_schedule_dataset_for_validation  [RUN]
09:24:05  23 of 37 START sql table model farhad_mart_transit_database.dim_gtfs_datasets .. [RUN]
09:24:05  16 of 37 OK created sql table model farhad_staging.int_transit_database__services_dim  [CREATE TABLE (8.9k rows, 10.4 GiB processed) in 4.39s]
09:24:05  24 of 37 START sql table model farhad_mart_transit_database.dim_services ....... [RUN]
09:24:05  25 of 37 START sql table model farhad_staging.int_transit_database__gtfs_service_data_dim  [RUN]
09:24:07  23 of 37 OK created sql table model farhad_mart_transit_database.dim_gtfs_datasets  [CREATE TABLE (5.1k rows, 1.6 MiB processed) in 2.25s]
09:24:07  26 of 37 START sql table model farhad_staging.int_transit_database__urls_to_gtfs_datasets  [RUN]
09:24:07  24 of 37 OK created sql table model farhad_mart_transit_database.dim_services .. [CREATE TABLE (8.9k rows, 1.6 MiB processed) in 2.21s]
09:24:07  22 of 37 OK created sql table model farhad_mart_transit_database.bridge_schedule_dataset_for_validation  [CREATE TABLE (3.0k rows, 530.3 KiB processed) in 2.53s]
09:24:08  21 of 37 OK created sql table model farhad_staging.int_transit_database__organizations_dim  [CREATE TABLE (10.1k rows, 16.1 GiB processed) in 4.27s]
09:24:08  27 of 37 START sql table model farhad_mart_transit_database.bridge_organizations_x_services_managed  [RUN]
09:24:08  28 of 37 START sql table model farhad_mart_transit_database.dim_organizations .. [RUN]
09:24:09  26 of 37 OK created sql table model farhad_staging.int_transit_database__urls_to_gtfs_datasets  [CREATE TABLE (5.1k rows, 901.4 KiB processed) in 2.22s]
09:24:10  28 of 37 OK created sql table model farhad_mart_transit_database.dim_organizations  [CREATE TABLE (10.1k rows, 2.2 MiB processed) in 2.21s]
09:24:10  27 of 37 OK created sql table model farhad_mart_transit_database.bridge_organizations_x_services_managed  [CREATE TABLE (17.4k rows, 2.1 MiB processed) in 2.23s]
09:24:10  25 of 37 OK created sql table model farhad_staging.int_transit_database__gtfs_service_data_dim  [CREATE TABLE (23.4k rows, 6.6 GiB processed) in 5.30s]
09:24:10  29 of 37 START sql table model farhad_mart_transit_database.dim_gtfs_service_data  [RUN]
09:24:12  29 of 37 OK created sql table model farhad_mart_transit_database.dim_gtfs_service_data  [CREATE TABLE (23.4k rows, 5.1 MiB processed) in 2.20s]
09:24:21  15 of 37 OK created sql incremental model farhad_staging.int_gtfs_rt__unioned_parse_outcomes  [SCRIPT (1.7 GiB processed) in 21.20s]

09:25:23  20 of 37 OK created sql table model farhad_mart_gtfs.dim_schedule_feeds ........ [CREATE TABLE (19.0k rows, 13.8 GiB processed) in 81.62s]
09:25:23  30 of 37 START sql incremental model farhad_mart_gtfs.dim_stops ................ [RUN]
09:25:23  31 of 37 START sql table model farhad_mart_gtfs.fct_daily_schedule_feeds ....... [RUN]
09:25:23  32 of 37 START sql table model farhad_mart_gtfs.fct_schedule_feed_downloads .... [RUN]
09:25:28  31 of 37 OK created sql table model farhad_mart_gtfs.fct_daily_schedule_feeds .. [CREATE TABLE (339.9k rows, 3.5 MiB processed) in 4.52s]
09:25:28  33 of 37 START sql incremental model farhad_mart_gtfs.fct_daily_rt_feed_files .. [RUN]
09:25:31  33 of 37 OK created sql incremental model farhad_mart_gtfs.fct_daily_rt_feed_files  [MERGE (428.0 rows, 95.1 MiB processed) in 2.91s]
09:25:33  32 of 37 OK created sql table model farhad_mart_gtfs.fct_schedule_feed_downloads  [CREATE TABLE (346.3k rows, 7.3 GiB processed) in 9.98s]
09:25:33  34 of 37 START sql table model farhad_staging.int_gtfs_quality__naive_organization_service_dataset_full_join  [RUN]
09:25:40  34 of 37 OK created sql table model farhad_staging.int_gtfs_quality__naive_organization_service_dataset_full_join  [CREATE TABLE (2.3m rows, 83.6 MiB processed) in 6.49s]
09:25:40  35 of 37 START sql table model farhad_staging.int_gtfs_quality__daily_assessment_candidate_entities  [RUN]
09:25:44  35 of 37 OK created sql table model farhad_staging.int_gtfs_quality__daily_assessment_candidate_entities  [CREATE TABLE (2.3m rows, 652.2 MiB processed) in 4.25s]
09:25:44  36 of 37 START sql table model farhad_staging.int_gtfs_quality__guideline_checks_index  [RUN]
09:25:56  36 of 37 OK created sql table model farhad_staging.int_gtfs_quality__guideline_checks_index  [CREATE TABLE (177.3m rows, 698.3 MiB processed) in 11.87s]
09:26:00  30 of 37 OK created sql incremental model farhad_mart_gtfs.dim_stops ........... [MERGE (27.1k rows, 2.0 GiB processed) in 36.18s]
09:26:00  37 of 37 START sql table model farhad_staging.int_gtfs_quality__wheelchair_boarding_stops  [RUN]
09:26:03  37 of 37 OK created sql table model farhad_staging.int_gtfs_quality__wheelchair_boarding_stops  [CREATE TABLE (2.3m rows, 2.7 GiB processed) in 3.68s]
09:26:03  
09:26:03  Finished running 15 view models, 19 table models, 3 incremental models in 0 hours 2 minutes and 9.66 seconds (129.66s).
09:26:04  
09:26:04  Completed successfully
09:26:04  
09:26:04  Done. PASS=37 WARN=0 ERROR=0 SKIP=0 TOTAL=37

jovyan@jupyter-fsalemi:~/data-infra/warehouse/models/intermediate/gtfs_quality$ poetry run dbt run -s +int_gtfs_quality__guideline_checks_long --exclude dim_stop_times 
22:41:50  Running with dbt=1.5.1
22:41:53  Found 612 models, 1224 tests, 0 snapshots, 0 analyses, 854 macros, 0 operations, 13 seed files, 223 sources, 4 exposures, 0 metrics, 0 groups
22:41:54  
22:42:11  Concurrency: 8 threads (target='dev')
22:42:11  
22:42:11  1 of 142 START sql view model farhad_staging.int_gtfs_quality__schedule_validator_rule_details_unioned  [RUN]
22:42:11  2 of 142 START sql view model farhad_staging.stg_gtfs_quality__rt_validation_code_descriptions  [RUN]
22:42:11  3 of 142 START sql view model farhad_staging.stg_gtfs_quality__scraped_urls .... [RUN]
22:42:11  4 of 142 START sql view model farhad_staging.stg_gtfs_rt__service_alerts ....... [RUN]
22:42:11  5 of 142 START sql view model farhad_staging.stg_gtfs_rt__service_alerts_outcomes  [RUN]
22:42:11  6 of 142 START sql view model farhad_staging.stg_gtfs_rt__service_alerts_validation_notices  [RUN]
22:42:11  7 of 142 START sql view model farhad_staging.stg_gtfs_rt__service_alerts_validation_outcomes  [RUN]
22:42:11  8 of 142 START sql view model farhad_staging.stg_gtfs_rt__trip_updates ......... [RUN]
22:42:12  3 of 142 OK created sql view model farhad_staging.stg_gtfs_quality__scraped_urls  [CREATE VIEW (0 processed) in 1.24s]
.
.
.
22:52:41  140 of 142 START sql table model farhad_staging.int_gtfs_quality__all_tu_in_vp . [RUN]
22:52:41  141 of 142 START sql table model farhad_staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [RUN]
22:52:48  140 of 142 OK created sql table model farhad_staging.int_gtfs_quality__all_tu_in_vp  [CREATE TABLE (2.3m rows, 1.2 GiB processed) in 6.51s]
22:52:54  141 of 142 OK created sql table model farhad_staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [CREATE TABLE (2.3m rows, 24.7 GiB processed) in 13.13s]
22:52:54  142 of 142 START sql table model farhad_staging.int_gtfs_quality__guideline_checks_long  [RUN]
22:53:14  142 of 142 OK created sql table model farhad_staging.int_gtfs_quality__guideline_checks_long  [CREATE TABLE (177.3m rows, 96.8 GiB processed) in 19.64s]
22:53:14  
22:53:14  Finished running 43 view models, 77 table models, 22 incremental models in 0 hours 11 minutes and 20.31 seconds (680.31s).
22:53:15  
22:53:15  Completed successfully
22:53:15  
22:53:15  Done. PASS=142 WARN=0 ERROR=0 SKIP=0 TOTAL=142
```
## Post-merge follow-ups

- [ ] No action required
- [X] Actions required (specified below)

This PR prepares the necessary tables for the next phase, where Python code will be added to the report repository to generate the *Beyond Compliance* section on the report website.
