### PR TITLE
Tune settings for local Airflow environment

### DIFF
--- a/airflow/.development.env
+++ b/airflow/.development.env
@@ -1,5 +1,4 @@
 AIRFLOW__CORE__EXECUTOR=LocalExecutor
-AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT='google-cloud-platform://'
 AIRFLOW_CONN_HTTP_BLACKCAT=https://services.blackcattransit.com
 AIRFLOW_CONN_HTTP_MOBILITY_DATABASE=https://bit.ly/catalogs-csv
 AIRFLOW_CONN_HTTP_NTD=https://data.transportation.gov

--- a/airflow/.development.env
+++ b/airflow/.development.env
@@ -1,3 +1,4 @@
+AIRFLOW__CORE__PARALLELISM=4
 AIRFLOW__CORE__EXECUTOR=LocalExecutor
 AIRFLOW_CONN_HTTP_BLACKCAT=https://services.blackcattransit.com
 AIRFLOW_CONN_HTTP_MOBILITY_DATABASE=https://bit.ly/catalogs-csv


### PR DESCRIPTION
# Description

This PR addresses some issues @mjumbewu and I faced while configuring a local Airflow environment, specifically related to Cosmos execution (the default parallelism is 32, which results in the airflow server getting reaped) and configuring the GCP connection.
 
Related to #3767 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`composer-dev start` and running DAGs against staging

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
