### PR TITLE
Re-Productionizing trip update trip summaries

### DIFF
--- a/warehouse/macros/incremental_max_date.sql
+++ b/warehouse/macros/incremental_max_date.sql
@@ -1,0 +1,28 @@
+{% macro incremental_max_date(default_start_var, this_dt_column = 'dt', filter_dt_column = 'dt', dev_lookback_days = 7) -%}
+{# BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
+{# save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
+
+{%- if is_incremental() -%}
+    {%- if var('INCREMENTAL_MAX_DT') -%}
+        {% set max_dt = var('INCREMENTAL_MAX_DT') %}
+    {%- else -%}
+        {% set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
+        {% set max_dt = dates[0] %}
+    {%- endif -%}
+    {%- if target.name.startswith('prod') or not dev_lookback_days -%}
+        {% set start_dt = max_dt %}
+    {%- else -%}
+        {% set start_dt = [max_dt, (modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days))] | max %}
+    {%- endif -%}
+{%- endif -%}
+
+{%- if not start_dt -%}
+    {# full refresh, or the table was empty #}
+    {%- if target.name.startswith('prod') or not dev_lookback_days -%}
+        {% set start_dt = var(default_start_var) %}
+    {%- else -%}
+        {% set start_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
+    {%- endif -%}
+{%- endif -%}
+{{ start_dt }}
+{% endmacro %}

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -606,7 +606,7 @@ models:
       to enable:
         1. Incremental materialization based on `dt` (to make efficient use of upstream partitions)
         2. Downstream grouping by `service_date` alone (since that is the appropriate final grain for trip-based analysis)
-      See downstream `fct_trip_updates_summaries` table for further documentation.
+      See downstream `fct_trip_updates_trip_summaries` table for further documentation.
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_day_map_grouping.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_day_map_grouping.sql
@@ -14,7 +14,7 @@
 WITH stop_time_updates AS (
     SELECT *
     FROM {{ ref('fct_stop_time_updates') }}
-    WHERE dt >= "2024-01-01" AND dt <= "2024-02-29"
+    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }}
 ),
 
 -- group by *both* the UTC date that data was scraped (dt) *and* calculated service date

--- a/warehouse/models/mart/gtfs/fct_trip_updates_trip_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_trip_summaries.sql
@@ -15,7 +15,8 @@
 WITH trip_updates AS( --noqa: ST03
     SELECT *
     FROM {{ ref('int_gtfs_rt__trip_updates_trip_day_map_grouping') }}
-    WHERE dt >= "2024-01-01" AND dt <= '2024-02-29'
+    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START', this_dt_column='service_date', filter_dt_column='service_date') }}
+    #TODO make sure this is the correct incremental filter - 3 days worth
 ),
 
  base_fct AS (


### PR DESCRIPTION
# Description

Adjusts filters to reprocess last few days of data to catch all incoming trip updates.

Resolves #4103 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
```
#This exact record was in both
SELECT * FROM `cal-itp-data-infra.mart_gtfs.fct_trip_updates_trip_summaries`
where service_date = '2025-07-14'
and trip_id = "468"
and base64_url = 'aHR0cHM6Ly9rYXJ0LmNvbm5leGlvbnoubmV0L3J0dC9wdWJsaWMvdXRpbGl0eS9ndGZzcmVhbHRpbWUuYXNweC90cmlwdXBkYXRl'


#These matched within reason
SELECT service_date, count(distinct(base64_url)), count(distinct(trip_id)) FROM `cal-itp-data-infra.mart_gtfs.fct_trip_updates_trip_summaries` 
group by 1
order by service_date DESC

I just did a visual check, i didn't do a full query based comparison of both tables.
```

IN PROD.  JUST FOR PROS WHEN PAIRING WITH @erikamov
```
➜  warehouse git:(productionize_trip_summaries) ✗ poetry run dbt run --select +fct_trip_updates_trip_summaries+ --target prod
22:50:29  Running with dbt=1.10.1
22:50:30  Registered adapter: bigquery=1.10.0
22:50:31  Found 610 models, 1236 data tests, 14 seeds, 223 sources, 4 exposures, 1052 macros
22:50:31  
22:50:31  Concurrency: 8 threads (target='prod')
22:50:31  
22:50:33  1 of 27 START sql view model staging.stg_gtfs_rt__trip_updates ................. [RUN]
22:50:33  2 of 27 START sql view model staging.stg_gtfs_schedule__agency ................. [RUN]
22:50:33  3 of 27 START sql view model staging.stg_gtfs_schedule__download_outcomes ...... [RUN]
22:50:33  4 of 27 START sql view model staging.stg_gtfs_schedule__file_parse_outcomes .... [RUN]
22:50:33  5 of 27 START sql view model staging.stg_gtfs_schedule__unzip_outcomes ......... [RUN]
22:50:33  6 of 27 START sql view model staging.stg_transit_database__gtfs_datasets ....... [RUN]
/Users/vivek/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-1QJyB9-Z-py3.11/lib/python3.11/site-packages/jinja2/lexer.py:654: DeprecationWarning: invalid escape sequence '\w'
/Users/vivek/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-1QJyB9-Z-py3.11/lib/python3.11/site-packages/jinja2/lexer.py:654: DeprecationWarning: invalid escape sequence '\?'
22:50:34  2 of 27 OK created sql view model staging.stg_gtfs_schedule__agency ............ [CREATE VIEW (0 processed) in 1.03s]
22:50:34  1 of 27 OK created sql view model staging.stg_gtfs_rt__trip_updates ............ [CREATE VIEW (0 processed) in 1.04s]
22:50:34  6 of 27 OK created sql view model staging.stg_transit_database__gtfs_datasets .. [CREATE VIEW (0 processed) in 1.04s]
22:50:34  5 of 27 OK created sql view model staging.stg_gtfs_schedule__unzip_outcomes .... [CREATE VIEW (0 processed) in 1.03s]
22:50:34  3 of 27 OK created sql view model staging.stg_gtfs_schedule__download_outcomes . [CREATE VIEW (0 processed) in 1.04s]
22:50:34  7 of 27 START sql table model staging.int_transit_database__gtfs_datasets_dim .. [RUN]
22:50:34  4 of 27 OK created sql view model staging.stg_gtfs_schedule__file_parse_outcomes  [CREATE VIEW (0 processed) in 1.30s]
22:50:34  8 of 27 START sql view model staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [RUN]
22:50:35  8 of 27 OK created sql view model staging.int_gtfs_schedule__grouped_feed_file_parse_outcomes  [CREATE VIEW (0 processed) in 1.19s]
22:50:35  9 of 27 START sql view model staging.int_gtfs_schedule__joined_feed_outcomes ... [RUN]
22:50:37  9 of 27 OK created sql view model staging.int_gtfs_schedule__joined_feed_outcomes  [CREATE VIEW (0 processed) in 1.30s]
22:50:37  10 of 27 START sql table model mart_gtfs.dim_schedule_feeds .................... [RUN]
22:50:38  7 of 27 OK created sql table model staging.int_transit_database__gtfs_datasets_dim  [CREATE TABLE (821.0 rows, 192.0 MiB processed) in 4.39s]
22:50:38  11 of 27 START sql table model mart_transit_database.bridge_schedule_dataset_for_validation  [RUN]
22:50:38  12 of 27 START sql table model mart_transit_database.dim_gtfs_datasets ......... [RUN]
22:50:41  11 of 27 OK created sql table model mart_transit_database.bridge_schedule_dataset_for_validation  [CREATE TABLE (487.0 rows, 87.9 KiB processed) in 2.32s]
22:50:41  12 of 27 OK created sql table model mart_transit_database.dim_gtfs_datasets .... [CREATE TABLE (821.0 rows, 316.5 KiB processed) in 2.48s]
22:50:41  13 of 27 START sql table model staging.int_transit_database__urls_to_gtfs_datasets  [RUN]
22:50:43  13 of 27 OK created sql table model staging.int_transit_database__urls_to_gtfs_datasets  [CREATE TABLE (821.0 rows, 146.6 KiB processed) in 2.42s]
22:50:45  10 of 27 OK created sql table model mart_gtfs.dim_schedule_feeds ............... [CREATE TABLE (427.0 rows, 117.9 MiB processed) in 8.15s]
22:50:45  14 of 27 START sql table model mart_gtfs.fct_daily_schedule_feeds .............. [RUN]
22:50:48  14 of 27 OK created sql table model mart_gtfs.fct_daily_schedule_feeds ......... [CREATE TABLE (12.5k rows, 196.2 KiB processed) in 2.91s]
22:50:48  15 of 27 START sql view model mart_gtfs.fct_trip_updates_messages .............. [RUN]
22:50:49  15 of 27 OK created sql view model mart_gtfs.fct_trip_updates_messages ......... [CREATE VIEW (0 processed) in 1.07s]
22:50:49  16 of 27 START sql view model mart_gtfs.fct_stop_time_updates .................. [RUN]
22:50:50  16 of 27 OK created sql view model mart_gtfs.fct_stop_time_updates ............. [CREATE VIEW (0 processed) in 1.37s]
22:50:50  17 of 27 START sql incremental model staging.int_gtfs_rt__trip_updates_trip_day_map_grouping  [RUN]
22:50:57  17 of 27 OK created sql incremental model staging.int_gtfs_rt__trip_updates_trip_day_map_grouping  [SCRIPT (1.7 MiB processed) in 7.11s]
22:50:57  18 of 27 START sql incremental model mart_gtfs.fct_trip_updates_trip_summaries . [RUN]
22:51:20  18 of 27 OK created sql incremental model mart_gtfs.fct_trip_updates_trip_summaries  [SCRIPT (239.4 MiB processed) in 23.19s]
22:51:20  19 of 27 START sql incremental model mart_gtfs.fct_observed_trips .............. [RUN]
22:52:21  19 of 27 OK created sql incremental model mart_gtfs.fct_observed_trips ......... [SCRIPT (71.5 GiB processed) in 60.08s]
22:52:21  20 of 27 START sql table model mart_gtfs_quality.fct_daily_trip_updates_vehicle_positions_completeness  [RUN]
22:52:21  21 of 27 START sql table model staging.int_gtfs_quality__all_tu_in_vp .......... [RUN]
22:52:21  22 of 27 START sql table model staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [RUN]
22:52:30  21 of 27 OK created sql table model staging.int_gtfs_quality__all_tu_in_vp ..... [CREATE TABLE (2.5m rows, 6.4 GiB processed) in 9.38s]
22:52:35  20 of 27 OK created sql table model mart_gtfs_quality.fct_daily_trip_updates_vehicle_positions_completeness  [CREATE TABLE (182.2k rows, 19.5 GiB processed) in 14.22s]
22:52:41  22 of 27 OK created sql table model staging.int_gtfs_quality__scheduled_trips_in_tu_feed  [CREATE TABLE (2.5m rows, 39.3 GiB processed) in 20.22s]
22:52:41  23 of 27 START sql table model staging.int_gtfs_quality__guideline_checks_long . [RUN]
22:53:01  23 of 27 OK created sql table model staging.int_gtfs_quality__guideline_checks_long  [CREATE TABLE (187.8m rows, 102.5 GiB processed) in 19.96s]
22:53:01  24 of 27 START sql table model mart_gtfs_quality.fct_daily_organization_combined_guideline_checks  [RUN]
22:53:01  25 of 27 START sql table model mart_gtfs_quality.fct_daily_service_combined_guideline_checks  [RUN]
22:53:01  26 of 27 START sql table model mart_gtfs_quality.fct_implemented_checks ........ [RUN]
22:53:04  26 of 27 OK created sql table model mart_gtfs_quality.fct_implemented_checks ... [CREATE TABLE (76.0 rows, 17.3 GiB processed) in 3.11s]
22:53:21  25 of 27 OK created sql table model mart_gtfs_quality.fct_daily_service_combined_guideline_checks  [CREATE TABLE (19.8m rows, 55.1 GiB processed) in 19.22s]
22:53:22  24 of 27 OK created sql table model mart_gtfs_quality.fct_daily_organization_combined_guideline_checks  [CREATE TABLE (16.7m rows, 58.2 GiB processed) in 20.46s]
22:53:22  27 of 27 START sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_guideline_checks  [RUN]
22:53:26  27 of 27 OK created sql table model mart_gtfs_quality.fct_monthly_reports_site_organization_guideline_checks  [CREATE TABLE (1.0m rows, 2.3 GiB processed) in 3.90s]
22:53:26  
22:53:26  Finished running 3 incremental models, 14 table models, 10 view models in 0 hours 2 minutes and 54.33 seconds (174.33s).
22:53:26  
22:53:26  Completed successfully
22:53:26  
22:53:26  Done. PASS=27 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=27
➜  warehouse git:(productionize_trip_summaries) ✗ git status
```
## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] Actions required (specified below)
Watch airflow thursday morning make sure things are okay.