### PR TITLE
Fix: Coalesce blank and null Benefits extra_claims

### DIFF
--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -47,7 +47,11 @@ WITH fct_benefits_events_raw AS (
     {{ json_extract_column('event_properties', 'error.name') }},
     {{ json_extract_column('event_properties', 'error.status') }},
     {{ json_extract_column('event_properties', 'error.sub') }},
-    {{ json_extract_flattened_column('event_properties', 'extra_claims') }},
+    -- Combining null and blank extra_claims into blank, to avoid counting them separately
+    COALESCE(
+      {{ json_extract_flattened_column('event_properties', 'extra_claims', no_alias = true) }},
+      ""
+    ) AS event_properties_extra_claims,
     {{ json_extract_column('event_properties', 'href') }},
     {{ json_extract_column('event_properties', 'language') }},
     {{ json_extract_column('event_properties', 'origin') }},


### PR DESCRIPTION
# Description

Follow up to #4059 

We saw in Metabase charts that these two types of "empty" values were being counted separately, when really we want them to be combined. E.g.

<img width="2144" height="2334" alt="image" src="https://github.com/user-attachments/assets/aeac89e3-730a-4fb7-b9f9-af608a060318" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

### Without `COALESCE`:

```
SELECT
  `mart_benefits.fct_benefits_events`.`event_properties_extra_claims`,
  COUNT(*) as count
FROM
  `mart_benefits.fct_benefits_events`
WHERE
    `mart_benefits.fct_benefits_events`.`event_type` = 'returned enrollment'
  AND
    `mart_benefits.fct_benefits_events`.`event_properties_status` = 'success'
  AND
    `mart_benefits.fct_benefits_events`.`event_properties_enrollment_flows` = 'medicare'
GROUP BY
  `event_properties_extra_claims`
ORDER BY
  `event_properties_extra_claims` ASC
```

Result:

| Row | event_properties_extra_claims | count |
| ------ | -------------------------------------------- | ----- |
| 1 | _null_ | 38 |
| 2 | | 25 |
| 3 | disabled | 23 |

### With `COALESCE`:

```
SELECT
  COALESCE(
    `mart_benefits.fct_benefits_events`.`event_properties_extra_claims`,
    ""
  ) AS `event_properties_extra_claims`,
  COUNT(*) as count
FROM
  `mart_benefits.fct_benefits_events`
WHERE
    `mart_benefits.fct_benefits_events`.`event_type` = 'returned enrollment'
  AND
    `mart_benefits.fct_benefits_events`.`event_properties_status` = 'success'
  AND
    `mart_benefits.fct_benefits_events`.`event_properties_enrollment_flows` = 'medicare'
GROUP BY
  `event_properties_extra_claims`
ORDER BY
  `event_properties_extra_claims` ASC
```

Result:

| Row | event_properties_extra_claims | count |
| ------ | -------------------------------------------- | ----- |
| 1 | | 63 |
| 2 | disabled | 23 |


And in Metabase:

<img width="2144" height="2334" alt="image" src="https://github.com/user-attachments/assets/36f677c1-6154-4031-aa2c-ff5f2afd0aa1" />


## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
