### PR TITLE
Set external table dataset using project name

### DIFF
--- a/.github/workflows/deploy-airflow.yml
+++ b/.github/workflows/deploy-airflow.yml
@@ -7,16 +7,12 @@ on:
     paths:
       - .github/workflows/deploy-airflow.yml
       - 'airflow/**'
-  pull_request:
-    paths:
-      - .github/workflows/deploy-airflow.yml
-      - 'airflow/**'
 
 env:
-  SERVICE_ACCOUNT: ${{ github.ref == 'refs/heads/main' && 'github-actions-service-account@cal-itp-data-infra.iam.gserviceaccount.com' || 'github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com' }}
-  WORKLOAD_IDENTITY_PROVIDER: ${{ github.ref == 'refs/heads/main' && 'projects/1005246706141/locations/global/workloadIdentityPools/github-actions/providers/data-infra' || 'projects/473674835135/locations/global/workloadIdentityPools/github-actions/providers/data-infra' }}
-  PROJECT_ID: ${{ github.ref == 'refs/heads/main' && 'cal-itp-data-infra' || 'cal-itp-data-infra-staging' }}
-  AIRFLOW_BUCKET: ${{ github.ref == 'refs/heads/main' && 'us-west2-calitp-airflow2-pr-f6bb9855-bucket' || 'calitp-staging-composer' }}
+  SERVICE_ACCOUNT: github-actions-service-account@cal-itp-data-infra.iam.gserviceaccount.com
+  WORKLOAD_IDENTITY_PROVIDER: projects/1005246706141/locations/global/workloadIdentityPools/github-actions/providers/data-infra
+  PROJECT_ID: cal-itp-data-infra
+  AIRFLOW_BUCKET: us-west2-calitp-airflow2-pr-f6bb9855-bucket
 
 jobs:
   build:

