### PR TITLE
fix(ci): install hologit through NPM instead of Habitat/Biome

### DIFF
--- a/.github/workflows/deploy-kubernetes.yml
+++ b/.github/workflows/deploy-kubernetes.yml
@@ -39,14 +39,9 @@ jobs:
           location: ${{ env.GKE_REGION }}
       - run: curl -sSL https://install.python-poetry.org | python -
       - name: Set up hologit
-        env:
-          BIO_RELEASE: 1.6.821
+        run: npm install -g hologit
+      - name: Configure git identity
         run: |
-          curl -LO "https://github.com/biome-sh/biome/releases/download/v${BIO_RELEASE}/bio-${BIO_RELEASE}-x86_64-linux.tar.gz"
-          tar xzvf "bio-${BIO_RELEASE}-x86_64-linux.tar.gz"
-          sudo mv bio /usr/local/bin/bio
-          sudo bio pkg install --binlink jarvus/hologit
-
           git config user.name "Github Action $GITHUB_JOB"
           git config user.email "$(whoami)@$(uname -n)"
 

--- a/.github/workflows/preview-kubernetes.yml
+++ b/.github/workflows/preview-kubernetes.yml
@@ -39,14 +39,9 @@ jobs:
           location: ${{ env.GKE_REGION }}
       - run: curl -sSL https://install.python-poetry.org | python -
       - name: Set up hologit
-        env:
-          BIO_RELEASE: 1.6.821
+        run: npm install -g hologit
+      - name: Configure git identity
         run: |
-          curl -LO "https://github.com/biome-sh/biome/releases/download/v${BIO_RELEASE}/bio-${BIO_RELEASE}-x86_64-linux.tar.gz"
-          tar xzvf "bio-${BIO_RELEASE}-x86_64-linux.tar.gz"
-          sudo mv bio /usr/local/bin/bio
-          sudo bio pkg install --binlink jarvus/hologit
-
           git config user.name "Github Action $GITHUB_JOB"
           git config user.email "$(whoami)@$(uname -n)"
 


### PR DESCRIPTION
# Description

Habitat, originally by Chef, was acquired some years ago and we were using the community fork Biome but it still used Habitat's public package repository and the new owners recently shut down public use of the package repository

This has recently caused the Kubernetes CI jobs to start failing as they used Biome to install Hologit for generating a working tree of all Helm chart sources

This PR should fix this by installing Hologit through NPM instead of Biome—which only offered the advantage of guaranteeing the `git` version but current GitHub runners come with a new enough git version stock

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Opening this PR will be the test, if the kicked-off `preview-kubernetes` action succeeds we're goo to go

## Post-merge follow-ups

- [ ] No action required
- [X] Actions required (specified below)
  - [ ] Ensure the `deploy-kubernetes` action succeeds too