### PR TITLE
Change `calitp-ntd-api-products` bucket location to `us-west2`

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -326,10 +326,6 @@ output "google_storage_bucket_acl_tfer--test-calitp-gtfs-schedule-validation_id"
   value = google_storage_bucket_acl.tfer--test-calitp-gtfs-schedule-validation.id
 }
 
-output "google_storage_bucket_acl_tfer--test-calitp-ntd-api-products_id" {
-  value = google_storage_bucket_acl.tfer--test-calitp-ntd-api-products.id
-}
-
 output "google_storage_bucket_acl_tfer--test-calitp-ntd-report-validation_id" {
   value = google_storage_bucket_acl.tfer--test-calitp-ntd-report-validation.id
 }
@@ -728,10 +724,6 @@ output "google_storage_bucket_iam_binding_tfer--test-calitp-gtfs-schedule-valida
 
 output "google_storage_bucket_iam_binding_tfer--test-calitp-gtfs-schedule-validation_id" {
   value = google_storage_bucket_iam_binding.tfer--test-calitp-gtfs-schedule-validation.id
-}
-
-output "google_storage_bucket_iam_binding_tfer--test-calitp-ntd-api-products_id" {
-  value = google_storage_bucket_iam_binding.tfer--test-calitp-ntd-api-products.id
 }
 
 output "google_storage_bucket_iam_binding_tfer--test-calitp-ntd-report-validation_id" {
@@ -1142,10 +1134,6 @@ output "google_storage_bucket_iam_member_tfer--test-calitp-gtfs-schedule-validat
   value = google_storage_bucket_iam_member.tfer--test-calitp-gtfs-schedule-validation.id
 }
 
-output "google_storage_bucket_iam_member_tfer--test-calitp-ntd-api-products_id" {
-  value = google_storage_bucket_iam_member.tfer--test-calitp-ntd-api-products.id
-}
-
 output "google_storage_bucket_iam_member_tfer--test-calitp-ntd-report-validation_id" {
   value = google_storage_bucket_iam_member.tfer--test-calitp-ntd-report-validation.id
 }
@@ -1552,10 +1540,6 @@ output "google_storage_bucket_iam_policy_tfer--test-calitp-gtfs-schedule-validat
 
 output "google_storage_bucket_iam_policy_tfer--test-calitp-gtfs-schedule-validation_id" {
   value = google_storage_bucket_iam_policy.tfer--test-calitp-gtfs-schedule-validation.id
-}
-
-output "google_storage_bucket_iam_policy_tfer--test-calitp-ntd-api-products_id" {
-  value = google_storage_bucket_iam_policy.tfer--test-calitp-ntd-api-products.id
 }
 
 output "google_storage_bucket_iam_policy_tfer--test-calitp-ntd-report-validation_id" {
@@ -2302,14 +2286,6 @@ output "google_storage_bucket_tfer--test-calitp-gtfs-schedule-validation_self_li
   value = google_storage_bucket.tfer--test-calitp-gtfs-schedule-validation.self_link
 }
 
-output "google_storage_bucket_tfer--test-calitp-ntd-api-products_name" {
-  value = google_storage_bucket.tfer--test-calitp-ntd-api-products.name
-}
-
-output "google_storage_bucket_tfer--test-calitp-ntd-api-products_self_link" {
-  value = google_storage_bucket.tfer--test-calitp-ntd-api-products.self_link
-}
-
 output "google_storage_bucket_tfer--test-calitp-ntd-report-validation_name" {
   value = google_storage_bucket.tfer--test-calitp-ntd-report-validation.name
 }
@@ -2784,10 +2760,6 @@ output "google_storage_default_object_acl_tfer--test-calitp-gtfs-schedule-valida
 
 output "google_storage_default_object_acl_tfer--test-calitp-gtfs-schedule-validation_id" {
   value = google_storage_default_object_acl.tfer--test-calitp-gtfs-schedule-validation.id
-}
-
-output "google_storage_default_object_acl_tfer--test-calitp-ntd-api-products_id" {
-  value = google_storage_default_object_acl.tfer--test-calitp-ntd-api-products.id
 }
 
 output "google_storage_default_object_acl_tfer--test-calitp-ntd-report-validation_id" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -471,7 +471,7 @@ resource "google_storage_bucket" "tfer--calitp-metabase-data-public" {
 resource "google_storage_bucket" "tfer--calitp-ntd-api-products" {
   default_event_based_hold    = "false"
   force_destroy               = "false"
-  location                    = "US"
+  location                    = "US-WEST2"
   name                        = "calitp-ntd-api-products"
   project                     = "cal-itp-data-infra"
   public_access_prevention    = "enforced"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -1644,33 +1644,6 @@ resource "google_storage_bucket" "tfer--test-calitp-gtfs-schedule-validation-hou
   }
 }
 
