### PR TITLE
NTD: make fields in ridership external tables explicit

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/historical__complete_monthly_ridership_with_adjustments_and_estimates.yml
@@ -13,3 +13,40 @@ hive_options:
   mode: CUSTOM
   require_partition_filter: false
   source_uri_prefix: "complete_monthly_ridership_with_adjustments_and_estimates/historical/{dt:DATE}/{execution_ts:TIMESTAMP}"
+schema_fields:
+  - name: ntd_id
+    type: STRING
+  - name: legacy_ntd_id
+    type: STRING
+  - name: agency
+    type: STRING
+  - name: mode_type_of_service_status
+    type: STRING
+  - name: reporter_type
+    type: STRING
+  - name: uace_cd
+    type: STRING
+  - name: uza_name
+    type: STRING
+  - name: mode
+    type: STRING
+  - name: tos
+    type: STRING
+  - name: _3_mode
+    type: STRING
+  - name: date
+    type: DATETIME
+  - name: upt
+    type: NUMERIC
+  - name: voms
+    type: NUMERIC
+  - name: vrh
+    type: NUMERIC
+  - name: vrm
+    type: NUMERIC
+  - name: agency_mode_tos_date
+    type: STRING
+  - name: state
+    type: STRING
+  - name: fta_region
+    type: STRING


### PR DESCRIPTION
# Description
To handle issues with interpreted data types in the warehouse, this changes the `create_external_tables` dag task for the new ridership table from the FTA API to explicitly define column names and data types.

## Type of change
- [x] New feature

## How has this been tested?
<img width="732" height="30" alt="Screenshot 2025-09-10 at 14 03 26" src="https://github.com/user-attachments/assets/bd513bb1-14f2-449f-af49-b24bd0897041" />

## Post-merge follow-ups
- [x] Actions required (specified below)
ensure this dag tasks runs appropriately, finish warehouse tables