### PR TITLE
Increase Composer environment size

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -27,13 +27,13 @@ resource "google_composer_environment" "calitp-composer" {
       worker {
         cpu        = 3
         memory_gb  = 13
-        storage_gb = 10
+        storage_gb = 5
         min_count  = 1
-        max_count  = 16
+        max_count  = 32
       }
     }
 
-    environment_size = "ENVIRONMENT_SIZE_SMALL"
+    environment_size = "ENVIRONMENT_SIZE_MEDIUM"
 
     software_config {
       image_version = "composer-2.8.6-airflow-2.7.3"


### PR DESCRIPTION
# Description

This PR increases the size of the Composer environment to Medium from Small. This is necessary because the Composer database CPU is currently oversubscribed.

Relates to #4197 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Configuration

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor production composer environment