### PR TITLE
Update production composer deployment to use terraform

### DIFF
--- a/.github/workflows/composer-apply-files.yml
+++ b/.github/workflows/composer-apply-files.yml
@@ -57,4 +57,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path: iac/cal-itp-data-infra-staging/airflow/us
+          path: iac/cal-itp-data-infra/airflow/us

--- a/.github/workflows/composer-apply-files.yml
+++ b/.github/workflows/composer-apply-files.yml
@@ -31,3 +31,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: iac/cal-itp-data-infra-staging/airflow/us
+
+  production:
+    name: Production
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          create_credentials_file: 'true'
+          project_id: cal-itp-data-infra
+          workload_identity_provider: 'projects/1005246706141/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
+          service_account: 'github-actions-terraform@cal-itp-data-infra.iam.gserviceaccount.com'
+
+      - name: Terraform Apply
+        uses: dflook/terraform-apply@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: iac/cal-itp-data-infra-staging/airflow/us

--- a/.github/workflows/composer-plan-files.yml
+++ b/.github/workflows/composer-plan-files.yml
@@ -33,3 +33,31 @@ jobs:
         with:
           add_github_comment: changes-only
           path: iac/cal-itp-data-infra-staging/airflow/us
+
+  production:
+    name: Production
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: 'google-github-actions/auth@v2'
+        with:
+          create_credentials_file: 'true'
+          project_id: cal-itp-data-infra
+          workload_identity_provider: 'projects/1005246706141/locations/global/workloadIdentityPools/github-actions/providers/data-infra'
+          service_account: 'github-actions-terraform@cal-itp-data-infra.iam.gserviceaccount.com'
+
+      - name: Terraform Plan
+        uses: dflook/terraform-plan@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          add_github_comment: changes-only
+          path: iac/cal-itp-data-infra-staging/airflow/us

--- a/.github/workflows/composer-plan-files.yml
+++ b/.github/workflows/composer-plan-files.yml
@@ -60,4 +60,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           add_github_comment: changes-only
-          path: iac/cal-itp-data-infra-staging/airflow/us
+          path: iac/cal-itp-data-infra/airflow/us

--- a/iac/cal-itp-data-infra/airflow/us/.terraform.lock.hcl
+++ b/iac/cal-itp-data-infra/airflow/us/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.29.0"
+  constraints = "~> 6.29.0"
+  hashes = [
+    "h1:U0Ca/+zZMMuea+r80qu9SRzWu8Waxny5aWGZXn+kVhc=",
+    "zh:01a501df2fb9ecbf0935b27e588bc7b6bcaf4ab0043747f4229c25e4ba47dadb",
+    "zh:056f8ab2b73755cf5a67228ab4a07882e76265fa25b07f2794d9939288164f48",
+    "zh:0dbdfa564f7db8a2e6f7e76437a9850b6101450120c08e87cf9846330736c0c6",
+    "zh:3c3e4ee801de22812bd07cb3d36b227f8057d7825998fb4d97051764a565b89b",
+    "zh:4e440eb4c60da9cd7d23b3b99be54c869472fd70006c39639a04b9a51248929c",
+    "zh:659490efd20b3e98e4166b2925baa18549d82e4c16751bc92baed0185d22d108",
+    "zh:9ae24b98a3a3346b8004c6b87e3b59decba2f64c7407e106263859c275105ef8",
+    "zh:c64cff9c17e302236bb9e0a6d5eff4c92540ce3947269f3db94e2b9a1b1a3f4e",
+    "zh:d2fd0aecbbbba463bcb0640f54c8df5e7a63918bdd44236dcd36dff33bb8de09",
+    "zh:f022316369ea676f5f9d11768b4c621abd3304c1e6d1f0c2361e4e2620c4b65d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:feb7d4fdbebdfabac2aaa73376f754736ccf089fa90adf6388701f89801188e6",
+  ]
+}

