### PR TITLE
Reduce parallelism for GTFS schedule unzipping

### DIFF
--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/unzip_gtfs_schedule.py
@@ -274,7 +274,7 @@ def airflow_unzip_extracts(
     unzip_extracts(
         data_interval_start,
         data_interval_end,
-        threads=2,
+        threads=1,
         progress=True,
     )
 


### PR DESCRIPTION
# Description

This PR reduces the parallelism for unzipping GTFS schedules, which is currently running out of resources.

Relates to #4198

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`composer-dev`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor execution in production