### PR TITLE
Reduce more the dt filter on Staging GTFS RT models to run downstream models

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Run dbt against changed files
         working-directory: warehouse
-        run: poetry run dbt run --select "${{ needs.dbt-changed.outputs.changed }}+" --target ${{ env.DBT_TARGET }} --full-refresh
+        run: poetry run dbt run --select "${{ needs.dbt-changed.outputs.changed }}+" --target ${{ env.DBT_TARGET }} --exclude source:external_gtfs_rt+ source:gtfs_rt_external_tables+ --full-refresh
 
       - name: Synchronize Metabase
         working-directory: warehouse

--- a/warehouse/macros/gtfs_rt_stg_outcomes.sql
+++ b/warehouse/macros/gtfs_rt_stg_outcomes.sql
@@ -5,7 +5,7 @@ WITH raw_outcomes AS (
         *,
         {{ to_url_safe_base64('`extract`.config.url') }} AS base64_url
     FROM {{ source_table }}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
+    WHERE dt >= '2025-07-01' -- Temporary filter
 ),
 
 stg_gtfs_rt__agg_outcomes AS (

--- a/warehouse/macros/gtfs_rt_stg_validation_notices.sql
+++ b/warehouse/macros/gtfs_rt_stg_validation_notices.sql
@@ -23,7 +23,7 @@ WITH stg_gtfs_rt__validation_notices AS (
         errorMessage.validationRule.occurrenceSuffix AS error_message_validation_rule_occurrence_suffix,
         occurrenceList AS occurrence_list
     FROM {{ source_table }}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
+    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__validation_notices

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__service_alerts AS (
     SELECT
         dt,

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
@@ -31,7 +31,7 @@ WITH stg_gtfs_rt__service_alerts AS (
         alert.severityLevel AS severity_level
 
     FROM {{ source('external_gtfs_rt', 'service_alerts') }}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
+    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__service_alerts

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts_outcomes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts_outcomes.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__service_alerts_outcomes AS (
     {{ gtfs_rt_stg_outcomes('parse', source('external_gtfs_rt', 'service_alerts_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__trip_updates AS (
     SELECT
         dt,

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
@@ -35,7 +35,7 @@ WITH stg_gtfs_rt__trip_updates AS (
         tripUpdate.stopTimeUpdate AS stop_time_updates,
 
     FROM {{ source('external_gtfs_rt', 'trip_updates') }}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
+    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__trip_updates

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates_outcomes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates_outcomes.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__trip_updates_outcomes AS (
     {{ gtfs_rt_stg_outcomes('parse', source('external_gtfs_rt', 'trip_updates_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__vehicle_positions AS (
     SELECT
         dt,

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
@@ -44,7 +44,7 @@ WITH stg_gtfs_rt__vehicle_positions AS (
         vehicle.position.speed AS position_speed
 
     FROM {{ source('external_gtfs_rt', 'vehicle_positions') }}
-    WHERE dt >= DATE_SUB(CURRENT_DATE(), INTERVAL 6 MONTH) -- last 6 months
+    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__vehicle_positions

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions_outcomes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions_outcomes.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__vehicle_positions_outcomes AS (
     {{ gtfs_rt_stg_outcomes('parse', source('external_gtfs_rt', 'vehicle_positions_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_notices.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_notices.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__service_alerts_validation_notices AS (
     {{ gtfs_rt_stg_validation_notices(source('external_gtfs_rt', 'service_alerts_validation_notices')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_outcomes.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__service_alerts_validation_outcomes.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__service_alerts_validation_outcomes AS (
     {{ gtfs_rt_stg_outcomes('validation', source('external_gtfs_rt', 'service_alerts_validation_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_notices.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_notices.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__trip_updates_validation_notices AS (
     {{ gtfs_rt_stg_validation_notices(source('external_gtfs_rt', 'trip_updates_validation_notices')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_outcomes.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__trip_updates_validation_outcomes.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__trip_updates_validation_outcomes AS (
     {{ gtfs_rt_stg_outcomes('validation', source('external_gtfs_rt', 'trip_updates_validation_outcomes')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_notices.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_notices.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__vehicle_positions_validation_notices AS (
     {{ gtfs_rt_stg_validation_notices(source('external_gtfs_rt', 'vehicle_positions_validation_notices')) }}
 )

--- a/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_outcomes.sql
+++ b/warehouse/models/staging/gtfs_quality/stg_gtfs_rt__vehicle_positions_validation_outcomes.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 WITH stg_gtfs_rt__vehicle_positions_validation_outcomes AS (
     {{ gtfs_rt_stg_outcomes('validation', source('external_gtfs_rt', 'vehicle_positions_validation_outcomes')) }}
 )


### PR DESCRIPTION
# Description

This PR changes the `dt` filter on Staging GTFS RT models to `>= '2025-07-01'` to try to run all the models.

In conversation with @vevetron, we decided to use the fix date '2025-07-01' to reduce more the range (instead of 6 months) to see if BigQuery is able to run successfully all models. The date is also fixed for now because we are planning incrementally add more dates.

I removed the previous materialization on `stg_` models since it didn't help the process.

Related to previous [PR 412](https://github.com/cal-itp/data-infra/pull/4126)

Also based on old full-refresh sundays DAG, I added `--exclude source:external_gtfs_rt+ source:gtfs_rt_external_tables+` to the command`poetry run dbt run ... --full-refresh` to avoid full-refresh on those models because of the size and incremental settings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running locally and on staging.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Drop materialized tables created on the previous PR in order to be recreated as View:
* staging.stg_gtfs_rt__service_alerts
* staging.stg_gtfs_rt__trip_updates
* staging.stg_gtfs_rt__vehicle_positions
* staging.stg_gtfs_rt__service_alerts_outcomes
* staging.stg_gtfs_rt__trip_updates_outcomes
* staging.stg_gtfs_rt__vehicle_positions_outcomes
* staging.stg_gtfs_rt__service_alerts_validation_outcomes
* staging.stg_gtfs_rt__trip_updates_validation_outcomes
* staging.stg_gtfs_rt__vehicle_positions_validation_outcomes
* staging.stg_gtfs_rt__service_alerts_validation_notices
* staging.stg_gtfs_rt__trip_updates_validation_notices
* staging.stg_gtfs_rt__vehicle_positions_validation_notices

Monitor the deployment and run models on `dbt_all`.