### PR TITLE
Include partial_parse.msgpack when uploading latest dbt artifacts

### DIFF
--- a/warehouse/scripts/run_and_upload.py
+++ b/warehouse/scripts/run_and_upload.py
@@ -16,7 +16,14 @@ CALITP_BUCKET__DBT_ARTIFACTS = os.environ.get("CALITP_BUCKET__DBT_ARTIFACTS")
 CALITP_BUCKET__DBT_DOCS = os.environ.get("CALITP_BUCKET__DBT_DOCS")
 
 artifacts = map(
-    Path, ["index.html", "catalog.json", "manifest.json", "run_results.json"]
+    Path,
+    [
+        "index.html",
+        "catalog.json",
+        "manifest.json",
+        "run_results.json",
+        "partial_parse.msgpack",
+    ],
 )
 
 sentry_sdk.init()


### PR DESCRIPTION
# Description

To complete the partial parse improvement as a dbt artifact, I've updated `run_and_upload.py` to include `partial_parse.msgpack`. This will upload it to `{CALITP_BUCKET__DBT_ARTIFACTS}/latest/`.

Related to #3908 and #4010 changes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?



## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
