### PR TITLE
Increase `parse_and_validate_rt_v2` timeout to 2 hours

### DIFF
--- a/airflow/dags/parse_and_validate_rt_v2/METADATA.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/METADATA.yml
@@ -17,5 +17,5 @@ default_args:
     concurrency: 5
     #sla: !timedelta 'hours: 2'
 wait_for_defaults:
-    timeout: 3600
+    timeout: 7200
 latest_only: False


### PR DESCRIPTION
# Description

This PR increases `parse_and_validate_rt_v2` timeout to 2 hours to allow tasks to have more time to process all files.

[#4197]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Just a config change, need to test the production DAG to see if it fixes it.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor if `parse_and_validate_rt_v2` tasks are able to run.