### PR TITLE
Do not remove equals sign from base64 urls

### DIFF
--- a/airflow/dags/parse_and_validate_rt_filtered.py
+++ b/airflow/dags/parse_and_validate_rt_filtered.py
@@ -1,0 +1,32 @@
+import os
+from datetime import datetime
+
+from operators.gcs_to_gtfs_rt_command_operator import GCSToGTFSRTCommandOperator
+
+from airflow import DAG, XComArg
+from airflow.operators.bash import BashOperator
+
+with DAG(
+    dag_id="parse_and_validate_rt_filtered",
+    tags=["gtfs", "gtfs-rt"],
+    # Every hour at 15 minutes past the hour
+    schedule="15 * * * *",
+    start_date=datetime(2025, 7, 8),
+    catchup=True,
+):
+    for process in ["parse", "validate"]:
+        for feed in ["service_alerts", "trip_updates", "vehicle_positions"]:
+            commands = GCSToGTFSRTCommandOperator(
+                task_id=f"build_{process}_rt_{feed}",
+                bucket=os.environ["CALITP_BUCKET__GTFS_RT_RAW"],
+                process=process,
+                feed=feed,
+                filter_by="=",
+            )
+
+            BashOperator.partial(
+                task_id=f"{process}_rt_{feed}",
+                pool=f"rt_{process}_pool",
+                append_env=True,
+                do_xcom_push=False,
+            ).expand(bash_command=XComArg(commands))

--- a/airflow/plugins/operators/gcs_to_gtfs_rt_command_operator.py
+++ b/airflow/plugins/operators/gcs_to_gtfs_rt_command_operator.py
@@ -24,16 +24,17 @@ class UniquePartitionValues:
         )
 
         partitions = []
+        partition_name = f"{self.partition_name}="  # "base64_url="
+
         for path in keys:
             # path = trip_updates/dt=2024-10-22/hour=2024-10-22T18:00:00+00:00/ts=2024-10-22T18:59:40+00:00/base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw==/feed
             for partition in path.split("/"):
                 # partition = [ "trip_updates", "dt=2024-10-22", "hour=2024-10-22T18:00:00+00:00", "ts=2024-10-22T18:59:40+00:00", "base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw==", "feed"]
-                if partition.startswith(f"{self.partition_name}="):
-                    # partition_name = "base64_url"
-                    # partition = "base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw=="
-                    name_size = len(f"{self.partition_name}=")
-                    # Append value without the partition name and first equals sign: "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw=="
-                    partitions.append(partition[name_size:])
+                if partition.startswith(partition_name):
+                    # base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw==
+                    # Append the value: aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw==
+                    partitions.append(partition.split(partition_name[1]))
+
         return list(set(partitions))
 
 

--- a/airflow/plugins/operators/gcs_to_gtfs_rt_command_operator.py
+++ b/airflow/plugins/operators/gcs_to_gtfs_rt_command_operator.py
@@ -31,7 +31,7 @@ class UniquePartitionValues:
                 if partition.startswith(f"{self.partition_name}="):
                     # partition_name = "base64_url"
                     # partition = "base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw=="
-                    name_size = len("{self.partition_name}=")
+                    name_size = len(f"{self.partition_name}=")
                     # Append value without the partition name and first equals sign: "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw=="
                     partitions.append(partition[name_size:])
         return list(set(partitions))

--- a/airflow/plugins/operators/gcs_to_gtfs_rt_command_operator.py
+++ b/airflow/plugins/operators/gcs_to_gtfs_rt_command_operator.py
@@ -25,9 +25,15 @@ class UniquePartitionValues:
 
         partitions = []
         for path in keys:
+            # path = trip_updates/dt=2024-10-22/hour=2024-10-22T18:00:00+00:00/ts=2024-10-22T18:59:40+00:00/base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw==/feed
             for partition in path.split("/"):
+                # partition = [ "trip_updates", "dt=2024-10-22", "hour=2024-10-22T18:00:00+00:00", "ts=2024-10-22T18:59:40+00:00", "base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw==", "feed"]
                 if partition.startswith(f"{self.partition_name}="):
-                    partitions.append(partition.split("=")[1])
+                    # partition_name = "base64_url"
+                    # partition = "base64_url=aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw=="
+                    name_size = len("{self.partition_name}=")
+                    # Append value without the partition name and first equals sign: "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3RyaXB1cGRhdGVzP2FnZW5jeT1HRw=="
+                    partitions.append(partition[name_size:])
         return list(set(partitions))
 
 

--- a/airflow/tests/operators/test_gcs_to_gtfs_rt_command_operator.py
+++ b/airflow/tests/operators/test_gcs_to_gtfs_rt_command_operator.py
@@ -59,6 +59,6 @@ class TestGCSToGTFSRTCommandOperator:
             "service_alerts "
             "2024-10-22T18:00:00 "
             "--base64url "
-            "aHR0cHM6Ly9hcGkuNTExLm9yZy90cmFuc2l0L3NlcnZpY2VhbGVydHM_YWdlbmN5PUFN "
+            "aHR0cHM6Ly90aGVidXNsaXZlLmNvbS9ndGZzLXJ0L2FsZXJ0cw== "
             "--verbose" in xcom_value
         )

--- a/airflow/tests/operators/test_gcs_to_gtfs_rt_command_operator.py
+++ b/airflow/tests/operators/test_gcs_to_gtfs_rt_command_operator.py
@@ -32,6 +32,7 @@ class TestGCSToGTFSRTCommandOperator:
             gcp_conn_id="google_cloud_default",
             process="parse",
             feed="service_alerts",
+            filter_by="=",
             bucket=os.environ.get("CALITP_BUCKET__GTFS_RT_RAW"),
             dag=test_dag,
         )


### PR DESCRIPTION
# Description

This PR fixes de issue of removing equals sign from base64 url from GCSToGTFSRTCommandOperator that processes parse and validate files.

Also created a temporary DAG `parse_and_validate_rt_filtered` to run all the base64 urls that contains equal signs from 2025-07-08. 

Resolves [#4304]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally using pytest: `poetry run pytest tests/operators/test_gcs_to_gtfs_rt_command_operator.py`.

Tested on Staging Airflow and it run succesfully.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Turn on `parse_and_validate_rt_filtered` to re-run all parse and validate commands for base64 url that contains equals signs.