### PR TITLE
Increase sentry disk space to match values in lens - pvc

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -118,7 +118,7 @@ sentry:
     clickhouse:
       persistentVolumeClaim:
         dataPersistentVolume:
-          storage: "50Gi"
+          storage: "120Gi"
 
   hooks:
     activeDeadlineSeconds: 1200


### PR DESCRIPTION
# Description

The [runbook](https://github.com/cal-itp/data-infra/blob/main/runbooks/workflow/disk-space.md) says an option is to manually increase the disk space and then make sure it matches in the kubernetes specification.

<img width="863" height="396" alt="image" src="https://github.com/user-attachments/assets/7dd8346e-a9d4-4847-adb2-3dc65b35acc7" />


Resolves #4066

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested.


## Post-merge follow-ups
- [ ] No action required
- [x] Actions required (specified below)
Make sure the alerts stop in slack.