### PR TITLE
Create Kuba sync and external table

### DIFF
--- a/airflow/.test.env
+++ b/airflow/.test.env
@@ -22,6 +22,7 @@ CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED=gs://calitp-staging-pytest
 CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED_HOURLY=gs://calitp-staging-pytest
 CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION=gs://calitp-staging-pytest
 CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY=gs://calitp-staging-pytest
+CALITP_BUCKET__KUBA=gs://calitp-staging-pytest
 CALITP_BUCKET__LITTLEPAY_PARSED=gs://calitp-staging-pytest
 CALITP_BUCKET__LITTLEPAY_PARSED_V3=gs://calitp-staging-pytest
 CALITP_BUCKET__LITTLEPAY_RAW=gs://calitp-staging-pytest

--- a/airflow/dags/create_external_tables/kuba/device_properties.yml
+++ b/airflow/dags/create_external_tables/kuba/device_properties.yml
@@ -1,0 +1,196 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__KUBA') }}"
+source_objects:
+  - "device_properties/*.jsonl"
+destination_project_dataset_table: "kuba.device_properties"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "device_properties/{dt:DATE}/{ts:TIMESTAMP}/"
+schema_fields:
+  - name: device
+    type: RECORD
+    fields:
+      - name: fo_device_logical_id
+        type: STRING
+      - name: fo_device_type
+        type: STRING
+      - name: fo_device_type_model
+        type: STRING
+      - name: fo_device_serial_number
+        type: STRING
+      - name: fo_device_description
+        type: STRING
+      - name: fo_device_location_id
+        type: STRING
+      - name: fo_device_location
+        type: STRING
+      - name: fo_device_last_connection
+        type: STRING
+  - name: device_replicator_info
+    type: RECORD
+    fields:
+      - name: software_version
+        type: STRING
+      - name: software_last_connection
+        type: STRING
+      - name: cd_version
+        type: STRING
+      - name: cd_last_connection
+        type: STRING
+      - name: dataset_version
+        type: STRING
+      - name: dataset_last_connection
+        type: STRING
+      - name: denylist_version
+        type: STRING
+      - name: denylist_last_connection
+        type: STRING
+      - name: acceptlist_version
+        type: STRING
+      - name: acceptlist_last_connection
+        type: STRING
+      - name: binlist_version
+        type: STRING
+      - name: binlist_last_connection
+        type: STRING
+      - name: asset_last_connection
+        type: STRING
+      - name: monitoring_last_connection
+        type: STRING
+      - name: ud_last_transaction_time
+        type: STRING
+  - name: device_monitor_info
+    type: RECORD
+    fields:
+      - name: application__isdisabled
+        type: STRING
+      - name: application__isinservice
+        type: STRING
+      - name: application__servicestatus
+        type: RECORD
+        fields:
+          - name: Rows
+            type: RECORD
+            mode: REPEATED
+            fields:
+              - name: Id
+                type: STRING
+      - name: gps__position
+        type: RECORD
+        fields:
+          - name: altitude
+            type: STRING
+          - name: dateTime
+            type: STRING
+          - name: direction
+            type: STRING
+          - name: gpsFix
+            type: STRING
+          - name: groundSpeed
+            type: STRING
+          - name: hasAltitude
+            type: STRING
+          - name: hasDateTime
+            type: STRING
+          - name: hasDirection
+            type: STRING
+          - name: hasGpsFix
+            type: STRING
+          - name: hasGroundSpeed
+            type: STRING
+          - name: hasLatitude
+            type: STRING
+          - name: hasLongitude
+            type: STRING
+          - name: latitude
+            type: STRING
+          - name: longitude
+            type: STRING
+          - name: numberSatelites
+            type: STRING
+          - name: properties
+            type: RECORD
+            fields:
+              - name: Id
+                type: STRING
+      - name: location__location__servicestatus
+        type: STRING
+      - name: location__location__source
+        type: STRING
+      - name: os__uptime
+        type: STRING
+      - name: smartmedium__emv3000__batterylevel
+        type: STRING
+      - name: ngwifi__gps__apistatus
+        type: RECORD
+        fields:
+          - name: status
+            type: STRING
+      - name: ngwifi__gps__position
+        type: RECORD
+        fields:
+          - name: altitude
+            type: STRING
+          - name: fix
+            type: STRING
+          - name: heading
+            type: STRING
+          - name: latitude
+            type: STRING
+          - name: longitude
+            type: STRING
+          - name: speed
+            type: STRING
+          - name: success
+            type: STRING
+          - name: timestamp
+            type: STRING
+      - name: location__location__info
+        type: RECORD
+        fields:
+          - name: dataid
+            type: STRING
+          - name: dataversion
+            type: STRING
+          - name: locationProviderSource
+            type: STRING
+          - name: type
+            type: STRING
+          - name: properties
+            type: RECORD
+            fields:
+              - name: Id
+                type: STRING
+          - name: current
+            type: RECORD
+            fields:
+              - name: zoneinfo
+                type: RECORD
+                fields:
+                  - name: name
+                    type: STRING
+                  - name: reference
+                    type: STRING
+              - name: stopinfo
+                type: RECORD
+                fields:
+                  - name: abbreviation
+                    type: STRING
+                  - name: farematrixreference
+                    type: STRING
+                  - name: name
+                    type: STRING
+                  - name: reference
+                    type: STRING
+                  - name: shortname
+                    type: STRING
+                  - name: type
+                    type: STRING
+              - name: properties
+                type: RECORD
+                fields:
+                  - name: Id
+                    type: STRING

--- a/airflow/dags/create_external_tables/kuba/device_properties.yml
+++ b/airflow/dags/create_external_tables/kuba/device_properties.yml
@@ -1,8 +1,12 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__KUBA') }}"
+post_hook: |
+  SELECT *
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_kuba.device_properties
+  LIMIT 1;
 source_objects:
-  - "device_properties/*.jsonl"
-destination_project_dataset_table: "kuba.device_properties"
+  - "device_properties/*.jsonl.gz"
+destination_project_dataset_table: "external_kuba.device_properties"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:

--- a/airflow/dags/sync_kuba/METADATA.yml
+++ b/airflow/dags/sync_kuba/METADATA.yml
@@ -1,0 +1,17 @@
+description: "Capture the Kuba API to GCS"
+schedule_interval: "0 0 * * *"
+tags:
+  - all_gusty_features
+default_args:
+    owner: airflow
+    depends_on_past: False
+    start_date: "2025-07-14"
+    catchup: False
+    email:
+      - "hello@calitp.org"
+    email_on_failure: True
+    pool: default_pool
+    concurrency: 50
+wait_for_defaults:
+    timeout: 3600
+latest_only: True

