### PR TITLE
Add public access to calitp-dbt-docs bucket

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -627,3 +627,9 @@ resource "google_storage_bucket_iam_member" "calitp_gtfs_public_web_access" {
   role   = "roles/storage.objectViewer"
   member = "allUsers"
 }
+
+resource "google_storage_bucket_iam_member" "calitp_dbt_docs_public_web_access" {
+  bucket = google_storage_bucket.calitp-dbt-docs.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}


### PR DESCRIPTION
# Description

This PR adds public access to `calitp-dbt-docs` bucket to allow `https://dbt-docs.dds.dot.ca.gov` to display the static site.

Currently is returning `Access denied`.

[#3855]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running `terraform plan` locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Access `https://dbt-docs.dds.dot.ca.gov` and see the docs site.