### PR TITLE
Request NTD Excel files with Chrome 139 user agent and security headers

### DIFF
--- a/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
+++ b/airflow/dags/sync_ntd_data_xlsx/scrape_ntd_xlsx_urls.py
@@ -22,11 +22,14 @@ xlsx_urls = {
     "asset_inventory_time_series_url": "https://www.transit.dot.gov/ntd/data-product/ts41-asset-inventory-time-series-4",
 }
 
+# We want to look like a real browser, in this case Chrome 139
 headers = {
-    "User-Agent": "CalITP/1.0.0",
-    "sec-ch-ua": '"CalITP";v="1"',
-    "sec-ch-ua-mobile": "?0",
-    "sec-ch-ua-platform": '"macOS"',
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "sec-ch-ua": '"Not A;Brand"',
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "sec-fetch-user": "?1",
 }
 
 


### PR DESCRIPTION
# Description

This pull request resolves an issue with NTD scraping related to providing user agent strings that look like bots to the DOT WAF, by switching the user agent used for the request from `Cal-ITP/1.0.0` to Chrome 139. This also includes up to date security header definitions.

Resolves #4205 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`curl`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `sync_ntd_data_xslx` runs