### PR TITLE
NTD: make API sync operator more efficient

### DIFF
--- a/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/amkt-4ehs.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns.yml
@@ -5,4 +5,5 @@ product: breakdowns
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/amkt-4ehs.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns_by_agency.yml
@@ -5,4 +5,5 @@ product: breakdowns_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/fk8n-qvag.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/fk8n-qvag.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_capital_use.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_capital_use.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/fphd-jyyj.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_capital_use.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_capital_use.yml
@@ -5,4 +5,5 @@ product: capital_expenses_by_capital_use
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/fphd-jyyj.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_mode.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/2667-vitc.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_mode.yml
@@ -5,4 +5,5 @@ product: capital_expenses_by_mode
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/2667-vitc.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_existing_service.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_existing_service.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/7kqv-yqbn.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_existing_service.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_existing_service.yml
@@ -5,4 +5,5 @@ product: capital_expenses_for_existing_service
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/7kqv-yqbn.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_expansion_of_service.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_expansion_of_service.yml
@@ -5,4 +5,5 @@ product: capital_expenses_for_expansion_of_service
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/nvgd-g6pj.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_expansion_of_service.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_expansion_of_service.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/nvgd-g6pj.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/brbd-9azc.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_agency.yml
@@ -5,4 +5,5 @@ product: employees_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/brbd-9azc.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wsxw-2rpq.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode.yml
@@ -5,4 +5,5 @@ product: employees_by_mode
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wsxw-2rpq.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode_and_employee_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode_and_employee_type.yml
@@ -5,4 +5,5 @@ product: employees_by_mode_and_employee_type
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/uyv8-9jek.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode_and_employee_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode_and_employee_type.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/uyv8-9jek.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/8ehq-7his.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy.yml
@@ -5,4 +5,5 @@ product: fuel_and_energy
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/8ehq-7his.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy_by_agency.yml
@@ -5,4 +5,5 @@ product: fuel_and_energy_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wwem-ata9.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wwem-ata9.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_by_expense_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_by_expense_type.yml
@@ -5,4 +5,5 @@ product: funding_sources_by_expense_type
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/4tmr-gwuu.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_by_expense_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_by_expense_type.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/4tmr-gwuu.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_directly_generated.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_directly_generated.yml
@@ -5,4 +5,5 @@ product: funding_sources_directly_generated
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/yuaq-zdvc.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_directly_generated.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_directly_generated.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/yuaq-zdvc.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_federal.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_federal.yml
@@ -5,4 +5,5 @@ product: funding_sources_federal
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/qpjk-b3zw.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_federal.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_federal.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/qpjk-b3zw.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_local.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_local.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/8tvb-ywj3.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_local.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_local.yml
@@ -5,4 +5,5 @@ product: funding_sources_local
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/8tvb-ywj3.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_state.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_state.yml
@@ -5,4 +5,5 @@ product: funding_sources_state
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/dd43-h6wv.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_state.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_state.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/dd43-h6wv.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_taxes_levied_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_taxes_levied_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/c8k8-y2cj.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_taxes_levied_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_taxes_levied_by_agency.yml
@@ -5,4 +5,5 @@ product: funding_sources_taxes_levied_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/c8k8-y2cj.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities.yml
@@ -5,4 +5,5 @@ product: maintenance_facilities
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/9yj4-fiiz.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/9yj4-fiiz.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/s68b-wvgx.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities_by_agency.yml
@@ -5,4 +5,5 @@ product: maintenance_facilities_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/s68b-wvgx.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/metrics.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/metrics.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/ekg5-frzt.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/metrics.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/metrics.yml
@@ -5,4 +5,5 @@ product: metrics
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/ekg5-frzt.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/dkxx-zjd6.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function.yml
@@ -5,4 +5,5 @@ product: operating_expenses_by_function
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/dkxx-zjd6.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function_and_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function_and_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/i5ki-dc58.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function_and_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function_and_agency.yml
@@ -5,4 +5,5 @@ product: operating_expenses_by_function_and_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/i5ki-dc58.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type.yml
@@ -5,4 +5,5 @@ product: operating_expenses_by_type
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/j5uj-anzx.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/j5uj-anzx.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type_and_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type_and_agency.yml
@@ -5,4 +5,5 @@ product: operating_expenses_by_type_and_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/i4ua-cjx4.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type_and_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type_and_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/i4ua-cjx4.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_agency.yml
@@ -5,4 +5,5 @@ product: service_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/6y83-7vuw.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/6y83-7vuw.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/4fir-qbim.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode.yml
@@ -5,4 +5,5 @@ product: service_by_mode
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/4fir-qbim.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode_and_time_period.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode_and_time_period.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wwdp-t4re.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode_and_time_period.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode_and_time_period.yml
@@ -5,4 +5,5 @@ product: service_by_mode_and_time_period
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wwdp-t4re.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/stations_and_facilities_by_agency_and_facility_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/stations_and_facilities_by_agency_and_facility_type.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/aqct-knjk.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/stations_and_facilities_by_agency_and_facility_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/stations_and_facilities_by_agency_and_facility_type.yml
@@ -5,4 +5,5 @@ product: stations_and_facilities_by_agency_and_facility_type
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/aqct-knjk.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/stations_by_mode_and_age.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/stations_by_mode_and_age.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wfz2-eft6.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/stations_by_mode_and_age.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/stations_by_mode_and_age.yml
@@ -5,4 +5,5 @@ product: stations_by_mode_and_age
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/wfz2-eft6.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/pvgq-a73e.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_agency.yml
@@ -5,4 +5,5 @@ product: track_and_roadway_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/pvgq-a73e.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_mode.yml
@@ -5,4 +5,5 @@ product: track_and_roadway_by_mode
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/fzbb-f6kc.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_mode.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/fzbb-f6kc.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_guideway_age_distribution.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_guideway_age_distribution.yml
@@ -5,4 +5,5 @@ product: track_and_roadway_guideway_age_distribution
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/j9q7-53ae.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_guideway_age_distribution.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_guideway_age_distribution.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/j9q7-53ae.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_age_distribution.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_age_distribution.yml
@@ -5,4 +5,5 @@ product: vehicles_age_distribution
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/6abt-uhgq.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_age_distribution.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_age_distribution.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/6abt-uhgq.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_type_count_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_type_count_by_agency.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/nimp-626k.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_type_count_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_type_count_by_agency.yml
@@ -5,4 +5,5 @@ product: vehicles_type_count_by_agency
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/nimp-626k.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/ridership/complete_monthly_ridership_with_adjustments_and_estimates.yml
+++ b/airflow/dags/sync_ntd_data_api/ridership/complete_monthly_ridership_with_adjustments_and_estimates.yml
@@ -5,4 +5,5 @@ product: complete_monthly_ridership_with_adjustments_and_estimates
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/8bui-9xvu.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/ridership/complete_monthly_ridership_with_adjustments_and_estimates.yml
+++ b/airflow/dags/sync_ntd_data_api/ridership/complete_monthly_ridership_with_adjustments_and_estimates.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/8bui-9xvu.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/fra_regulated_mode_major_security_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/fra_regulated_mode_major_security_events.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/65fa-qbkf.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/fra_regulated_mode_major_security_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/fra_regulated_mode_major_security_events.yml
@@ -5,4 +5,5 @@ product: fra_regulated_mode_major_security_events
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/65fa-qbkf.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/major_safety_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/major_safety_events.yml
@@ -5,4 +5,5 @@ product: major_safety_events
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/9ivb-8ae9.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/major_safety_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/major_safety_events.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/9ivb-8ae9.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/monthly_modal_time_series_safety_and_service.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/monthly_modal_time_series_safety_and_service.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/5ti2-5uiv.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/monthly_modal_time_series_safety_and_service.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/monthly_modal_time_series_safety_and_service.yml
@@ -5,4 +5,5 @@ product: monthly_modal_time_series_safety_and_service
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/5ti2-5uiv.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/nonmajor_safety_and_security_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/nonmajor_safety_and_security_events.yml
@@ -5,4 +5,5 @@ product: nonmajor_safety_and_security_events
 bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/urir-txqm.json
 parameters:
