### PR TITLE
Set dbt DAGs to retry once if a job fails

### DIFF
--- a/airflow/dags/dbt_all_dag.py
+++ b/airflow/dags/dbt_all_dag.py
@@ -45,7 +45,7 @@ with DAG(
         operator_args={
             "install_deps": True,
         },
-        default_args={"retries": 0},
+        default_args={"retries": 1},
     )
 
     latest_only >> dbt_all

--- a/airflow/dags/dbt_daily_dag.py
+++ b/airflow/dags/dbt_daily_dag.py
@@ -42,7 +42,7 @@ with DAG(
         operator_args={
             "install_deps": True,
         },
-        default_args={"retries": 0},
+        default_args={"retries": 1},
     )
 
     latest_only >> dbt_daily

--- a/airflow/dags/dbt_payments_dag.py
+++ b/airflow/dags/dbt_payments_dag.py
@@ -43,7 +43,7 @@ with DAG(
         operator_args={
             "install_deps": True,
         },
-        default_args={"retries": 0},
+        default_args={"retries": 1},
     )
 
     latest_only >> dbt_payments


### PR DESCRIPTION
# Description

This PR sets back dbt DAGs (`dbt_all`, `dbt_payments`, and `dbt_daily`) to retry once when a job fails.

Part of the process of fixing parse errors and models #4197 .

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
