### PR TITLE
Configure copy_production_to_staging DAG tasks

### DIFF
--- a/airflow/dags/copy_production_to_staging/airtable_california_transit.yml
+++ b/airflow/dags/copy_production_to_staging/airtable_california_transit.yml
@@ -1,0 +1,17 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-airtable
+source_objects:
+  - california_transit__county_geography/dt={{ ds }}/*
+  - california_transit__eligibility_programs/dt={{ ds }}/*
+  - california_transit__fare_systems/dt={{ ds }}/*
+  - california_transit__funding_programs/dt={{ ds }}/*
+  - california_transit__gtfs_datasets/dt={{ ds }}/*
+  - california_transit__gtfs_service_data/dt={{ ds }}/*
+  - california_transit__modes/dt={{ ds }}/*
+  - california_transit__ntd_agency_info/dt={{ ds }}/*
+  - california_transit__organizations/dt={{ ds }}/*
+  - california_transit__place_geography/dt={{ ds }}/*
+  - california_transit__rider_requirements/dt={{ ds }}/*
+  - california_transit__services/dt={{ ds }}/*
+destination_bucket: calitp-staging-airtable
+replace: false

--- a/airflow/dags/copy_production_to_staging/airtable_transit_data_quality_issues.yml
+++ b/airflow/dags/copy_production_to_staging/airtable_transit_data_quality_issues.yml
@@ -1,0 +1,9 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-airtable
+source_objects:
+  - transit_data_quality_issues__gtfs_datasets/dt={{ ds }}/*
+  - transit_data_quality_issues__issue_types/dt={{ ds }}/*
+  - transit_data_quality_issues__services/dt={{ ds }}/*
+  - transit_data_quality_issues__transit_data_quality_issues/dt={{ ds }}/*
+destination_bucket: calitp-staging-airtable
+replace: false

--- a/airflow/dags/copy_production_to_staging/airtable_transit_technology_stacks.yml
+++ b/airflow/dags/copy_production_to_staging/airtable_transit_technology_stacks.yml
@@ -1,0 +1,14 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-airtable
+source_objects:
+  - transit_technology_stacks__components/dt={{ ds }}/*
+  - transit_technology_stacks__contracts/dt={{ ds }}/*
+  - transit_technology_stacks__data_schemas/dt={{ ds }}/*
+  - transit_technology_stacks__organizations/dt={{ ds }}/*
+  - transit_technology_stacks__products/dt={{ ds }}/*
+  - transit_technology_stacks__properties_and_features/dt={{ ds }}/*
+  - transit_technology_stacks__relationships_service_components/dt={{ ds }}/*
+  - transit_technology_stacks__service_components/dt={{ ds }}/*
+  - transit_technology_stacks__services/dt={{ ds }}/*
+destination_bucket: calitp-staging-airtable
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_aggregator_scrape_results.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_aggregator_scrape_results.yml
@@ -1,0 +1,5 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-aggregator-scraper
+source_object: gtfs_aggregator_scrape_results/dt={{ ds }}/*
+destination_bucket: calitp-staging-aggregator-scraper
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_parsed_service_alerts.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_parsed_service_alerts.yml
@@ -1,0 +1,7 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-rt-parsed
+source_objects:
+  - service_alerts/dt={{ ds }}/hour={{ ts }}/*
+  - service_alerts_outcomes/dt={{ ds }}/hour={{ ts }}/*
+destination_bucket: calitp-staging-gtfs-rt-parsed
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_parsed_trip_updates.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_parsed_trip_updates.yml
@@ -1,0 +1,7 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-rt-parsed
+source_objects:
+  - trip_updates/dt={{ ds }}/hour={{ ts }}/*
+  - trip_updates_outcomes/dt={{ ds }}/hour={{ ts }}/*
+destination_bucket: calitp-staging-gtfs-rt-parsed
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_parsed_vehicle_positions.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_parsed_vehicle_positions.yml
@@ -1,0 +1,7 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-rt-parsed
+source_objects:
+  - vehicle_positions/dt={{ ds }}/hour={{ ts }}/*
+  - vehicle_positions_outcomes/dt={{ ds }}/hour={{ ts }}/*
+destination_bucket: calitp-staging-gtfs-rt-parsed
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_raw_v2.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_raw_v2.yml
@@ -1,9 +1,0 @@
-operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
-source_bucket: calitp-gtfs-rt-raw-v2
-source_objects:
-  - service_alerts/dt={{ ds }}/hour={{ ts }}/*
-  - trip_updates/dt={{ ds }}/hour={{ ts }}/*
-  - vehicle_positions/dt={{ ds }}/hour={{ ts }}/*
-destination_bucket: calitp-staging-gtfs-rt-raw-v2
-source_object_required: true
-replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_schedule_parsed.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_schedule_parsed.yml
@@ -1,0 +1,28 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-schedule-parsed-hourly
+source_objects:
+  - agency/dt={{ ds }}/*
+  - areas/dt={{ ds }}/*
+  - attributions/dt={{ ds }}/*
+  - calendar/dt={{ ds }}/*
+  - calendar_dates/dt={{ ds }}/*
+  - fare_attributes/dt={{ ds }}/*
+  - fare_leg_rules/dt={{ ds }}/*
+  - fare_media/dt={{ ds }}/*
+  - fare_products/dt={{ ds }}/*
+  - fare_rules/dt={{ ds }}/*
+  - fare_transfer_rules/dt={{ ds }}/*
+  - feed_info/dt={{ ds }}/*
+  - frequencies/dt={{ ds }}/*
+  - levels/dt={{ ds }}/*
+  - pathways/dt={{ ds }}/*
+  - routes/dt={{ ds }}/*
+  - shapes/dt={{ ds }}/*
+  - stop_areas/dt={{ ds }}/*
+  - stop_times/dt={{ ds }}/*
+  - stops/dt={{ ds }}/*
+  - transfers/dt={{ ds }}/*
+  - translations/dt={{ ds }}/*
+  - trips/dt={{ ds }}/*
+destination_bucket: calitp-staging-gtfs-schedule-parsed-hourly
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_schedule_parsed_txt_results.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_schedule_parsed_txt_results.yml
@@ -1,0 +1,28 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-schedule-parsed-hourly
+source_objects:
+  - agency.txt_parsing_results/dt={{ ds }}/*
+  - areas.txt_parsing_results/dt={{ ds }}/*
+  - attributions.txt_parsing_results/dt={{ ds }}/*
+  - calendar_dates.txt_parsing_results/dt={{ ds }}/*
+  - calendar.txt_parsing_results/dt={{ ds }}/*
+  - fare_attributes.txt_parsing_results/dt={{ ds }}/*
+  - feed_info.txt_parsing_results/dt={{ ds }}/*
+  - fare_leg_rules.txt_parsing_results/dt={{ ds }}/*
+  - fare_media.txt_parsing_results/dt={{ ds }}/*
+  - fare_products.txt_parsing_results/dt={{ ds }}/*
+  - fare_rules.txt_parsing_results/dt={{ ds }}/*
+  - fare_transfer_rules.txt_parsing_results/dt={{ ds }}/*
+  - frequencies.txt_parsing_results/dt={{ ds }}/*
+  - levels.txt_parsing_results/dt={{ ds }}/*
+  - pathways.txt_parsing_results/dt={{ ds }}/*
+  - routes.txt_parsing_results/dt={{ ds }}/*
+  - shapes.txt_parsing_results/dt={{ ds }}/*
+  - stop_areas.txt_parsing_results/dt={{ ds }}/*
+  - stop_times.txt_parsing_results/dt={{ ds }}/*
+  - stops.txt_parsing_results/dt={{ ds }}/*
+  - transfers.txt_parsing_results/dt={{ ds }}/*
+  - translations.txt_parsing_results/dt={{ ds }}/*
+  - trips.txt_parsing_results/dt={{ ds }}/*
+destination_bucket: calitp-staging-gtfs-schedule-parsed-hourly
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_validation_service_alerts.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_validation_service_alerts.yml
@@ -1,0 +1,7 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-rt-validation
+source_objects:
+  - service_alerts_validation_notices/dt={{ ds }}/hour={{ ts }}/*
+  - service_alerts_validation_outcomes/dt={{ ds }}/hour={{ ts }}/*
+destination_bucket: calitp-staging-gtfs-rt-validation
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_validation_trip_updates.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_validation_trip_updates.yml
@@ -1,0 +1,7 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-rt-validation
+source_objects:
+  - trip_updates_validation_notices/dt={{ ds }}/hour={{ ts }}/*
+  - trip_updates_validation_outcomes/dt={{ ds }}/hour={{ ts }}/*
+destination_bucket: calitp-staging-gtfs-rt-validation
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_rt_validation_vehicle_positions.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_rt_validation_vehicle_positions.yml
@@ -1,0 +1,7 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-rt-validation
+source_objects:
+  - vehicle_positions_validation_notices/dt={{ ds }}/hour={{ ts }}/*
+  - vehicle_positions_validation_outcomes/dt={{ ds }}/hour={{ ts }}/*
+destination_bucket: calitp-staging-gtfs-rt-validation
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_schedule_download_configs.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_schedule_download_configs.yml
@@ -1,0 +1,5 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-download-config
+source_object: gtfs_download_configs/dt={{ ds }}/*
+destination_bucket: calitp-staging-gtfs-download-config
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_schedule_download_outcomes.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_schedule_download_outcomes.yml
@@ -1,5 +1,5 @@
 operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
 source_bucket: calitp-gtfs-schedule-raw-v2
-source_object: schedule/dt={{ ds }}/*
+source_object: download_schedule_feed_results/dt={{ ds }}/*
 destination_bucket: calitp-staging-gtfs-schedule-raw-v2
 replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_schedule_unzip_outcomes.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_schedule_unzip_outcomes.yml
@@ -1,0 +1,5 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-schedule-unzipped-hourly
+source_object: unzipping_results/dt={{ ds }}/*
+destination_bucket: calitp-staging-gtfs-schedule-unzipped-hourly
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_schedule_validation_notices.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_schedule_validation_notices.yml
@@ -1,0 +1,5 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-schedule-validation-hourly
+source_object: validation_notices/dt={{ ds }}/*
+destination_bucket: calitp-staging-gtfs-schedule-validation-hourly
+replace: false

--- a/airflow/dags/copy_production_to_staging/gtfs_schedule_validation_outcomes.yml
+++ b/airflow/dags/copy_production_to_staging/gtfs_schedule_validation_outcomes.yml
@@ -1,0 +1,5 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-gtfs-schedule-validation-hourly
+source_object: validation_job_results/dt={{ ds }}/*
+destination_bucket: calitp-staging-gtfs-schedule-validation-hourly
+replace: false

--- a/airflow/dags/copy_production_to_staging/state_highway_network.yml
+++ b/airflow/dags/copy_production_to_staging/state_highway_network.yml
@@ -1,0 +1,5 @@
+operator: airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSToGCSOperator
+source_bucket: calitp-state-geoportal-scrape
+source_object: state_highway_network_geodata/dt={{ ds }}/*
+destination_bucket: calitp-staging-state-geoportal-scrape
+replace: false


### PR DESCRIPTION
# Description

This PR add tasks to `copy_production_to_staging` DAG to copy buckets and paths that generates external tables.

NTD, Kuba, and Payments buckets were not included.

Resolves [#4195]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on Airflow staging.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Review logs to confirm tasks are running successfully on production.