### PR TITLE
Adds a dag that updates key tdq tables daily

### DIFF
--- a/airflow/dags/dbt_daily_dag.py
+++ b/airflow/dags/dbt_daily_dag.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime
+
+from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.constants import TestBehavior
+
+from airflow import DAG
+from airflow.operators.latest_only import LatestOnlyOperator
+
+DBT_TARGET = os.environ.get("DBT_TARGET")
+
+with DAG(
+    dag_id="dbt_daily",
+    tags=["dbt", "daily"],
+    # Tuesday, Wednesday, Friday at 7am PDT/8am PST (2pm UTC)
+    schedule="0 14 * * 2,3,5",
+    start_date=datetime(2025, 7, 6),
+    catchup=False,
+):
+    latest_only = LatestOnlyOperator(task_id="latest_only", depends_on_past=False)
+
+    dbt_daily = DbtTaskGroup(
+        group_id="dbt_daily",
+        project_config=ProjectConfig(
+            dbt_project_path="/home/airflow/gcs/data/warehouse",
+            manifest_path="/home/airflow/gcs/data/warehouse/target/manifest.json",
+            project_name="calitp_warehouse",
+            seeds_relative_path="seeds/",
+        ),
+        profile_config=ProfileConfig(
+            target_name=DBT_TARGET,
+            profile_name="calitp_warehouse",
+            profiles_yml_filepath="/home/airflow/gcs/data/warehouse/profiles.yml",
+        ),
+        render_config=RenderConfig(
+            select=[
+                "+path:models/mart/gtfs/fct_schedule_feed_downloads",
+            ],
+            test_behavior=TestBehavior.AFTER_ALL,
+        ),
+        operator_args={
+            "install_deps": True,
+        },
+        default_args={"retries": 0},
+    )
+
+    latest_only >> dbt_daily


### PR DESCRIPTION
# Description

TDQ needs daily info about which gtfs downloads are working and not working.  This dag has a few tables update daily, similar to payments.

I thought it made more sense to keep it separate from the payments dags so it is easier to track.

Minor backpeddle of https://github.com/cal-itp/data-infra/issues/3753

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Tested locally.  Worked fine.

## Post-merge follow-ups

Check costs and optimize.