### PR TITLE
Fix conversion error on `external_airtable.california_transit__ntd_agency_info`

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -491,12 +491,13 @@ jobs:
         run: poetry run python scripts/visualize.py ci-report --latest-dir='./target/latest/'
 
       - name: Archive CI report
+        working-directory: warehouse/target
         uses: actions/upload-artifact@v4
         with:
           name: ci-report
           path: |
-            target/*.md
-            target/*.png
+            *.md
+            *.png
 
       - name: Create GitHub comment
         working-directory: warehouse

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_ntd_agency_info.yml
@@ -13,3 +13,92 @@ hive_options:
   mode: AUTO
   require_partition_filter: false
   source_uri_prefix: "california_transit__ntd_agency_info/"
+schema_fields:
+  - name: id
+    type: STRING
+  - name: ntd_id
+    type: STRING
+  - name: legacy_ntd_id
+    type: STRING
+  - name: agency_name
+    type: STRING
+  - name: reporter_acronym
+    type: STRING
+  - name: doing_business_as
+    type: STRING
+  - name: reporter_status
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: reporting_module
+    type: STRING
+  - name: organization_type
+    type: STRING
+  - name: organizations_copy
+    type: STRING
+    mode: REPEATED
+  - name: organizations
+    type: STRING
+    mode: REPEATED
+  - name: reported_by_ntd_id
+    type: STRING
+  - name: reported_by_name
+    type: STRING
+  - name: subrecipient_type
+    type: STRING
+  - name: fy_end_date
+    type: STRING
+  - name: original_due_date
+    type: STRING
+  - name: address_line_1
+    type: STRING
+  - name: address_line_2
+    type: STRING
+  - name: p_o__box
+    type: FLOAT
+  - name: city
+    type: STRING
+  - name: state
+    type: STRING
+  - name: zip_code
+    type: FLOAT
+  - name: zip_code_ext
+    type: FLOAT
+  - name: region
+    type: FLOAT
+  - name: url
+    type: STRING
+  - name: fta_recipient_id
+    type: FLOAT
+  - name: duns_number
+    type: FLOAT
+  - name: service_area_sq_miles
+    type: FLOAT
+  - name: service_area_pop
+    type: FLOAT
+  - name: primary_uza
+    type: FLOAT
+  - name: uza_name
+    type: STRING
+  - name: tribal_area_name
+    type: STRING
+  - name: population
+    type: FLOAT
+  - name: density
+    type: FLOAT
+  - name: sq_miles
+    type: FLOAT
+  - name: voms_do
+    type: FLOAT
+  - name: voms_pt
+    type: FLOAT
+  - name: total_voms
+    type: FLOAT
+  - name: volunteer_drivers
+    type: FLOAT
+  - name: personal_vehicles
+    type: FLOAT
+  - name: dt
+    type: DATE
+  - name: ts
+    type: TIMESTAMP

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -107,7 +107,7 @@ x-airflow-common:
     CALITP_BUCKET__NTD_API_DATA_PRODUCTS: "gs://calitp-staging-ntd-api-products"
     CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__RAW: "gs://calitp-staging-ntd-xlsx-products-raw"
     CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN: "gs://calitp-staging-ntd-xlsx-products-clean"
-    CALITP_BUCKET__NTD_REPORT_VALIDATIONN: "gs://calitp-staging-ntd-report-validation"
+    CALITP_BUCKET__NTD_REPORT_VALIDATION: "gs://calitp-staging-ntd-report-validation"
     CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS: "gs://calitp-staging-state-geoportal-scrape"
 
     DBT_TARGET: staging_service_account

--- a/warehouse/models/mart/payments/indexes/payments_tests_daily_date_spine.sql
+++ b/warehouse/models/mart/payments/indexes/payments_tests_daily_date_spine.sql
@@ -1,12 +1,8 @@
 {{ config(materialized='ephemeral') }}
 
-{% set min_date_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific', max_records = 1) %}
+{% set min_date = modules.datetime.date.today() - modules.datetime.timedelta(days=1) %}
 
-{% set min_date = min_date_list[0] %}
-
-{% set max_date_list = dbt_utils.get_column_values(table=ref('fct_payments_rides_v2'), column='transaction_date_pacific', where='transaction_date_pacific IS NOT NULL', order_by = 'transaction_date_pacific DESC', max_records = 1) %}
-
-{% set max_date = max_date_list[0] %}
+{% set max_date = modules.datetime.date.today() %}
 
 WITH payments_rides AS (
     SELECT * FROM {{ ref('fct_payments_rides_v2') }}


### PR DESCRIPTION
# Description

This PR adds schema definition for `external_airtable.california_transit__ntd_agency_info` to specify column types.
Previous json files generated contain INTEGER fields with a decimal zero `.0`, so when the AUTO definition tries to create numeric columns as INTEGER it generates the conversion error `Could not convert value 'number_value: 	 "96120.0"' to integer`.

Also converted `original_due_date` and `fy_end_date` to STRING due to conversion error `400 Invalid date: '10/31/18' Field: original_due_date; Value: 10/31/18`

Resolves [#4021]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running external table DAG locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor DAGs to confirm the error were fixed.