### PR TITLE
Bump JH prototype image profiles

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -9,7 +9,7 @@ jupyterhub:
     startTimeout: 300
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
-      tag: 2025.8.8
+      tag: 2025.8.28
     memory:
       # Much more than 10 and we risk bumping up against the actual capacity of e2-highmem-2
       limit: 10G
@@ -31,26 +31,26 @@ jupyterhub:
               mkdir -p -- /home/jovyan/.jupyter;
               cp /tmp/jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py;
     profileList:
-      - display_name: "Default Image - 2025.8.8, Python 3.11"
+      - display_name: "Default Image - 2025.8.28, Python 3.11"
         description: "Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         default: true
-      - display_name: "Power Default Image - 2025.8.8, Python 3.11"
+      - display_name: "Power Default Image - 2025.8.28, Python 3.11"
         description: "Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-      - display_name: "Prototype Image - 2025.8.28, Python 3.11"
+      - display_name: "Prototype Image - 2025.9.12, Python 3.11"
         description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.28
-      - display_name: "Power Prototype Image - 2025.8.28, Python 3.11"
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.9.12
+      - display_name: "Power Prototype Image - 2025.9.12, Python 3.11"
         description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.8.28
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.9.12
       - display_name: "Legacy Image - 2025.6.10, Python 3.11"
         description: "This is the older environment from before the dependency updates work. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:


### PR DESCRIPTION
# Description

This PR bumps the JH image profiles so that default is 2025.8.28 (this version includes the addition of Chrome and removal of unneeded package dependencies) and prototype is 2025.9.12 (this version includes updated calitp-data-analysis that deprecates some siuba-related code).

Need to merge https://github.com/cal-itp/data-infra/pull/4290 first.

Relates to https://github.com/cal-itp/data-infra/issues/3361

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Dependency upgrades

## How has this been tested?

This work represented in both 2025.8.28 and 2025.9.12 has been tested by running the image and importing impacted modules.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

- [x] Confirm deployment of new image profiles
