### PR TITLE
Fix target name on Cosmos payment DAG

### DIFF
--- a/airflow/dags/cosmos_payment_dag.py
+++ b/airflow/dags/cosmos_payment_dag.py
@@ -1,7 +1,10 @@
+import os
 from datetime import datetime
 
 from cosmos import DbtDag, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import TestBehavior
+
+DBT_TARGET = os.environ.get("DBT_TARGET")
 
 cosmos_payment = DbtDag(
     # dbt/cosmos-specific parameters
@@ -12,7 +15,7 @@ cosmos_payment = DbtDag(
         seeds_relative_path="seeds/",
     ),
     profile_config=ProfileConfig(
-        target_name="staging",
+        target_name=DBT_TARGET,
         profile_name="calitp_warehouse",
         profiles_yml_filepath="/home/airflow/gcs/data/warehouse/profiles.yml",
     ),

--- a/airflow/dags/deploy_dbt_docs/deploy_dbt_docs_site.yml
+++ b/airflow/dags/deploy_dbt_docs/deploy_dbt_docs_site.yml
@@ -25,7 +25,7 @@ env_vars:
   CALITP_BUCKET__DBT_DOCS: "{{ env_var('CALITP_BUCKET__DBT_DOCS') }}"
   CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
 
 secrets:

--- a/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse/dbt_run_and_upload_artifacts.yml
@@ -27,7 +27,7 @@ env_vars:
   CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"

--- a/airflow/dags/transform_warehouse/dbt_test.yml
+++ b/airflow/dags/transform_warehouse/dbt_test.yml
@@ -27,7 +27,7 @@ env_vars:
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_run_and_upload_artifacts.yml
@@ -26,7 +26,7 @@ env_vars:
   CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"

--- a/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/dbt_test.yml
@@ -28,7 +28,7 @@ env_vars:
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_full_refresh_exclude_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_full_refresh_exclude_rt.yml
@@ -26,7 +26,7 @@ env_vars:
   CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_select_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_run_and_upload_artifacts_select_rt.yml
@@ -29,7 +29,7 @@ env_vars:
   CALITP_BUCKET__PUBLISH: "{{ env_var('CALITP_BUCKET__PUBLISH') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_DATABASE: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_exclude_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_exclude_rt.yml
@@ -27,7 +27,7 @@ env_vars:
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_select_rt.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/dbt_test_select_rt.yml
@@ -27,7 +27,7 @@ env_vars:
   GOOGLE_CLOUD_PROJECT: "{{ env_var('GOOGLE_CLOUD_PROJECT') }}"
   BIGQUERY_KEYFILE_LOCATION: /secrets/jobs-data/service_account.json
   DBT_PROJECT_DIR: /app
-  DBT_PROFILE_DIR: /app
+  DBT_PROFILES_DIR: /app
   DBT_TARGET: "{{ env_var('DBT_TARGET') }}"
   SENTRY_DSN: "{{ env_var('SENTRY_DSN') }}"
   SENTRY_ENVIRONMENT: "{{ env_var('SENTRY_ENVIRONMENT') }}"


### PR DESCRIPTION
# Description

This PR updates Cosmos payment DAG to use `DBT_TARGET` (prod or staging) as the target name to run correcly on Production.

Related to #3780

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running `cosmos_payment` DAG on Staging.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Run Cosmos payment DAG after the change to check if it uses the correct target.