### PR TITLE
payments: create and add new service account for VCTC RBAC policy to terraform

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -58,6 +58,12 @@ resource "google_project_iam_member" "tfer--projects-002F-cal-itp-data-infra-002
   role    = "projects/cal-itp-data-infra/roles/AgencyPaymentsServiceReader"
 }
 
+resource "google_project_iam_member" "" {
+  member  = "serviceAccount:vctc-payments-user@cal-itp-data-infra.iam.gserviceaccount.com"
+  project = "cal-itp-data-infra"
+  role    = "projects/cal-itp-data-infra/roles/AgencyPaymentsServiceReader"
+}
+
 resource "google_project_iam_member" "tfer--roles-002F-appengine-002E-serviceAgentserviceAccount-003A-service-1005246706141-0040-gcp-gae-service-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:service-1005246706141@gcp-gae-service.iam.gserviceaccount.com"
   project = "cal-itp-data-infra"

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -58,7 +58,7 @@ resource "google_project_iam_member" "tfer--projects-002F-cal-itp-data-infra-002
   role    = "projects/cal-itp-data-infra/roles/AgencyPaymentsServiceReader"
 }
 
-resource "google_project_iam_member" "" {
+resource "google_project_iam_member" "tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-AgencyPaymentsServiceReaderserviceAccount-003A-vctc-payments-user-0040-cal-itp-data-infra-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:vctc-payments-user@cal-itp-data-infra.iam.gserviceaccount.com"
   project = "cal-itp-data-infra"
   role    = "projects/cal-itp-data-infra/roles/AgencyPaymentsServiceReader"

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -271,3 +271,9 @@ resource "google_service_account" "composer-service-account" {
   display_name = "composer"
   project      = "cal-itp-data-infra"
 }
+
+resource "google_service_account" "tfer--100119052859631924010" {
+  account_id = "vctc-payments-user"
+  disabled   = "false"
+  project    = "cal-itp-data-infra"
+}

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -272,7 +272,7 @@ resource "google_service_account" "composer-service-account" {
   project      = "cal-itp-data-infra"
 }
 
-resource "google_service_account" "tfer--100119052859631924010" {
+resource "google_service_account" "vctc-payments-user" {
   account_id = "vctc-payments-user"
   disabled   = "false"
   project    = "cal-itp-data-infra"


### PR DESCRIPTION
# Description
As we onboard VCTC to the payments data pipeline, we need to add their new payments agency reader service account to Terraform so as to include their data in the pipeline via our row-based access control policy.

Resolves #4312

## Type of change
- [x] New feature

## Post-merge follow-ups
- [x] Actions required (specified below)
#4309 