### PR TITLE
Change Composer Worker Memory Size to the maximum allowed 13 GB

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -26,7 +26,7 @@ resource "google_composer_environment" "calitp-composer" {
       }
       worker {
         cpu        = 2
-        memory_gb  = 16
+        memory_gb  = 13
         storage_gb = 10
         min_count  = 1
         max_count  = 6


### PR DESCRIPTION
# Description

This PR increases Composer Worker Memory Size to the maximum allowed 13 GB.

On previous PR https://github.com/cal-itp/data-infra/pull/4227, I tried to increase the memory to 16 GB but it didn't work due to a maximum limit.
When Terraform tried to apply it returned an error:

```
Error: googleapi: Error 400: Found 1 problem:
	1) Worker memory must be between 2.00GB and 13.00GB for given vCpu., badRequest
```

[#4198]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Terraform Plan

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

 Monitor Terraform Apply and rerun failed tasks on `unzip_and_validate_gtfs_schedule_hourly` to see if it can process those files with the memory increased.