### PR TITLE
Restore the old Composer provisioning

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -17,7 +17,7 @@ resource "google_composer_environment" "calitp-composer" {
         cpu        = 2
         memory_gb  = 2
         storage_gb = 1
-        count      = 2
+        count      = 1
       }
       web_server {
         cpu        = 1
@@ -25,21 +25,21 @@ resource "google_composer_environment" "calitp-composer" {
         storage_gb = 1
       }
       worker {
-        cpu        = 4
+        cpu        = 2
         memory_gb  = 13
         storage_gb = 5
         min_count  = 1
-        max_count  = 32
+        max_count  = 8
       }
     }
 
-    environment_size = "ENVIRONMENT_SIZE_LARGE"
+    environment_size = "ENVIRONMENT_SIZE_SMALL"
 
     software_config {
       image_version = "composer-2.8.6-airflow-2.7.3"
 
       airflow_config_overrides = {
-        celery-worker_concurrency                  = 6
+        celery-worker_concurrency                  = 4
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = "True"


### PR DESCRIPTION
# Description

This PR restores lower settings for Composer to pre-backfill status

Relates to #4197 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Configuration

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor production composer environment