### PR TITLE
Use GKE workload identity federation in composer

### DIFF
--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/validate_gtfs_schedule.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/validate_gtfs_schedule.yml
@@ -17,18 +17,11 @@ is_delete_operator_pod: true
 get_logs: true
 
 env_vars:
-  GOOGLE_APPLICATION_CREDENTIALS: /secrets/jobs-data/service_account.json
   AIRFLOW_ENV: "{{ env_var('AIRFLOW_ENV') }}"
   CALITP_USER: "{{ env_var('CALITP_USER') }}"
   CALITP_BUCKET__GTFS_SCHEDULE_RAW: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_RAW') }}"
   CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY: "{{ env_var('CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY') }}"
   GRAAS_SERVER_URL: "{{ env_var('GRAAS_SERVER_URL') }}"
-
-secrets:
-  - deploy_type: volume
-    deploy_target: /secrets/jobs-data/
-    secret: jobs-data
-    key: service_account.json
 
 k8s_resources:
   request_memory: 5.0Gi

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -65,7 +65,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         "POD_LOCATION"                                         = "us-west2",
         "POD_CLUSTER_NAME"                                     = data.terraform_remote_state.gke.outputs.google_container_cluster_airflow-jobs-staging_name,
         "POD_SECRETS_NAMESPACE"                                = local.namespace,
-        "SERVICE_ACCOUNT_NAME"                                 = local.service_account_name,
+        "SERVICE_ACCOUNT_NAME"                                 = local.kubernetes_service_account,
         "CALITP_BUCKET__AGGREGATOR_SCRAPER"                    = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-aggregator-scraper_name}",
         "CALITP_BUCKET__AIRTABLE"                              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-airtable_name}",
         "CALITP_BUCKET__AMPLITUDE_BENEFITS_EVENTS"             = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-amplitude-benefits-events_name}",

--- a/iac/cal-itp-data-infra-staging/composer/us/kubernetes.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/kubernetes.tf
@@ -22,8 +22,7 @@ resource "kubernetes_secret" "composer" {
     namespace = local.namespace
   }
   data = {
-    "service_account.json" = base64decode(google_service_account_key.composer.private_key)
-    transitland-api-key    = data.kubernetes_secret.composer.data.transitland-api-key
+    transitland-api-key = data.kubernetes_secret.composer.data.transitland-api-key
   }
 }
 
@@ -38,7 +37,7 @@ resource "kubernetes_priority_class" "dbt-high-priority" {
 
 resource "kubernetes_service_account" "composer-service-account" {
   metadata {
-    name      = local.service_account_name
+    name      = local.kubernetes_service_account
     namespace = local.namespace
     annotations = {
       "iam.gke.io/gcp-service-account" = data.terraform_remote_state.iam.outputs.google_service_account_composer-service-account_email

--- a/iac/cal-itp-data-infra-staging/composer/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/variables.tf
@@ -1,7 +1,7 @@
 locals {
-  namespace            = "airflow-jobs"
-  secret               = "jobs-data"
-  service_account_name = "composer-service-account"
+  namespace                  = "airflow-jobs"
+  secret                     = "jobs-data"
+  kubernetes_service_account = "composer-service-account"
 
   # This regular expression corresponds to the Python package name specification
   # https://packaging.python.org/en/latest/specifications/name-normalization/

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -65,7 +65,7 @@ resource "google_composer_environment" "calitp-composer" {
         "POD_LOCATION"                                         = "us-west2",
         "POD_CLUSTER_NAME"                                     = data.terraform_remote_state.gke.outputs.google_container_cluster_airflow-jobs_name,
         "POD_SECRETS_NAMESPACE"                                = local.namespace,
-        "SERVICE_ACCOUNT_NAME"                                 = local.service_account_name,
+        "SERVICE_ACCOUNT_NAME"                                 = local.kubernetes_service_account,
         "CALITP_BUCKET__AGGREGATOR_SCRAPER"                    = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-aggregator-scraper_name}",
         "CALITP_BUCKET__AIRTABLE"                              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-airtable_name}",
         "CALITP_BUCKET__AMPLITUDE_BENEFITS_EVENTS"             = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-amplitude-benefits-events_name}",

--- a/iac/cal-itp-data-infra/composer/us/kubernetes.tf
+++ b/iac/cal-itp-data-infra/composer/us/kubernetes.tf
@@ -24,7 +24,6 @@ resource "kubernetes_secret" "composer" {
 
   data = {
     calitp-ckan-gtfs-schedule-key = data.kubernetes_secret.composer.data.calitp-ckan-gtfs-schedule-key
-    "service_account.json"        = base64decode(google_service_account_key.composer.private_key)
     transitland-api-key           = data.kubernetes_secret.composer.data.transitland-api-key
   }
 }
@@ -40,7 +39,7 @@ resource "kubernetes_priority_class" "dbt-high-priority" {
 
 resource "kubernetes_service_account" "composer-service-account" {
   metadata {
-    name      = local.service_account_name
+    name      = local.kubernetes_service_account
     namespace = local.namespace
     annotations = {
       "iam.gke.io/gcp-service-account" = data.terraform_remote_state.iam.outputs.google_service_account_composer-service-account_email

--- a/iac/cal-itp-data-infra/composer/us/variables.tf
+++ b/iac/cal-itp-data-infra/composer/us/variables.tf
@@ -1,7 +1,7 @@
 locals {
-  namespace            = "airflow-jobs"
-  secret               = "jobs-data"
-  service_account_name = "composer-service-account"
+  namespace                  = "airflow-jobs"
+  secret                     = "jobs-data"
+  kubernetes_service_account = "composer-service-account"
 
   # This regular expression corresponds to the Python package name specification
   # https://packaging.python.org/en/latest/specifications/name-normalization/

--- a/warehouse/profiles.yml
+++ b/warehouse/profiles.yml
@@ -26,10 +26,6 @@ calitp_warehouse:
             spark.executor.instances: "4" # dbt defaults to 2
             spark.executor.memory: 4g
             spark.dynamicAllocation.maxExecutors: "16"
-    prod_service_account:
-      <<: *prod
-      method: service-account
-      keyfile: "{{ env_var('BIGQUERY_KEYFILE_LOCATION', '/secrets/jobs-data/service-account.json') }}"
     staging:
       &staging
       <<: *prod
@@ -37,7 +33,3 @@ calitp_warehouse:
       database: cal-itp-data-infra-staging
       schema: staging
       gcs_bucket: test-calitp-dbt-python-models
-    staging_service_account:
-      <<: *staging
-      method: service-account
-      keyfile: "{{ env_var('BIGQUERY_KEYFILE_LOCATION', '/secrets/jobs-data/service-account.json') }}"


### PR DESCRIPTION
# Description

This PR proposes to stop passing service_account.json as a secret, and instead rely on GKE workload identity federation, just like we do for Github Actions.

Relates to #3780 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan` and test runs on staging

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Remove `service_acount.json`/`service-account.json` from the `jobs-data` Kubernetes secret.