### PR TITLE
Add additional permission to metabase service account to view query history

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_custom_role.tf
@@ -69,3 +69,14 @@ resource "google_project_iam_custom_role" "calitp-dds-analyst" {
   project = "cal-itp-data-infra-staging"
   title   = "DDS Analyst"
 }
+
+resource "google_project_iam_custom_role" "metabase_additional" {
+  description = "Extra permission to view all BigQuery query jobs for cost estimation"
+  permissions = [
+    "bigquery.jobs.listAll"
+  ]
+  project = "cal-itp-data-infra-staging"
+  role_id = "MetabaseAdditional"
+  stage   = "GA"
+  title   = "Metabase additional custom permission jobs.listAll"
+}

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -298,3 +298,9 @@ resource "google_project_iam_member" "ms-entra-id-DDS_Cloud_Admins" {
   member  = "principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DDS_Cloud_Admins"
   project = "cal-itp-data-infra-staging"
 }
+
+resource "google_project_iam_member" "metabase_custom_role_assignment" {
+  member  = "serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com"
+  project = "cal-itp-data-infra-staging"
+  role    = google_project_iam_custom_role.metabase_additional.id
+}

--- a/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_custom_role.tf
@@ -36,6 +36,7 @@ resource "google_project_iam_custom_role" "tfer--projects-002F-cal-itp-data-infr
     "bigquery.datasets.getIamPolicy",
     "bigquery.jobs.create",
     "bigquery.jobs.list",
+    "bigquery.jobs.listAll",
     "bigquery.models.list",
     "bigquery.readsessions.create",
     "bigquery.readsessions.getData",
@@ -60,4 +61,15 @@ resource "google_project_iam_custom_role" "tfer--projects-002F-cal-itp-data-infr
   role_id = "DataAnalyst"
   stage   = "ALPHA"
   title   = "Data Analyst"
+}
+
+resource "google_project_iam_custom_role" "metabase_additional" {
+  description = "Extra permission to view all BigQuery query jobs for cost estimation"
+  permissions = [
+    "bigquery.jobs.listAll"
+  ]
+  project = "cal-itp-data-infra"
+  role_id = "MetabaseAdditional"
+  stage   = "GA"
+  title   = "Metabase additional custom permission jobs.listAll"
 }

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -618,3 +618,9 @@ resource "google_project_iam_member" "staging-github-actions-service-account" {
   member  = "serviceAccount:github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com"
   project = "cal-itp-data-infra"
 }
+
+resource "google_project_iam_member" "metabase_custom_role_assignment" {
+  member  = "serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com"
+  project = "cal-itp-data-infra"
+  role    = google_project_iam_custom_role.metabase_additional.id
+}


### PR DESCRIPTION
# Description

Adds a custom additional role to allow metabase to query information schema.  This will allow for better cost tracking of queries / processes.

I went over how payments row based metabase works and I don't think this should interfere with that.

Furthers work on https://github.com/cal-itp/data-infra/issues/4142

Continuation of https://github.com/cal-itp/data-infra/pull/4183

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
- https://github.com/cal-itp/data-infra/pull/4183 - this pr did what we wanted
- Ran terraform plan locally
## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
Make sure metabase payments users don't have too much access now.