### PR TITLE
Analysts see decoded URLs in parse and validate task logs

### DIFF
--- a/airflow/plugins/scripts/gtfs_rt_parser.py
+++ b/airflow/plugins/scripts/gtfs_rt_parser.py
@@ -291,7 +291,7 @@ class MostRecentSchedule:
                 )
             except KeyError:
                 typer.secho(
-                    f"no schedule data found for {self.base64_validation_url} on day {day}"
+                    f"no schedule data found for {self.base64_validation_url} ({base64.urlsafe_b64decode(self.base64_validation_url)}) on day {day}"
                 )
                 continue
 
@@ -301,7 +301,7 @@ class MostRecentSchedule:
                 return gtfs_zip
             except FileNotFoundError:
                 typer.secho(
-                    f"no schedule file found for {self.base64_validation_url} on day {day}"
+                    f"no schedule file found for {self.base64_validation_url} ({base64.urlsafe_b64decode(self.base64_validation_url)}) on day {day}"
                 )
                 continue
         return None
@@ -935,7 +935,8 @@ def main(
 
     if base64url:
         typer.secho(
-            f"url filter applied, only processing {base64url}", fg=typer.colors.YELLOW
+            f"url filter applied, only processing {base64url} ({base64.urlsafe_b64decode(base64url)})",
+            fg=typer.colors.YELLOW,
         )
 
     if limit:


### PR DESCRIPTION
# Description

This PR updates the logging for `parse_and_validate_rt` to display the decoded base64 URL used to filter runs.

Resolves #4280 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

pytest

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