-resource "google_storage_bucket" "tfer--test-calitp-ntd-api-products" {
-  default_event_based_hold    = "false"
-  force_destroy               = "false"
-  location                    = "US"
-  name                        = "test-calitp-ntd-api-products"
-  project                     = "cal-itp-data-infra"
-  public_access_prevention    = "enforced"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "true"
-
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-
-    condition {
-      age                        = "30"
-      created_before             = ""
-      days_since_custom_time     = "0"
-      days_since_noncurrent_time = "0"
-      num_newer_versions         = "0"
-      with_state                 = "ANY"
-    }
-  }
-}
-
 resource "google_storage_bucket" "tfer--test-calitp-ntd-report-validation" {
   default_event_based_hold    = "false"
   force_destroy               = "false"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_acl.tf
@@ -326,10 +326,6 @@ resource "google_storage_bucket_acl" "tfer--test-calitp-gtfs-schedule-validation
   bucket = "test-calitp-gtfs-schedule-validation-hourly"
 }
 
-resource "google_storage_bucket_acl" "tfer--test-calitp-ntd-api-products" {
-  bucket = "test-calitp-ntd-api-products"
-}
-
 resource "google_storage_bucket_acl" "tfer--test-calitp-ntd-report-validation" {
   bucket = "test-calitp-ntd-report-validation"
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -502,12 +502,6 @@ resource "google_storage_bucket_iam_binding" "tfer--test-calitp-gtfs-schedule-va
   role    = "roles/storage.legacyBucketOwner"
 }
 
-resource "google_storage_bucket_iam_binding" "tfer--test-calitp-ntd-api-products" {
-  bucket  = "b/test-calitp-ntd-api-products"
-  members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
-  role    = "roles/storage.legacyObjectOwner"
-}
-
 resource "google_storage_bucket_iam_binding" "tfer--test-calitp-ntd-report-validation" {
   bucket  = "b/test-calitp-ntd-report-validation"
   members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -502,12 +502,6 @@ resource "google_storage_bucket_iam_member" "tfer--test-calitp-gtfs-schedule-val
   role   = "roles/storage.legacyBucketOwner"
 }
 
-resource "google_storage_bucket_iam_member" "tfer--test-calitp-ntd-api-products" {
-  bucket = "b/test-calitp-ntd-api-products"
-  member = "projectOwner:cal-itp-data-infra"
-  role   = "roles/storage.legacyObjectOwner"
-}
-
 resource "google_storage_bucket_iam_member" "tfer--test-calitp-ntd-report-validation" {
   bucket = "b/test-calitp-ntd-report-validation"
   member = "projectViewer:cal-itp-data-infra"

--- a/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
@@ -333,10 +333,6 @@ resource "google_storage_default_object_acl" "tfer--test-calitp-gtfs-schedule-va
   bucket = "test-calitp-gtfs-schedule-validation-hourly"
 }
 
-resource "google_storage_default_object_acl" "tfer--test-calitp-ntd-api-products" {
-  bucket = "test-calitp-ntd-api-products"
-}
-
 resource "google_storage_default_object_acl" "tfer--test-calitp-ntd-report-validation" {
   bucket = "test-calitp-ntd-report-validation"
 }


### PR DESCRIPTION
# Description

This PR changes `calitp-ntd-api-products` bucket location to `us-west2` through Terraform.

It is currently using `US` region and since all data was clean up in order to fix some data changes, we can replace the location now without having to copy any data.

This change is important to keep buckets at the same region as BigQuery and part of the Cost Savings plan: [Chore: Review buckets’ location #3712](https://github.com/cal-itp/data-infra/issues/3711)

It also deletes the unused test bucket `test-calitp-ntd-api-products` replaced by `calitp-staging-ntd-api-products`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running `terraform plan` locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm if the correct region `us-west2`  was set to `calitp-ntd-api-products` bucket.