### PR TITLE
Add missing gcloud setup step from dbt Github Action

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -404,6 +404,9 @@ jobs:
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.SERVICE_ACCOUNT }}
 
+      - name: Setup GCloud utilities
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Push Airflow code to Composer
         run: gsutil -m rsync -d -c -r warehouse gs://${{ env.AIRFLOW_BUCKET }}/data/warehouse
 


### PR DESCRIPTION
# Description

This adds a missing setup step that is causing the dbt github action workflow to fail when synchronizing the dbt directory to GCS: https://github.com/cal-itp/data-infra/actions/runs/16034393514/job/45242743985

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Copied from other job steps

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor execution of deploy-dag.yml