--- a/airflow/dags/sync_kuba/README.md
+++ b/airflow/dags/sync_kuba/README.md
@@ -1,0 +1,5 @@
+# `sync_kuba`
+
+Type: [Now / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
+
+This DAG orchestrates the syncing of raw Kuba data.

--- a/airflow/dags/sync_kuba/device_monitoring.yml
+++ b/airflow/dags/sync_kuba/device_monitoring.yml
@@ -1,0 +1,7 @@
+operator: operators.KubaToGCS
+
+product: device_properties
+endpoint: monitoring/deviceproperties/v1/ForLocations/all
+parameters:
+    location_type: 1
+bucket: "{{ env_var('CALITP_BUCKET__KUBA') }}"

--- a/airflow/dags/sync_kuba/device_monitoring.yml
+++ b/airflow/dags/sync_kuba/device_monitoring.yml
@@ -1,4 +1,4 @@
-operator: operators.KubaToGCS
+operator: operators.KubaToGCSOperator
 
 product: device_properties
 endpoint: monitoring/deviceproperties/v1/ForLocations/all

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -109,6 +109,7 @@ x-airflow-common:
     CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN: "gs://calitp-staging-ntd-xlsx-products-clean"
     CALITP_BUCKET__NTD_REPORT_VALIDATION: "gs://calitp-staging-ntd-report-validation"
     CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS: "gs://calitp-staging-state-geoportal-scrape"
+    CALITP_BUCKET__KUBA: "gs://calitp-staging-kuba"
 
     DBT_TARGET: staging_service_account
 

--- a/airflow/plugins/hooks/kuba_hook.py
+++ b/airflow/plugins/hooks/kuba_hook.py
@@ -1,0 +1,44 @@
+from airflow.hooks.base import BaseHook
+from airflow.hooks.http_hook import HttpHook
+
+
+class KubaHook(BaseHook):
+    _http_conn_id: str
+    _method: str
+    _session_id: str
+
+    def __init__(self, method: str = "GET", http_conn_id: str = "kuba_default"):
+        super().__init__()
+        self._http_conn_id: str = http_conn_id
+        self._method: str = method
+        self._session_id: str = None
+        self._get_connection()
+
+    def _get_connection(self):
+        conn = self.get_connection(self._http_conn_id)
+        data = {
+            "UserName": conn.login,
+            "Password": conn.password,
+            "OperatorIdentifier": int(conn.schema)
+        }
+        headers = {"Content-Type": "application/json"}
+        kuba_api = HttpHook(method="POST", http_conn_id=self._http_conn_id)
+        authenticate_path = "monitoring/authenticate/v1"
+        result = kuba_api.run(endpoint=authenticate_path, headers=headers, json=data).json()
+        assert result["Error"] == None
+        self._session_id = result["SessionId"]
+
+    def get_headers(self):
+        return {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Cookie": f"session-id={self._session_id}"
+        }
+
+    def run(self, endpoint, data=None, headers=None):
+        if headers is None:
+            headers = self.get_headers()
+
+        kuba_api = HttpHook(method=self._method, http_conn_id=self._http_conn_id)
+        response = kuba_api.run(endpoint=endpoint, headers=headers, data=data)
+        return response.json()

--- a/airflow/plugins/hooks/kuba_hook.py
+++ b/airflow/plugins/hooks/kuba_hook.py
@@ -19,20 +19,22 @@ class KubaHook(BaseHook):
         data = {
             "UserName": conn.login,
             "Password": conn.password,
-            "OperatorIdentifier": int(conn.schema)
+            "OperatorIdentifier": int(conn.schema),
         }
         headers = {"Content-Type": "application/json"}
         kuba_api = HttpHook(method="POST", http_conn_id=self._http_conn_id)
         authenticate_path = "monitoring/authenticate/v1"
-        result = kuba_api.run(endpoint=authenticate_path, headers=headers, json=data).json()
-        assert result["Error"] == None
+        result = kuba_api.run(
+            endpoint=authenticate_path, headers=headers, json=data
+        ).json()
+        assert result["Error"] is None
         self._session_id = result["SessionId"]
 
     def get_headers(self):
         return {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "Cookie": f"session-id={self._session_id}"
+            "Cookie": f"session-id={self._session_id}",
         }
 
     def run(self, endpoint, data=None, headers=None):

--- a/airflow/plugins/operators/__init__.py
+++ b/airflow/plugins/operators/__init__.py
@@ -8,6 +8,7 @@ from operators.blackcat_to_gcs_operator import BlackCatToGCSOperator
 from operators.external_table import ExternalTable
 from operators.gtfs_csv_to_jsonl import GtfsGcsToJsonlOperator
 from operators.gtfs_csv_to_jsonl_hourly import GtfsGcsToJsonlOperatorHourly
+from operators.kuba_to_gcs_operator import KubaToGCSOperator
 from operators.littlepay_raw_sync import LittlepayRawSync
 from operators.littlepay_raw_sync_feed_v3 import LittlepayRawSyncV3
 from operators.littlepay_to_jsonl import LittlepayToJSONL

--- a/airflow/plugins/operators/kuba_to_gcs_operator.py
+++ b/airflow/plugins/operators/kuba_to_gcs_operator.py
@@ -1,0 +1,121 @@
+import json
+import os
+from datetime import datetime
+from typing import Sequence
+
+from src.bigquery_cleaner import BigQueryKeyCleaner, BigQueryValueCleaner
+from hooks.kuba_hook import KubaHook
+
+from airflow.models import BaseOperator, DagRun
+from airflow.models.taskinstance import Context
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+
+class KubaRowCleaner:
+    row: dict
+
+    def __init__(self, row: dict):
+        self.row = row
+
+    def clean(self) -> dict:
+        columns = {}
+        for key, value in self.row.items():
+            if isinstance(value, dict):
+                result = {}
+                for k, v in value.items():
+                    if "::" in k and "{" in v:
+                        result[BigQueryKeyCleaner(k).clean()] = json.loads(v.replace("\\n", ""))
+                    else:
+                        result[BigQueryKeyCleaner(k).clean()] = BigQueryValueCleaner(
+                            v
+                        ).clean()
+                columns[BigQueryKeyCleaner(key).clean()] = result
+            else:
+                columns[BigQueryKeyCleaner(key).clean()] = BigQueryValueCleaner(
+                    value
+                ).clean()
+        return columns
+
+
+class KubaCleaner:
+    rows: list
+
+    def __init__(self, rows: list):
+        self.rows = rows
+
+    def clean(self) -> list:
+        return [KubaRowCleaner(row).clean() for row in self.rows]
+
+
+class KubaObjectPath:
+    def __init__(self, product: str) -> None:
+        self.product = product
+
+    def resolve(self, logical_date: datetime) -> str:
+        return os.path.join(
+            self.product,
+            f"dt={logical_date.date().isoformat()}",
+            f"ts={logical_date.isoformat()}",
+            f"results.jsonl.gz",
+        )
+
+
+class KubaToGCSOperator(BaseOperator):
+    template_fields: Sequence[str] = (
+        "bucket",
+        "endpoint",
+        "product",
+        "parameters",
+        "http_conn_id",
+        "gcp_conn_id",
+    )
+
+    def __init__(
+        self,
+        bucket: str,
+        endpoint: str,
+        parameters: dict,
+        product: str,
+        http_conn_id: str = "http_kuba",
+        gcp_conn_id: str = "google_cloud_default",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+
+        self.bucket = bucket
+        self.endpoint = endpoint
+        self.parameters = parameters
+        self.product = product
+        self.http_conn_id = http_conn_id
+        self.gcp_conn_id = gcp_conn_id
+
+    def bucket_name(self) -> str:
+        return self.bucket.replace("gs://", "")
+
+    def object_path(self) -> KubaObjectPath:
+        return KubaObjectPath(product=self.product)
+
+    def gcs_hook(self) -> GCSHook:
+        return GCSHook(gcp_conn_id=self.gcp_conn_id)
+
+    def kuba_hook(self) -> KubaHook:
+        return KubaHook(method="GET", http_conn_id=self.http_conn_id)
+
+    def cleaned_rows(self) -> list:
+        result = self.kuba_hook().run(endpoint=self.endpoint, data=self.parameters)
+        return [
+            json.dumps(x, separators=(",", ":"))
+            for x in KubaCleaner(result["List"]).clean()
+        ]
+
+    def execute(self, context: Context) -> str:
+        dag_run: DagRun = context["dag_run"]
+        object_name: str = self.object_path().resolve(dag_run.logical_date)
+        self.gcs_hook().upload(
+            bucket_name=self.bucket_name(),
+            object_name=object_name,
+            data="\n".join(self.cleaned_rows()),
+            mime_type="application/jsonl",
+            gzip=True,
+        )
+        return os.path.join(self.bucket, object_name)

--- a/airflow/plugins/operators/kuba_to_gcs_operator.py
+++ b/airflow/plugins/operators/kuba_to_gcs_operator.py
@@ -3,8 +3,8 @@ import os
 from datetime import datetime
 from typing import Sequence
 
-from src.bigquery_cleaner import BigQueryKeyCleaner, BigQueryValueCleaner
 from hooks.kuba_hook import KubaHook
+from src.bigquery_cleaner import BigQueryKeyCleaner, BigQueryValueCleaner
 
 from airflow.models import BaseOperator, DagRun
 from airflow.models.taskinstance import Context
@@ -24,7 +24,9 @@ class KubaRowCleaner:
                 result = {}
                 for k, v in value.items():
                     if "::" in k and "{" in v:
-                        result[BigQueryKeyCleaner(k).clean()] = json.loads(v.replace("\\n", ""))
+                        result[BigQueryKeyCleaner(k).clean()] = json.loads(
+                            v.replace("\\n", "")
+                        )
                     else:
                         result[BigQueryKeyCleaner(k).clean()] = BigQueryValueCleaner(
                             v
@@ -56,7 +58,7 @@ class KubaObjectPath:
             self.product,
             f"dt={logical_date.date().isoformat()}",
             f"ts={logical_date.isoformat()}",
-            f"results.jsonl.gz",
+            "results.jsonl.gz",
         )
 
 

--- a/airflow/plugins/src/bigquery_cleaner.py
+++ b/airflow/plugins/src/bigquery_cleaner.py
@@ -18,7 +18,10 @@ class BigQueryValueCleaner:
         result = self.value
         if isinstance(result, dict):
             for k, v in result.items():
-                result[k] = BigQueryValueCleaner(v).clean()
+                if isinstance(v, dict):
+                    result[k] = BigQueryRowCleaner(v).clean()
+                else:
+                    result[k] = BigQueryValueCleaner(v).clean()
         elif isinstance(result, list):
             types = set(type(entry) for entry in result if entry is not None)
             if not types:

--- a/airflow/tests/conftest.py
+++ b/airflow/tests/conftest.py
@@ -87,10 +87,10 @@ def clean_connections(session, conn_id: str):
 @pytest.fixture(scope="session", autouse=True)
 def setup_module():
     session = Session()
-    clean_connections(session, "kuba_default")
+    clean_connections(session, "http_kuba")
     add_connection(
         session,
-        conn_id="kuba_default",
+        conn_id="http_kuba",
         conn_type="http",
         host=os.environ.get("KUBA_HOST"),
         login=os.environ.get("KUBA_LOGIN"),

--- a/airflow/tests/hooks/cassettes/test_kuba_hook/TestKubaHook.test_run.yaml
+++ b/airflow/tests/hooks/cassettes/test_kuba_hook/TestKubaHook.test_run.yaml
@@ -1,0 +1,227 @@
+interactions:
+- request:
+    body: '{"UserName": "monitoringAPI", "Password": "MST_@87_987", "OperatorIdentifier":
+      66}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://proxima-demo.pptexcellence.com/monitoring/authenticate/v1
+  response:
+    body:
+      string: '{"Error":null,"UserId":"monitoringAPI","FirstName":"device","LastName":"monitoringAPI","SessionId":"03e113a3-9ece-47e8-a379-c2e1aba66d33"}'
+    headers:
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Jul 2025 15:45:52 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Set-Cookie:
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=proxima-demo.pptexcellence.com; path=/
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=localhost; path=/
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=proxima-demo.pptexcellence.com; path=/
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=proxima-eu.pptexcellence.com; path=/
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=proxima-gapte.pptexcellence.com; path=/
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=proxima-denmark.pptexcellence.com; path=/
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=pptexcellence.com; path=/
+      - session-id=03e113a3-9ece-47e8-a379-c2e1aba66d33; expires=Fri, 11 Jul 2025
+        20:45:52 GMT; domain=; path=/
+      X-Powered-By:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      cookie:
+      - FILTERED
+    method: GET
+    uri: https://proxima-demo.pptexcellence.com/monitoring/deviceproperties/v1/ForLocations/all?location_type=1
+  response:
+    body:
+      string: '{"Response_date_time":"2025-07-11T15:45:53.9371965Z","List":[{"Device":{"Fo_device_logical_id":"66001","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"604","Fo_device_location":"604","Fo_device_last_connection":"2025-03-20T13:46:52.4000000Z"},"Device_replicator_info":{"Software_version":"1.2.3.4","Software_last_connection":null,"Cd_version":"7","Cd_last_connection":"2025-03-20T12:55:50.3500000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":"2025-03-20T13:46:52.4000000Z"},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66002","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"635","Fo_device_location":"635","Fo_device_last_connection":"2025-03-20T13:47:31.7230000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:41:28.0370000Z","Cd_version":"333","Cd_last_connection":"2025-03-20T12:19:23.2300000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":"2025-03-20T13:47:31.7230000Z"},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66003","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"636","Fo_device_location":"636","Fo_device_last_connection":"2025-03-20T12:41:10.1870000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:41:10.1870000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66004","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"637","Fo_device_location":"637","Fo_device_last_connection":"2025-03-20T12:40:57.4470000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:40:57.4470000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66005","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"638","Fo_device_location":"638","Fo_device_last_connection":"2025-03-20T12:40:39.0870000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:40:39.0870000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66006","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"639","Fo_device_location":"639","Fo_device_last_connection":"2025-03-20T12:40:23.9370000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:40:23.9370000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66007","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"639","Fo_device_location":"639","Fo_device_last_connection":"2025-03-20T12:53:42.7270000Z"},"Device_replicator_info":{"Software_version":"5.16.48.6283","Software_last_connection":"2025-03-20T12:39:40.6170000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":"2025-03-20T12:53:42.7270000Z","Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66008","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"640","Fo_device_location":"640","Fo_device_last_connection":"2025-03-20T12:51:25.5330000Z"},"Device_replicator_info":{"Software_version":"5.16.48.6283","Software_last_connection":"2025-03-20T12:39:30.4730000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":"2025-03-20T12:51:25.5300000Z","Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66009","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"641","Fo_device_location":"641","Fo_device_last_connection":"2025-03-20T12:50:58.2230000Z"},"Device_replicator_info":{"Software_version":"5.16.48.6283","Software_last_connection":"2025-03-20T12:39:18.0100000Z","Cd_version":"333","Cd_last_connection":"2025-03-20T12:20:09.8670000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":"2025-03-20T12:50:58.2230000Z","Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66010","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"642","Fo_device_location":"642","Fo_device_last_connection":null},"Device_replicator_info":{"Software_version":"0","Software_last_connection":null,"Cd_version":"0","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{}}]}'
+    headers:
+      Content-Length:
+      - '23814'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Jul 2025 15:45:53 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/airflow/tests/hooks/test_kuba_hook.py
+++ b/airflow/tests/hooks/test_kuba_hook.py
@@ -9,10 +9,16 @@ class TestKubaHook:
 
     @pytest.mark.vcr()
     def test_run(self, hook: KubaHook):
-        result = hook.run(endpoint="monitoring/deviceproperties/v1/ForLocations/all?location_type=1")
+        result = hook.run(
+            endpoint="monitoring/deviceproperties/v1/ForLocations/all?location_type=1"
+        )
         assert result["Response_date_time"]
         assert len(result["List"]) > 0
-        assert list(result["List"][0].keys()) == ["Device", "Device_replicator_info", "Device_monitor_info"]
+        assert list(result["List"][0].keys()) == [
+            "Device",
+            "Device_replicator_info",
+            "Device_monitor_info",
+        ]
         assert list(result["List"][0]["Device"].keys()) == [
             "Fo_device_logical_id",
             "Fo_device_type",
@@ -21,7 +27,7 @@ class TestKubaHook:
             "Fo_device_description",
             "Fo_device_location_id",
             "Fo_device_location",
-            "Fo_device_last_connection"
+            "Fo_device_last_connection",
         ]
         assert result["List"][0]["Device"]["Fo_device_logical_id"]
         assert result["List"][0]["Device"]["Fo_device_type"] == "Validator"

--- a/airflow/tests/hooks/test_kuba_hook.py
+++ b/airflow/tests/hooks/test_kuba_hook.py
@@ -1,0 +1,27 @@
+import pytest
+from hooks.kuba_hook import KubaHook
+
+
+class TestKubaHook:
+    @pytest.fixture
+    def hook(self) -> KubaHook:
+        return KubaHook(method="GET", http_conn_id="http_kuba")
+
+    @pytest.mark.vcr()
+    def test_run(self, hook: KubaHook):
+        result = hook.run(endpoint="monitoring/deviceproperties/v1/ForLocations/all?location_type=1")
+        assert result["Response_date_time"]
+        assert len(result["List"]) > 0
+        assert list(result["List"][0].keys()) == ["Device", "Device_replicator_info", "Device_monitor_info"]
+        assert list(result["List"][0]["Device"].keys()) == [
+            "Fo_device_logical_id",
+            "Fo_device_type",
+            "Fo_device_type_model",
+            "Fo_device_serial_number",
+            "Fo_device_description",
+            "Fo_device_location_id",
+            "Fo_device_location",
+            "Fo_device_last_connection"
+        ]
+        assert result["List"][0]["Device"]["Fo_device_logical_id"]
+        assert result["List"][0]["Device"]["Fo_device_type"] == "Validator"

--- a/airflow/tests/operators/cassettes/test_kuba_to_gcs_operator/TestKubaToGCSOperator.test_execute.yaml
+++ b/airflow/tests/operators/cassettes/test_kuba_to_gcs_operator/TestKubaToGCSOperator.test_execute.yaml
@@ -1,0 +1,414 @@
+interactions:
+- request:
+    body: '{"UserName": "monitoringAPI", "Password": "MST_@87_987", "OperatorIdentifier":
+      66}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://proxima-demo.pptexcellence.com/monitoring/authenticate/v1
+  response:
+    body:
+      string: '{"Error":null,"UserId":"monitoringAPI","FirstName":"device","LastName":"monitoringAPI","SessionId":"4b04abfd-5699-4827-bffd-b3eab0c4acdf"}'
+    headers:
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 14 Jul 2025 02:49:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      Set-Cookie:
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=proxima-demo.pptexcellence.com; path=/
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=localhost; path=/
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=proxima-demo.pptexcellence.com; path=/
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=proxima-eu.pptexcellence.com; path=/
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=proxima-gapte.pptexcellence.com; path=/
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=proxima-denmark.pptexcellence.com; path=/
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=pptexcellence.com; path=/
+      - session-id=4b04abfd-5699-4827-bffd-b3eab0c4acdf; expires=Mon, 14 Jul 2025
+        07:49:02 GMT; domain=; path=/
+      X-Powered-By:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      cookie:
+      - FILTERED
+    method: GET
+    uri: https://proxima-demo.pptexcellence.com/monitoring/deviceproperties/v1/ForLocations/all?location_type=1
+  response:
+    body:
+      string: '{"Response_date_time":"2025-07-14T02:49:03.3165582Z","List":[{"Device":{"Fo_device_logical_id":"66001","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"604","Fo_device_location":"604","Fo_device_last_connection":"2025-03-20T13:46:52.4000000Z"},"Device_replicator_info":{"Software_version":"1.2.3.4","Software_last_connection":null,"Cd_version":"7","Cd_last_connection":"2025-03-20T12:55:50.3500000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":"2025-03-20T13:46:52.4000000Z"},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66002","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"635","Fo_device_location":"635","Fo_device_last_connection":"2025-03-20T13:47:31.7230000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:41:28.0370000Z","Cd_version":"333","Cd_last_connection":"2025-03-20T12:19:23.2300000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":"2025-03-20T13:47:31.7230000Z"},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66003","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"636","Fo_device_location":"636","Fo_device_last_connection":"2025-03-20T12:41:10.1870000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:41:10.1870000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66004","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"637","Fo_device_location":"637","Fo_device_last_connection":"2025-03-20T12:40:57.4470000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:40:57.4470000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66005","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"638","Fo_device_location":"638","Fo_device_last_connection":"2025-03-20T12:40:39.0870000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:40:39.0870000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66006","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"639","Fo_device_location":"639","Fo_device_last_connection":"2025-03-20T12:40:23.9370000Z"},"Device_replicator_info":{"Software_version":"5.12.70.5349","Software_last_connection":"2025-03-20T12:40:23.9370000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66007","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"639","Fo_device_location":"639","Fo_device_last_connection":"2025-03-20T12:53:42.7270000Z"},"Device_replicator_info":{"Software_version":"5.16.48.6283","Software_last_connection":"2025-03-20T12:39:40.6170000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":"2025-03-20T12:53:42.7270000Z","Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66008","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"640","Fo_device_location":"640","Fo_device_last_connection":"2025-03-20T12:51:25.5330000Z"},"Device_replicator_info":{"Software_version":"5.16.48.6283","Software_last_connection":"2025-03-20T12:39:30.4730000Z","Cd_version":"333","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":"2025-03-20T12:51:25.5300000Z","Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66009","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"641","Fo_device_location":"641","Fo_device_last_connection":"2025-03-20T12:50:58.2230000Z"},"Device_replicator_info":{"Software_version":"5.16.48.6283","Software_last_connection":"2025-03-20T12:39:18.0100000Z","Cd_version":"333","Cd_last_connection":"2025-03-20T12:20:09.8670000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":"2025-03-20T12:50:58.2230000Z","Ud_last_transaction_time":null},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"false","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+        31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
+        10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
+        false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
+        true,\\n    \"hasLongitude\": true,\\n    \"latitude\": 36.58474333333334,\\n    \"longitude\":
+        -121.82932299999999,\\n    \"numberSatelites\": 5,\\n    \"properties\": {\\n    }\\n}\\n","location::location::info":"{\\n    \"current\":
+        {\\n        \"properties\": {\\n        },\\n        \"stopinfo\": {\\n            \"abbreviation\":
+        \"\",\\n            \"farematrixreference\": 3,\\n            \"name\": \"Davis\",\\n            \"reference\":
+        3,\\n            \"shortname\": \"\",\\n            \"type\": 0\\n        },\\n        \"zoneinfo\":
+        {\\n            \"name\": \"Davis\",\\n            \"reference\": 3\\n        }\\n    },\\n    \"dataid\":
+        \"\",\\n    \"dataversion\": 0,\\n    \"locationProviderSource\": \"location::devicesettings::provider\",\\n    \"properties\":
+        {\\n    },\\n    \"type\": 65535\\n}\\n","location::location::serviceStatus":"Closed","location::location::source":"location::ngwifi::provider","ngwifi::gps::apistatus":"{
+        \"status\": 1 }","ngwifi::gps::position":"{ \"altitude\": 129, \"fix\": 10,
+        \"heading\": 0, \"latitude\": 35.371917667, \"longitude\": -119.008193167,
+        \"speed\": 0.013, \"success\": true, \"timestamp\": 1721886667 }","os::uptime":"0
+        00:48:33.000","smartmedium::emv3000::batterylevel":"3118"}},{"Device":{"Fo_device_logical_id":"66010","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"642","Fo_device_location":"642","Fo_device_last_connection":null},"Device_replicator_info":{"Software_version":"0","Software_last_connection":null,"Cd_version":"0","Cd_last_connection":null,"Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":null},"Device_monitor_info":{}}]}'
+    headers:
+      Content-Length:
+      - '23814'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 14 Jul 2025 02:49:02 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      LS09PT09PT09PT09PT09PT03OTMzNzk1MjAxNTE4NzUyMjM0PT0NCmNvbnRlbnQtdHlwZTogYXBw
+      bGljYXRpb24vanNvbjsgY2hhcnNldD1VVEYtOA0KDQp7Im5hbWUiOiAiZGV2aWNlX3Byb3BlcnRp
+      ZXMvZHQ9MjAyNS0wNi0wMS90cz0yMDI1LTA2LTAxVDAwOjAwOjAwKzAwOjAwL3Jlc3VsdHMuanNv
+      bmwuZ3oifQ0KLS09PT09PT09PT09PT09PT03OTMzNzk1MjAxNTE4NzUyMjM0PT0NCmNvbnRlbnQt
+      dHlwZTogYXBwbGljYXRpb24vanNvbmwNCg0KH4sIAC5wdGgC/+2cS2/jNhDH7/0Uhc4OwYcelG7b
+      LrqXPRTdoIcWC4G26CwBWRJIytk08Hfv6GFbsiNvvJt66yx9icwZzgzJP+cHx0gevUyu1UJ6yaO3
+      LNPuTZqXd2oh8lRlXuKFIcbEmw3M9qGCCd6fIleZsKU+MqarMpM5uLz55ZZhjEcORmoFsYt6NZca
+      fAjmGHPKCCGccMxCOnLPpFloVVlVFl5S1Hk+GxW6EI2lrxT73lPWp0zC2HRRFoVc9B4U0+AGsxuK
+      bwlL/DAJKPJx+/rL28z6fUq1rHLYG1h1qopl2eybKZf2XmiZrqU2XTCCKGKoSbkzHmXs1rLIBtMi
+      rx04XRxNgiAJMGJBXxzUJqww0g4i4cHoROZMFg+5MoNZB+MT88RiISs7ntnmGximV0D4LY4T4id+
+      ANsbbVcwV8VBRD/g8cBwck8wTxg+iCjMibWvykLBEaribsqj7o/BalEY0ZpSq1by+Urpc+xkIqpO
+      OU2kVJlMGTHPZaPbpciNbEoee6gCrkp3OT2r6yOP3mqssLVpMvxR3sPPvz9CDXeVSdOqNKpbE2TP
+      rbJ1BrEYaaUhb7vVNEJRert43E79TX3uHnVZF9mHSjZlEhj4JMybXaCmpnbo7S5au5JubB9zP/iu
+      D72b+W6YYDf6XhyleF8Wd6OxfOfDQhRwP/JZ//LBuPe+IZQgTmNGady/Zl7Xez5A2bmyEvYsmHmV
+      LiuprWrePm42TZDtRu+ftme5qLWWhW0ex/Pgwtuy2h35fK5BDNsm1HQgaAUrYbX6rOVSQozmdBlU
+      JNrDeCvWyoDb2Gg+ldr2HmDs2i+GXP+UhdzmOhGhWU3TDNom2TeG3UXD+5X+rsu1ymBjylq3qtsa
+      kqTTNNwoC3fGJEnVu3qzow3oyguDgAUTu3ggXO/XvDQggAnn42KKu3u1VKMiuqE0bXUvKrW/FNsn
+      sjnwevp2EAr6WDYibfUuRQYL7nZpr7gAsYjEJArD6EBsJEYAMxIz0phMJ2yMMGmOsYYGacxWwU03
+      geJWFaSKKOE8hHBQZAm11VXfa/DPGBobtDeGOo6aldB2JTNVr9JUrtYNXtN0LqyV+iGX6xa7wFLu
+      bTY/PT6P7vQ66M6CSbofmr5E9wi6IIoo+zq6B4hQFGEUMD8+ifgDbvskoRxhtmPUCP7Qup6HfxIn
+      lKGueIf/743/KSm9KP6fdHH8d/x3/Hf8/2b+syvhfzjN//AM/rcgJhgRHl2c/8O0z+Z/D2ZH+ctR
+      vrE7ljuWO5Y7ll8Vy/0rYXk0zfLoPJbjJIiQ71+a5eO0juU/JMvdr+Udyh3KHcr/E5QHV4JyPo1y
+      fi7KGRwUvzzKh2kdyh3KHcodyh3KHcpfCuXhlaA8nkZ5fC7KKUMxuzzKh2kdyh3KHcodyh3KHcpf
+      CuXRj4bygCU+wJh+PcpD5HMUUs7OQTmLgeYoJA7l3x3lpwXhvkZ3lHeUd5R/VZTn10F5H09S/tD0
+      paZOEhrA5212ccozjPyIOcr/3yjfCwI7yjvKO8o7yr9CysdXQnkyTXlyHuVxEnBE6eUpTzhoAX/b
+      H75RnOAY8TByf/h2Af6PpeL47/jv+O/4/5r4T/CV8J9O85+e5v+4NT+P8vjcf1uD3Yf0q/hWfbP5
+      FxlnhU3vSQAADQotLT09PT09PT09PT09PT09PTc5MzM3OTUyMDE1MTg3NTIyMzQ9PS0t
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1533'
+      User-Agent:
+      - gcloud-python/2.19.0  gl-python/3.11.11 grpc/1.70.0 gax/2.24.1 gccl/2.19.0
+      X-Goog-API-Client:
+      - gcloud-python/2.19.0  gl-python/3.11.11 grpc/1.70.0 gax/2.24.1 gccl/2.19.0
+        gccl-invocation-id/9602fbc9-171f-4ceb-a9ed-152d9b464222
+      content-type:
+      - !!binary |
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT03OTMzNzk1MjAxNTE4
+        NzUyMjM0PT0i
+      x-goog-user-project:
+      - cal-itp-data-infra-staging
+      x-upload-content-type:
+      - application/jsonl
+    method: POST
+    uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/device_properties/dt=2025-06-01/ts=2025-06-01T00:00:00+00:00/results.jsonl.gz/1752461359207855\",\n
+        \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/device_properties%2Fdt=2025-06-01%2Fts=2025-06-01T00:00:00%2B00:00%2Fresults.jsonl.gz\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/device_properties%2Fdt=2025-06-01%2Fts=2025-06-01T00:00:00%2B00:00%2Fresults.jsonl.gz?generation=1752461359207855&alt=media\",\n
+        \ \"name\": \"device_properties/dt=2025-06-01/ts=2025-06-01T00:00:00+00:00/results.jsonl.gz\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1752461359207855\",\n
+        \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"1236\",\n  \"md5Hash\": \"pZZWRr2ctIGSk9tXc0+jBA==\",\n
+        \ \"crc32c\": \"UxSUAQ==\",\n  \"etag\": \"CK+rsaaru44DEAE=\",\n  \"timeCreated\":
+        \"2025-07-14T02:49:19.229Z\",\n  \"updated\": \"2025-07-14T02:49:19.229Z\",\n
+        \ \"timeStorageClassUpdated\": \"2025-07-14T02:49:19.229Z\",\n  \"timeFinalized\":
+        \"2025-07-14T02:49:19.229Z\"\n}\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '1105'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 14 Jul 2025 02:49:19 GMT
+      ETag:
+      - CK+rsaaru44DEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - ABgVH8_rBsM0DwKEW_dpMkD4VR7lru6eDMvOPJWE0duiNcxkz6sACuY_hx8SNDiuesO8guT6QSmTuuM
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/2.19.0  gl-python/3.11.11 grpc/1.70.0 gax/2.24.1 gccl/2.19.0
+      X-Goog-API-Client:
+      - gcloud-python/2.19.0  gl-python/3.11.11 grpc/1.70.0 gax/2.24.1 gccl/2.19.0
+        gccl-invocation-id/2f0f47de-ff23-420c-812a-803963d74401
+      accept-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=UTF-8
+      x-goog-user-project:
+      - cal-itp-data-infra-staging
+      x-upload-content-type:
+      - application/json; charset=UTF-8
+    method: GET
+    uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/device_properties%2Fdt%3D2025-06-01%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2Fresults.jsonl.gz?alt=media
+  response:
+    body:
+      string: !!binary |
+        H4sIAC5wdGgC/+2cS2/jNhDH7/0Uhc4OwYcelG7bLrqXPRTdoIcWC4G26CwBWRJIytk08Hfv6GFb
+        siNvvJt66yx9icwZzgzJP+cHx0gevUyu1UJ6yaO3LNPuTZqXd2oh8lRlXuKFIcbEmw3M9qGCCd6f
+        IleZsKU+MqarMpM5uLz55ZZhjEcORmoFsYt6NZcafAjmGHPKCCGccMxCOnLPpFloVVlVFl5S1Hk+
+        GxW6EI2lrxT73lPWp0zC2HRRFoVc9B4U0+AGsxuKbwlL/DAJKPJx+/rL28z6fUq1rHLYG1h1qopl
+        2eybKZf2XmiZrqU2XTCCKGKoSbkzHmXs1rLIBtMirx04XRxNgiAJMGJBXxzUJqww0g4i4cHoROZM
+        Fg+5MoNZB+MT88RiISs7ntnmGximV0D4LY4T4id+ANsbbVcwV8VBRD/g8cBwck8wTxg+iCjMibWv
+        ykLBEaribsqj7o/BalEY0ZpSq1by+Urpc+xkIqpOOU2kVJlMGTHPZaPbpciNbEoee6gCrkp3OT2r
+        6yOP3mqssLVpMvxR3sPPvz9CDXeVSdOqNKpbE2TPrbJ1BrEYaaUhb7vVNEJRert43E79TX3uHnVZ
+        F9mHSjZlEhj4JMybXaCmpnbo7S5au5JubB9zP/iuD72b+W6YYDf6XhyleF8Wd6OxfOfDQhRwP/JZ
+        //LBuPe+IZQgTmNGady/Zl7Xez5A2bmyEvYsmHmVLiuprWrePm42TZDtRu+ftme5qLWWhW0ex/Pg
+        wtuy2h35fK5BDNsm1HQgaAUrYbX6rOVSQozmdBlUJNrDeCvWyoDb2Gg+ldr2HmDs2i+GXP+Uhdzm
+        OhGhWU3TDNom2TeG3UXD+5X+rsu1ymBjylq3qtsakqTTNNwoC3fGJEnVu3qzow3oyguDgAUTu3gg
+        XO/XvDQggAnn42KKu3u1VKMiuqE0bXUvKrW/FNsnsjnwevp2EAr6WDYibfUuRQYL7nZpr7gAsYjE
+        JArD6EBsJEYAMxIz0phMJ2yMMGmOsYYGacxWwU03geJWFaSKKOE8hHBQZAm11VXfa/DPGBobtDeG
+        Oo6aldB2JTNVr9JUrtYNXtN0LqyV+iGX6xa7wFLubTY/PT6P7vQ66M6CSbofmr5E9wi6IIoo+zq6
+        B4hQFGEUMD8+ifgDbvskoRxhtmPUCP7Qup6HfxInlKGueIf/743/KSm9KP6fdHH8d/x3/Hf8/2b+
+        syvhfzjN//AM/rcgJhgRHl2c/8O0z+Z/D2ZH+ctRvrE7ljuWO5Y7ll8Vy/0rYXk0zfLoPJbjJIiQ
+        71+a5eO0juU/JMvdr+Udyh3KHcr/E5QHV4JyPo1yfi7KGRwUvzzKh2kdyh3KHcodyh3KHcpfCuXh
+        laA8nkZ5fC7KKUMxuzzKh2kdyh3KHcodyh3KHcpfCuXRj4bygCU+wJh+PcpD5HMUUs7OQTmLgeYo
+        JA7l3x3lpwXhvkZ3lHeUd5R/VZTn10F5H09S/tD0paZOEhrA5212ccozjPyIOcr/3yjfCwI7yjvK
+        O8o7yr9CysdXQnkyTXlyHuVxEnBE6eUpTzhoAX/bH75RnOAY8TByf/h2Af6PpeL47/jv+O/4/5r4
+        T/CV8J9O85+e5v+4NT+P8vjcf1uD3Yf0q/hWfbP5FxlnhU3vSQAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '1236'
+      Content-Type:
+      - application/jsonl
+      Date:
+      - Mon, 14 Jul 2025 02:49:19 GMT
+      ETag:
+      - CK+rsaaru44DEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Last-Modified:
+      - Mon, 14 Jul 2025 02:49:19 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - ABgVH8_XEvjKeYfKPoPHdtdvzpOc253xd2vNtfr9xb-sVHoZekeMdZotM7fVKU9nEW8rIxemx6982i4
+      X-Goog-Generation:
+      - '1752461359207855'
+      X-Goog-Hash:
+      - crc32c=UxSUAQ==,md5=pZZWRr2ctIGSk9tXc0+jBA==
+      X-Goog-Metageneration:
+      - '1'
+      X-Goog-Storage-Class:
+      - STANDARD
+      X-Goog-Stored-Content-Encoding:
+      - identity
+      X-Goog-Stored-Content-Length:
+      - '1236'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/airflow/tests/operators/test_kuba_to_gcs_operator.py
+++ b/airflow/tests/operators/test_kuba_to_gcs_operator.py
@@ -1,0 +1,176 @@
+import gzip
+import json
+import os
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from operators.kuba_to_gcs_operator import KubaObjectPath, KubaToGCSOperator
+from src.bigquery_cleaner import BigQueryValueCleaner
+
+from airflow.models.dag import DAG
+from airflow.models.taskinstance import TaskInstance
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+
+class TestKubaToGCSOperator:
+    @pytest.fixture
+    def execution_date(self) -> datetime:
+        return datetime.fromisoformat("2025-06-01").replace(tzinfo=timezone.utc)
+
+    @pytest.fixture
+    def gcs_hook(self) -> GCSHook:
+        return GCSHook()
+
+    @pytest.fixture
+    def object_path(self) -> KubaObjectPath:
+        return KubaObjectPath(product="device_properties")
+
+    @pytest.fixture
+    def test_dag(self, execution_date: datetime) -> DAG:
+        return DAG(
+            "test_dag",
+            default_args={
+                "owner": "airflow",
+                "start_date": execution_date,
+                "end_date": execution_date + timedelta(days=1),
+            },
+            schedule=timedelta(days=1),
+        )
+
+    @pytest.fixture
+    def operator(self, test_dag: DAG) -> KubaToGCSOperator:
+        return KubaToGCSOperator(
+            task_id="kuba_to_gcs",
+            http_conn_id="http_kuba",
+            gcp_conn_id="google_cloud_default",
+            product="device_properties",
+            endpoint="monitoring/deviceproperties/v1/ForLocations/all",
+            parameters={"location_type": "1"},
+            bucket=os.environ.get("CALITP_BUCKET__KUBA"),
+            dag=test_dag,
+        )
+
+    @pytest.mark.vcr
+    def test_execute(
+        self,
+        test_dag: DAG,
+        operator: KubaToGCSOperator,
+        execution_date: datetime,
+        object_path: KubaObjectPath,
+        gcs_hook: GCSHook,
+    ):
+        operator.run(
+            start_date=execution_date,
+            end_date=execution_date + timedelta(hours=1) - timedelta(seconds=1),
+            ignore_first_depends_on_past=True,
+        )
+
+        task = test_dag.get_task("kuba_to_gcs")
+        task_instance = TaskInstance(task, execution_date=execution_date)
+        xcom_value = task_instance.xcom_pull()
+        assert xcom_value == os.path.join(
+            os.environ.get("CALITP_BUCKET__KUBA"),
+            "device_properties",
+            "dt=2025-06-01",
+            "ts=2025-06-01T00:00:00+00:00",
+            "results.jsonl.gz",
+        )
+
+        compressed_result = gcs_hook.download(
+            bucket_name=os.environ.get("CALITP_BUCKET__KUBA").replace(
+                "gs://", ""
+            ),
+            object_name=object_path.resolve(execution_date),
+        )
+        decompressed_result = gzip.decompress(compressed_result)
+        result = [json.loads(x) for x in decompressed_result.splitlines()]
+
+        assert result[0] == {
+            "device": {
+                "fo_device_logical_id": "66001",
+                "fo_device_type": "Validator",
+                "fo_device_type_model": "ABT3000",
+                "fo_device_serial_number": "108008231118180362",
+                "fo_device_description": None,
+                "fo_device_location_id": "604",
+                "fo_device_location": "604",
+                "fo_device_last_connection": "2025-03-20T13:46:52.4000000Z"
+            },
+            "device_replicator_info": {
+                "software_version": "1.2.3.4",
+                "software_last_connection": None,
+                "cd_version": "7",
+                "cd_last_connection": "2025-03-20T12:55:50.3500000Z",
+                "dataset_version": "0",
+                "dataset_last_connection": None,
+                "denylist_version": None,
+                "denylist_last_connection": None,
+                "acceptlist_version": "0",
+                "acceptlist_last_connection": "2025-03-18T09:14:45.4070000Z",
+                "binlist_version": "4589",
+                "binlist_last_connection": "2025-03-20T08:30:45.4070000Z",
+                "asset_last_connection": None,
+                "monitoring_last_connection": None,
+                "ud_last_transaction_time": "2025-03-20T13:46:52.4000000Z"
+            },
+            "device_monitor_info": {
+                "application__isdisabled": "false",
+                "application__isinservice": "true",
+                "application__servicestatus": {"Rows": []},
+                "gps__position": {
+                    "altitude": 31,
+                    "dateTime": "",
+                    "direction": 0,
+                    "gpsFix": 0,
+                    "groundSpeed": 10,
+                    "hasAltitude": True,
+                    "hasDateTime": False,
+                    "hasDirection": False,
+                    "hasGpsFix": True,
+                    "hasGroundSpeed": True,
+                    "hasLatitude": True,
+                    "hasLongitude": True,
+                    "latitude": 36.58474333333334,
+                    "longitude": -121.82932299999999,
+                    "numberSatelites": 5,
+                    "properties": {}
+                },
+                "location__location__info": {
+                    "current": {
+                        "properties": {},
+                        "stopinfo": {
+                            "abbreviation": "",
+                            "farematrixreference": 3,
+                            "name": "Davis",
+                            "reference": 3,
+                            "shortname": "",
+                            "type": 0
+                        },
+                        "zoneinfo": {
+                            "name": "Davis",
+                            "reference": 3
+                        }
+                    },
+                    "dataid": "",
+                    "dataversion": 0,
+                    "locationProviderSource": "location::devicesettings::provider",
+                    "properties": {},
+                    "type": 65535
+                },
+                "location__location__servicestatus": "Closed",
+                "location__location__source": "location::ngwifi::provider",
+                "ngwifi__gps__apistatus": {"status": 1},
+                "ngwifi__gps__position": {
+                    "altitude": 129,
+                    "fix": 10,
+                    "heading": 0,
+                    "latitude": 35.371917667,
+                    "longitude": -119.008193167,
+                    "speed": 0.013,
+                    "success": True,
+                    "timestamp": 1721886667
+                },
+                "os__uptime": "0 00:48:33.000",
+                "smartmedium__emv3000__batterylevel": "3118"
+            }
+        }

