### PR TITLE
Adjust Composer permission and Size

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -27,7 +27,7 @@ resource "google_composer_environment" "calitp-composer" {
       worker {
         cpu        = 2
         memory_gb  = 8
-        storage_gb = 2
+        storage_gb = 10
         min_count  = 1
         max_count  = 6
       }

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -582,6 +582,13 @@ resource "google_project_iam_member" "composer-service-account" {
   project = "cal-itp-data-infra"
 }
 
+# Allow composer to copy data to staging buckets
+resource "google_project_iam_member" "composer-service-account__staging" {
+  role    = "roles/storage.objectUser"
+  member  = "serviceAccount:${google_service_account.composer-service-account.email}"
+  project = "cal-itp-data-infra-staging"
+}
+
 resource "google_project_iam_member" "ms-entra-id-DOT_DDS_Data_Pipeline_and_Warehouse_Users" {
   for_each = toset([
     "roles/viewer",


### PR DESCRIPTION
# Description

This PR adjusts two Composer configuration through Terraform:

* Adds permission to `composer-service-account@cal-itp-data-infra.iam.gserviceaccount.com` to copy data to staging buckets. The permission will fix the error (bellow) on the DAG `copy_production_to_staging` created recently [#4195](https://github.com/cal-itp/data-infra/issues/4195).

```
403 GET https://storage.googleapis.com/storage/v1/b/calitp-staging-gtfs-rt-raw-v2/o?projection=noAcl&prefix=service_alerts%2Fdt%3D2025-08-23%2Fhour%3D2025-08-23T00%3A00%3A00%2B00%3A00%2F&delimiter=&prettyPrint=false: composer-service-account@cal-itp-data-infra.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).; 18559)
[2025-08-26, 20:59:19 UTC] {local_task_job_runner.py:228}
```

* Increases the Worker size on Composer to see if `unzip_and_validate_gtfs_schedule_hourly` is able to process bigger files [#4198](https://github.com/cal-itp/data-infra/issues/4198).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

This change will restart the workers, so it is recommended to do this when no DAGs are running.

## How has this been tested?

Tested with `terraform plan`.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor DAGs to see if the issues were fixed.
If `unzip_and_validate_gtfs_schedule_hourly` continues with the same problem we can also increase `memory_gb = 16` next.