### PR TITLE
Add chrome browser to jupyterhub-singleuser

### DIFF
--- a/images/jupyter-singleuser/Dockerfile
+++ b/images/jupyter-singleuser/Dockerfile
@@ -16,6 +16,11 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/g
 RUN apt update \
     && apt install -y gh
 RUN apt-get install -y gdal-bin libgdal-dev # for rasterio
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+RUN apt-get update && apt-get -y install google-chrome-stable
+
 # create these ahead of time, then chown to the notebook user
 ENV GCLOUD_HOME=/gcloud
 ENV POETRY_HOME="/poetry"


### PR DESCRIPTION
This is required to run accessibility checks on portfolio sites 
references: #3977


- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
 built container locally
 ran `portfolio/portfolio.py check-accessibility` to verify error was resolved.
