### PR TITLE
Set tasks under parse_and_validate_rt_v2 to only 1 thread

### DIFF
--- a/airflow/dags/parse_and_validate_rt_v2/parse_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/parse_rt_service_alerts.yml
@@ -13,6 +13,7 @@ arguments:
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH:mm:ss') }}"
   - "--verbose"
+  - "--threads=1"
 
 is_delete_operator_pod: true
 get_logs: true

--- a/airflow/dags/parse_and_validate_rt_v2/parse_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/parse_rt_trip_updates.yml
@@ -13,6 +13,7 @@ arguments:
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH:mm:ss') }}"
   - "--verbose"
+  - "--threads=1"
 
 
 is_delete_operator_pod: true

--- a/airflow/dags/parse_and_validate_rt_v2/parse_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/parse_rt_vehicle_positions.yml
@@ -13,6 +13,7 @@ arguments:
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH:mm:ss') }}"
   - "--verbose"
+  - "--threads=1"
 
 is_delete_operator_pod: true
 get_logs: true

--- a/airflow/dags/parse_and_validate_rt_v2/validate_rt_service_alerts.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/validate_rt_service_alerts.yml
@@ -13,7 +13,7 @@ arguments:
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH:mm:ss') }}"
   - "--verbose"
-  - "--threads=2"
+  - "--threads=1"
 
 is_delete_operator_pod: true
 get_logs: true

--- a/airflow/dags/parse_and_validate_rt_v2/validate_rt_trip_updates.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/validate_rt_trip_updates.yml
@@ -13,7 +13,7 @@ arguments:
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH:mm:ss') }}"
   - "--verbose"
-  - "--threads=2"
+  - "--threads=1"
 
 is_delete_operator_pod: true
 get_logs: true

--- a/airflow/dags/parse_and_validate_rt_v2/validate_rt_vehicle_positions.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/validate_rt_vehicle_positions.yml
@@ -13,7 +13,7 @@ arguments:
   # we run on a delay because of archiver write latency but then we process the prior _hour_
   - "{{ execution_date.replace(minute=0, second=0).format('YYYY-MM-DDTHH:mm:ss') }}"
   - "--verbose"
-  - "--threads=2"
+  - "--threads=1"
 
 is_delete_operator_pod: true
 get_logs: true

--- a/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
+++ b/jobs/gtfs-rt-parser-v2/gtfs_rt_parser.py
@@ -830,6 +830,9 @@ def main(
     verbose: bool = False,
     base64url: Optional[str] = None,
 ):
+    typer.secho(f"INFO: threads set to {threads}.", fg=typer.colors.MAGENTA)
+    typer.secho(f"INFO: verbose set to {verbose}.", fg=typer.colors.MAGENTA)
+
     hourly_feed_files = FeedStorage(feed_type).get_hour(hour)
     if not hourly_feed_files.valid():
         typer.secho(f"missing: {hourly_feed_files.files_missing_metadata}")


### PR DESCRIPTION
# Description

In order to compare logs between Staging BashOperator and Prod PodOperator properly.

Continuous work on [#4197]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on Staging.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor logs.