### PR TITLE
Increase Composer environment size to Large

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -25,7 +25,7 @@ resource "google_composer_environment" "calitp-composer" {
         storage_gb = 1
       }
       worker {
-        cpu        = 3
+        cpu        = 4
         memory_gb  = 13
         storage_gb = 5
         min_count  = 1
@@ -33,13 +33,13 @@ resource "google_composer_environment" "calitp-composer" {
       }
     }
 
-    environment_size = "ENVIRONMENT_SIZE_MEDIUM"
+    environment_size = "ENVIRONMENT_SIZE_LARGE"
 
     software_config {
       image_version = "composer-2.8.6-airflow-2.7.3"
 
       airflow_config_overrides = {
-        celery-worker_concurrency                  = 4
+        celery-worker_concurrency                  = 6
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = "True"


### PR DESCRIPTION
# Description

This PR bumps up the size of the Composer environment in order to run even more composer tasks in parallel

Relates to #4284 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Configuration

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor production environment