### PR TITLE
Create dbt_manual DAG without schedule to run models as needed

### DIFF
--- a/airflow/dags/dbt_manual_dag.py
+++ b/airflow/dags/dbt_manual_dag.py
@@ -10,17 +10,16 @@ from airflow.operators.latest_only import LatestOnlyOperator
 DBT_TARGET = os.environ.get("DBT_TARGET")
 
 with DAG(
-    dag_id="dbt_all",
-    tags=["dbt", "all"],
-    # Monday, Thursday at 7am PDT/8am PST (2pm UTC)
-    schedule="0 14 * * 1,4",
-    start_date=datetime(2025, 7, 6),
+    dag_id="dbt_manual",
+    tags=["dbt", "manual", "ad-hoc"],
+    schedule=None,
+    start_date=datetime(2025, 7, 21),
     catchup=False,
 ):
     latest_only = LatestOnlyOperator(task_id="latest_only", depends_on_past=False)
 
-    dbt_all = DbtTaskGroup(
-        group_id="dbt_all",
+    dbt_manual = DbtTaskGroup(
+        group_id="dbt_manual",
         project_config=ProjectConfig(
             dbt_project_path="/home/airflow/gcs/data/warehouse",
             manifest_path="/home/airflow/gcs/data/warehouse/target/manifest.json",
@@ -33,7 +32,7 @@ with DAG(
             profiles_yml_filepath="/home/airflow/gcs/data/warehouse/profiles.yml",
         ),
         render_config=RenderConfig(
-            exclude=[
+            select=[
                 "models/mart/gtfs/fct_stop_time_arrivals_week.sql",
                 "models/mart/gtfs/fct_stop_time_updates_metrics_week.sql",
                 "models/mart/gtfs/fct_stop_time_updates_week.sql",
@@ -47,4 +46,4 @@ with DAG(
         default_args={"retries": 0},
     )
 
-    latest_only >> dbt_all
+    latest_only >> dbt_manual


### PR DESCRIPTION
# Description

This PR creates `dbt_manual` DAG without schedule to run models as needed. It also removes them from the `dbt_all`.

Initial tables requested to be in the new manual DAG:
* `fct_stop_time_arrivals_week`
* `fct_stop_time_updates_metrics_week`
* `fct_stop_time_updates_week`
* `fct_stop_time_updates_with_arrivals_week`

Resolves [#4113]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on Composer Staging.

<img width="1651" height="975" alt="Screenshot 2025-07-21 at 4 59 58 PM" src="https://github.com/user-attachments/assets/cf3b1f6e-75e1-4fc1-ab1f-2f65ff142efe" />

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm that `fct_stop_time_arrivals_week`, `fct_stop_time_updates_metrics_week`, `fct_stop_time_updates_week`, and `fct_stop_time_updates_with_arrivals_week` were excluded from `dbt_all` and included on `dbt_manual`.
            