### PR TITLE
Create static site configuration for reports.dds.dot.ca.gov

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2862,6 +2862,10 @@ output "google_storage_bucket_calitp-dbt-docs_name" {
   value = google_storage_bucket.calitp-dbt-docs.name
 }
 
+output "google_storage_bucket_calitp-reports_name" {
+  value = google_storage_bucket.calitp-reports.name
+}
+
 output "google_storage_bucket_calitp-aggregator-scraper_name" {
   value = google_storage_bucket.tfer--calitp-aggregator-scraper.name
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -2198,3 +2198,19 @@ resource "google_storage_bucket" "calitp-composer" {
     ignore_changes = [labels]
   }
 }
+
+resource "google_storage_bucket" "calitp-reports" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-reports"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+
+  website {
+    main_page_suffix = "index.html"
+  }
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -633,3 +633,9 @@ resource "google_storage_bucket_iam_member" "calitp-composer" {
   member = "projectEditor:cal-itp-data-infra"
   role   = "roles/storage.legacyBucketOwner"
 }
+
+resource "google_storage_bucket_iam_member" "calitp-reports" {
+  bucket = google_storage_bucket.calitp-reports.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}

--- a/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
@@ -35,3 +35,20 @@ resource "google_iam_workload_identity_pool_provider" "gtfs-calitp-org" {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
+
+resource "google_iam_workload_identity_pool_provider" "reports" {
+  workload_identity_pool_provider_id = "reports"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.reports_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}

--- a/iac/cal-itp-data-infra/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra/iam/us/variables.tf
@@ -2,4 +2,5 @@ locals {
   project_id                             = "1005246706141"
   data-infra_github_repository_name      = "cal-itp/data-infra"
   gtfs-calitp-org_github_repository_name = "cal-itp/gtfs.calitp.org"
+  reports_github_repository_name         = "cal-itp/reports"
 }


### PR DESCRIPTION
# Description

This adds a bucket and CDN for the reports.dds.dot.ca.gov static site.

Relates to #3890 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` github action