### PR TITLE
Add email configuration to new production composer

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -47,6 +47,11 @@ resource "google_composer_environment" "calitp-composer" {
         scheduler-scheduler_health_check_threshold = 120
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
         webserver-reload_on_plugin_change          = "True"
+        email-email_backend                        = "airflow.utils.email.send_email_smtp"
+        email-from_email                           = "bot@calitp.org"
+        email-email_conn_id                        = "smtp_postmark"
+        smtp-smtp_starttls                         = true
+        smtp-smtp_mail_from                        = "bot@calitp.org"
       }
 
       pypi_packages = local.pypi_packages


### PR DESCRIPTION
# Description

This PR adds email configuration to new production composer. This values were on Staging and copied from old production composer.

[#3766]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running `terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check if this setting fixes `download_gtfs_schedule_v2.email_download_failures`