### PR TITLE
Deploy jupyter-singleuser 2025.8.28

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -40,17 +40,17 @@ jupyterhub:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-      - display_name: "Prototype Image - 2025.8.22, Python 3.11"
+      - display_name: "Prototype Image - 2025.8.28, Python 3.11"
         description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.22
-      - display_name: "Power Prototype Image - 2025.8.22, Python 3.11"
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.28
+      - display_name: "Power Prototype Image - 2025.8.28, Python 3.11"
         description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.22
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.28
       - display_name: "Legacy Image - 2025.6.10, Python 3.11"
         description: "This is the older environment from before the dependency updates work. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:


### PR DESCRIPTION
# Description

This PR makes 2025.8.28 the prototype image profile on JupyterHub. It should be merges only after https://github.com/cal-itp/data-infra/pull/4254 is merged.

Resolves https://github.com/cal-itp/data-analyses/issues/1670

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

See https://github.com/cal-itp/data-infra/pull/4254

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- [ ] Confirm deployment to JupyterHub
