### PR TITLE
Add service account admin permissions to terraform service accounts

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -227,6 +227,7 @@ resource "google_project_iam_member" "github-actions-terraform" {
     "roles/editor",
     "roles/storage.admin",
     "roles/iam.roleAdmin",
+    "roles/iam.serviceAccountAdmin",
     "roles/logging.configWriter"
   ])
   role    = each.key

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -542,6 +542,7 @@ resource "google_project_iam_member" "github-actions-terraform" {
   for_each = toset([
     "roles/resourcemanager.projectIamAdmin",
     "roles/iam.roleAdmin",
+    "roles/iam.serviceAccountAdmin",
     "roles/editor",
     "roles/storage.admin"
   ])


### PR DESCRIPTION
# Description

This PR adds service account admin permissions to terraform service accounts needed to apply changes made on PR `Add GKE workload identity federation for composer service account` #4020.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Run `terraform plan`.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)