### PR TITLE
Remove partial_parse.msgpack synchronization from Terraform Airflow Apply

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,7 +33,7 @@ The GCP Composer deployment of Airflow [uploads composer, warehouse, and dbt art
 
   * Warehouse files: `dbt_project.yml`, `packages.yml`, `profiles.yml`, and all files from `macros/`, `models/`, `seeds/`, and `tests/` folders.
 
-  * dbt artifact files: `manifest.json`, `catalog.json`, `index.html`, and `partial_parse.msgpack`.
+  * dbt artifact files: `manifest.json`, `catalog.json`, and `index.html`.
 
 
   For more details, check [iac/cal-itp-data-infra/airflow/us/variables.tf](https://github.com/cal-itp/data-infra/blob/main/iac/cal-itp-data-infra/airflow/us/variables.tf).

--- a/iac/cal-itp-data-infra-staging/airflow/us/storage_bucket_object.tf
+++ b/iac/cal-itp-data-infra-staging/airflow/us/storage_bucket_object.tf
@@ -32,12 +32,3 @@ resource "google_storage_bucket_object" "calitp-staging-composer-index" {
   bucket       = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-composer_id
   content_type = "text/html; charset=utf-8"
 }
-
-resource "google_storage_bucket_object" "calitp-staging-composer-partial_parse" {
-  depends_on     = [data.google_storage_bucket_object_content.calitp-staging-dbt-partial_parse]
-  name           = "data/warehouse/target/partial_parse.msgpack"
-  source_md5hash = data.google_storage_bucket_object_content.calitp-staging-dbt-partial_parse.md5hash
-  content        = data.google_storage_bucket_object_content.calitp-staging-dbt-partial_parse.content
-  bucket         = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-composer_id
-  content_type   = "application/vnd.msgpack"
-}

--- a/iac/cal-itp-data-infra-staging/airflow/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/airflow/us/variables.tf
@@ -32,11 +32,6 @@ data "google_storage_bucket_object_content" "calitp-staging-dbt-index" {
   bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-dbt-docs_name
 }
 
-data "google_storage_bucket_object_content" "calitp-staging-dbt-partial_parse" {
-  name   = "partial_parse.msgpack"
-  bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-dbt-docs_name
-}
-
 data "terraform_remote_state" "networks" {
   backend = "gcs"
 

--- a/iac/cal-itp-data-infra/airflow/us/storage_bucket_object.tf
+++ b/iac/cal-itp-data-infra/airflow/us/storage_bucket_object.tf
@@ -32,12 +32,3 @@ resource "google_storage_bucket_object" "calitp-composer-index" {
   bucket       = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-composer_name
   content_type = "text/html; charset=utf-8"
 }
-
-resource "google_storage_bucket_object" "calitp-composer-partial_parse" {
-  depends_on     = [data.google_storage_bucket_object_content.calitp-dbt-partial_parse]
-  name           = "data/warehouse/target/partial_parse.msgpack"
-  content        = data.google_storage_bucket_object_content.calitp-dbt-partial_parse.content
-  bucket         = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-composer_name
-  source_md5hash = data.google_storage_bucket_object_content.calitp-dbt-partial_parse.md5hash
-  content_type   = "application/vnd.msgpack"
-}

--- a/iac/cal-itp-data-infra/airflow/us/variables.tf
+++ b/iac/cal-itp-data-infra/airflow/us/variables.tf
@@ -32,11 +32,6 @@ data "google_storage_bucket_object_content" "calitp-dbt-index" {
   bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-dbt-docs_name
 }
 
-data "google_storage_bucket_object_content" "calitp-dbt-partial_parse" {
-  name   = "partial_parse.msgpack"
-  bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-dbt-docs_name
-}
-
 data "terraform_remote_state" "networks" {
   backend = "gcs"
 


### PR DESCRIPTION
# Description

This PR removes `partial_parse.msgpack` from the synchronization process for Airflow changes when `Terraform Airflow Apply` runs.

Locally it works, but through workflow is returning the following error:

```
Error: Provider produced inconsistent final plan

When expanding the plan for google_storage_bucket_object.calitp-staging-composer-partial_parse to include new values learned so far during apply, provider "registry.terraform.io/hashicorp/google" produced an invalid new value for .content: inconsistent values for sensitive attribute.
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested with `terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm if `Terraform Airflow Apply` runs successfully.