### PR TITLE
Change VCR.py cassette request recording logic to scrub sensitive strings

### DIFF
--- a/airflow/tests/conftest.py
+++ b/airflow/tests/conftest.py
@@ -50,6 +50,20 @@ def dag_bag() -> DagBag:
     return dag_bag
 
 
+FILTER_BODY_STRINGS: list = [
+    (os.environ.get("KUBA_PASSWORD"), "FILTERED"),
+]
+
+
+def scrub_sensitive_data(request):
+    for body_string, replacement in FILTER_BODY_STRINGS:
+        if request.body and body_string and replacement:
+            request.body = request.body.replace(
+                str.encode(body_string), str.encode(replacement)
+            )
+    return request
+
+
 @pytest.fixture(scope="module")
 def vcr_config():
     return {
@@ -58,6 +72,7 @@ def vcr_config():
             ("Authorization", "FILTERED"),
             ("apikey", "FILTERED"),
         ],
+        "before_record_request": scrub_sensitive_data,
         "allow_playback_repeats": True,
         "ignore_hosts": [
             "run-actions-1-azure-eastus.actions.githubusercontent.com",
@@ -92,10 +107,10 @@ def setup_module():
         session,
         conn_id="http_kuba",
         conn_type="http",
-        host=os.environ.get("KUBA_HOST"),
-        login=os.environ.get("KUBA_LOGIN"),
+        host="https://proxima-demo.pptexcellence.com/",
+        login="monitoringAPI",
         password=os.environ.get("KUBA_PASSWORD"),
-        schema=os.environ.get("KUBA_SCHEMA"),
+        schema="66",
     )
     clean_connections(session, "airtable_default")
     add_connection(

--- a/airflow/tests/hooks/cassettes/test_kuba_hook/TestKubaHook.test_run.yaml
+++ b/airflow/tests/hooks/cassettes/test_kuba_hook/TestKubaHook.test_run.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://proxima-demo.pptexcellence.com/monitoring/authenticate/v1
   response:
     body:
-      string: '{"Error":null,"UserId":"monitoringAPI","FirstName":"device","LastName":"monitoringAPI","SessionId":"03e113a3-9ece-47e8-a379-c2e1aba66d33"}'
+      string: '{"Error":null,"UserId":"monitoringAPI","FirstName":"device","LastName":"monitoringAPI","SessionId":"f259ea7f-14ab-4f7b-8e51-04793b4f5120"}'
     headers:
       Content-Length:
       - '138'
@@ -74,7 +74,7 @@ interactions:
     uri: https://proxima-demo.pptexcellence.com/monitoring/deviceproperties/v1/ForLocations/all?location_type=1
   response:
     body:
-      string: '{"Response_date_time":"2025-07-11T15:45:53.9371965Z","List":[{"Device":{"Fo_device_logical_id":"66001","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"604","Fo_device_location":"604","Fo_device_last_connection":"2025-03-20T13:46:52.4000000Z"},"Device_replicator_info":{"Software_version":"1.2.3.4","Software_last_connection":null,"Cd_version":"7","Cd_last_connection":"2025-03-20T12:55:50.3500000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":"2025-03-20T13:46:52.4000000Z"},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
+      string: '{"Response_date_time":"2025-07-15T22:44:08.7724383Z","List":[{"Device":{"Fo_device_logical_id":"66001","Fo_device_type":"Validator","Fo_device_type_model":"ABT3000","Fo_device_serial_number":"108008231118180362","Fo_device_description":null,"Fo_device_location_id":"604","Fo_device_location":"604","Fo_device_last_connection":"2025-03-20T13:46:52.4000000Z"},"Device_replicator_info":{"Software_version":"1.2.3.4","Software_last_connection":null,"Cd_version":"7","Cd_last_connection":"2025-03-20T12:55:50.3500000Z","Dataset_version":"0","Dataset_last_connection":null,"Denylist_version":null,"Denylist_last_connection":null,"Acceptlist_version":"0","Acceptlist_last_connection":"2025-03-18T09:14:45.4070000Z","Binlist_version":"4589","Binlist_last_connection":"2025-03-20T08:30:45.4070000Z","Asset_last_connection":null,"Monitoring_last_connection":null,"Ud_last_transaction_time":"2025-03-20T13:46:52.4000000Z"},"Device_monitor_info":{"application::isdisabled":"false","application::isinservice":"true","application::servicestatus":"{\"Rows\":[]}","gps::position":"{\\n    \"altitude\":
         31,\\n    \"dateTime\": \"\",\\n    \"direction\": 0,\\n    \"gpsFix\": 0,\\n    \"groundSpeed\":
         10,\\n    \"hasAltitude\": true,\\n    \"hasDateTime\": false,\\n    \"hasDirection\":
         false,\\n    \"hasGpsFix\": true,\\n    \"hasGroundSpeed\": true,\\n    \"hasLatitude\":
@@ -216,7 +216,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 11 Jul 2025 15:45:53 GMT
+      - Tue, 15 Jul 2025 22:44:08 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Powered-By:


### PR DESCRIPTION
# Description

This PR addresses a recent issue with #4083, which added VCR cassettes for the Kuba Proxima API. These VCR cassettes leaked a password string, and should instead filter the KUBA_PASSWORD.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`pytest`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Force-push to main and overwrite the password string