### PR TITLE
dbt: create new env variable override for local development on prod external tables

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -23,13 +23,14 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 vars:
   surrogate_key_treat_nulls_as_empty_strings: true # enable legacy behavior for dbt_utils surrogate keys, i.e. coalesce nulls to empty strings
-  GTFS_SCHEDULE_START: '2021-04-16'
-  PROD_GTFS_RT_START: '2022-09-15'
-  KUBA_DEVICE_START: '2025-08-11'
-  INCREMENTAL_MAX_DT: ''
+  GTFS_SCHEDULE_START: '2021-04-16' # oldest date that GTFS Schedule tables would be populated if full-refreshed
+  PROD_GTFS_RT_START: '2022-09-15' # oldest date that GTFS RT tables would be populated if full-refreshed
+  KUBA_DEVICE_START: '2025-08-11' # oldest date that Kuba tables would be populated if full-refreshed
+  INCREMENTAL_MAX_DT: '' # it is used by the incremental_where macro, but you can override to a different date if you need to re-run incremental tables: poetry run dbt compile -s model_to_run --vars 'INCREMENTAL_MAX_DT: 2025-07-01'
   'dbt_date:time_zone': 'America/Los_Angeles'
-  GOOGLE_CLOUD_PROJECT: cal-itp-data-infra-staging # you can override with GOOGLE_CLOUD_PROJECT env var rather than constantly using --vars
   CALITP_BUCKET__PUBLISH: "gs://calitp-staging-publish" # you can override with CALITP_BUCKET__PUBLISH env var rather than constantly using --vars
+  GOOGLE_CLOUD_PROJECT: cal-itp-data-infra-staging # only override it if you need to use a different data source: cal-itp-data-infra-staging or cal-itp-data-infra (prod)
+  EXTERNAL_TABLE_SOURCE: cal-itp-data-infra-staging # you can override it to point external tables to a different data source to test the data, but it may increase extra running costs. Be careful. How to use: poetry run dbt compile -s model_to_run --vars 'EXTERNAL_TABLE_SOURCE: cal-itp-data-infra-staging'
 
 models:
   calitp_warehouse:

--- a/warehouse/models/_source_gtfs_schedule_history.yml
+++ b/warehouse/models/_source_gtfs_schedule_history.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: gtfs_schedule_history
     description: Data in the gtfs_schedule_history dataset in BigQuery
-    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: gtfs_schedule_history
     tables:
       - name: calitp_feed_parse_result

--- a/warehouse/models/staging/amplitude/_amplitude.yml
+++ b/warehouse/models/staging/amplitude/_amplitude.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: amplitude
     description: Data exported from Amplitude's Data Destination.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_amplitude
     tables:
       - name: benefits_events

--- a/warehouse/models/staging/audit/_src_audit.yml
+++ b/warehouse/models/staging/audit/_src_audit.yml
@@ -1,15 +1,12 @@
 version: 2
 
-# NOTE: many of these sources lack enumerated tables and/or are manually
-# queried in SQL without the source() macros for a variety of reasons;
-
 sources:
   - name: cloudaudit
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
     schema: audit
 
   - name: information_schema
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
     # this schema is queried as `region-us`.information_schema
     schema: information_schema
     tables:

--- a/warehouse/models/staging/gtfs/_src_gtfs_rt_external_tables.yml
+++ b/warehouse/models/staging/gtfs/_src_gtfs_rt_external_tables.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_gtfs_rt
     description: Hive-partitioned external tables reading GTFS RT data and validation errors from GCS.
-    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_gtfs_rt_v2
     tables:
       - name: service_alerts

--- a/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
+++ b/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
@@ -4,14 +4,14 @@ sources:
   - name: feed_aggregator_scrapes
     description: |
       URLs scraped at moments in time from various feed aggregators.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_feed_aggregator
     tables:
       - name: scraped_urls
 
   - name: external_gtfs_schedule
     description: Hive-partitioned external tables reading GTFS schedule data and validation errors from GCS.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_gtfs_schedule
     tables:
       - name: download_outcomes

--- a/warehouse/models/staging/hqta/_hqta.yml
+++ b/warehouse/models/staging/hqta/_hqta.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: hqta_external_tables
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_hqta
     tables:
       - name: areas

--- a/warehouse/models/staging/kuba/_src.yml
+++ b/warehouse/models/staging/kuba/_src.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_kuba
     description: Kuba devices data
-    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_kuba
     tables:
       - name: device_properties

--- a/warehouse/models/staging/ntd_annual_reporting/_src.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_src.yml
@@ -275,7 +275,7 @@ x-common-fields:
 sources:
   - name: external_ntd__annual_reporting
     description: Annual data tables for multiple years, loaded from DOT NTD API https://www.transit.dot.gov/ntd/ntd-data.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_ntd__annual_reporting
     tables:
       - name: 2022__annual_database_agency_information