--- a/airflow/tests/operators/test_kuba_to_gcs_operator.py
+++ b/airflow/tests/operators/test_kuba_to_gcs_operator.py
@@ -1,11 +1,10 @@
 import gzip
 import json
 import os
-import pytest
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from operators.kuba_to_gcs_operator import KubaObjectPath, KubaToGCSOperator
-from src.bigquery_cleaner import BigQueryValueCleaner
 
 from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance
@@ -77,9 +76,7 @@ class TestKubaToGCSOperator:
         )
 
         compressed_result = gcs_hook.download(
-            bucket_name=os.environ.get("CALITP_BUCKET__KUBA").replace(
-                "gs://", ""
-            ),
+            bucket_name=os.environ.get("CALITP_BUCKET__KUBA").replace("gs://", ""),
             object_name=object_path.resolve(execution_date),
         )
         decompressed_result = gzip.decompress(compressed_result)
@@ -94,7 +91,7 @@ class TestKubaToGCSOperator:
                 "fo_device_description": None,
                 "fo_device_location_id": "604",
                 "fo_device_location": "604",
-                "fo_device_last_connection": "2025-03-20T13:46:52.4000000Z"
+                "fo_device_last_connection": "2025-03-20T13:46:52.4000000Z",
             },
             "device_replicator_info": {
                 "software_version": "1.2.3.4",
@@ -111,7 +108,7 @@ class TestKubaToGCSOperator:
                 "binlist_last_connection": "2025-03-20T08:30:45.4070000Z",
                 "asset_last_connection": None,
                 "monitoring_last_connection": None,
-                "ud_last_transaction_time": "2025-03-20T13:46:52.4000000Z"
+                "ud_last_transaction_time": "2025-03-20T13:46:52.4000000Z",
             },
             "device_monitor_info": {
                 "application__isdisabled": "false",
@@ -133,7 +130,7 @@ class TestKubaToGCSOperator:
                     "latitude": 36.58474333333334,
                     "longitude": -121.82932299999999,
                     "numberSatelites": 5,
-                    "properties": {}
+                    "properties": {},
                 },
                 "location__location__info": {
                     "current": {
@@ -144,18 +141,15 @@ class TestKubaToGCSOperator:
                             "name": "Davis",
                             "reference": 3,
                             "shortname": "",
-                            "type": 0
+                            "type": 0,
                         },
-                        "zoneinfo": {
-                            "name": "Davis",
-                            "reference": 3
-                        }
+                        "zoneinfo": {"name": "Davis", "reference": 3},
                     },
                     "dataid": "",
                     "dataversion": 0,
                     "locationProviderSource": "location::devicesettings::provider",
                     "properties": {},
