### PR TITLE
Materialize Staging GTFS RT models and filter dt by the last 6 months

### DIFF
--- a/warehouse/macros/gtfs_rt_stg_outcomes.sql
+++ b/warehouse/macros/gtfs_rt_stg_outcomes.sql
@@ -5,6 +5,7 @@ WITH raw_outcomes AS (
         *,
         {{ to_url_safe_base64('`extract`.config.url') }} AS base64_url
     FROM {{ source_table }}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
 ),
 
 stg_gtfs_rt__agg_outcomes AS (

--- a/warehouse/macros/gtfs_rt_stg_validation_notices.sql
+++ b/warehouse/macros/gtfs_rt_stg_validation_notices.sql
@@ -1,9 +1,6 @@
 {% macro gtfs_rt_stg_validation_notices(source_table) %}
-WITH raw_validation_notices AS (
-    SELECT * FROM {{ source_table }}
-),
 
-stg_gtfs_rt__validation_notices AS (
+WITH stg_gtfs_rt__validation_notices AS (
     SELECT
         -- this mainly exists so we can use WHERE in tests
         {{ dbt_utils.generate_surrogate_key(['metadata.extract_ts', 'base64_url', 'errorMessage.validationRule.errorId']) }} AS key,
@@ -25,7 +22,8 @@ stg_gtfs_rt__validation_notices AS (
         errorMessage.validationRule.errorDescription AS error_message_validation_rule_error_description,
         errorMessage.validationRule.occurrenceSuffix AS error_message_validation_rule_occurrence_suffix,
         occurrenceList AS occurrence_list
-    FROM raw_validation_notices
+    FROM {{ source_table }}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
 )
 
 SELECT * FROM stg_gtfs_rt__validation_notices

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
@@ -1,9 +1,6 @@
-WITH external_service_alerts AS (
-    SELECT *
-    FROM {{ source('external_gtfs_rt', 'service_alerts') }}
-),
+{{ config(materialized='table') }}
 
-stg_gtfs_rt__service_alerts AS (
+WITH stg_gtfs_rt__service_alerts AS (
     SELECT
         dt,
         hour,
@@ -19,8 +16,8 @@ stg_gtfs_rt__service_alerts AS (
 
         id,
 
-        external_service_alerts.alert.activePeriod AS active_period,
-        external_service_alerts.alert.informedEntity AS informed_entity,
+        alert.activePeriod AS active_period,
+        alert.informedEntity AS informed_entity,
 
         alert.cause AS cause,
         alert.effect AS effect,
@@ -33,7 +30,8 @@ stg_gtfs_rt__service_alerts AS (
 
         alert.severityLevel AS severity_level
 
-    FROM external_service_alerts
+    FROM {{ source('external_gtfs_rt', 'service_alerts') }}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
 )
 
 SELECT * FROM stg_gtfs_rt__service_alerts

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts_outcomes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts_outcomes.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__service_alerts_outcomes AS (
     {{ gtfs_rt_stg_outcomes('parse', source('external_gtfs_rt', 'service_alerts_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
@@ -1,9 +1,6 @@
-WITH external_trip_updates AS (
-    SELECT *
-    FROM {{ source('external_gtfs_rt', 'trip_updates') }}
-),
+{{ config(materialized='table') }}
 
-stg_gtfs_rt__trip_updates AS (
+WITH stg_gtfs_rt__trip_updates AS (
     SELECT
         dt,
         hour,
@@ -37,7 +34,8 @@ stg_gtfs_rt__trip_updates AS (
 
         tripUpdate.stopTimeUpdate AS stop_time_updates,
 
-    FROM external_trip_updates
+    FROM {{ source('external_gtfs_rt', 'trip_updates') }}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
 )
 
 SELECT * FROM stg_gtfs_rt__trip_updates

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates_outcomes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates_outcomes.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__trip_updates_outcomes AS (
     {{ gtfs_rt_stg_outcomes('parse', source('external_gtfs_rt', 'trip_updates_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
@@ -1,9 +1,6 @@
-WITH external_vehicle_positions AS (
-    SELECT *
-    FROM {{ source('external_gtfs_rt', 'vehicle_positions') }}
-),
+{{ config(materialized='table') }}
 
-stg_gtfs_rt__vehicle_positions AS (
+WITH stg_gtfs_rt__vehicle_positions AS (
     SELECT
         dt,
         hour,
@@ -46,7 +43,8 @@ stg_gtfs_rt__vehicle_positions AS (
         vehicle.position.odometer AS position_odometer,
         vehicle.position.speed AS position_speed
 
-    FROM external_vehicle_positions
+    FROM {{ source('external_gtfs_rt', 'vehicle_positions') }}
+    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
 )
 
 SELECT * FROM stg_gtfs_rt__vehicle_positions

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions_outcomes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions_outcomes.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__vehicle_positions_outcomes AS (
     {{ gtfs_rt_stg_outcomes('parse', source('external_gtfs_rt', 'vehicle_positions_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_notices.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_notices.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__service_alerts_validation_notices AS (
     {{ gtfs_rt_stg_validation_notices(source('external_gtfs_rt', 'service_alerts_validation_notices')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_outcomes.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_outcomes.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__service_alerts_validation_outcomes AS (
     {{ gtfs_rt_stg_outcomes('validation', source('external_gtfs_rt', 'service_alerts_validation_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_notices.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_notices.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__trip_updates_validation_notices AS (
     {{ gtfs_rt_stg_validation_notices(source('external_gtfs_rt', 'trip_updates_validation_notices')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_outcomes.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_outcomes.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__trip_updates_validation_outcomes AS (
     {{ gtfs_rt_stg_outcomes('validation', source('external_gtfs_rt', 'trip_updates_validation_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_notices.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_notices.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__vehicle_positions_validation_notices AS (
     {{ gtfs_rt_stg_validation_notices(source('external_gtfs_rt', 'vehicle_positions_validation_notices')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_outcomes.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_outcomes.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 WITH stg_gtfs_rt__vehicle_positions_validation_outcomes AS (
     {{ gtfs_rt_stg_outcomes('validation', source('external_gtfs_rt', 'vehicle_positions_validation_outcomes')) }}
 )


### PR DESCRIPTION
# Description

The `mart_gtfs.fct_trip_updates_summaries` is not able to run anymore due to the size and is cancelled by BigQuery returning the error reported on issue [#4103](https://github.com/cal-itp/data-infra/issues/4103).

In order to reduce the size from the beginning of the process, I am filtering the following staging tables to return only the last 6 months of data from the GTFS RT external tables (`WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH)`) and materializing to reduce the processing time and allowing cache to be used.

Added filter directly: 
* staging.stg_gtfs_rt__service_alerts
* staging.stg_gtfs_rt__trip_updates
* staging.stg_gtfs_rt__vehicle_positions

Added filter to macro `gtfs_rt_stg_outcomes` that filters:
* staging.stg_gtfs_rt__service_alerts_outcomes
* staging.stg_gtfs_rt__trip_updates_outcomes
* staging.stg_gtfs_rt__vehicle_positions_outcomes
* staging.stg_gtfs_rt__service_alerts_validation_outcomes
* staging.stg_gtfs_rt__trip_updates_validation_outcomes
* staging.stg_gtfs_rt__vehicle_positions_validation_outcomes

Added filter to macro `gtfs_rt_stg_validation_notices` that filters:
* staging.stg_gtfs_rt__service_alerts_validation_notices
* staging.stg_gtfs_rt__trip_updates_validation_notices
* staging.stg_gtfs_rt__vehicle_positions_validation_notices

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running models locally and validated by `deploy_dbt` workflow on this PR.

```
>  poetry run dbt run -s models/mart/gtfs/fct_trip_updates_messages.sql+ models/staging/gtfs/stg_gtfs_rt__service_alerts.sql+ models/staging/gtfs/stg_gtfs_rt__service_alerts_outcomes.sql+ models/staging/gtfs/stg_gtfs_rt__trip_updates.sql+ models/staging/gtfs/stg_gtfs_rt__trip_updates_outcomes.sql+ models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql+ models/staging/gtfs/stg_gtfs_rt__vehicle_positions_outcomes.sql+ models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_notices.sql+ models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_outcomes.sql+ models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_notices.sql+ models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_outcomes.sql+ models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_notices.sql+ models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_outcomes.sql+ --target staging --full-refresh
\01:20:38  Running with dbt=1.8.1
01:20:39  Registered adapter: bigquery=1.8.1
01:20:40  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
01:20:41  Found 617 models, 1236 data tests, 14 seeds, 223 sources, 4 exposures, 1041 macros
01:20:41
01:20:45  Concurrency: 8 threads (target='staging')
01:20:45
01:20:45  1 of 115 START sql table model staging.stg_gtfs_rt__service_alerts ............. [RUN]
01:20:45  2 of 115 START sql table model staging.stg_gtfs_rt__service_alerts_outcomes .... [RUN]
01:20:45  3 of 115 START sql table model staging.stg_gtfs_rt__service_alerts_validation_notices  [RUN]
01:20:45  4 of 115 START sql table model staging.stg_gtfs_rt__service_alerts_validation_outcomes  [RUN]
01:20:45  5 of 115 START sql table model staging.stg_gtfs_rt__trip_updates ............... [RUN]
01:20:45  6 of 115 START sql table model staging.stg_gtfs_rt__trip_updates_outcomes ...... [RUN]
01:20:45  7 of 115 START sql table model staging.stg_gtfs_rt__trip_updates_validation_notices  [RUN]
01:20:45  8 of 115 START sql table model staging.stg_gtfs_rt__trip_updates_validation_outcomes  [RUN]
01:20:48  7 of 115 OK created sql table model staging.stg_gtfs_rt__trip_updates_validation_notices  [CREATE TABLE (354.0 rows, 423.6 KiB processed) in 3.35s]
01:20:48  9 of 115 START sql table model staging.stg_gtfs_rt__vehicle_positions .......... [RUN]
01:20:48  3 of 115 OK created sql table model staging.stg_gtfs_rt__service_alerts_validation_notices  [CREATE TABLE (192.0 rows, 193.4 KiB processed) in 3.37s]
01:20:48  10 of 115 START sql table model staging.stg_gtfs_rt__vehicle_positions_outcomes  [RUN]
01:20:49  1 of 115 OK created sql table model staging.stg_gtfs_rt__service_alerts ........ [CREATE TABLE (1.5k rows, 2.5 MiB processed) in 3.56s]
01:20:49  11 of 115 START sql table model staging.stg_gtfs_rt__vehicle_positions_validation_notices  [RUN]
01:20:50  6 of 115 OK created sql table model staging.stg_gtfs_rt__trip_updates_outcomes . [CREATE TABLE (25.2k rows, 41.0 MiB processed) in 5.27s]
01:20:50  12 of 115 START sql table model staging.stg_gtfs_rt__vehicle_positions_validation_outcomes  [RUN]
01:20:51  2 of 115 OK created sql table model staging.stg_gtfs_rt__service_alerts_outcomes  [CREATE TABLE (49.9k rows, 69.7 MiB processed) in 5.54s]
01:20:51  13 of 115 START sql view model mart_gtfs.fct_service_alerts_messages ........... [RUN]
01:20:51  4 of 115 OK created sql table model staging.stg_gtfs_rt__service_alerts_validation_outcomes  [CREATE TABLE (50.0k rows, 96.3 MiB processed) in 5.59s]
01:20:51  14 of 115 START sql incremental model staging.int_gtfs_rt__distinct_download_configs  [RUN]
01:20:51  5 of 115 OK created sql table model staging.stg_gtfs_rt__trip_updates .......... [CREATE TABLE (32.4k rows, 83.5 MiB processed) in 5.67s]
01:20:51  15 of 115 START sql view model mart_gtfs.fct_trip_updates_messages ............. [RUN]
01:20:52  8 of 115 OK created sql table model staging.stg_gtfs_rt__trip_updates_validation_outcomes  [CREATE TABLE (50.8k rows, 93.8 MiB processed) in 6.50s]
01:20:52  11 of 115 OK created sql table model staging.stg_gtfs_rt__vehicle_positions_validation_notices  [CREATE TABLE (208.0 rows, 225.7 KiB processed) in 3.18s]
01:20:52  16 of 115 START sql incremental model staging.int_gtfs_quality__rt_validation_notices  [RUN]
01:20:52  9 of 115 OK created sql table model staging.stg_gtfs_rt__vehicle_positions ..... [CREATE TABLE (7.7k rows, 6.6 MiB processed) in 3.54s]
01:20:52  17 of 115 START sql view model mart_gtfs.fct_vehicle_positions_messages ........ [RUN]
01:20:52  13 of 115 OK created sql view model mart_gtfs.fct_service_alerts_messages ...... [CREATE VIEW (0 processed) in 1.45s]
01:20:52  18 of 115 START sql incremental model mart_gtfs_quality.fct_daily_service_alerts_message_age_summary  [RUN]
01:20:52  19 of 115 START sql view model staging.int_gtfs_rt__service_alerts_fully_unnested  [RUN]
01:20:52  15 of 115 OK created sql view model mart_gtfs.fct_trip_updates_messages ........ [CREATE VIEW (0 processed) in 1.42s]
01:20:52  20 of 115 START sql view model mart_gtfs.fct_stop_time_updates ................. [RUN]
01:20:53  17 of 115 OK created sql view model mart_gtfs.fct_vehicle_positions_messages ... [CREATE VIEW (0 processed) in 1.41s]
01:20:53  21 of 115 START sql incremental model mart_gtfs.fct_trip_updates_no_stop_times . [RUN]
01:20:53  10 of 115 OK created sql table model staging.stg_gtfs_rt__vehicle_positions_outcomes  [CREATE TABLE (26.6k rows, 47.3 MiB processed) in 4.99s]
01:20:53  22 of 115 START sql incremental model mart_gtfs_quality.fct_daily_vehicle_positions_latency_statistics  [RUN]
01:20:54  19 of 115 OK created sql view model staging.int_gtfs_rt__service_alerts_fully_unnested  [CREATE VIEW (0 processed) in 1.69s]
01:20:54  23 of 115 START sql incremental model mart_gtfs_quality.fct_daily_vehicle_positions_message_age_summary  [RUN]
01:20:54  14 of 115 OK created sql incremental model staging.int_gtfs_rt__distinct_download_configs  [CREATE TABLE (1.0 rows, 779.1 KiB processed) in 3.15s]
01:20:54  24 of 115 START sql incremental model mart_gtfs_quality.fct_daily_vendor_vehicle_positions_message_age_summary  [RUN]
01:20:54  20 of 115 OK created sql view model mart_gtfs.fct_stop_time_updates ............ [CREATE VIEW (0 processed) in 1.68s]
01:20:54  25 of 115 START sql incremental model mart_gtfs_quality.fct_daily_with_trip_vehicle_positions_message_age_summary  [RUN]
01:20:55  16 of 115 OK created sql incremental model staging.int_gtfs_quality__rt_validation_notices  [CREATE TABLE (0.0 rows, 434.1 KiB processed) in 2.98s]
01:20:55  26 of 115 START sql incremental model staging.int_gtfs_rt__vehicle_positions_trip_day_map_grouping  [RUN]
01:20:56  12 of 115 OK created sql table model staging.stg_gtfs_rt__vehicle_positions_validation_outcomes  [CREATE TABLE (53.6k rows, 100.7 MiB processed) in 5.72s]
01:20:56  27 of 115 START sql incremental model staging.int_gtfs_rt__unioned_parse_outcomes  [RUN]
01:20:57  21 of 115 OK created sql incremental model mart_gtfs.fct_trip_updates_no_stop_times  [CREATE TABLE (0.0 rows, 8.8 MiB processed) in 3.67s]
01:20:57  28 of 115 START sql incremental model mart_gtfs.fct_service_alerts_messages_unnested  [RUN]
01:20:57  18 of 115 OK created sql incremental model mart_gtfs_quality.fct_daily_service_alerts_message_age_summary  [CREATE TABLE (0.0 rows, 1.2 MiB processed) in 5.04s]
01:20:57  29 of 115 START sql table model staging.int_gtfs_rt__daily_url_index ........... [RUN]
01:20:58  22 of 115 OK created sql incremental model mart_gtfs_quality.fct_daily_vehicle_positions_latency_statistics  [CREATE TABLE (0.0 rows, 2.0 MiB processed) in 3.72s]
01:20:58  25 of 115 OK created sql incremental model mart_gtfs_quality.fct_daily_with_trip_vehicle_positions_message_age_summary  [CREATE TABLE (0.0 rows, 2.1 MiB processed) in 3.53s]
01:20:58  30 of 115 START sql view model mart_gtfs.fct_stop_time_arrivals ................ [RUN]
01:20:58  31 of 115 START sql incremental model mart_gtfs.fct_stop_time_updates_week ..... [RUN]
01:20:58  24 of 115 OK created sql incremental model mart_gtfs_quality.fct_daily_vendor_vehicle_positions_message_age_summary  [CREATE TABLE (0.0 rows, 2.1 MiB processed) in 3.98s]
01:20:58  32 of 115 START sql incremental model staging.int_gtfs_rt__trip_updates_trip_day_map_grouping  [RUN]
01:20:59  26 of 115 OK created sql incremental model staging.int_gtfs_rt__vehicle_positions_trip_day_map_grouping  [CREATE TABLE (0.0 rows, 2.6 MiB processed) in 3.95s]
01:20:59  33 of 115 START sql incremental model staging.int_gtfs_quality__rt_validation_outcomes  [RUN]
01:20:59  23 of 115 OK created sql incremental model mart_gtfs_quality.fct_daily_vehicle_positions_message_age_summary  [CREATE TABLE (0.0 rows, 2.0 MiB processed) in 5.01s]
01:20:59  34 of 115 START sql incremental model mart_gtfs_quality.fct_daily_trip_updates_message_age_summary  [RUN]
01:20:59  30 of 115 OK created sql view model mart_gtfs.fct_stop_time_arrivals ........... [CREATE VIEW (0 processed) in 1.48s]
01:20:59  35 of 115 START sql table model mart_gtfs.fct_vehicle_positions_trip_summaries . [RUN]
01:21:00  27 of 115 OK created sql incremental model staging.int_gtfs_rt__unioned_parse_outcomes  [CREATE TABLE (25.0k rows, 43.7 MiB processed) in 3.52s]
01:21:00  36 of 115 START sql view model mart_gtfs.fct_stop_time_updates_with_arrivals ... [RUN]
01:21:01  36 of 115 OK created sql view model mart_gtfs.fct_stop_time_updates_with_arrivals  [CREATE VIEW (0 processed) in 1.14s]
01:21:01  37 of 115 START sql incremental model mart_gtfs.fct_daily_rt_feed_files ........ [RUN]
01:21:01  31 of 115 OK created sql incremental model mart_gtfs.fct_stop_time_updates_week  [CREATE TABLE (0.0 rows, 26.2 MiB processed) in 3.37s]
01:21:01  38 of 115 START sql incremental model mart_gtfs.fct_stop_time_arrivals_week .... [RUN]
01:21:01  28 of 115 OK created sql incremental model mart_gtfs.fct_service_alerts_messages_unnested  [CREATE TABLE (0.0 rows, 2.6 MiB processed) in 4.01s]
01:21:01  39 of 115 START sql incremental model staging.int_gtfs_rt__service_alerts_day_map_grouping  [RUN]
01:21:01  29 of 115 OK created sql table model staging.int_gtfs_rt__daily_url_index ...... [CREATE TABLE (0.0 rows, 56.8 MiB processed) in 4.29s]
01:21:01  40 of 115 START sql incremental model staging.int_gtfs_rt__service_alerts_trip_day_map_grouping  [RUN]
01:21:01  32 of 115 OK created sql incremental model staging.int_gtfs_rt__trip_updates_trip_day_map_grouping  [CREATE TABLE (0.0 rows, 16.1 MiB processed) in 3.62s]
01:21:01  41 of 115 START sql table model mart_gtfs.fct_trip_updates_summaries ........... [RUN]
01:21:02  33 of 115 OK created sql incremental model staging.int_gtfs_quality__rt_validation_outcomes  [CREATE TABLE (0.0 rows, 65.7 MiB processed) in 3.35s]
01:21:03  34 of 115 OK created sql incremental model mart_gtfs_quality.fct_daily_trip_updates_message_age_summary  [CREATE TABLE (0.0 rows, 0 processed) in 3.84s]
01:21:03  35 of 115 OK created sql table model mart_gtfs.fct_vehicle_positions_trip_summaries  [CREATE TABLE (0.0 rows, 0 processed) in 4.32s]
01:21:03  42 of 115 START sql incremental model mart_gtfs.fct_vehicle_locations .......... [RUN]
01:21:04  37 of 115 OK created sql incremental model mart_gtfs.fct_daily_rt_feed_files ... [CREATE TABLE (139.0 rows, 3.2 MiB processed) in 3.25s]
01:21:04  43 of 115 START sql table model mart_gtfs_quality.fct_daily_rt_feed_validation_notices  [RUN]
01:21:04  44 of 115 START sql incremental model mart_gtfs.fct_hourly_rt_feed_files ....... [RUN]
01:21:04  45 of 115 START sql incremental model mart_gtfs.fct_hourly_rt_feed_files_success  [RUN]
01:21:04  39 of 115 OK created sql incremental model staging.int_gtfs_rt__service_alerts_day_map_grouping  [CREATE TABLE (0.0 rows, 0 processed) in 2.94s]
01:21:04  46 of 115 START sql table model staging.int_gtfs_quality__naive_organization_service_dataset_full_join  [RUN]
01:21:04  38 of 115 OK created sql incremental model mart_gtfs.fct_stop_time_arrivals_week  [CREATE TABLE (0.0 rows, 0 processed) in 3.32s]
01:21:04  47 of 115 START sql table model mart_gtfs.fct_daily_service_alerts ............. [RUN]
01:21:04  40 of 115 OK created sql incremental model staging.int_gtfs_rt__service_alerts_trip_day_map_grouping  [CREATE TABLE (0.0 rows, 0 processed) in 3.08s]
01:21:04  48 of 115 START sql incremental model mart_gtfs.fct_stop_time_updates_with_arrivals_week  [RUN]
01:21:06  41 of 115 OK created sql table model mart_gtfs.fct_trip_updates_summaries ...... [CREATE TABLE (0.0 rows, 0 processed) in 4.52s]
01:21:06  49 of 115 START sql table model mart_gtfs.fct_service_alerts_trip_summaries .... [RUN]
01:21:07  44 of 115 OK created sql incremental model mart_gtfs.fct_hourly_rt_feed_files .. [CREATE TABLE (0.0 rows, 2.7 MiB processed) in 3.17s]
01:21:07  50 of 115 START sql table model mart_gtfs.fct_observed_trips ................... [RUN]
01:21:07  45 of 115 OK created sql incremental model mart_gtfs.fct_hourly_rt_feed_files_success  [CREATE TABLE (0.0 rows, 2.7 MiB processed) in 3.54s]
01:21:07  51 of 115 START sql view model mart_gtfs.fct_stop_time_updates_metrics ......... [RUN]
01:21:08  42 of 115 OK created sql incremental model mart_gtfs.fct_vehicle_locations ..... [CREATE TABLE (0.0 rows, 3.6 MiB processed) in 4.16s]
01:21:08  52 of 115 START sql incremental model mart_gtfs.fct_vehicle_locations_path ..... [RUN]
01:21:08  48 of 115 OK created sql incremental model mart_gtfs.fct_stop_time_updates_with_arrivals_week  [CREATE TABLE (0.0 rows, 0 processed) in 3.17s]
01:21:08  53 of 115 START sql table model mart_gtfs.fct_vehicle_positions_trip_metrics ... [RUN]
01:21:08  47 of 115 OK created sql table model mart_gtfs.fct_daily_service_alerts ........ [CREATE TABLE (0.0 rows, 0 processed) in 3.57s]
01:21:08  54 of 115 START sql table model mart_gtfs.fct_stop_time_updates_metrics_week ... [RUN]
01:21:08  43 of 115 OK created sql table model mart_gtfs_quality.fct_daily_rt_feed_validation_notices  [CREATE TABLE (7.9k rows, 20.9 KiB processed) in 4.02s]
01:21:09  51 of 115 OK created sql view model mart_gtfs.fct_stop_time_updates_metrics .... [CREATE VIEW (0 processed) in 1.21s]
01:21:10  49 of 115 OK created sql table model mart_gtfs.fct_service_alerts_trip_summaries  [CREATE TABLE (0.0 rows, 0 processed) in 4.14s]
01:21:10  50 of 115 OK created sql table model mart_gtfs.fct_observed_trips .............. [CREATE TABLE (0.0 rows, 128.1 KiB processed) in 3.21s]
01:21:11  46 of 115 OK created sql table model staging.int_gtfs_quality__naive_organization_service_dataset_full_join  [CREATE TABLE (104.8k rows, 2.0 MiB processed) in 6.62s]
01:21:11  55 of 115 START sql table model staging.int_gtfs_quality__daily_assessment_candidate_entities  [RUN]
01:21:11  54 of 115 OK created sql table model mart_gtfs.fct_stop_time_updates_metrics_week  [CREATE TABLE (0.0 rows, 0 processed) in 3.00s]
01:21:11  52 of 115 OK created sql incremental model mart_gtfs.fct_vehicle_locations_path  [CREATE TABLE (0.0 rows, 0 processed) in 3.59s]
01:21:15  55 of 115 OK created sql table model staging.int_gtfs_quality__daily_assessment_candidate_entities  [CREATE TABLE (104.8k rows, 27.1 MiB processed) in 4.29s]
01:21:15  56 of 115 START sql table model mart_transit_database.dim_provider_gtfs_data ... [RUN]
01:21:15  57 of 115 START sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_gtfs_vendors  [RUN]
01:21:15  58 of 115 START sql table model staging.int_gtfs_quality__guideline_checks_index  [RUN]
01:21:15  59 of 115 START sql table model staging.int_gtfs_quality__organization_dataset_map  [RUN]
01:21:15  53 of 115 OK created sql table model mart_gtfs.fct_vehicle_positions_trip_metrics  [CREATE TABLE (0.0 rows, 833.9 MiB processed) in 7.78s]
01:21:18  59 of 115 OK created sql table model staging.int_gtfs_quality__organization_dataset_map  [CREATE TABLE (96.8k rows, 15.6 MiB processed) in 3.50s]
01:21:18  60 of 115 START sql table model mart_gtfs_quality.fct_daily_reports_site_organization_scheduled_service_summary  [RUN]
01:21:18  61 of 115 START sql table model mart_gtfs_quality.fct_daily_trip_updates_vehicle_positions_completeness  [RUN]
01:21:19  57 of 115 OK created sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_gtfs_vendors  [CREATE TABLE (336.0 rows, 7.5 MiB processed) in 3.68s]
01:21:20  56 of 115 OK created sql table model mart_transit_database.dim_provider_gtfs_data  [CREATE TABLE (1.9k rows, 18.4 MiB processed) in 4.90s]
01:21:20  62 of 115 START sql table model mart_transit_database.dim_mobility_mart_providers  [RUN]
01:21:22  58 of 115 OK created sql table model staging.int_gtfs_quality__guideline_checks_index  [CREATE TABLE (8.0m rows, 29.3 MiB processed) in 7.00s]
01:21:22  63 of 115 START sql table model staging.int_gtfs_quality__all_tu_in_vp ......... [RUN]
01:21:22  64 of 115 START sql table model staging.int_gtfs_quality__authentication_acceptable  [RUN]
01:21:22  65 of 115 START sql table model staging.int_gtfs_quality__complete_wheelchair_accessibility_data  [RUN]
01:21:22  66 of 115 START sql table model staging.int_gtfs_quality__contact_on_website ... [RUN]
01:21:22  67 of 115 START sql table model staging.int_gtfs_quality__data_license ......... [RUN]
01:21:22  60 of 115 OK created sql table model mart_gtfs_quality.fct_daily_reports_site_organization_scheduled_service_summary  [CREATE TABLE (5.6k rows, 9.2 MiB processed) in 3.51s]
01:21:22  68 of 115 START sql table model staging.int_gtfs_quality__demand_responsive_routes_match  [RUN]
01:21:22  61 of 115 OK created sql table model mart_gtfs_quality.fct_daily_trip_updates_vehicle_positions_completeness  [CREATE TABLE (2.1k rows, 140.0 MiB processed) in 3.91s]
01:21:22  69 of 115 START sql table model staging.int_gtfs_quality__feed_aggregator ...... [RUN]
01:21:26  68 of 115 OK created sql table model staging.int_gtfs_quality__demand_responsive_routes_match  [CREATE TABLE (104.8k rows, 51.1 MiB processed) in 3.58s]
01:21:26  70 of 115 START sql table model staging.int_gtfs_quality__feed_listed .......... [RUN]
01:21:26  62 of 115 OK created sql table model mart_transit_database.dim_mobility_mart_providers  [CREATE TABLE (237.0 rows, 52.5 MiB processed) in 5.78s]
01:21:26  71 of 115 START sql table model staging.int_gtfs_quality__fixed_routes_match ... [RUN]
01:21:26  65 of 115 OK created sql table model staging.int_gtfs_quality__complete_wheelchair_accessibility_data  [CREATE TABLE (104.8k rows, 159.0 MiB processed) in 3.72s]
01:21:26  72 of 115 START sql table model staging.int_gtfs_quality__grading_scheme_v1 .... [RUN]
01:21:26  63 of 115 OK created sql table model staging.int_gtfs_quality__all_tu_in_vp .... [CREATE TABLE (104.8k rows, 67.5 MiB processed) in 3.93s]
01:21:26  73 of 115 START sql table model staging.int_gtfs_quality__include_tts .......... [RUN]
01:21:26  66 of 115 OK created sql table model staging.int_gtfs_quality__contact_on_website  [CREATE TABLE (104.8k rows, 44.6 MiB processed) in 4.21s]
01:21:26  74 of 115 START sql table model staging.int_gtfs_quality__lead_time ............ [RUN]
01:21:27  64 of 115 OK created sql table model staging.int_gtfs_quality__authentication_acceptable  [CREATE TABLE (419.2k rows, 296.5 MiB processed) in 5.12s]
01:21:27  75 of 115 START sql table model staging.int_gtfs_quality__link_to_dataset_on_website  [RUN]
01:21:27  67 of 115 OK created sql table model staging.int_gtfs_quality__data_license .... [CREATE TABLE (419.2k rows, 183.1 MiB processed) in 5.51s]
01:21:27  76 of 115 START sql table model staging.int_gtfs_quality__modification_date_present  [RUN]
01:21:29  72 of 115 OK created sql table model staging.int_gtfs_quality__grading_scheme_v1  [CREATE TABLE (104.8k rows, 91.7 MiB processed) in 3.70s]
01:21:29  77 of 115 START sql table model staging.int_gtfs_quality__modification_date_present_rt  [RUN]
01:21:30  71 of 115 OK created sql table model staging.int_gtfs_quality__fixed_routes_match  [CREATE TABLE (104.8k rows, 97.0 MiB processed) in 4.49s]
01:21:30  78 of 115 START sql table model staging.int_gtfs_quality__no_30_day_feed_expiration  [RUN]
01:21:31  73 of 115 OK created sql table model staging.int_gtfs_quality__include_tts ..... [CREATE TABLE (104.8k rows, 68.8 MiB processed) in 4.80s]
01:21:31  79 of 115 START sql table model staging.int_gtfs_quality__no_7_day_feed_expiration  [RUN]
01:21:31  70 of 115 OK created sql table model staging.int_gtfs_quality__feed_listed ..... [CREATE TABLE (419.2k rows, 183.8 MiB processed) in 5.30s]
01:21:31  80 of 115 START sql table model staging.int_gtfs_quality__no_expired_services .. [RUN]
01:21:31  76 of 115 OK created sql table model staging.int_gtfs_quality__modification_date_present  [CREATE TABLE (104.8k rows, 97.1 MiB processed) in 3.78s]
01:21:31  81 of 115 START sql table model staging.int_gtfs_quality__no_rt_validation_errors  [RUN]
01:21:32  69 of 115 OK created sql table model staging.int_gtfs_quality__feed_aggregator . [CREATE TABLE (838.5k rows, 485.8 MiB processed) in 9.82s]
01:21:32  82 of 115 START sql table model staging.int_gtfs_quality__no_schedule_validation_errors  [RUN]
01:21:32  74 of 115 OK created sql table model staging.int_gtfs_quality__lead_time ....... [CREATE TABLE (104.8k rows, 307.4 MiB processed) in 6.07s]
01:21:32  83 of 115 START sql table model staging.int_gtfs_quality__no_stale_service_alerts  [RUN]
01:21:33  75 of 115 OK created sql table model staging.int_gtfs_quality__link_to_dataset_on_website  [CREATE TABLE (419.2k rows, 299.9 MiB processed) in 5.74s]
01:21:33  84 of 115 START sql table model staging.int_gtfs_quality__no_stale_trip_updates  [RUN]
01:21:34  78 of 115 OK created sql table model staging.int_gtfs_quality__no_30_day_feed_expiration  [CREATE TABLE (104.8k rows, 161.3 MiB processed) in 3.90s]
01:21:34  85 of 115 START sql table model staging.int_gtfs_quality__no_stale_vehicle_positions  [RUN]
01:21:35  77 of 115 OK created sql table model staging.int_gtfs_quality__modification_date_present_rt  [CREATE TABLE (314.4k rows, 188.1 MiB processed) in 5.44s]
01:21:35  86 of 115 START sql table model staging.int_gtfs_quality__passes_fares_validator  [RUN]
01:21:35  79 of 115 OK created sql table model staging.int_gtfs_quality__no_7_day_feed_expiration  [CREATE TABLE (104.8k rows, 111.4 MiB processed) in 4.19s]
01:21:35  87 of 115 START sql table model staging.int_gtfs_quality__pathways_valid ....... [RUN]
01:21:35  80 of 115 OK created sql table model staging.int_gtfs_quality__no_expired_services  [CREATE TABLE (104.8k rows, 92.5 MiB processed) in 4.17s]
01:21:35  88 of 115 START sql table model staging.int_gtfs_quality__persistent_ids_schedule  [RUN]
01:21:36  82 of 115 OK created sql table model staging.int_gtfs_quality__no_schedule_validation_errors  [CREATE TABLE (104.8k rows, 136.7 MiB processed) in 3.60s]
01:21:36  89 of 115 START sql table model staging.int_gtfs_quality__rt_20sec_tu .......... [RUN]
01:21:37  83 of 115 OK created sql table model staging.int_gtfs_quality__no_stale_service_alerts  [CREATE TABLE (104.8k rows, 44.7 MiB processed) in 3.90s]
01:21:37  90 of 115 START sql table model staging.int_gtfs_quality__rt_20sec_vp .......... [RUN]
01:21:37  84 of 115 OK created sql table model staging.int_gtfs_quality__no_stale_trip_updates  [CREATE TABLE (104.8k rows, 88.5 MiB processed) in 3.95s]
01:21:37  91 of 115 START sql table model staging.int_gtfs_quality__rt_feeds_present ..... [RUN]
01:21:37  81 of 115 OK created sql table model staging.int_gtfs_quality__no_rt_validation_errors  [CREATE TABLE (314.4k rows, 185.9 MiB processed) in 6.03s]
01:21:37  92 of 115 START sql table model staging.int_gtfs_quality__rt_https ............. [RUN]
01:21:38  85 of 115 OK created sql table model staging.int_gtfs_quality__no_stale_vehicle_positions  [CREATE TABLE (104.8k rows, 45.0 MiB processed) in 4.24s]
01:21:38  93 of 115 START sql table model staging.int_gtfs_quality__rt_protobuf_error .... [RUN]
01:21:39  87 of 115 OK created sql table model staging.int_gtfs_quality__pathways_valid .. [CREATE TABLE (104.8k rows, 179.4 MiB processed) in 4.42s]
01:21:39  94 of 115 START sql table model staging.int_gtfs_quality__schedule_download_success  [RUN]
01:21:39  89 of 115 OK created sql table model staging.int_gtfs_quality__rt_20sec_tu ..... [CREATE TABLE (104.8k rows, 88.5 MiB processed) in 3.59s]
01:21:39  95 of 115 START sql table model staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [RUN]
01:21:40  86 of 115 OK created sql table model staging.int_gtfs_quality__passes_fares_validator  [CREATE TABLE (104.8k rows, 113.9 MiB processed) in 4.86s]
01:21:40  96 of 115 START sql table model staging.int_gtfs_quality__shapes_accurate ...... [RUN]
01:21:40  90 of 115 OK created sql table model staging.int_gtfs_quality__rt_20sec_vp ..... [CREATE TABLE (104.8k rows, 86.4 MiB processed) in 3.59s]
01:21:40  97 of 115 START sql table model staging.int_gtfs_quality__shapes_file_present .. [RUN]
01:21:40  88 of 115 OK created sql table model staging.int_gtfs_quality__persistent_ids_schedule  [CREATE TABLE (104.8k rows, 70.0 MiB processed) in 5.35s]
01:21:40  98 of 115 START sql table model staging.int_gtfs_quality__shapes_for_all_trips . [RUN]
01:21:41  91 of 115 OK created sql table model staging.int_gtfs_quality__rt_feeds_present  [CREATE TABLE (314.4k rows, 286.5 MiB processed) in 3.93s]
01:21:41  99 of 115 START sql table model staging.int_gtfs_quality__shapes_valid ......... [RUN]
01:21:42  92 of 115 OK created sql table model staging.int_gtfs_quality__rt_https ........ [CREATE TABLE (314.4k rows, 164.8 MiB processed) in 4.76s]
01:21:42  100 of 115 START sql table model staging.int_gtfs_quality__stable_url .......... [RUN]
01:21:43  96 of 115 OK created sql table model staging.int_gtfs_quality__shapes_accurate . [CREATE TABLE (104.8k rows, 51.4 MiB processed) in 3.32s]
01:21:43  101 of 115 START sql table model staging.int_gtfs_quality__technical_contact_listed  [RUN]
01:21:43  93 of 115 OK created sql table model staging.int_gtfs_quality__rt_protobuf_error  [CREATE TABLE (314.4k rows, 190.2 MiB processed) in 4.85s]
01:21:43  102 of 115 START sql table model staging.int_gtfs_quality__trip_id_alignment ... [RUN]
01:21:43  94 of 115 OK created sql table model staging.int_gtfs_quality__schedule_download_success  [CREATE TABLE (104.8k rows, 85.3 MiB processed) in 3.89s]
01:21:43  103 of 115 START sql table model staging.int_gtfs_quality__trip_planners ....... [RUN]
01:21:44  98 of 115 OK created sql table model staging.int_gtfs_quality__shapes_for_all_trips  [CREATE TABLE (104.8k rows, 111.2 MiB processed) in 3.59s]
01:21:44  104 of 115 START sql table model staging.int_gtfs_quality__wheelchair_accessible_trips  [RUN]
01:21:45  95 of 115 OK created sql table model staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [CREATE TABLE (104.8k rows, 283.9 MiB processed) in 5.24s]
01:21:45  105 of 115 START sql table model staging.int_gtfs_quality__wheelchair_boarding_stops  [RUN]
01:21:45  99 of 115 OK created sql table model staging.int_gtfs_quality__shapes_valid .... [CREATE TABLE (104.8k rows, 115.4 MiB processed) in 4.26s]
01:21:45  106 of 115 START sql table model mart_gtfs_quality.idx_monthly_reports_site .... [RUN]
01:21:46  97 of 115 OK created sql table model staging.int_gtfs_quality__shapes_file_present  [CREATE TABLE (104.8k rows, 107.0 MiB processed) in 5.37s]
01:21:47  101 of 115 OK created sql table model staging.int_gtfs_quality__technical_contact_listed  [CREATE TABLE (104.8k rows, 52.1 MiB processed) in 3.56s]
01:21:47  100 of 115 OK created sql table model staging.int_gtfs_quality__stable_url ..... [CREATE TABLE (419.2k rows, 297.1 MiB processed) in 5.10s]
01:21:48  103 of 115 OK created sql table model staging.int_gtfs_quality__trip_planners .. [CREATE TABLE (209.6k rows, 189.9 MiB processed) in 4.75s]
01:21:48  104 of 115 OK created sql table model staging.int_gtfs_quality__wheelchair_accessible_trips  [CREATE TABLE (104.8k rows, 147.8 MiB processed) in 4.40s]
01:21:48  102 of 115 OK created sql table model staging.int_gtfs_quality__trip_id_alignment  [CREATE TABLE (104.8k rows, 90.5 MiB processed) in 5.37s]
01:21:49  105 of 115 OK created sql table model staging.int_gtfs_quality__wheelchair_boarding_stops  [CREATE TABLE (104.8k rows, 55.6 MiB processed) in 4.08s]
01:21:49  107 of 115 START sql table model staging.int_gtfs_quality__guideline_checks_long  [RUN]
01:21:49  106 of 115 OK created sql table model mart_gtfs_quality.idx_monthly_reports_site  [CREATE TABLE (183.0 rows, 25.2 MiB processed) in 4.20s]
01:21:49  108 of 115 START sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_file_checks  [RUN]
01:21:49  109 of 115 START sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_validation_codes  [RUN]
01:21:49  110 of 115 START sql view model mart_gtfs_quality.fct_monthly_route_id_changes . [RUN]
01:21:49  111 of 115 START sql view model mart_gtfs_quality.fct_monthly_stop_id_changes .. [RUN]
01:21:51  110 of 115 OK created sql view model mart_gtfs_quality.fct_monthly_route_id_changes  [CREATE VIEW (0 processed) in 1.49s]
01:21:51  111 of 115 OK created sql view model mart_gtfs_quality.fct_monthly_stop_id_changes  [CREATE VIEW (0 processed) in 1.49s]
01:21:53  108 of 115 OK created sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_file_checks  [CREATE TABLE (2.2k rows, 5.6 MiB processed) in 3.88s]
01:21:53  109 of 115 OK created sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_validation_codes  [CREATE TABLE (1.0k rows, 85.0 MiB processed) in 3.88s]
01:22:06  107 of 115 OK created sql table model staging.int_gtfs_quality__guideline_checks_long  [CREATE TABLE (9.0m rows, 4.2 GiB processed) in 16.79s]
01:22:06  112 of 115 START sql table model mart_gtfs_quality.fct_daily_organization_combined_guideline_checks  [RUN]
01:22:06  113 of 115 START sql table model mart_gtfs_quality.fct_daily_service_combined_guideline_checks  [RUN]
01:22:06  114 of 115 START sql table model mart_gtfs_quality.fct_implemented_checks ...... [RUN]
01:22:10  114 of 115 OK created sql table model mart_gtfs_quality.fct_implemented_checks . [CREATE TABLE (76.0 rows, 842.1 MiB processed) in 3.52s]
01:22:18  112 of 115 OK created sql table model mart_gtfs_quality.fct_daily_organization_combined_guideline_checks  [CREATE TABLE (605.0k rows, 2.5 GiB processed) in 12.82s]
01:22:18  115 of 115 START sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_guideline_checks  [RUN]
01:22:19  113 of 115 OK created sql table model mart_gtfs_quality.fct_daily_service_combined_guideline_checks  [CREATE TABLE (641.4k rows, 2.4 GiB processed) in 13.53s]
01:22:22  115 of 115 OK created sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_guideline_checks  [CREATE TABLE (13.9k rows, 87.2 MiB processed) in 3.67s]
01:22:22
01:22:22  Finished running 81 table models, 10 view models, 24 incremental models in 0 hours 1 minutes and 41.24 seconds (101.24s).
01:22:22
01:22:22  Completed successfully
01:22:22
01:22:22  Done. PASS=115 WARN=0 ERROR=0 SKIP=0 TOTAL=115
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm the data being filtered on the tables above and the successful run of `mart_gtfs.fct_trip_updates_summaries` in `dbt_all` DAG.