### PR TITLE
Bump staging composer to 2.8.4

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -36,7 +36,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
     environment_size = "ENVIRONMENT_SIZE_SMALL"
 
     software_config {
-      image_version = "composer-2.8.3-airflow-2.6.3"
+      image_version = "composer-2.8.4-airflow-2.6.3"
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 2


### PR DESCRIPTION
# Description

This is the next incremental update to the Composer image, composer-2.8.4-airflow-2.6.3

Related to #3059 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

terraform plan

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
Monitor terraform apply