-                    "type": 65535
+                    "type": 65535,
                 },
                 "location__location__servicestatus": "Closed",
                 "location__location__source": "location::ngwifi::provider",
@@ -168,9 +162,9 @@ class TestKubaToGCSOperator:
                     "longitude": -119.008193167,
                     "speed": 0.013,
                     "success": True,
-                    "timestamp": 1721886667
+                    "timestamp": 1721886667,
                 },
                 "os__uptime": "0 00:48:33.000",
-                "smartmedium__emv3000__batterylevel": "3118"
-            }
+                "smartmedium__emv3000__batterylevel": "3118",
+            },
         }

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -82,6 +82,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         "CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED_HOURLY"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-schedule-unzipped-hourly_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION"              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-schedule-validation_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY"       = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-schedule-validation-hourly_name}",
+        "CALITP_BUCKET__KUBA"                                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-kuba_name}",
         "CALITP_BUCKET__LITTLEPAY_PARSED"                      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-payments-littlepay-parsed_name}",
         "CALITP_BUCKET__LITTLEPAY_PARSED_V3"                   = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-payments-littlepay-parsed-v3_name}",
         "CALITP_BUCKET__LITTLEPAY_RAW"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-payments-littlepay-raw_name}",

--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -202,6 +202,10 @@ output "google_storage_bucket_calitp-staging-gtfs-schedule-validation-hourly_nam
   value = google_storage_bucket.calitp-staging["calitp-staging-gtfs-schedule-validation-hourly"].name
 }
 
