### PR TITLE
Make the composer service account a BigQuery data owner on staging

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -253,7 +253,7 @@ resource "google_project_iam_member" "github-actions-service-account" {
 
 resource "google_project_iam_member" "composer-service-account" {
   for_each = toset([
-    "roles/bigquery.dataEditor",
+    "roles/bigquery.dataOwner",
     "roles/bigquery.jobUser",
     "roles/cloudbuild.builds.viewer",
     "roles/composer.ServiceAgentV2Ext",


### PR DESCRIPTION
# Description

When running the dbt DAGs via Cosmos on staging, Airflow throws the following error:

```
cosmos.exceptions.CosmosDbtRunError: dbt invocation completed with errors: fct_payments_chargeback_transactions: Database Error in model fct_payments_chargeback_transactions (models/mart/payments/fct_payments_chargeback_transactions.sql)
  Access Denied: Table cal-itp-data-infra-staging:staging_mart_payments.fct_payments_chargeback_transactions: Permission bigquery.rowAccessPolicies.create denied on table cal-itp-data-infra-staging:staging_mart_payments.fct_payments_chargeback_transactions (or it may not exist). at [3:9]
  compiled Code at target/run/calitp_warehouse/models/mart/payments/fct_payments_chargeback_transactions.sql
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Re-run failing Cosmos DAGs