### PR TITLE
Do not catchup old unzip/validate GTFS schedule data jobs

### DIFF
--- a/airflow/dags/sync_elavon/METADATA.yml
+++ b/airflow/dags/sync_elavon/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2023-03-22"
+    start_date: "2025-07-06"
     catchup: False
     email:
       - "soren.s@jarv.us"
@@ -14,3 +14,4 @@ default_args:
     concurrency: 50
 wait_for_defaults:
     timeout: 3600
+latest_only: True

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2021-04-15"
+    start_date: "2025-07-06"
     catchup: False
     email:
       - "hello@calitp.org"
@@ -16,5 +16,4 @@ default_args:
     retry_delay: !timedelta 'minutes: 2'
     concurrency: 50
     pool: schedule_unzip_pool
-    #sla: !timedelta 'hours: 2'
 latest_only: False

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
@@ -6,6 +6,7 @@ default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2021-04-15"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -43,10 +43,15 @@ resource "google_composer_environment" "calitp-staging-composer" {
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = "True"
+        email-email_backend                        = "airflow.utils.email.send_email_smtp"
+        email-from_email                           = "bot@calitp.org"
+        email-email_conn_id                        = "smtp_postmark"
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
-        webserver-reload_on_plugin_change          = "True"
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
+        smtp-smtp_starttls                         = true
+        smtp-smtp_mail_from                        = "bot@calitp.org"
+        webserver-reload_on_plugin_change          = "True"
       }
 
       pypi_packages = local.pypi_packages

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -45,8 +45,8 @@ resource "google_composer_environment" "calitp-composer" {
         core-dags_are_paused_at_creation           = "True"
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
-        webserver-reload_on_plugin_change          = "True"
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
+        webserver-reload_on_plugin_change          = "True"
       }
 
       pypi_packages = local.pypi_packages


### PR DESCRIPTION
# Description

When deploying new composer environments, and enabling the `unzip_and_validate_gtfs_schedule_hourly` DAG, currently jobs are enqueued all the way back to 2021. This makes it so that new environments don't enqueue those old jobs. This also configures SMTP settings for staging and production.

Related to #3765 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Validated on staging

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor production environment