--- a/iac/cal-itp-data-infra/airflow/us/provider.tf
+++ b/iac/cal-itp-data-infra/airflow/us/provider.tf
@@ -1,0 +1,16 @@
+provider "google" {
+  project = "cal-itp-data-infra"
+}
+
+terraform {
+  required_providers {
+    google = {
+      version = "~> 6.29.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/airflow"
+  }
+}

--- a/iac/cal-itp-data-infra/airflow/us/storage_bucket_object.tf
+++ b/iac/cal-itp-data-infra/airflow/us/storage_bucket_object.tf
@@ -1,0 +1,37 @@
+resource "google_storage_bucket_object" "calitp-composer" {
+  for_each = local.composer_files
+  name     = each.value
+  source   = "../../../../airflow/${each.value}"
+  bucket   = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket_name
+}
+
+resource "google_storage_bucket_object" "calitp-composer-dags" {
+  for_each = local.warehouse_files
+  name     = "data/warehouse/${each.value}"
+  source   = "../../../../warehouse/${each.value}"
+  bucket   = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket_name
+}
+
+resource "google_storage_bucket_object" "calitp-composer-manifest" {
+  name    = "data/warehouse/target/manifest.json"
+  content = data.google_storage_bucket_object_content.calitp-dbt-manifest.content
+  bucket  = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket_name
+}
+
+resource "google_storage_bucket_object" "calitp-composer-catalog" {
+  name    = "data/warehouse/target/catalog.json"
+  content = data.google_storage_bucket_object_content.calitp-dbt-catalog.content
+  bucket  = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket_name
+}
+
+resource "google_storage_bucket_object" "calitp-composer-index" {
+  name    = "data/warehouse/target/index.html"
+  content = data.google_storage_bucket_object_content.calitp-dbt-index.content
+  bucket  = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket_name
+}
+
+resource "google_storage_bucket_object" "calitp-composer-run_results" {
+  name    = "data/warehouse/target/run_results.json"
+  content = data.google_storage_bucket_object_content.calitp-dbt-run_results.content
+  bucket  = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket_name
+}

--- a/iac/cal-itp-data-infra/airflow/us/variables.tf
+++ b/iac/cal-itp-data-infra/airflow/us/variables.tf
@@ -1,0 +1,56 @@
+locals {
+  composer_files = setunion(
+    fileset("../../../../airflow", "dags/**/*.py"),
+    fileset("../../../../airflow", "dags/**/*.yml"),
+    fileset("../../../../airflow", "dags/**/*.md"),
+    fileset("../../../../airflow", "plugins/**/*.py")
+  )
+
+  warehouse_files = setunion(
+    fileset("../../../../warehouse", "dbt_project.yml"),
+    fileset("../../../../warehouse", "packages.yml"),
+    fileset("../../../../warehouse", "profiles.yml"),
+    fileset("../../../../warehouse", "macros/**/*"),
+    fileset("../../../../warehouse", "models/**/*"),
+    fileset("../../../../warehouse", "seeds/**/*"),
+    fileset("../../../../warehouse", "tests/**/*")
+  )
+}
+
+data "google_storage_bucket_object_content" "calitp-dbt-manifest" {
+  name   = "latest/manifest.json"
+  bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--calitp-dbt-artifacts_name
+}
+
+data "google_storage_bucket_object_content" "calitp-dbt-catalog" {
+  name   = "latest/catalog.json"
+  bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--calitp-dbt-artifacts_name
+}
+
+data "google_storage_bucket_object_content" "calitp-dbt-run_results" {
+  name   = "latest/run_results.json"
+  bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--calitp-dbt-artifacts_name
+}
+
+data "google_storage_bucket_object_content" "calitp-dbt-index" {
+  name   = "latest/index.html"
+  bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_tfer--calitp-dbt-artifacts_name
+}
+
+data "terraform_remote_state" "networks" {
+  backend = "gcs"
+
+  config = {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/networks"
+  }
+}
+
+data "terraform_remote_state" "gcs" {
+  backend = "gcs"
+
+  config = {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/gcs"
+  }
+}

--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2450,6 +2450,10 @@ output "google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket_
   value = google_storage_bucket.tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket.name
 }
 
