### PR TITLE
Staging terraform is able to update bigquery datasets

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -223,6 +223,7 @@ resource "google_project_iam_member" "tfer--roles-002F-storage-002E-objectViewer
 resource "google_project_iam_member" "github-actions-terraform" {
   for_each = toset([
     "roles/resourcemanager.projectIamAdmin",
+    "roles/bigquery.dataOwner",
     "roles/editor",
     "roles/storage.admin",
     "roles/iam.roleAdmin",


### PR DESCRIPTION
# Description

After merging PR #3983, the Terraform service account is unable to apply changes related to BigQuery datasets. According to the documentation, the least-privileged prebaked role for dataset administration is `roles/bigquery.dataOwner`.

Addresses issue in #3983 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor output of `terraform apply`