### PR TITLE
Round decimal points when cleaning data on BigQueryCleaner

### DIFF
--- a/airflow/plugins/src/bigquery_cleaner.py
+++ b/airflow/plugins/src/bigquery_cleaner.py
@@ -16,6 +16,7 @@ class BigQueryValueCleaner:
         to the type of data in the array.
         """
         result = self.value
+
         if isinstance(result, dict):
             for k, v in result.items():
                 if isinstance(v, dict):
@@ -30,6 +31,9 @@ class BigQueryValueCleaner:
                 result = [x if x is not None else -1 for x in result]
             else:
                 result = [x if x is not None else "" for x in result]
+        elif isinstance(result, float):
+            result = round(result, 8)
+
         return result
 
 

--- a/airflow/tests/src/test_bigquery_cleaner.py
+++ b/airflow/tests/src/test_bigquery_cleaner.py
@@ -1,0 +1,28 @@
+from src.bigquery_cleaner import BigQueryCleaner
+
+
+class TestBigQueryCleaner:
+    def test_cleaning_a_standard_row(self):
+        rows = [{"id": "abc123", "fields": ""}]
+        cleaner = BigQueryCleaner(rows)
+        assert cleaner.clean() == [{"id": "abc123", "fields": ""}]
+
+    def test_fixing_column_names(self):
+        rows = [{"2010": "abc123"}, {" fields ": "green", "@super": "happy"}]
+        cleaner = BigQueryCleaner(rows)
+        assert cleaner.clean() == [
+            {"_2010": "abc123"},
+            {"_fields_": "green", "_super": "happy"},
+        ]
+
+    def test_cleaning_a_none_value(self):
+        rows = [{"id": "abc123", "fields": None}]
+        cleaner = BigQueryCleaner(rows)
+        assert cleaner.clean() == [{"id": "abc123", "fields": None}]
+
+    def test_cleaning_numeric_values(self):
+        rows = [{"id": 0, "score": -2, "amount": 123.000555555555, "total": 0.5}]
+        cleaner = BigQueryCleaner(rows)
+        assert cleaner.clean() == [
+            {"id": 0, "score": -2, "amount": 123.00055556, "total": 0.5}
+        ]

--- a/airflow/tests/src/test_kuba_cleaner.py
+++ b/airflow/tests/src/test_kuba_cleaner.py
@@ -11,9 +11,6 @@ class TestKubaCleaner:
         rows = [
             {"id": "abc123", "fields": "", "nested": {"other": "", "keys": "jangly"}}
         ]
-        rows = [
-            {"id": "abc123", "fields": "", "nested": {"other": "", "keys": "jangly"}}
-        ]
         cleaner = KubaCleaner(rows)
         assert cleaner.clean() == [{"id": "abc123", "nested": {"keys": "jangly"}}]
 


### PR DESCRIPTION
# Description

This PR rounds decimal numbers to fix error on issue #4276 where the value has too many numbers.
Rounding to 8 decimal numbers to give enough precision if needed.

Resolves [#4276]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally running `poetry run pytest tests/src/test_bigquery_cleaner.py`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Run tables `fct_track_and_roadway_by_agency` and `fct_track_and_roadway_guideway_age_distribution` on `dbt_all` DAG to see if the new json files have the numbers fixed.

Delete previous json files with the invalid numbers.