### PR TITLE
Disable retries for parse_and_validate_rt_v2

### DIFF
--- a/airflow/dags/parse_and_validate_rt_v2/METADATA.yml
+++ b/airflow/dags/parse_and_validate_rt_v2/METADATA.yml
@@ -12,7 +12,7 @@ default_args:
     email_on_failure: False
     email_on_retry: False
     max_active_dag_runs: 6
-    retries: 1
+    retries: 0
     retry_delay: !timedelta 'minutes: 2'
     concurrency: 5
     #sla: !timedelta 'hours: 2'


### PR DESCRIPTION
# Description

This PR disables retries for the `parse_and_validate_rt_v2` DAG.

Relates to #4197 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

Local execution

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