-  $limit: 5000000
+  $limit: 50000000
+page_size: 100000

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/nonmajor_safety_and_security_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/nonmajor_safety_and_security_events.yml
@@ -6,4 +6,4 @@ bucket: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 endpoint: resource/urir-txqm.json
 parameters:
   $limit: 50000000
-page_size: 100000
+page_size: 10000

--- a/airflow/plugins/operators/ntd_to_gcs_operator.py
+++ b/airflow/plugins/operators/ntd_to_gcs_operator.py
@@ -1,6 +1,8 @@
 import gzip
+import io
 import logging
 import os
+import time
 from datetime import datetime
 from typing import Sequence
 
@@ -44,7 +46,7 @@ class NTDToGCSOperator(BaseOperator):
         product: str,
         year: str,
         endpoint: str,
-        parameters: dict = {},
+        parameters: dict = None,
         http_conn_id: str = "http_ntd",
         gcp_conn_id: str = "google_cloud_default",
         page_size: int = 100000,
@@ -56,7 +58,7 @@ class NTDToGCSOperator(BaseOperator):
         self.product = product
         self.year = year
         self.endpoint = endpoint
-        self.parameters = parameters
+        self.parameters = parameters if parameters is not None else {}
         self.http_conn_id = http_conn_id
         self.gcp_conn_id = gcp_conn_id
         self.page_size = page_size
@@ -78,8 +80,6 @@ class NTDToGCSOperator(BaseOperator):
         object_name: str = self.object_path().resolve(dag_run.logical_date)
 
         # Stream data directly to compressed buffer to avoid memory accumulation
-        import io
-
         buffer = io.BytesIO()
 
         with gzip.GzipFile(fileobj=buffer, mode="wb") as gz_file:
@@ -165,8 +165,6 @@ class NTDToGCSOperator(BaseOperator):
                         raise
                     else:
                         logging.info("Retrying upload in 30 seconds...")
-                        import time
-
                         time.sleep(30)
         else:
             logging.info(


### PR DESCRIPTION
# Description
The NTD API sync operator `ntd_to_gcs_operator` was mostly successful in production, but failed consistently during local Airflow development.

This PR addresses NTD API data pipeline memory and reliability Issues, as the operator was failing on large datasets due to memory exhaustion and upload timeouts. It also introduces appropriate pagination to the operator.

Changes made to the operator:
- Pagination - Handle large datasets with configurable page size (default is 100k records)
- Memory streaming - Stream data directly to compressed files instead of loading everything into memory
- Upload retry logic - 3 attempts with progressive timeouts (5, 10, 15 minutes) and backoff
- Updated configurations - Increased limits and added page_size to all NTD dataset configs

Files Changed
- `airflow/plugins/operators/ntd_to_gcs_operator.py`
- 39 YAML config files in `airflow/dags/sync_ntd_data_api/` - Updated limits and page sizes

Resolves #4320 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
<img width="628" height="199" alt="Screenshot 2025-09-22 at 10 55 47" src="https://github.com/user-attachments/assets/1729de01-c33c-4c9c-a3de-838c0ba3c3f3" />

## Post-merge follow-ups
- [x] Actions required (specified below)
monitor production for successful runs
