### PR TITLE
Fix dbt deprecation warnings

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -42,15 +42,15 @@ x-airflow-common:
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres/airflow
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__CORE__DAGS_FOLDER: /opt/airflow/gcs/dags
-    AIRFLOW__CORE__BASE_LOG_FOLDER: /opt/airflow/gcs/logs
     AIRFLOW__CORE__PLUGINS_FOLDER: /opt/airflow/gcs/plugins
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+    AIRFLOW__LOGGING__BASE_LOG_FOLDER: /opt/airflow/gcs/logs
     AIRFLOW__WEBSERVER__RELOAD_ON_PLUGIN_CHANGE: 'true'
     # AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 120
 

--- a/warehouse/packages.yml
+++ b/warehouse/packages.yml
@@ -1,7 +1,7 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.0.0
-  - package: calogica/dbt_expectations
-    version: [">=0.8.0", "<0.9.0"]
+    version: 1.3.0
+  - package: metaplane/dbt_expectations
+    version: 0.10.5
   - package: dbt-labs/metrics
     version: [">=1.5.0", "<1.6.0"]

--- a/warehouse/pyproject.toml
+++ b/warehouse/pyproject.toml
@@ -22,7 +22,6 @@ python-slugify = "^6.1.2"
 sentry-sdk = "^1.9.8"
 backoff = "^2.2.1"
 gcsfs = "^2023.1.0"
-# should migrate to 1.x soon; 0.10.3 appears to be the end of the line for pre-1.0
 dbt-metabase = "^1.5.0"
 networkx = {version = "<3", extras = ["default"]}
 # from https://github.com/pygraphviz/pygraphviz/issues/398#issuecomment-1450367670


### PR DESCRIPTION
# Description

This PR fixes some deprecation warnings as part of the [Quarterly Maintenance: 2025:Q1/Q2 - DBT #3703](https://github.com/cal-itp/data-infra/issues/3703).

1. DeprecationWarning: The sql_alchemy_conn option in [core] has been moved to the sql_alchemy_conn option in [database] - the old setting has been used, but please update your config

    Updated `AIRFLOW__CORE__SQL_ALCHEMY_CONN` to `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN` in [airflow/docker-compose.yaml](https://github.com/cal-itp/data-infra/blob/d2a6af7df6ca0c5a9972a26a6f2eed6402a58c37/airflow/docker-compose.yaml#L45)

2. DeprecationWarning: The base_log_folder option in [core] has been moved to the base_log_folder option in [logging] - the old setting has been used, but please update your config

    Updated `AIRFLOW__CORE__BASE_LOG_FOLDER` to `AIRFLOW__LOGGING__BASE_LOG_FOLDER` in [airflow/docker-compose.yaml](https://github.com/cal-itp/data-infra/blob/d2a6af7df6ca0c5a9972a26a6f2eed6402a58c37/airflow/docker-compose.yaml#L52)

3. [WARNING]: Deprecated functionality The `calogica/dbt_expectations` package is deprecated in favor of
`metaplane/dbt_expectations`. Please update your `packages.yml` configuration to
use `metaplane/dbt_expectations` instead.

    Updated `calogica/dbt_expectations` to `metaplane/dbt_expectations` in [warehouse/packages.yml](https://github.com/cal-itp/data-infra/blob/a4e5f548de98aecdc9905a5ddf8e571a408a7c4e/warehouse/packages.yml)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally running:
* `docker compose run airflow db init` on `airflow` folder to see for warnings 1 and 2
* `poetry run dbt deps` on `warehouse` folder for warnings 3

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
