### PR TITLE
Payments: adjust dbt_payments_dag to also run on weekends

### DIFF
--- a/airflow/dags/dbt_payments_dag.py
+++ b/airflow/dags/dbt_payments_dag.py
@@ -12,8 +12,8 @@ DBT_TARGET = os.environ.get("DBT_TARGET")
 with DAG(
     dag_id="dbt_payments",
     tags=["dbt", "payments"],
-    # Tuesday, Wednesday, Friday at 7am PDT/8am PST (2pm UTC)
-    schedule="0 14 * * 2,3,5,6,7",
+    # Sunday, Tuesday, Wednesday, Friday, Saturday at 7am PDT/8am PST (2pm UTC)
+    schedule="0 14 * * 0,2,3,5,6",
     start_date=datetime(2025, 7, 6),
     catchup=False,
 ):

--- a/airflow/dags/dbt_payments_dag.py
+++ b/airflow/dags/dbt_payments_dag.py
@@ -13,7 +13,7 @@ with DAG(
     dag_id="dbt_payments",
     tags=["dbt", "payments"],
     # Tuesday, Wednesday, Friday at 7am PDT/8am PST (2pm UTC)
-    schedule="0 14 * * 2,3,5",
+    schedule="0 14 * * 2,3,5,6,7",
     start_date=datetime(2025, 7, 6),
     catchup=False,
 ):


### PR DESCRIPTION
# Description
We noticed an issue with our Littlepay Settlements Email Reports from Metabase sometimes being delivered without data, captured in #4222. After investigating, we determined that this was occurring because the `dbt_payments_dag` is not being run on the weekends, although agencies reply on payments warehouse tables being run 7 days a week to provide daily reconciliations. This PR adds Saturday and Sunday to the DAG's schedule.

Resolves #4222 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Post-merge follow-ups
- [x] Actions required (specified below)
Verify the DAG is being run and data is available after merge