### PR TITLE
Change `Unzip and Validate GTFS Schedule Hourly` start date to allow creating jobs for older dates

### DIFF
--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
@@ -5,7 +5,7 @@ tags:
 default_args:
     owner: airflow
     depends_on_past: False
-    start_date: "2025-07-06"
+    start_date: "2024-01-01"
     catchup: False
     email:
       - "hello@calitp.org"


### PR DESCRIPTION
# Description

This PR changes `Unzip and Validate GTFS Schedule Hourly` start date to allow run dates from January 1 2024.

[#4294]
Also related to #4471 - @vevetron 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

It is just a config setting.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Check if `unzip_and_validate_gtfs_schedule_hourly` DAG is able to run the dates needed in production.