### PR TITLE
Temporarily Bumping up composer to increase power for backfill processes

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -17,7 +17,7 @@ resource "google_composer_environment" "calitp-composer" {
         cpu        = 2
         memory_gb  = 2
         storage_gb = 1
-        count      = 1
+        count      = 2
       }
       web_server {
         cpu        = 1
@@ -25,21 +25,21 @@ resource "google_composer_environment" "calitp-composer" {
         storage_gb = 1
       }
       worker {
-        cpu        = 2
+        cpu        = 4
         memory_gb  = 13
         storage_gb = 5
         min_count  = 1
-        max_count  = 8
+        max_count  = 32
       }
     }
 
-    environment_size = "ENVIRONMENT_SIZE_MEDIUM"
+    environment_size = "ENVIRONMENT_SIZE_LARGE"
 
     software_config {
       image_version = "composer-2.8.6-airflow-2.7.3"
 
       airflow_config_overrides = {
-        celery-worker_concurrency                  = 4
+        celery-worker_concurrency                  = 6
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true


### PR DESCRIPTION
# Description

Bumping up composer for backfill operations.  

Emulating changes reversed in https://github.com/cal-itp/data-infra/pull/4286.

Continuing work on https://github.com/cal-itp/data-infra/issues/4294

## Type of change

- [x] New feature

## How has this been tested?

Not tested.

## Post-merge follow-ups

- [x] Actions required (specified below)
Monitor.  And bump back down when backfill completes.