+output "google_storage_bucket_calitp-staging-kuba_name" {
+  value = google_storage_bucket.calitp-staging["calitp-staging-kuba"].name
+}
+
 output "google_storage_bucket_calitp-staging-payments-littlepay-parsed_name" {
   value = google_storage_bucket.calitp-staging["calitp-staging-payments-littlepay-parsed"].name
 }

--- a/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
@@ -30,6 +30,7 @@ locals {
     "calitp-staging-pytest",
     "calitp-staging-sentry",
     "calitp-staging-state-geoportal-scrape",
+    "calitp-staging-kuba-raw",
   ])
 }
 

--- a/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
@@ -18,6 +18,7 @@ locals {
     "calitp-staging-gtfs-schedule-unzipped-hourly",
     "calitp-staging-gtfs-schedule-validation",
     "calitp-staging-gtfs-schedule-validation-hourly",
+    "calitp-staging-kuba",
     "calitp-staging-ntd-api-products",
     "calitp-staging-ntd-report-validation",
     "calitp-staging-ntd-xlsx-products-clean",
@@ -30,7 +31,6 @@ locals {
     "calitp-staging-pytest",
     "calitp-staging-sentry",
     "calitp-staging-state-geoportal-scrape",
-    "calitp-staging-kuba-raw",
   ])
 }
 

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -82,6 +82,7 @@ resource "google_composer_environment" "calitp-composer" {
         "CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED_HOURLY"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-unzipped-hourly_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION"              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-validation_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY"       = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-validation-hourly_name}",
