### PR TITLE
Create pytest buckets for GTFS validation and parse outputs

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -122,6 +122,18 @@ resource "google_storage_bucket" "calitp-staging-composer" {
   }
 }
 
+resource "google_storage_bucket" "calitp-staging-pytest" {
+  name                        = "calitp-staging-pytest"
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  project                     = "cal-itp-data-infra-staging"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
 resource "google_storage_bucket" "calitp-staging" {
   for_each                    = local.environment_buckets
   name                        = each.key

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_binding.tf
@@ -34,6 +34,12 @@ resource "google_storage_bucket_iam_binding" "calitp-staging-composer-composer-s
   role    = "roles/storage.legacyBucketOwner"
 }
 
+resource "google_storage_bucket_iam_binding" "calitp-staging-pytest" {
+  bucket  = google_storage_bucket.calitp-staging-pytest.name
+  members = ["projectEditor:cal-itp-data-infra-staging", "projectOwner:cal-itp-data-infra-staging"]
+  role    = "roles/storage.legacyObjectOwner"
+}
+
 resource "google_storage_bucket_iam_binding" "calitp-staging" {
   for_each = local.environment_buckets
   bucket   = google_storage_bucket.calitp-staging[each.key].name

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
@@ -40,6 +40,12 @@ resource "google_storage_bucket_iam_member" "calitp-staging-composer" {
   role   = "roles/storage.legacyBucketOwner"
 }
 
+resource "google_storage_bucket_iam_member" "calitp-staging-pytest" {
+  bucket = google_storage_bucket.calitp-staging-pytest.name
+  member = "projectViewer:cal-itp-data-infra-staging"
+  role   = "roles/storage.legacyBucketReader"
+}
+
 resource "google_storage_bucket_iam_member" "calitp-staging" {
   for_each = local.environment_buckets
   bucket   = google_storage_bucket.calitp-staging[each.key].name

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_policy.tf
@@ -143,6 +143,42 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-staging-gcp-components
 POLICY
 }
 
+resource "google_storage_bucket_iam_policy" "calitp-staging-pytest" {
+  bucket      = google_storage_bucket.calitp-staging-pytest.name
+  policy_data = <<POLICY
+{
+  "bindings": [
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra-staging",
+        "projectOwner:cal-itp-data-infra-staging"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra-staging"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "projectEditor:cal-itp-data-infra-staging",
+        "projectOwner:cal-itp-data-infra-staging"
+      ],
+      "role": "roles/storage.legacyObjectOwner"
+    },
+    {
+      "members": [
+        "projectViewer:cal-itp-data-infra-staging"
+      ],
+      "role": "roles/storage.legacyObjectReader"
+    }
+  ]
+}
+POLICY
+}
+
 resource "google_storage_bucket_iam_policy" "calitp-staging" {
   for_each    = local.environment_buckets
   bucket      = google_storage_bucket.calitp-staging[each.key].name

--- a/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
@@ -28,7 +28,8 @@ locals {
     "calitp-staging-payments-littlepay-raw",
     "calitp-staging-payments-littlepay-raw-v3",
     "calitp-staging-publish",
-    "calitp-staging-pytest",
+    "calitp-staging-pytest-validation",
+    "calitp-staging-pytest-parsed",
     "calitp-staging-sentry",
     "calitp-staging-state-geoportal-scrape",
   ])


### PR DESCRIPTION
# Description

This PR creates two new buckets to be used when running GTFS RT pytests.
It also removes the expiration rule from `calitp-staging-pytest`.

Work as part of issue #4197.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally using `terraform plan`.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm the successful execution of Terraform Apply.