### PR TITLE
Update JupyterHub onboarding video link

### DIFF
--- a/docs/warehouse/developing_dbt_models.md
+++ b/docs/warehouse/developing_dbt_models.md
@@ -59,7 +59,7 @@ Because the warehouse is collectively maintained and changes can affect a variet
 
 #### Video walkthrough
 
-For an example of working with dbt in JupyterHub, see the recording of the [original onboarding call in April 2023 (requires Cal-ITP Google Drive access).](https://drive.google.com/file/d/1NDh_4u0-ROsH0w8J3Z1ccn_ICLAHtDhX/view?usp=drive_link) A few notes on this video:
+For an example of working with dbt in JupyterHub, see the recording of the [original onboarding call in April 2023 (requires SharePoint access).](https://caltrans.sharepoint.com/sites/DOTPMPHQ-DataandDigitalServices/_layouts/15/stream.aspx?id=%2Fsites%2FDOTPMPHQ%2DDataandDigitalServices%2FShared%20Documents%2FData%20Quality%2FPresentations%2Fdbt%20%5F%20JupyterHub%20onboarding%2D2023%2D04%2D27%2Emp4&referrer=StreamWebApp%2EWeb&referrerScenario=AddressBarCopied%2Eview%2E97c7cbba%2D07bc%2D47bc%2D89c8%2D6c290d7c95ff&ga=1) A few notes on this video:
 
 - The documentation shown is an older version of this docs page; the information shared verbally is correct but the page has been updated.
 - The bug encountered towards the end of the video (that prevented us from running dbt tests) has been fixed.


### PR DESCRIPTION
# Description

This PR updates the link for the JupyterHub onboarding video in the Data Services Documentation, from Google Drive to SharePoint.

Resolves https://github.com/cal-itp/data-infra/issues/4110

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and `poetry run dbt test -s CHANGED_MODEL`, then include the output in this section of the PR._

<img width="985" height="328" alt="image" src="https://github.com/user-attachments/assets/b1a2398e-b821-4e47-8f75-f157e60f5150" />

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
