### PR TITLE
Adjust GTFS RT models and configuration

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Compile dbt
         working-directory: warehouse
-        run: poetry run dbt compile --target ${{ env.DBT_TARGET }} --full-refresh
+        run: poetry run dbt compile --target ${{ env.DBT_TARGET }}
 
       - name: Generate dbt documentation
         working-directory: warehouse

--- a/warehouse/macros/gtfs_rt_stg_outcomes.sql
+++ b/warehouse/macros/gtfs_rt_stg_outcomes.sql
@@ -5,7 +5,6 @@ WITH raw_outcomes AS (
         *,
         {{ to_url_safe_base64('`extract`.config.url') }} AS base64_url
     FROM {{ source_table }}
-    WHERE dt >= '2025-07-01' -- Temporary filter
 ),
 
 stg_gtfs_rt__agg_outcomes AS (

--- a/warehouse/macros/gtfs_rt_stg_validation_notices.sql
+++ b/warehouse/macros/gtfs_rt_stg_validation_notices.sql
@@ -23,7 +23,6 @@ WITH stg_gtfs_rt__validation_notices AS (
         errorMessage.validationRule.occurrenceSuffix AS error_message_validation_rule_occurrence_suffix,
         occurrenceList AS occurrence_list
     FROM {{ source_table }}
-    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__validation_notices

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_metrics.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_metrics.sql
@@ -1,9 +1,4 @@
-{{
-    config(
-        materialized='table',
-        cluster_by='base64_url',
-    )
-}}
+-- Probably need to be an incremental table
 
 WITH vehicle_positions AS (
     SELECT

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
@@ -29,7 +29,6 @@ WITH stg_gtfs_rt__service_alerts AS (
         alert.severityLevel AS severity_level
 
     FROM {{ source('external_gtfs_rt', 'service_alerts') }}
-    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__service_alerts

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__trip_updates.sql
@@ -33,7 +33,6 @@ WITH stg_gtfs_rt__trip_updates AS (
         tripUpdate.stopTimeUpdate AS stop_time_updates,
 
     FROM {{ source('external_gtfs_rt', 'trip_updates') }}
-    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__trip_updates

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql
@@ -42,7 +42,6 @@ WITH stg_gtfs_rt__vehicle_positions AS (
         vehicle.position.speed AS position_speed
 
     FROM {{ source('external_gtfs_rt', 'vehicle_positions') }}
-    WHERE dt >= '2025-07-01' -- Temporary filter
 )
 
 SELECT * FROM stg_gtfs_rt__vehicle_positions


### PR DESCRIPTION
# Description

This PR is part of the work trying to fix issue #4103 to run stg_ GTFS TR models.
After meeting with @lauriemerrell, she explained that upstream tables were supposed to be filtered when incremental tables run accordantly with the filter there, so we probably don't need to have the filters on `dt` as we have been trying to do. So I am removing it to see it working as before.

Since `fct_vehicle_positions_trip_metrics` has not been able to run we are changing it to a View, just to keep the table but it will stop burning BigQuery resources when `dbt_all` DAG runs.

I am also removing `full-refresh` from `poetry run dbt compile` so make sure Macros return the correct date when building queries and hoping that it may help to speed the run process.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running models locally.

```
❯ poetry run dbt run -s models/mart/gtfs/fct_vehicle_positions_trip_metrics.sql --target staging
22:56:29  Running with dbt=1.8.1
22:56:30  Registered adapter: bigquery=1.8.1
22:56:31  Found 617 models, 1236 data tests, 14 seeds, 223 sources, 4 exposures, 1041 macros
22:56:31
22:56:34  Concurrency: 8 threads (target='staging')
22:56:34
22:56:34  1 of 1 START sql view model mart_gtfs.fct_vehicle_positions_trip_metrics ....... [RUN]
22:56:35  1 of 1 OK created sql view model mart_gtfs.fct_vehicle_positions_trip_metrics .. [CREATE VIEW (0 processed) in 1.61s]
22:56:36
22:56:36  Finished running 1 view model in 0 hours 0 minutes and 4.68 seconds (4.68s).
22:56:36
22:56:36  Completed successfully
22:56:36
22:56:36  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1


❯ poetry run dbt run -s macros/gtfs_rt_stg_outcomes.sql macros/gtfs_rt_stg_validation_notices.sql models/staging/gtfs/stg_gtfs_rt__service_alerts.sql models/staging/gtfs/stg_gtfs_rt__trip_updates.sql models/staging/gtfs/stg_gtfs_rt__vehicle_positions.sql --target staging

00:17:35  Running with dbt=1.8.1
00:17:36  Registered adapter: bigquery=1.8.1
00:17:37  Found 617 models, 1236 data tests, 14 seeds, 223 sources, 4 exposures, 1041 macros
00:17:37  The selection criterion 'macros/gtfs_rt_stg_outcomes.sql' does not match any enabled nodes
00:17:37  The selection criterion 'macros/gtfs_rt_stg_validation_notices.sql' does not match any enabled nodes
00:17:37
00:17:40  Concurrency: 8 threads (target='staging')
00:17:40
00:17:40  1 of 3 START sql view model staging.stg_gtfs_rt__service_alerts ................ [RUN]
00:17:40  2 of 3 START sql view model staging.stg_gtfs_rt__trip_updates .................. [RUN]
00:17:40  3 of 3 START sql view model staging.stg_gtfs_rt__vehicle_positions ............. [RUN]
00:17:42  2 of 3 OK created sql view model staging.stg_gtfs_rt__trip_updates ............. [CREATE VIEW (0 processed) in 1.43s]
00:17:42  3 of 3 OK created sql view model staging.stg_gtfs_rt__vehicle_positions ........ [CREATE VIEW (0 processed) in 1.44s]
00:17:42  1 of 3 OK created sql view model staging.stg_gtfs_rt__service_alerts ........... [CREATE VIEW (0 processed) in 1.45s]
00:17:42
00:17:42  Finished running 3 view models in 0 hours 0 minutes and 4.75 seconds (4.75s).
00:17:42
00:17:42  Completed successfully
00:17:42
00:17:42  Done. PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

* `fct_vehicle_positions_trip_metrics` need to be dropped before re-run since it switching from Materialized Table to a View.
* Rerun erroring tables and `dbt_all` on weekend to see if it can run successfully.