### PR TITLE
Analyst sees 30 days of data in staging

### DIFF
--- a/airflow/dags/copy_production_to_staging/METADATA.yml
+++ b/airflow/dags/copy_production_to_staging/METADATA.yml
@@ -1,0 +1,17 @@
+description: Copies data from production buckets to staging buckets
+schedule_interval: "@hourly"
+tags:
+  - production
+default_args:
+  owner: airflow
+  depends_on_past: False
+  start_date: "2025-08-22"
+  catchup: False
+  email:
+    - "hello@calitp.org"
+  email_on_failure: True
+  pool: default_pool
+  max_active_dag_runs: 1
+  concurrency: 1
+wait_for_defaults:
+  timeout: 3600

--- a/airflow/dags/copy_production_to_staging/README.md
+++ b/airflow/dags/copy_production_to_staging/README.md
@@ -1,0 +1,5 @@
+# `copy_production_to_staging`
+
+Type: [Now / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
+
+This DAG copies data from production to staging to enable ongoing development of DAGs against production data in a limited environment.

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_raw_v2.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_raw_v2.yml
@@ -1,0 +1,9 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-rt-raw-v2
+source_objects:
+  - service_alerts/dt={{ ds }}/hour={{ ts }}/*
+  - trip_updates/dt={{ ds }}/hour={{ ts }}/*
+  - vehicle_positions/dt={{ ds }}/hour={{ ts }}/*
+destination_bucket: calitp-staging-gtfs-rt-raw-v2
+source_object_required: true
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_schedule_raw_v2.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_schedule_raw_v2.yml
@@ -1,0 +1,5 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-schedule-raw-v2
+source_object: schedule/dt={{ ds }}/*
+destination_bucket: calitp-staging-gtfs-schedule-raw-v2
+replace: false


### PR DESCRIPTION
# Description

This PR adds a mechanism for analysts to push data from production GCS buckets to staging GCS buckets on an hourly schedule. So far, the buckets involved relate to raw GTFS/GTFS-RT data.

Resolves #4195

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`composer-dev`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Add other buckets as needed, and remove GTFS/GTFS-RT raw buckets if desired