### PR TITLE
Bump staging composer to composer-2.9.7-airflow-2.7.3

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -36,7 +36,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
     environment_size = "ENVIRONMENT_SIZE_SMALL"
 
     software_config {
-      image_version = "composer-2.8.6-airflow-2.7.3"
+      image_version = "composer-2.9.7-airflow-2.7.3"
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4


### PR DESCRIPTION
# Description

This PR upgrades staging composer to composer-2.9.7-airflow-2.7.3

Relates to #3768

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running on staging

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Run all DAGs on staging