--- a/warehouse/models/staging/ntd_assets/_src.yml
+++ b/warehouse/models/staging/ntd_assets/_src.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_ntd__assets
     description: Historical assets data tables, loaded from DOT NTD API https://www.transit.dot.gov/ntd/ntd-data.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_ntd__assets
     tables:
       - name: historical__asset_inventory_time_series__active_fleet

--- a/warehouse/models/staging/ntd_funding_and_expenses/_src.yml
+++ b/warehouse/models/staging/ntd_funding_and_expenses/_src.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_ntd__funding_and_expenses
     description: Historical funding and expense data tables, loaded from DOT NTD data portal https://www.transit.dot.gov/ntd/ntd-data.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_ntd__funding_and_expenses
     tables:
       - name: historical__capital_expenditures_time_series__facilities

--- a/warehouse/models/staging/ntd_ridership/_src.yml
+++ b/warehouse/models/staging/ntd_ridership/_src.yml
@@ -120,7 +120,7 @@ sources:
       This file will be updated periodically by FTA to include data for subsequent months, and to incorporate revisions
       to prior months in the calendar year made by the transit properties. In some cases, this may include revisions to data
       from previous report years.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_ntd__ridership
     tables:
       - name: historical__complete_monthly_ridership_with_adjustments_and_estimates__calendar_year_upt

--- a/warehouse/models/staging/ntd_safety_and_security/_src.yml
+++ b/warehouse/models/staging/ntd_safety_and_security/_src.yml
@@ -4,7 +4,7 @@ sources:
   - name: external_ntd__safety_and_security
     description: |
       Historical safety and security data tables, loaded from DOT NTD API https://www.transit.dot.gov/ntd/ntd-data.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_ntd__safety_and_security
     tables:
       - name: historical__fra_regulated_mode_major_security_events

--- a/warehouse/models/staging/ntd_validation/_src_api_externaltable.yml
+++ b/warehouse/models/staging/ntd_validation/_src_api_externaltable.yml
@@ -6,7 +6,7 @@ sources:
       Data from BlackCat API. Each org's data is be in 1 row, and for each separate table in the API,
             a nested column holds all of it's data.
             NOTE: all of the snapshots of the API data that are stored in Google Cloud, are viewed together in this ONE table.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_blackcat
     tables:
       - name: all_ntdreports

--- a/warehouse/models/staging/payments/elavon/_elavon.yml
+++ b/warehouse/models/staging/payments/elavon/_elavon.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: elavon_external_tables
     description: Hive-partitioned external tables reading Elavon transactions from GCS.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_elavon
     tables:
       - name: transactions

--- a/warehouse/models/staging/payments/littlepay/_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_littlepay.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_littlepay
     description: Hive-partitioned external tables reading Littlepay payments data.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_littlepay
     tables:
       - name: authorisations

--- a/warehouse/models/staging/payments/littlepay_v3/_littlepay_v3.yml
+++ b/warehouse/models/staging/payments/littlepay_v3/_littlepay_v3.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_littlepay_v3
     description: Hive-partitioned external tables reading Littlepay feed v3 payments data.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_littlepay_v3
     tables:
       - name: authorisations

--- a/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
+++ b/warehouse/models/staging/rt/_src_gtfs_rt_external_tables.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: gtfs_rt_external_tables
     description: Hive-partitioned external tables reading GTFS RT data and validation errors from GCS.
-    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_gtfs_rt
     tables:
       - name: service_alerts

--- a/warehouse/models/staging/state_geoportal/_src.yml
+++ b/warehouse/models/staging/state_geoportal/_src.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_state_geoportal
     description: Data tables scraped from state geoportal.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_state_geoportal
     tables:
       - name: state_highway_network

--- a/warehouse/models/staging/transit_database/_src_airtable.yml
+++ b/warehouse/models/staging/transit_database/_src_airtable.yml
@@ -4,7 +4,7 @@ sources:
   - name: airtable
     description: |
       Data from Airtable.
-    database: "{{ env_var('DEV_SOURCE_GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
+    database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('EXTERNAL_TABLE_SOURCE')) }}"
     schema: external_airtable
     tables:
       - name: california_transit__county_geography


### PR DESCRIPTION
# Description
During our infrastructure refactor, we determined the need to preserve local warehouse development on production external tables as sources of truth **WITH THE EXCEPTION OF RT EXTERNAL TABLES**. This PR introduces environment variable `DEV_SOURCE_GOOGLE_CLOUD_PROJECT` which, when added locally, allows for dbt to reference production external tables at runtime **WITH THE EXCEPTION OF RT EXTERNAL TABLES**.

Resolves: #4188 

## Type of change
- [x] New feature

## How has this been tested?
<img width="972" height="245" alt="Screenshot 2025-08-12 at 14 58 10" src="https://github.com/user-attachments/assets/cb10162b-5e69-4d0e-ad73-89ede2b3d330" />

## Post-merge follow-ups
- [x] Action required
To use the production external tables in local warehouse development, the following line needs to be added to your environment: 

`export DEV_SOURCE_GOOGLE_CLOUD_PROJECT='cal-itp-data-infra'`