### PR TITLE
Bump production composer instance sizing

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -26,8 +26,8 @@ resource "google_composer_environment" "calitp-composer" {
       }
       worker {
         cpu        = 2
-        memory_gb  = 4
-        storage_gb = 1
+        memory_gb  = 8
+        storage_gb = 2
         min_count  = 1
         max_count  = 6
       }
@@ -39,7 +39,7 @@ resource "google_composer_environment" "calitp-composer" {
       image_version = "composer-2.8.3-airflow-2.6.3"
 
       airflow_config_overrides = {
-        celery-worker_concurrency                  = 1
+        celery-worker_concurrency                  = 4
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = "True"


### PR DESCRIPTION
# Description

After running all workloads on the new production cluster, it appears that more and higher-powered worker instances are required to run tasks.

Related to #3765

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Converged and ran overnight, production console is now green 

<img width="616" alt="Screenshot 2025-07-09 at 09 54 16" src="https://github.com/user-attachments/assets/b30c3d6e-087d-44ce-87fe-5ab7e0f18a32" />

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`