### PR TITLE
Update DAG arguments to reduce runs when creating new composer environments

### DIFF
--- a/airflow/dags/copy_prod_archiver_configs_to_test/METADATA.yml
+++ b/airflow/dags/copy_prod_archiver_configs_to_test/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2024-03-24"
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "evan.siroky@dot.ca.gov"
       - "hunter.owens@dot.ca.gov"

--- a/airflow/dags/create_external_tables/METADATA.yml
+++ b/airflow/dags/create_external_tables/METADATA.yml
@@ -6,7 +6,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
+++ b/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/ntd_report_from_blackcat/METADATA.yml
+++ b/airflow/dags/ntd_report_from_blackcat/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2023-10-02"
+    start_date: "2025-07-06"
     catchup: False
     email:
       - "christian.suyat@dot.ca.gov"

--- a/airflow/dags/parse_and_validate_rt_v2/METADATA.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2022-09-14"
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/parse_elavon/METADATA.yml
+++ b/airflow/dags/parse_elavon/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2023-03-22"
+    start_date: "2025-07-06"
     catchup: False
     email:
       - "soren.s@jarv.us"

--- a/airflow/dags/parse_littlepay/METADATA.yml
+++ b/airflow/dags/parse_littlepay/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2023-03-12"
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/parse_littlepay_v3/METADATA.yml
+++ b/airflow/dags/parse_littlepay_v3/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2025-03-12"
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/publish_open_data/METADATA.yml
+++ b/airflow/dags/publish_open_data/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2022-09-12"
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "eric.dasmalchi@dot.ca.gov"
     email_on_failure: True

--- a/airflow/dags/scrape_feed_aggregators/METADATA.yml
+++ b/airflow/dags/scrape_feed_aggregators/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/scrape_state_geoportal/METADATA.yml
+++ b/airflow/dags/scrape_state_geoportal/METADATA.yml
@@ -5,8 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
+    start_date: "2025-07-06"
     catchup: False
-    start_date: "2024-09-15"
     email:
       - "hello@calitp.org"
     email_on_failure: True

--- a/airflow/dags/sync_littlepay/METADATA.yml
+++ b/airflow/dags/sync_littlepay/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/sync_littlepay_v3/METADATA.yml
+++ b/airflow/dags/sync_littlepay_v3/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/sync_ntd_data_api/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_api/METADATA.yml
@@ -5,8 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
+    start_date: "2025-07-06"
     catchup: False
-    start_date: "2024-09-15"
     email:
       - "hello@calitp.org"
     email_on_failure: True

--- a/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
@@ -5,8 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
+    start_date: "2025-07-06"
     catchup: False
-    start_date: "2024-09-15"
     email:
       - "hello@calitp.org"
     email_on_failure: True

--- a/airflow/dags/transform_warehouse/METADATA.yml
+++ b/airflow/dags/transform_warehouse/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2024-09-17"
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/transform_warehouse_full_refresh/METADATA.yml
+++ b/airflow/dags/transform_warehouse_full_refresh/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: !days_ago 1
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "hello@calitp.org"
     email_on_failure: False

--- a/airflow/dags/transform_warehouse_full_refresh_sunday/METADATA.yml
+++ b/airflow/dags/transform_warehouse_full_refresh_sunday/METADATA.yml
@@ -5,7 +5,8 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2024-03-24"
+    start_date: "2025-07-06"
+    catchup: False
     email:
       - "evan.siroky@dot.ca.gov"
       - "hunter.owens@dot.ca.gov"


### PR DESCRIPTION
# Description

Update DAG arguments `start_date` to a recent date and `catchup` to `False` reduce runs when creating new composer environments.

Part of testing and updating #3765

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Checked Staging start date on DAG details.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
