### PR TITLE
Add GKE workload identity federation for composer service account

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -55,6 +55,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         "POD_LOCATION"                                         = "us-west2",
         "POD_CLUSTER_NAME"                                     = data.terraform_remote_state.gke.outputs.google_container_cluster_airflow-jobs-staging_name,
         "POD_SECRETS_NAMESPACE"                                = local.namespace,
+        "SERVICE_ACCOUNT_NAME"                                 = data.terraform_remote_state.iam.outputs.google_service_account_composer-service-account_email,
         "CALITP_BUCKET__AGGREGATOR_SCRAPER"                    = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-aggregator-scraper_name}",
         "CALITP_BUCKET__AIRTABLE"                              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-airtable_name}",
         "CALITP_BUCKET__AMPLITUDE_BENEFITS_EVENTS"             = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-amplitude-benefits-events_name}",

--- a/iac/cal-itp-data-infra-staging/composer/us/kubernetes.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/kubernetes.tf
@@ -26,3 +26,22 @@ resource "kubernetes_secret" "composer" {
     transitland-api-key    = data.kubernetes_secret.composer.data.transitland-api-key
   }
 }
+
+resource "kubernetes_priority_class" "dbt-high-priority" {
+  metadata {
+    name = "dbt-high-priority"
+  }
+  global_default = false
+  value          = 1000000
+  description    = "This priority class should be used for dbt pods only."
+}
+
+resource "kubernetes_service_account" "composer-service-account" {
+  metadata {
+    name      = "composer-service-account"
+    namespace = local.namespace
+    annotations = {
+      "iam.gke.io/gcp-service-account" = data.terraform_remote_state.iam.outputs.google_service_account_composer-service-account_email
+    }
+  }
+}

--- a/iac/cal-itp-data-infra-staging/gke/us/container_cluster.tf
+++ b/iac/cal-itp-data-infra-staging/gke/us/container_cluster.tf
@@ -10,4 +10,8 @@ resource "google_container_cluster" "airflow-jobs-staging" {
   secret_manager_config {
     enabled = true
   }
+
+  workload_identity_config {
+    workload_pool = "cal-itp-data-infra-staging.svc.id.goog"
+  }
 }

--- a/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
@@ -15,3 +15,9 @@ resource "google_service_account_iam_member" "custom_service_account" {
   role               = "roles/composer.ServiceAgentV2Ext"
   member             = "serviceAccount:service-${local.project_id}@cloudcomposer-accounts.iam.gserviceaccount.com"
 }
+
+resource "google_service_account_iam_member" "airflow-jobs_composer-service-account" {
+  service_account_id = google_service_account.composer-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:cal-itp-data-infra-staging.svc.id.goog[airflow-jobs/composer-service-account]"
+}


### PR DESCRIPTION
# Description

This PR adds Terraform configuration to allow Composer Service Account to authenticate via workload identity federation, like Github Actions, rather than by using a service account keyfile, which is not recommended. https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity

Related to #3780

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`