### PR TITLE
Add active tasks limit to `parse_and_validate_rt_filtered`

### DIFF
--- a/airflow/dags/parse_and_validate_rt_filtered.py
+++ b/airflow/dags/parse_and_validate_rt_filtered.py
@@ -13,6 +13,7 @@ with DAG(
     schedule="15 * * * *",
     start_date=datetime(2025, 7, 8),
     catchup=True,
+    max_active_tasks=128,
 ):
     for process in ["parse", "validate"]:
         for feed in ["service_alerts", "trip_updates", "vehicle_positions"]:


### PR DESCRIPTION
# Description

Limit parse_and_validate_rt_filtered to run maximum 128 tasks at a time since we need to re-run all past urls from 07/08/2025 and don't want to block other DAGs. #4284

Using the same strategy used before in https://github.com/cal-itp/data-infra/pull/4281/files.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Just configuration.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