+        "CALITP_BUCKET__KUBA"                                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-kuba_name}",
         "CALITP_BUCKET__LITTLEPAY_PARSED"                      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-payments-littlepay-parsed_name}",
         "CALITP_BUCKET__LITTLEPAY_PARSED_V3"                   = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-payments-littlepay-parsed-v3_name}",
         "CALITP_BUCKET__LITTLEPAY_RAW"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-payments-littlepay-raw_name}",

--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2993,3 +2993,7 @@ output "google_storage_bucket_calitp-composer_name" {
 output "google_storage_bucket_calitp-composer_id" {
   value = google_storage_bucket.calitp-composer.id
 }
+
+output "google_storage_bucket_calitp-kuba_name" {
+  value = google_storage_bucket.calitp["calitp-kuba"].name
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -2214,3 +2214,16 @@ resource "google_storage_bucket" "calitp-reports" {
     main_page_suffix = "index.html"
   }
 }
+
+resource "google_storage_bucket" "calitp" {
+  for_each                    = local.environment_buckets
+  name                        = each.key
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -621,3 +621,10 @@ resource "google_storage_bucket_iam_binding" "calitp-composer" {
   members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra", "serviceAccount:${data.terraform_remote_state.iam.outputs.google_service_account_composer-service-account_email}"]
   role    = "roles/storage.legacyBucketOwner"
 }
+
+resource "google_storage_bucket_iam_binding" "calitp" {
+  for_each = local.environment_buckets
+  bucket   = google_storage_bucket.calitp[each.key].name
+  members  = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
+  role     = "roles/storage.legacyObjectOwner"
+}

--- a/iac/cal-itp-data-infra/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra/gcs/us/variables.tf
@@ -1,3 +1,9 @@
+locals {
+  environment_buckets = toset([
+    "calitp-kuba",
+  ])
+}
+
 data "terraform_remote_state" "iam" {
   backend = "gcs"
 


### PR DESCRIPTION
# Description

This adds a bucket to capture raw Kuba output and adds a DAG to snapshot the current Kuba Device Monitoring API.

For future references, it needs: 
* `CALITP_BUCKET__KUBA` environment variable on Composer
* `airflow-connections-http_kuba` secret on secret-manager
* `calitp-kuba` bucket on production / `calitp-staging-kuba` bucket on staging

Relates to #3764 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`
Run sync_kuba and create_external_tables.kuba.device_properties on staging.

<img width="1444" height="844" alt="Screenshot 2025-07-14 at 5 46 26 PM" src="https://github.com/user-attachments/assets/3ea5c7b4-1659-45da-a632-8de441e6f04d" />

<img width="1643" height="844" alt="Screenshot 2025-07-14 at 5 46 50 PM" src="https://github.com/user-attachments/assets/a0d1b44f-f581-40d1-b53a-53060c49b2d1" />

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Test on production.