### PR TITLE
Fix: Benefits extra_claims is a JSON array

### DIFF
--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -47,7 +47,7 @@ WITH fct_benefits_events_raw AS (
     {{ json_extract_column('event_properties', 'error.name') }},
     {{ json_extract_column('event_properties', 'error.status') }},
     {{ json_extract_column('event_properties', 'error.sub') }},
-    {{ json_extract_column('event_properties', 'extra_claims') }},
+    {{ json_extract_flattened_column('event_properties', 'extra_claims') }},
     {{ json_extract_column('event_properties', 'href') }},
     {{ json_extract_column('event_properties', 'language') }},
     {{ json_extract_column('event_properties', 'origin') }},


### PR DESCRIPTION
# Description

This column is a JSON array inside a JSON object, so we need to use the `json_extract_flattened_column` macro to parse it correctly.

Follow up to #4166 / #4059

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

@erikamov tested with the correct function call that this macro expands to: https://cal-itp.slack.com/archives/C050ZNDUL21/p1755101944951569?thread_ts=1754936604.833429&cid=C050ZNDUL21

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
