### PR TITLE
Remove single quotes from dbt docs content-type files

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -258,7 +258,7 @@ jobs:
           process_gcloudignore: false
           destination: ${{ env.DBT_DOCS_BUCKET }}
           headers: |-
-            content-type: 'application/json'
+            content-type: application/json
 
       - name: Upload index.html
         uses: google-github-actions/upload-cloud-storage@v2
@@ -269,7 +269,7 @@ jobs:
           process_gcloudignore: false
           destination: ${{ env.DBT_DOCS_BUCKET }}
           headers: |-
-            content-type: 'text/html; charset=utf-8'
+            content-type: text/html; charset=utf-8
 
       - name: Upload partial_parse.msgpack
         uses: google-github-actions/upload-cloud-storage@v2
@@ -280,7 +280,7 @@ jobs:
           process_gcloudignore: false
           destination: ${{ env.DBT_DOCS_BUCKET }}
           headers: |-
-            content-type: 'application/vnd.msgpack'
+            content-type: application/vnd.msgpack
 
   upload_docs:
     name: Upload to dbt artifacts bucket
@@ -332,7 +332,7 @@ jobs:
           process_gcloudignore: false
           destination: "${{ env.DBT_ARTIFACTS_BUCKET }}/catalog.json/dt=${{ steps.current-date.outputs.formattedTime }}/ts=${{ steps.current-time.outputs.formattedTime }}/"
           headers: |-
-            content-type: 'application/json'
+            content-type: application/json
 
       - name: Upload manifest.json
         uses: google-github-actions/upload-cloud-storage@v2
@@ -343,7 +343,7 @@ jobs:
           process_gcloudignore: false
           destination: "${{ env.DBT_ARTIFACTS_BUCKET }}/manifest.json/dt=${{ steps.current-date.outputs.formattedTime }}/ts=${{ steps.current-time.outputs.formattedTime }}/"
           headers: |-
-            content-type: 'application/json'
+            content-type: application/json
 
       - name: Upload partial_parse.msgpack
         uses: google-github-actions/upload-cloud-storage@v2
@@ -354,7 +354,7 @@ jobs:
           process_gcloudignore: false
           destination: "${{ env.DBT_ARTIFACTS_BUCKET }}/partial_parse.msgpack/dt=${{ steps.current-date.outputs.formattedTime }}/ts=${{ steps.current-time.outputs.formattedTime }}/"
           headers: |-
-            content-type: 'application/vnd.msgpack'
+            content-type: application/vnd.msgpack
 
       - name: Upload run_results.json
         uses: google-github-actions/upload-cloud-storage@v2
@@ -365,7 +365,7 @@ jobs:
           process_gcloudignore: false
           destination: "${{ env.DBT_ARTIFACTS_BUCKET }}/run_results.json/dt=${{ steps.current-date.outputs.formattedTime }}/ts=${{ steps.current-time.outputs.formattedTime }}/"
           headers: |-
-            content-type: 'application/json'
+            content-type: application/json
 
       - name: Upload index.html
         uses: google-github-actions/upload-cloud-storage@v2
@@ -376,7 +376,7 @@ jobs:
           process_gcloudignore: false
           destination: "${{ env.DBT_ARTIFACTS_BUCKET }}/index.html/dt=${{ steps.current-date.outputs.formattedTime }}/ts=${{ steps.current-time.outputs.formattedTime }}/"
           headers: |-
-            content-type: 'text/html; charset=utf-8'
+            content-type: text/html; charset=utf-8
 
   upload_to_composer:
     name: Upload to composer bucket


### PR DESCRIPTION
# Description

The [new dbt docs site](https://dbt-docs.dds.dot.ca.gov) is triggering a file download instead of displaying the index.htm page. This PR removes single quotes around the content-type so the site works correctly.

[#4028]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Removing quotes manually from content-type on files in the dbt-docs bucket made the site works.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check if all files in the bucket have the correct content-type without quotes.