+output "google_storage_bucket_tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket_name" {
+  value = google_storage_bucket.tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket.name
+}
+
 output "google_storage_bucket_calitp-gtfs_name" {
   value = google_storage_bucket.calitp-gtfs.name
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -2107,6 +2107,21 @@ resource "google_storage_bucket" "tfer--us-west2-calitp-airflow2-pr-88ca8ec6-buc
   }
 }
 
+resource "google_storage_bucket" "tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket" {
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "us-west2-calitp-airflow2-pr-f6bb9855-bucket"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+  lifecycle {
+    ignore_changes = [labels]
+  }
+}
+
 resource "google_storage_bucket" "calitp-gtfs" {
   location                    = "US-WEST2"
   name                        = "calitp-gtfs"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
@@ -393,3 +393,7 @@ resource "google_storage_bucket_acl" "tfer--us-west2-calitp-airflow2-pr-31e41084
 resource "google_storage_bucket_acl" "tfer--us-west2-calitp-airflow2-pr-88ca8ec6-bucket" {
   bucket = "us-west2-calitp-airflow2-pr-88ca8ec6-bucket"
 }
+
+resource "google_storage_bucket_acl" "tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket" {
+  bucket = "us-west2-calitp-airflow2-pr-f6bb9855-bucket"
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -615,3 +615,9 @@ resource "google_storage_bucket_iam_binding" "tfer--us-west2-calitp-airflow2-pr-
   members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
   role    = "roles/storage.legacyObjectOwner"
 }
+
+resource "google_storage_bucket_iam_binding" "tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket" {
+  bucket  = "b/us-west2-calitp-airflow2-pr-f6bb9855-bucket"
+  members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
+  role    = "roles/storage.legacyObjectOwner"
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -616,6 +616,12 @@ resource "google_storage_bucket_iam_member" "tfer--us-west2-calitp-airflow2-pr-8
   role   = "roles/storage.legacyBucketReader"
 }
 
+resource "google_storage_bucket_iam_member" "tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket" {
+  bucket = "b/us-west2-calitp-airflow2-pr-f6bb9855-bucket"
+  member = "projectViewer:cal-itp-data-infra"
+  role   = "roles/storage.legacyBucketReader"
+}
+
 resource "google_storage_bucket_iam_member" "calitp_gtfs_public_web_access" {
   bucket = google_storage_bucket.calitp-gtfs.name
   role   = "roles/storage.objectViewer"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -3905,3 +3905,41 @@ resource "google_storage_bucket_iam_policy" "tfer--us-west2-calitp-airflow2-pr-8
 }
 POLICY
 }
+
+resource "google_storage_bucket_iam_policy" "tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket" {
+  bucket = "b/us-west2-calitp-airflow2-pr-f6bb9855-bucket"
+
+  policy_data = <<POLICY
+{
+  "bindings": [
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra",
+        "serviceAccount:composer2-service-account@cal-itp-data-infra.iam.gserviceaccount.com"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra",
+        "projectOwner:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra"
+      ],
+      "role": "roles/storage.legacyObjectReader"
+    }
+  ]
+}
+POLICY
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
@@ -404,3 +404,8 @@ resource "google_storage_default_object_acl" "tfer--us-west2-calitp-airflow2-pr-
   bucket      = "us-west2-calitp-airflow2-pr-88ca8ec6-bucket"
   role_entity = ["OWNER:project-editors-1005246706141", "OWNER:project-owners-1005246706141", "READER:project-viewers-1005246706141"]
 }
+
+resource "google_storage_default_object_acl" "tfer--us-west2-calitp-airflow2-pr-f6bb9855-bucket" {
+  bucket      = "us-west2-calitp-airflow2-pr-f6bb9855-bucket"
+  role_entity = ["OWNER:project-editors-1005246706141", "OWNER:project-owners-1005246706141", "READER:project-viewers-1005246706141"]
+}


### PR DESCRIPTION
# Description

This switches production Airflow deployment from from gsutil sync to terraform, matching staging. This starts syncing dbt so that cosmos can load.

Resolves #4010

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [ ] Actions required (specified below)
