### PR TITLE
Add missing workload identity federation for reports

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
@@ -16,6 +16,12 @@ resource "google_service_account_iam_member" "github-actions-service-account_gtf
   role               = "roles/iam.workloadIdentityUser"
 }
 
+resource "google_service_account_iam_member" "github-actions-service-account_reports" {
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.reports_github_repository_name}"
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+}
+
 resource "google_service_account_iam_member" "github-actions--github-actions-services-accoun" {
   service_account_id = "projects/cal-itp-data-infra/serviceAccounts/github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com"
   role               = "roles/iam.workloadIdentityUser"


### PR DESCRIPTION
# Description

Adds missing configuration to enable authentication from https://github.com/cal-itp/reports

Relates to #3890 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`