### PR TITLE
Resolve transform_warehouse issue caused by a missing bucket variable

### DIFF
--- a/airflow/dags/deploy_dbt_docs/deploy_dbt_docs_site.yml
+++ b/airflow/dags/deploy_dbt_docs/deploy_dbt_docs_site.yml
@@ -27,6 +27,7 @@ env_vars:
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
   CALITP_BUCKET__DBT_DOCS: "{{ env_var('CALITP_BUCKET__DBT_DOCS') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -28,6 +28,7 @@ env_vars:
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
   CALITP_BUCKET__DBT_DOCS: "{{ env_var('CALITP_BUCKET__DBT_DOCS') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app

--- a/airflow/dags/transform_warehouse/dbt_test.yml
+++ b/airflow/dags/transform_warehouse/dbt_test.yml
@@ -35,6 +35,7 @@ env_vars:
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
 
 secrets:
   - deploy_type: volume

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -27,6 +27,7 @@ env_vars:
   AIRFLOW_ENV: "{{ env_var('AIRFLOW_ENV') }}"
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -36,6 +36,7 @@ env_vars:
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
 
 secrets:
   - deploy_type: volume

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_full_refresh_exclude_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_full_refresh_exclude_rt.yml
@@ -27,6 +27,7 @@ env_vars:
   AIRFLOW_ENV: "{{ env_var('AIRFLOW_ENV') }}"
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_select_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_select_rt.yml
@@ -30,6 +30,7 @@ env_vars:
   AIRFLOW_ENV: "{{ env_var('AIRFLOW_ENV') }}"
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   CALITP_BUCKET__DBT_ARTIFACTS: "{{ env_var('CALITP_BUCKET__DBT_ARTIFACTS') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
   DBT_PROFILE_DIR: /app

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_exclude_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_exclude_rt.yml
@@ -35,6 +35,7 @@ env_vars:
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
 
 secrets:
   - deploy_type: volume

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_select_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_select_rt.yml
@@ -35,6 +35,7 @@ env_vars:
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"
+  CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
 
 secrets:
   - deploy_type: volume

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -28,6 +28,7 @@ vars:
   INCREMENTAL_MAX_DT: ''
   'dbt_date:time_zone': 'America/Los_Angeles'
   SOURCE_DATABASE: cal-itp-data-infra # you can override with DBT_SOURCE_DATABASE env var rather than constantly using --vars
+  PUBLISH_BUCKET: "gs://calitp-staging-publish" # you can override with CALITP_BUCKET__PUBLISH  env var rather than constantly using --vars
 
 models:
   calitp_warehouse:

--- a/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
+++ b/warehouse/models/mart/gtfs_schedule_latest/_gtfs_schedule_latest.yml
@@ -1471,7 +1471,7 @@ exposures:
     meta:
       destinations:
         - type: tiles
-          bucket: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
+          bucket: "{{ env_var('CALITP_BUCKET__PUBLISH', var('PUBLISH_BUCKET')) }}"
           format: geojsonl # note that this is the intermediary format
           tile_format: mbtiles
           geo_column: pt_array

--- a/warehouse/models/staging/hqta/_hqta.yml
+++ b/warehouse/models/staging/hqta/_hqta.yml
@@ -27,7 +27,7 @@ exposures:
     meta:
       destinations:
         - type: tiles
-          bucket: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
+          bucket: "{{ env_var('CALITP_BUCKET__PUBLISH', var('PUBLISH_BUCKET')) }}"
           format: geojsonl # note that this is the intermediary format
           tile_format: mbtiles
           geo_column: geometry


### PR DESCRIPTION
# Description

The following error occurred after #3974 was merged:
```
Failed to render models/staging/hqta/_hqta.yml from project calitp_warehouse: Parsing Error
[2025-06-11, 14:06:56 UTC] {pod_manager.py:435} INFO - [base]     Env var required but not provided: 'CALITP_BUCKET__PUBLISH'
```

This resolves that error by adding the `CALITP_BUCKET__PUBLISH` environment variable to DBT files and DAGs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`poetry run dbt compile  --full-refresh`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
