### PR TITLE
Only run the latest airtable loader DAG

### DIFF
--- a/airflow/dags/airtable_loader_v2/METADATA.yml
+++ b/airflow/dags/airtable_loader_v2/METADATA.yml
@@ -19,3 +19,4 @@ default_args:
     #sla: !timedelta 'hours: 2'
 wait_for_defaults:
     timeout: 3600
+latest_only: True


### PR DESCRIPTION
# Description

This modifies the `airtable_loader_v2` DAG to only run the latest instance.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Configured on staging

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Verify in the new composer environment