### PR TITLE
Enable Composer trigger configuration popup option when starting a DAG

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -42,11 +42,12 @@ resource "google_composer_environment" "calitp-composer" {
         celery-worker_concurrency                  = 4
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
-        core-dags_are_paused_at_creation           = "True"
+        core-dags_are_paused_at_creation           = true
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
-        webserver-reload_on_plugin_change          = "True"
+        webserver-reload_on_plugin_change          = true
+        webserver-show_trigger_form_if_no_params   = true
         email-email_backend                        = "airflow.utils.email.send_email_smtp"
         email-from_email                           = "bot@calitp.org"
         email-email_conn_id                        = "smtp_postmark"


### PR DESCRIPTION
# Description

This PR re-enables an option to trigger a DAG at a certain date, which was disabled by default in Airflow 2.7.

Relates to #4284 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Configuration

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