--- a/airflow/dags/create_external_tables/README.md
+++ b/airflow/dags/create_external_tables/README.md
@@ -7,15 +7,15 @@ This DAG orchestrates the creation of [external tables](https://cloud.google.com
 Here is an annotated example external table YAML file showing what the fields mean:
 
 ```yaml
-# throughout this example, <> brackets denote sample content to be filled in based on your use case and should be removed 
+# throughout this example, <> brackets denote sample content to be filled in based on your use case and should be removed
 operator: operators.ExternalTable   # the name of the operator; this does not change
 bucket: "{{ env_var('<BUCKET_VARIABLE>') }}"    # fill in the environment variable pointing to your source data bucket here
 post_hook: |    # this is optional; can provide an example query to check that external table was created successfully. this query will run every time the external table DAG runs
   SELECT *
-  FROM `{{ get_project_id() }}`.<your dataset as defined below under destination_project_dataset_table>.<your table name as defined below under destination_project_dataset_table>
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.<your dataset as defined below under destination_project_dataset_table>.<your table name as defined below under destination_project_dataset_table>
   LIMIT 1;
-source_objects: # this tells the external table which path & file format to look in for the objects that will be queryable through this external table 
-  - "<the top level folder name within your bucket that should be used for this external table like my_data>/*.<your file extension, most likely '.jsonl.gz'>"     
+source_objects: # this tells the external table which path & file format to look in for the objects that will be queryable through this external table
+  - "<the top level folder name within your bucket that should be used for this external table like my_data>/*.<your file extension, most likely '.jsonl.gz'>"
 destination_project_dataset_table: "<desired dataset name like external_my_data_source>.<desired table name, may be like topic_name__specific_data_name>"   # this defines the external table name (dataset and table name) through which the data will be accessible in BigQuery
 source_format: NEWLINE_DELIMITED_JSON   # file format of raw data; generally should not change -- allowable options are specified here: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration.FIELDS.source_format
 use_bq_client: true     # this option only exists for backwards compatibility; should always be true for new tables
@@ -39,6 +39,6 @@ schema_fields:  # here you fill in the schema of the actual files, which will be
 ## Testing
 
 When testing external table creation locally, pay attention to test environment details:
-* External tables created by local Airflow will be created in the `cal-itp-data-infra-staging` environment. 
-   * If you're trying to test dbt changes that rely on unmerged external tables changes, you can set the `DBT_SOURCE_DATABASE` environment variable to `cal-itp-data-infra-staging`. This will cause the dbt project to use the staging environment's externabl tables. If the staging external tables are pointed at a `test-` buckets (as described in the bullet above), then the dbt project will run on that test data, which may lead to unexpected results. 
+* External tables created by local Airflow will be created in the `cal-itp-data-infra-staging` environment.
+   * If you're trying to test dbt changes that rely on unmerged external tables changes, you can set the `DBT_SOURCE_DATABASE` environment variable to `cal-itp-data-infra-staging`. This will cause the dbt project to use the staging environment's externabl tables. If the staging external tables are pointed at a `test-` buckets (as described in the bullet above), then the dbt project will run on that test data, which may lead to unexpected results.
    * For this reason, it is often easier to make external tables updates in one pull request, get that approved and merged, and then make dbt changes once the external tables are already updated in production so you can test on the production source data.

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_county_geography.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_county_geography.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__county_geography
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__county_geography
   LIMIT 1;
 source_objects:
   - "california_transit__county_geography/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_eligibility_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_eligibility_programs.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__eligibility_programs
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__eligibility_programs
   LIMIT 1;
 source_objects:
   - "california_transit__eligibility_programs/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_fare_systems.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__fare_systems
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__fare_systems
   LIMIT 1;
 source_objects:
   - "california_transit__fare_systems/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_funding_programs.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__funding_programs
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__funding_programs
   LIMIT 1;
 source_objects:
   - "california_transit__funding_programs/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__gtfs_datasets
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__gtfs_datasets
   LIMIT 1;
 source_objects:
   - "california_transit__gtfs_datasets/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_service_data.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__gtfs_service_data
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__gtfs_service_data
   LIMIT 1;
 source_objects:
   - "california_transit__gtfs_service_data/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_modes.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_modes.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__modes
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__modes
   LIMIT 1;
 source_objects:
   - "california_transit__modes/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__ntd_agency_info
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__ntd_agency_info
   LIMIT 1;
 source_objects:
   - "california_transit__ntd_agency_info/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__organizations
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__organizations
   LIMIT 1;
 source_objects:
   - "california_transit__organizations/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_place_geography.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_place_geography.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__place_geography
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__place_geography
   LIMIT 1;
 source_objects:
   - "california_transit__place_geography/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_rider_requirements.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_rider_requirements.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__rider_requirements
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__rider_requirements
   LIMIT 1;
 source_objects:
   - "california_transit__rider_requirements/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.california_transit__services
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.california_transit__services
   LIMIT 1;
 source_objects:
   - "california_transit__services/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_gtfs_datasets.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_data_quality_issues__gtfs_datasets
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_data_quality_issues__gtfs_datasets
   LIMIT 1;
 source_objects:
   - "transit_data_quality_issues__gtfs_datasets/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_issue_types.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_issue_types.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_data_quality_issues__issue_types
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_data_quality_issues__issue_types
   LIMIT 1;
 source_objects:
   - "transit_data_quality_issues__issue_types/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_services.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_data_quality_issues__services
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_data_quality_issues__services
   LIMIT 1;
 source_objects:
   - "transit_data_quality_issues__services/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_transit_data_quality_issues.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_data_quality_issues_transit_data_quality_issues.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_data_quality_issues__transit_data_quality_issues
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_data_quality_issues__transit_data_quality_issues
   LIMIT 1;
 source_objects:
   - "transit_data_quality_issues__transit_data_quality_issues/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_components.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__components
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__components
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__components/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_contracts.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_contracts.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__contracts
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__contracts
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__contracts/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_data_schemas.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_data_schemas.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__data_schemas
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__data_schemas
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__data_schemas/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_organizations.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__organizations
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__organizations
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__organizations/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_products.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_products.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__products
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__products
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__products/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_properties_features.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_properties_features.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__properties_and_features
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__properties_and_features
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__properties_and_features/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_relationships_service_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_relationships_service_components.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__relationships_service_components
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__relationships_service_components
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__relationships_service_components/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_service_components.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_service_components.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__service_components
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__service_components
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__service_components/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_services.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__AIRTABLE') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_airtable.transit_technology_stacks__services
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_airtable.transit_technology_stacks__services
   LIMIT 1;
 source_objects:
   - "transit_technology_stacks__services/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/gtfs_download_configs.yml
+++ b/airflow/dags/create_external_tables/gtfs_download_configs.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_gtfs_schedule.download_configs
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_gtfs_schedule.download_configs
   WHERE dt = '{{ ds }}'
   LIMIT 1;
 source_objects:

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__annual_database_agency_information.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__annual_database_agency_information.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__annual_database_agency_information
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.2022__annual_database_agency_information
   LIMIT 1;
 source_objects:
   - "annual_database_agency_information/2022/_2022_agency_information/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/2022__annual_database_contractual_relationships.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2022__annual_database_contractual_relationships.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2022__annual_database_contractual_relationships
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.2022__annual_database_contractual_relationships
   LIMIT 1;
 source_objects:
   - "annual_database_contractual_relationship/2022/_2022_contractual_relationships/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/2023__annual_database_agency_information.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2023__annual_database_agency_information.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2023__annual_database_agency_information
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.2023__annual_database_agency_information
   LIMIT 1;
 source_objects:
   - "annual_database_agency_information/2023/agency_information/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/2023__annual_database_contractual_relationships.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2023__annual_database_contractual_relationships.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.2023__annual_database_contractual_relationships
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.2023__annual_database_contractual_relationships
   LIMIT 1;
 source_objects:
   - "annual_database_contractual_relationship/2023/contractual_relationships/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__active_fleet.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__active_fleet.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__active_fleet
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__assets.historical__asset_inventory_time_series__active_fleet
   LIMIT 1;
 source_objects:
   - "asset_inventory_time_series/historical/active_fleet/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__ada_fleet.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__ada_fleet.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__ada_fleet
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__assets.historical__asset_inventory_time_series__ada_fleet
   LIMIT 1;
 source_objects:
   - "asset_inventory_time_series/historical/ada_fleet/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_fleet_age.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_fleet_age.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_fleet_age
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_fleet_age
   LIMIT 1;
 source_objects:
   - "asset_inventory_time_series/historical/avg_fleet_age/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_seating_capacity.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_seating_capacity.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_seating_capacity
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_seating_capacity
   LIMIT 1;
 source_objects:
   - "asset_inventory_time_series/historical/avg_seating_capacity/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_standing_capacity.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__asset_inventory_time_series__avg_standing_capacity.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_standing_capacity
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__assets.historical__asset_inventory_time_series__avg_standing_capacity
   LIMIT 1;
 source_objects:
   - "asset_inventory_time_series/historical/avg_standing_capacity/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__facilities.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__facilities.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__facilities
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__facilities
   LIMIT 1;
 source_objects:
   - "capital_expenditures_time_series/historical/facilities/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__other.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__other.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__other
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__other
   LIMIT 1;
 source_objects:
   - "capital_expenditures_time_series/historical/other/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__rolling_stock.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__rolling_stock.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__rolling_stock
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__rolling_stock
   LIMIT 1;
 source_objects:
   - "capital_expenditures_time_series/historical/rolling_stock/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__total.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__capital_expenditures_time_series__total.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__total
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__capital_expenditures_time_series__total
   LIMIT 1;
 source_objects:
   - "capital_expenditures_time_series/historical/total/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/calendar_year_upt/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_vrm
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/calendar_year_vrm/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__master.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__master.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__master
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__master
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/master/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__upt.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__upt.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__upt
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__upt
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/upt/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__upt_estimates
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/upt_estimates/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__voms.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__voms.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__voms
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__voms
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/voms/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrh.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrh.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrh
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrh
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/vrh/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/vrm/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__ridership.historical__complete_monthly_ridership_with_adjustments_and_estimates__vrm_estimates
   LIMIT 1;
 source_objects:
   - "complete_monthly_ridership_with_adjustments_and_estimates/historical/vrm_estimates/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__fra_regulated_mode_major_security_events.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__fra_regulated_mode_major_security_events.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "fra_regulated_mode_major_security_events/historical/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__safety_and_security.historical__fra_regulated_mode_major_security_events"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__safety_and_security.historical__fra_regulated_mode_major_security_events LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__safety_and_security.historical__fra_regulated_mode_major_security_events LIMIT 1;
 schema_fields:
   - name: ntd_id
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__major_safety_events.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__major_safety_events.yml
@@ -9,4 +9,4 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "major_safety_events/historical/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__safety_and_security.historical__major_safety_events"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__safety_and_security.historical__major_safety_events LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__safety_and_security.historical__major_safety_events LIMIT 1;

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__monthly_modal_time_series_safety_and_service.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__monthly_modal_time_series_safety_and_service.yml
@@ -9,4 +9,4 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "monthly_modal_time_series_safety_and_service/historical/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__safety_and_security.historical__monthly_modal_time_series_safety_and_service"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__safety_and_security.historical__monthly_modal_time_series_safety_and_service LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__safety_and_security.historical__monthly_modal_time_series_safety_and_service LIMIT 1;

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__nonmajor_safety_and_security_events.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__nonmajor_safety_and_security_events.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "nonmajor_safety_and_security_events/historical/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__safety_and_security.historical__nonmajor_safety_and_security_events"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__safety_and_security.historical__nonmajor_safety_and_security_events LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__safety_and_security.historical__nonmajor_safety_and_security_events LIMIT 1;
 schema_fields:
   - name: _5_digit_ntd_id
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_federal.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_federal.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_federal
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_federal
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/capital_federal/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_local.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_local.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_local
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_local
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/capital_local/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_other.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_other.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_other
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_other
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/capital_other/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_state.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_state.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_state
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_state
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/capital_state/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_total.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__capital_total.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_total
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__capital_total
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/capital_total/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__decommissioned_operatingfares.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__decommissioned_operatingfares.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__decommissioned_operatingfares
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__decommissioned_operatingfares
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/decommissioned___operatingfares/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__decommissioned_operatingother.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__decommissioned_operatingother.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__decommissioned_operatingother
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__decommissioned_operatingother
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/decommissioned___operatingother/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_federal.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_federal.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_federal
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_federal
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/operating_federal/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_local.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_local.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_local
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_local
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/operating_local/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_other.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_other.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_other
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_other
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/operating_other/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_state.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_state.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_state
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_state
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/operating_state/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_total.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__operating_total.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_total
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__operating_total
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/operating_total/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__summary_total.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__operating_and_capital_funding_time_series__summary_total.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__summary_total
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__operating_and_capital_funding_time_series__summary_total
   LIMIT 1;
 source_objects:
   - "operating_and_capital_funding_time_series/historical/summary_total/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__drm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__drm.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__drm
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__drm
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/drm/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__fares.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__fares.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__fares
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__fares
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/fares/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_ga.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_ga.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_ga
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_ga
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/opexp_ga/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_nvm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_nvm.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_nvm
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_nvm
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/opexp_nvm/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_total.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_total.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_total
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_total
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/opexp_total/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vm.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vm
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vm
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/opexp_vm/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vo.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vo.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vo
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__opexp_vo
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/opexp_vo/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__pmt.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__pmt.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__pmt
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__pmt
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/pmt/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__upt.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__upt.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__upt
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__upt
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/upt/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__voms.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__voms.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__voms
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__voms
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/voms/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__vrh.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__vrh.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__vrh
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__vrh
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/vrh/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__vrm.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__service_data_and_operating_expenses_time_series_by_mode__vrm.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__vrm
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__funding_and_expenses.historical__service_data_and_operating_expenses_time_series_by_mode__vrm
   LIMIT 1;
 source_objects:
   - "service_data_and_operating_expenses_time_series_by_mode/historical/vrm/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__breakdowns.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__breakdowns.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "breakdowns/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__breakdowns"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__breakdowns LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__breakdowns LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__breakdowns_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__breakdowns_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "breakdowns_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__breakdowns_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__breakdowns_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__breakdowns_by_agency LIMIT 1;
 schema_fields:
   - name: count_major_mechanical_failures_questionable
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_by_capital_use.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_by_capital_use.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "capital_expenses_by_capital_use/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__capital_expenses_by_capital_use"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__capital_expenses_by_capital_use LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__capital_expenses_by_capital_use LIMIT 1;
 schema_fields:
   - name: administrative_buildings
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_by_mode.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "capital_expenses_by_mode/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__capital_expenses_by_mode"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__capital_expenses_by_mode LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__capital_expenses_by_mode LIMIT 1;
 schema_fields:
   - name: count_administrative_buildings_q
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_for_existing_service.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_for_existing_service.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "capital_expenses_for_existing_service/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__capital_expenses_for_existing_service"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__capital_expenses_for_existing_service LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__capital_expenses_for_existing_service LIMIT 1;
 schema_fields:
   - name: form_type
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_for_expansion_of_service.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__capital_expenses_for_expansion_of_service.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "capital_expenses_for_expansion_of_service/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__capital_expenses_for_expansion_of_service"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__capital_expenses_for_expansion_of_service LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__capital_expenses_for_expansion_of_service LIMIT 1;
 schema_fields:
   - name: form_type
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "employees_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__employees_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__employees_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__employees_by_agency LIMIT 1;
 schema_fields:
   - name: max_agency_1
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_mode.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "employees_by_mode/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__employees_by_mode"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__employees_by_mode LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__employees_by_mode LIMIT 1;
 schema_fields:
   - name: count_capital_labor_count_q
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_mode_and_employee_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__employees_by_mode_and_employee_type.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "employees_by_mode_and_employee_type/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__employees_by_mode_and_employee_type"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__employees_by_mode_and_employee_type LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__employees_by_mode_and_employee_type LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__fuel_and_energy.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__fuel_and_energy.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "fuel_and_energy/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__fuel_and_energy"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__fuel_and_energy LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__fuel_and_energy LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__fuel_and_energy_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__fuel_and_energy_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "fuel_and_energy_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__fuel_and_energy_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__fuel_and_energy_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__fuel_and_energy_by_agency LIMIT 1;
 schema_fields:
   - name: diesel_gal_questionable
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_by_expense_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_by_expense_type.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "funding_sources_by_expense_type/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__funding_sources_by_expense_type"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__funding_sources_by_expense_type LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__funding_sources_by_expense_type LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_directly_generated.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_directly_generated.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "funding_sources_directly_generated/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__funding_sources_directly_generated"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__funding_sources_directly_generated LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__funding_sources_directly_generated LIMIT 1;
 schema_fields:
   - name: advertising
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_federal.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_federal.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "funding_sources_federal/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__funding_sources_federal"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__funding_sources_federal LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__funding_sources_federal LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_local.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_local.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "funding_sources_local/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__funding_sources_local"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__funding_sources_local LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__funding_sources_local LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_state.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_state.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "funding_sources_state/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__funding_sources_state"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__funding_sources_state LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__funding_sources_state LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_taxes_levied_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__funding_sources_taxes_levied_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "funding_sources_taxes_levied_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__funding_sources_taxes_levied_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__funding_sources_taxes_levied_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__funding_sources_taxes_levied_by_agency LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__maintenance_facilities.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__maintenance_facilities.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "maintenance_facilities/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__maintenance_facilities"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__maintenance_facilities LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__maintenance_facilities LIMIT 1;
 schema_fields:
   - name: _200_to_300_vehicles
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__maintenance_facilities_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__maintenance_facilities_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "maintenance_facilities_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__maintenance_facilities_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__maintenance_facilities_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__maintenance_facilities_by_agency LIMIT 1;
 schema_fields:
   - name: max_agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__metrics.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__metrics.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "metrics/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__metrics"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__metrics LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__metrics LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_function.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_function.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "operating_expenses_by_function/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__operating_expenses_by_function"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_function LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_function LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_function_and_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_function_and_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "operating_expenses_by_function_and_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__operating_expenses_by_function_and_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_function_and_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_function_and_agency LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_type.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "operating_expenses_by_type/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__operating_expenses_by_type"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_type LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_type LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_type_and_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__operating_expenses_by_type_and_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "operating_expenses_by_type_and_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__operating_expenses_by_type_and_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_type_and_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__operating_expenses_by_type_and_agency LIMIT 1;
 schema_fields:
   - name: max_agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__service_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__service_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "service_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__service_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__service_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__service_by_agency LIMIT 1;
 schema_fields:
   - name: _5_digit_ntd_id
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__service_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__service_by_mode.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "service_by_mode/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__service_by_mode"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__service_by_mode LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__service_by_mode LIMIT 1;
 schema_fields:
   - name: _5_digit_ntd_id
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__service_by_mode_and_time_period.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__service_by_mode_and_time_period.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "service_by_mode_and_time_period/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__service_by_mode_and_time_period"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__service_by_mode_and_time_period LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__service_by_mode_and_time_period LIMIT 1;
 schema_fields:
   - name: _5_digit_ntd_id
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__stations_and_facilities_by_agency_and_facility_type.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__stations_and_facilities_by_agency_and_facility_type.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "stations_and_facilities_by_agency_and_facility_type/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__stations_and_facilities_by_agency_and_facility_type"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__stations_and_facilities_by_agency_and_facility_type LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__stations_and_facilities_by_agency_and_facility_type LIMIT 1;
 schema_fields:
   - name: administrative_and_other_non_passenger_facilities
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__stations_by_mode_and_age.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__stations_by_mode_and_age.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "stations_by_mode_and_age/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__stations_by_mode_and_age"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__stations_by_mode_and_age LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__stations_by_mode_and_age LIMIT 1;
 schema_fields:
   - name: _1940s
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "track_and_roadway_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__track_and_roadway_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__track_and_roadway_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__track_and_roadway_by_agency LIMIT 1;
 schema_fields:
   - name: max_agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_mode.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "track_and_roadway_by_mode/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__track_and_roadway_by_mode"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__track_and_roadway_by_mode LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__track_and_roadway_by_mode LIMIT 1;
 schema_fields:
   - name: agency
     type: STRING

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_guideway_age_distribution.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_guideway_age_distribution.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "track_and_roadway_guideway_age_distribution/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__track_and_roadway_guideway_age_distribution"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__track_and_roadway_guideway_age_distribution LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__track_and_roadway_guideway_age_distribution LIMIT 1;
 schema_fields:
   - name: _1940s
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__vehicles_age_distribution.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__vehicles_age_distribution.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "vehicles_age_distribution/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__vehicles_age_distribution"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__vehicles_age_distribution LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__vehicles_age_distribution LIMIT 1;
 schema_fields:
   - name: _0
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__vehicles_type_count_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__vehicles_type_count_by_agency.yml
@@ -9,7 +9,7 @@ hive_options:
   require_partition_filter: false
   source_uri_prefix: "vehicles_type_count_by_agency/multi_year/{dt:DATE}/{execution_ts:TIMESTAMP}"
 destination_project_dataset_table: "external_ntd__annual_reporting.multi_year__vehicles_type_count_by_agency"
-post_hook: SELECT * FROM `{{ get_project_id() }}`.external_ntd__annual_reporting.multi_year__vehicles_type_count_by_agency LIMIT 1;
+post_hook: SELECT * FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.multi_year__vehicles_type_count_by_agency LIMIT 1;
 schema_fields:
   - name: aerial_tram
     type: NUMERIC

--- a/airflow/dags/create_external_tables/ntd_report_validation/external_table_all_ntdreports.yml
+++ b/airflow/dags/create_external_tables/ntd_report_validation/external_table_all_ntdreports.yml
@@ -2,7 +2,7 @@ operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__NTD_REPORT_VALIDATION') }}"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_blackcat.all_ntdreports
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_blackcat.all_ntdreports
   LIMIT 1;
 source_objects:
   - "all_NTDReporting/*.jsonl.gz"

--- a/airflow/dags/create_external_tables/state_geoportal/state_highway_network.yml
+++ b/airflow/dags/create_external_tables/state_geoportal/state_highway_network.yml
@@ -11,7 +11,7 @@ hive_options:
 destination_project_dataset_table: "external_state_geoportal.state_highway_network"
 post_hook: |
   SELECT *
-  FROM `{{ get_project_id() }}`.external_state_geoportal.state_highway_network
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_state_geoportal.state_highway_network
   LIMIT 1;
 schema_fields:
   - name: Route

--- a/airflow/dags/macros.py
+++ b/airflow/dags/macros.py
@@ -5,8 +5,5 @@ data_infra_macros = {
     "image_tag": lambda: "development"
     if os.environ["AIRFLOW_ENV"] == "development"
     else "latest",
-    "get_project_id": lambda: "cal-itp-data-infra-staging"
-    if os.environ["AIRFLOW_ENV"] == "development"
-    else "cal-itp-data-infra",
-    "env_var": os.getenv,
+    "env_var": os.environ.get,
 }

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -31,7 +31,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_DATABASE: "{{ get_project_id() }}"
+  DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -30,7 +30,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_DATABASE: "{{ get_project_id() }}"
+  DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_full_refresh_exclude_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_full_refresh_exclude_rt.yml
@@ -30,7 +30,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_DATABASE: "{{ get_project_id() }}"
+  DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_select_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_select_rt.yml
@@ -33,7 +33,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
-  DBT_DATABASE: "{{ get_project_id() }}"
+  DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"


### PR DESCRIPTION
# Description

This commit closes the loop on [#3794](https://github.com/cal-itp/data-infra/pull/3974) by removing the get_project_id macro in favor of the `GOOGLE_CLOUD_PROJECT` environment variable. Currently, staging is unable to create external tables because the project identifier is assumed to be `cal-itp-data-infra` in a non-development context.

Relates to https://github.com/cal-itp/data-infra/issues/3780

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Staging Airflow

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
