### PR TITLE
Fix audit tables moving forward and move recent test tables to manual

### DIFF
--- a/airflow/dags/dbt_all_dag.py
+++ b/airflow/dags/dbt_all_dag.py
@@ -34,10 +34,11 @@ with DAG(
         ),
         render_config=RenderConfig(
             exclude=[
-                "models/mart/gtfs/fct_stop_time_arrivals_week.sql",
-                "models/mart/gtfs/fct_stop_time_updates_metrics_week.sql",
-                "models/mart/gtfs/fct_stop_time_updates_week.sql",
-                "models/mart/gtfs/fct_stop_time_updates_with_arrivals_week.sql",
+                "models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_stop_day_map_grouping.sql",
+                "models/mart/gtfs/fct_stop_time_metrics.sql",
+                "models/mart/gtfs/fct_stop_time_updates_sample.sql",
+                "models/mart/gtfs/fct_trip_updates_stop_metrics.sql",
+                "models/mart/gtfs/fct_trip_updates_trip_metrics.sql",
             ],
             test_behavior=TestBehavior.AFTER_ALL,
         ),

--- a/airflow/dags/dbt_daily_dag.py
+++ b/airflow/dags/dbt_daily_dag.py
@@ -12,9 +12,9 @@ DBT_TARGET = os.environ.get("DBT_TARGET")
 with DAG(
     dag_id="dbt_daily",
     tags=["dbt", "daily"],
-    # Tuesday, Wednesday, Friday at 7am PDT/8am PST (2pm UTC)
-    schedule="0 14 * * 2,3,5",
-    start_date=datetime(2025, 7, 6),
+    #  Sunday, Tuesday, Wednesday, Friday, Saturday at 7am PDT/8am PST (2pm UTC)
+    schedule="0 14 * * 0,2,3,5,6",
+    start_date=datetime(2025, 8, 19),
     catchup=False,
 ):
     latest_only = LatestOnlyOperator(task_id="latest_only", depends_on_past=False)
@@ -35,6 +35,7 @@ with DAG(
         render_config=RenderConfig(
             select=[
                 "+path:models/mart/gtfs/fct_schedule_feed_downloads",
+                "path:models/staging/stg_audit__cloudaudit_googleapis_com_data_access+",
             ],
             test_behavior=TestBehavior.AFTER_ALL,
         ),

--- a/airflow/dags/dbt_manual_dag.py
+++ b/airflow/dags/dbt_manual_dag.py
@@ -33,10 +33,11 @@ with DAG(
         ),
         render_config=RenderConfig(
             select=[
-                "models/mart/gtfs/fct_stop_time_arrivals_week.sql",
-                "models/mart/gtfs/fct_stop_time_updates_metrics_week.sql",
-                "models/mart/gtfs/fct_stop_time_updates_week.sql",
-                "models/mart/gtfs/fct_stop_time_updates_with_arrivals_week.sql",
+                "models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_stop_day_map_grouping.sql",
+                "models/mart/gtfs/fct_stop_time_metrics.sql",
+                "models/mart/gtfs/fct_stop_time_updates_sample.sql",
+                "models/mart/gtfs/fct_trip_updates_stop_metrics.sql",
+                "models/mart/gtfs/fct_trip_updates_trip_metrics.sql",
             ],
             test_behavior=TestBehavior.AFTER_ALL,
         ),

--- a/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
+++ b/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
@@ -1,3 +1,4 @@
+-- This code is designed to only run every day.  If you don't run it every day, it will skip dates.
 {{
     config(
         materialized='incremental',


### PR DESCRIPTION
# Description

Paired with @erikamov 

This table fct_bigquery_data_access wasn't updating every day.  We think it's because we switched to twice a week dbt_all runs
<img width="2012" height="1039" alt="image" src="https://github.com/user-attachments/assets/8b922de2-bdd3-4d4d-af8d-d6f83001d41c" />. 

We looked at the staging table and the code was designed to only run every day.  Instead of updating the code with incremental_where we added this run to daily_dags and updated daily dags to run every day.

Related to #4142

Also we were noticing costs for the querys in https://github.com/cal-itp/data-infra/pull/4172 were high so we moved these test tables to dbt_manual.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested yet.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Monitor
Manually update warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql for the days that are missing.