### PR TITLE
Review permissions for Developers and Analysts to access Payment tables

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
@@ -44,8 +44,6 @@ resource "google_project_iam_custom_role" "calitp-dds-analyst" {
     "bigquery.reservations.list",
     "bigquery.routines.get",
     "bigquery.routines.list",
-    "bigquery.rowAccessPolicies.create",
-    "bigquery.rowAccessPolicies.getFilteredData",
     "bigquery.savedqueries.get",
     "bigquery.savedqueries.list",
     "bigquery.tables.get",

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -273,7 +273,6 @@ resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Ware
     "roles/viewer",
     "roles/bigquery.user",
     "roles/bigquery.dataEditor",
-    "roles/bigquery.filteredDataViewer",
     "roles/storage.objectUser",
     "roles/secretmanager.secretAccessor",
     "roles/secretmanager.viewer",

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -585,7 +585,6 @@ resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Ware
   for_each = toset([
     "roles/viewer",
     "roles/bigquery.user",
-    "roles/bigquery.filteredDataViewer",
     "roles/bigquery.metadataViewer",
     "roles/storage.objectUser",
     "roles/secretmanager.secretAccessor",

--- a/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
@@ -31,5 +31,5 @@ resource "google_service_account_iam_member" "custom_service_account" {
 resource "google_service_account_iam_member" "airflow-jobs_composer-service-account" {
   service_account_id = google_service_account.composer-service-account.id
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${local.project_id}.svc.id.goog[airflow-jobs/composer-service-account]"
+  member             = "serviceAccount:cal-itp-data-infra.svc.id.goog[airflow-jobs/composer-service-account]"
 }

--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -87,14 +87,16 @@ filter using (
 ) }};
 
 {{ create_row_access_policy(
-    principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'group:cal-itp@jarv.us',
-                  'group:mov-project-team@jarv.us',
-                  'domain:calitp.org',
-                 ]
+    principals = [
+        'serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com',
+        'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DDS_Cloud_Admins',
+        'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DOT_DDS_Data_Pipeline_and_Warehouse_Users'
+    ]
 ) }};
 -- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context
 {% endmacro %}
@@ -168,14 +170,16 @@ filter using (
 ) }};
 
 {{ create_row_access_policy(
-    principals = ['serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
-                  'group:cal-itp@jarv.us',
-                  'group:mov-project-team@jarv.us',
-                  'domain:calitp.org',
-                 ]
+    principals = [
+        'serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:bq-transform-svcacct@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com',
+        'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DDS_Cloud_Admins',
+        'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DOT_DDS_Data_Pipeline_and_Warehouse_Users'
+    ]
 ) }};
 -- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context
 {% endmacro %}


### PR DESCRIPTION
# Description

@charlie-costanzo is using the SSO account and he is not able to see payments data anymore.
This PR changes the configuration to use DDS custom roles and service accounts to give access to payment’s tables instead of through individual emails.

[#4010]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running `terraform plan` locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check with @charlie-costanzo if he can see payment's data again.