### PR TITLE
[images/jupyter-singleuser] Bump prototype image profile to 2025.8.1

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -40,20 +40,16 @@ jupyterhub:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-      - display_name: "Prototype Image - 2025.7.29, Python 3.11"
+      - display_name: "Prototype Image - 2025.8.1, Python 3.11"
         description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.7.29
-      - display_name: "Power Prototype Image - 2025.7.29, Python 3.11"
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.1
+      - display_name: "Power Prototype Image - 2025.8.1, Python 3.11"
         description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.7.29
-      - display_name: "Dependency Upgrades Testing Image - 2025.8.1, Python 3.11"
-        description: "This is the newer environment for image dependency upgrades testing. Not recommended for analyst use."
-        kubespawner_override:
           image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.1
   scheduling:
     userPods:


### PR DESCRIPTION
# Description

I tested `make setup_env` from `cal-itp/data-analyses/_shared_utils` and it worked as expected. I also checked the dependency versions on JupyterHub after deploying to a test image profile and they were updated as expected.

Resolves https://github.com/cal-itp/data-infra/issues/4139

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and `poetry run dbt test -s CHANGED_MODEL`, then include the output in this section of the PR._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
    * verify deployment of new image profile
