### PR TITLE
Enable staging audit logging

### DIFF
--- a/iac/cal-itp-data-infra-staging/logging/us/.terraform.lock.hcl
+++ b/iac/cal-itp-data-infra-staging/logging/us/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.29.0"
+  constraints = "~> 6.29.0"
+  hashes = [
+    "h1:U0Ca/+zZMMuea+r80qu9SRzWu8Waxny5aWGZXn+kVhc=",
+    "zh:01a501df2fb9ecbf0935b27e588bc7b6bcaf4ab0043747f4229c25e4ba47dadb",
+    "zh:056f8ab2b73755cf5a67228ab4a07882e76265fa25b07f2794d9939288164f48",
+    "zh:0dbdfa564f7db8a2e6f7e76437a9850b6101450120c08e87cf9846330736c0c6",
+    "zh:3c3e4ee801de22812bd07cb3d36b227f8057d7825998fb4d97051764a565b89b",
+    "zh:4e440eb4c60da9cd7d23b3b99be54c869472fd70006c39639a04b9a51248929c",
+    "zh:659490efd20b3e98e4166b2925baa18549d82e4c16751bc92baed0185d22d108",
+    "zh:9ae24b98a3a3346b8004c6b87e3b59decba2f64c7407e106263859c275105ef8",
+    "zh:c64cff9c17e302236bb9e0a6d5eff4c92540ce3947269f3db94e2b9a1b1a3f4e",
+    "zh:d2fd0aecbbbba463bcb0640f54c8df5e7a63918bdd44236dcd36dff33bb8de09",
+    "zh:f022316369ea676f5f9d11768b4c621abd3304c1e6d1f0c2361e4e2620c4b65d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:feb7d4fdbebdfabac2aaa73376f754736ccf089fa90adf6388701f89801188e6",
+  ]
+}

--- a/iac/cal-itp-data-infra-staging/logging/us/audit_config.tf
+++ b/iac/cal-itp-data-infra-staging/logging/us/audit_config.tf
@@ -1,11 +1,3 @@
-# resource "google_project_iam_audit_config" "audit" {
-#   project = "cal-itp-data-infra-staging"
-
-#   audit_log_config {
-#     log_type = "ADMIN_READ"
-#   }
-# }
-
 resource "google_bigquery_dataset" "audit" {
   dataset_id                 = "audit"
   location                   = "us-west2"
@@ -13,7 +5,7 @@ resource "google_bigquery_dataset" "audit" {
   delete_contents_on_destroy = true
 }
 
-resource "google_logging_project_sink" "audit_sink" {
+resource "google_logging_project_sink" "audit" {
   name        = "bigquery-sink"
   destination = "bigquery.googleapis.com/projects/cal-itp-data-infra-staging/datasets/${google_bigquery_dataset.audit.dataset_id}"
   filter      = <<-EOT
@@ -26,4 +18,14 @@ resource "google_logging_project_sink" "audit_sink" {
   bigquery_options {
     use_partitioned_tables = true # always true if it is false, logs cant export to the bigquery
   }
+}
+
+resource "google_bigquery_dataset_iam_binding" "audit" {
+  project    = "cal-itp-data-infra-staging"
+  dataset_id = google_bigquery_dataset.audit.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  members = [
+    google_logging_project_sink.audit.writer_identity,
+  ]
+  depends_on = [google_bigquery_dataset.audit]
 }

--- a/iac/cal-itp-data-infra-staging/logging/us/audit_config.tf
+++ b/iac/cal-itp-data-infra-staging/logging/us/audit_config.tf
@@ -1,0 +1,29 @@
+# resource "google_project_iam_audit_config" "audit" {
+#   project = "cal-itp-data-infra-staging"
+
+#   audit_log_config {
+#     log_type = "ADMIN_READ"
+#   }
+# }
+
+resource "google_bigquery_dataset" "audit" {
+  dataset_id                 = "audit"
+  location                   = "us-west2"
+  project                    = "cal-itp-data-infra-staging"
+  delete_contents_on_destroy = true
+}
+
+resource "google_logging_project_sink" "audit_sink" {
+  name        = "bigquery-sink"
+  destination = "bigquery.googleapis.com/projects/cal-itp-data-infra-staging/datasets/${google_bigquery_dataset.audit.dataset_id}"
+  filter      = <<-EOT
+  protoPayload.metadata."@type"="type.googleapis.com/google.cloud.audit.BigQueryAuditMetadata"
+  EOT
+
+  unique_writer_identity = true
+  project                = "cal-itp-data-infra-staging"
+
+  bigquery_options {
+    use_partitioned_tables = true # always true if it is false, logs cant export to the bigquery
+  }
+}

--- a/iac/cal-itp-data-infra-staging/logging/us/provider.tf
+++ b/iac/cal-itp-data-infra-staging/logging/us/provider.tf
@@ -1,0 +1,16 @@
+provider "google" {
+  project = "cal-itp-data-infra-staging"
+}
+
+terraform {
+  required_providers {
+    google = {
+      version = "~> 6.29.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "calitp-staging-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra-staging/logging"
+  }
+}


### PR DESCRIPTION
# Description

On PR #3983 we are running into an issue syncing metabase caused by a lack of audit tables in BigQuery. These are created by GCP's internal logging sink apparatus. This enables a log sink for those audit logs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Watch `terraform apply` output and verify that audit logs are streamed to the right location.