### PR TITLE
Bump staging composer image to composer-2.8.6-airflow-2.6.3

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -36,7 +36,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
     environment_size = "ENVIRONMENT_SIZE_SMALL"
 
     software_config {
-      image_version = "composer-2.8.4-airflow-2.6.3"
+      image_version = "composer-2.8.6-airflow-2.6.3"
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 2


### PR DESCRIPTION
# Description

This advances the staging composer image further after the following error message:

```
Invalid image version: 'composer-2.8.4-airflow-2.6.3' derived based on your input. Currently supported environment update image versions are: [composer-3-airflow-2.10.5, composer-3-airflow-2.9.3, composer-3-airflow-2.10.2, composer-3-airflow-2.7.3, composer-2.13.6-airflow-2.10.5, composer-2.13.6-airflow-2.9.3, composer-2.13.5-airflow-2.10.5, composer-2.13.5-airflow-2.9.3, composer-2.13.4-airflow-2.10.5, composer-2.13.4-airflow-2.9.3, composer-2.13.3-airflow-2.10.5, composer-2.13.3-airflow-2.9.3, composer-2.13.1-airflow-2.10.5, composer-2.13.1-airflow-2.9.3, composer-2.12.1-airflow-2.10.5, composer-2.12.1-airflow-2.10.2, composer-2.12.1-airflow-2.9.3, composer-2.10.2-airflow-2.10.2, composer-2.10.2-airflow-2.9.3, composer-2.10.1-airflow-2.10.2, composer-2.10.1-airflow-2.9.3, composer-2.9.7-airflow-2.9.3, composer-2.9.7-airflow-2.7.3, composer-2.8.6-airflow-2.9.1, composer-2.8.6-airflow-2.7.3, composer-2.8.6-airflow-2.6.3, composer-2.8.3-airflow-2.7.3, composer-2.8.3-airflow-2.6.3, composer-2.6.5-airflow-2.7.3, composer-2.6.5-airflow-2.6.3, composer-2.6.5-airflow-2.5.3, composer-2.6.0-airflow-2.6.3, composer-2.6.0-airflow-2.5.3, composer-2.3.5-airflow-2.5.3, composer-2.3.5-airflow-2.4.3, composer-2.1.11-airflow-2.4.3, composer-2.1.11-airflow-2.3.4, composer-2.1.8-airflow-2.4.3, composer-2.1.8-airflow-2.3.4, composer-2.1.8-airflow-2.2.5, composer-2.1.2-airflow-2.3.4, composer-2.1.2-airflow-2.2.5, composer-2.0.19-airflow-2.2.5, composer-2.0.19-airflow-2.1.4, composer-2.0.0-preview.0-airflow-2.1.2, composer-2.0.0-preview.0-airflow-2.1.1, composer-2.0.0-preview.0-airflow-2.0.2]., badRequest
```

Related to #3765 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`