### PR TITLE
Use bignumeric on track_and_roadway_by_mode fields with long numbers

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_mode.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_mode.yml
@@ -114,7 +114,7 @@ schema_fields:
   - name: total_miles
     type: STRING
   - name: total_track_miles
-    type: NUMERIC
+    type: BIGNUMERIC
   - name: total_track_miles_q
     type: STRING
   - name: type_of_service

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_mode.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_mode.sql
@@ -64,7 +64,7 @@ stg_ntd__track_and_roadway_by_mode AS (
         {{ trim_make_empty_string_null('slip_switch_q') }} AS slip_switch_q,
         {{ trim_make_empty_string_null('state') }} AS state,
         SAFE_CAST(total_miles AS NUMERIC) AS total_miles,
-        SAFE_CAST(total_track_miles AS NUMERIC) AS total_track_miles,
+        SAFE_CAST(total_track_miles AS BIGNUMERIC) AS total_track_miles,
         {{ trim_make_empty_string_null('total_track_miles_q') }} AS total_track_miles_q,
         {{ trim_make_empty_string_null('type_of_service') }} AS type_of_service,
         {{ trim_make_empty_string_null('uace_code') }} AS uace_code,


### PR DESCRIPTION
# Description

This PR changes the data type from `NUMERIC` to `BIGNUMERIC` to fix `Invalid NUMERIC value` error accepting longer values on `track_and_roadway_by_mode`.`total_track_miles`.

Resolves #4319

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Compiling external table on Airflow Staging:
<img width="1154" height="475" alt="image" src="https://github.com/user-attachments/assets/8764df5a-e013-43d9-9d54-5ecadff0099d" />

Running models:
```
❯ poetry run dbt run -s +fct_track_and_roadway_by_mode
18:00:45  Running with dbt=1.10.1
18:00:46  Registered adapter: bigquery=1.10.0
18:00:47  Unable to do partial parsing because config vars, config profile, or config target have changed
18:00:47  Unable to do partial parsing because profile has changed
/Users/erikapacheco/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-s8ErtA5b-py3.11/lib/python3.11/site-packages/jinja2/lexer.py:654: DeprecationWarning: invalid escape sequence '\w'
/Users/erikapacheco/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-s8ErtA5b-py3.11/lib/python3.11/site-packages/jinja2/lexer.py:654: DeprecationWarning: invalid escape sequence '\?'
18:00:52  Found 620 models, 1241 data tests, 14 seeds, 225 sources, 4 exposures, 1052 macros
18:00:52
18:00:52  Concurrency: 8 threads (target='dev')
18:00:52
18:00:56  1 of 16 START sql view model erikap_staging.stg_ntd__2022_agency_information ... [RUN]
18:00:56  2 of 16 START sql view model erikap_staging.stg_ntd__2023_agency_information ... [RUN]
18:00:56  3 of 16 START sql view model erikap_staging.stg_ntd__track_and_roadway_by_mode . [RUN]
18:00:56  4 of 16 START sql view model erikap_staging.stg_transit_database__county_geography  [RUN]
18:00:56  5 of 16 START sql view model erikap_staging.stg_transit_database__ntd_agency_info  [RUN]
18:00:56  6 of 16 START sql view model erikap_staging.stg_transit_database__organizations  [RUN]
18:00:57  3 of 16 OK created sql view model erikap_staging.stg_ntd__track_and_roadway_by_mode  [CREATE VIEW (0 processed) in 0.98s]
18:00:57  6 of 16 OK created sql view model erikap_staging.stg_transit_database__organizations  [CREATE VIEW (0 processed) in 1.49s]
18:00:57  4 of 16 OK created sql view model erikap_staging.stg_transit_database__county_geography  [CREATE VIEW (0 processed) in 1.50s]
18:00:57  5 of 16 OK created sql view model erikap_staging.stg_transit_database__ntd_agency_info  [CREATE VIEW (0 processed) in 1.51s]
18:00:57  1 of 16 OK created sql view model erikap_staging.stg_ntd__2022_agency_information  [CREATE VIEW (0 processed) in 1.51s]
18:00:57  2 of 16 OK created sql view model erikap_staging.stg_ntd__2023_agency_information  [CREATE VIEW (0 processed) in 1.52s]
18:00:57  7 of 16 START sql table model erikap_staging.int_transit_database__county_geography_dim  [RUN]
18:00:57  8 of 16 START sql table model erikap_staging.int_transit_database__ntd_agency_info_dim  [RUN]
18:00:57  9 of 16 START sql view model erikap_staging.int_ntd__unioned_agency_information  [RUN]
18:00:58  9 of 16 OK created sql view model erikap_staging.int_ntd__unioned_agency_information  [CREATE VIEW (0 processed) in 1.00s]
18:01:01  7 of 16 OK created sql table model erikap_staging.int_transit_database__county_geography_dim  [CREATE TABLE (58.0 rows, 3.2 MiB processed) in 3.60s]
18:01:01  10 of 16 START sql table model erikap_mart_transit_database.dim_county_geography  [RUN]
18:01:02  8 of 16 OK created sql table model erikap_staging.int_transit_database__ntd_agency_info_dim  [CREATE TABLE (230.0 rows, 6.1 MiB processed) in 4.26s]
18:01:02  11 of 16 START sql table model erikap_staging.int_transit_database__organizations_dim  [RUN]
18:01:04  10 of 16 OK created sql table model erikap_mart_transit_database.dim_county_geography  [CREATE TABLE (58.0 rows, 77.0 KiB processed) in 3.33s]
18:01:07  11 of 16 OK created sql table model erikap_staging.int_transit_database__organizations_dim  [CREATE TABLE (1.5k rows, 403.0 MiB processed) in 5.30s]
18:01:07  12 of 16 START sql table model erikap_mart_transit_database.bridge_organizations_x_headquarters_county_geography  [RUN]
18:01:07  13 of 16 START sql table model erikap_mart_transit_database.dim_organizations .. [RUN]
18:01:09  12 of 16 OK created sql table model erikap_mart_transit_database.bridge_organizations_x_headquarters_county_geography  [CREATE TABLE (1.3k rows, 189.7 KiB processed) in 2.51s]
18:01:10  13 of 16 OK created sql table model erikap_mart_transit_database.dim_organizations  [CREATE TABLE (1.5k rows, 330.3 KiB processed) in 2.97s]
18:01:10  14 of 16 START sql view model erikap_mart_transit_database_latest.dim_organizations_latest_with_caltrans_district  [RUN]
18:01:11  14 of 16 OK created sql view model erikap_mart_transit_database_latest.dim_organizations_latest_with_caltrans_district  [CREATE VIEW (0 processed) in 0.81s]
18:01:11  15 of 16 START sql table model erikap_mart_ntd_annual_reporting.dim_agency_information  [RUN]
18:01:15  15 of 16 OK created sql table model erikap_mart_ntd_annual_reporting.dim_agency_information  [CREATE TABLE (5.9k rows, 78.2 MiB processed) in 4.54s]
18:01:15  16 of 16 START sql table model erikap_mart_ntd_annual_reporting.fct_track_and_roadway_by_mode  [RUN]
18:01:19  16 of 16 OK created sql table model erikap_mart_ntd_annual_reporting.fct_track_and_roadway_by_mode  [CREATE TABLE (485.0 rows, 2.2 MiB processed) in 3.78s]
18:01:19
18:01:19  Finished running 8 table models, 8 view models in 0 hours 0 minutes and 26.79 seconds (26.79s).
18:01:19
18:01:19  Completed successfully
18:01:19
18:01:19  Done. PASS=16 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=16
```

<img width="1000" height="269" alt="image" src="https://github.com/user-attachments/assets/29b398e0-786f-4d9d-86f7-1454c2cb0e8d" />


## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm if dbt_all is able to run successfully `fct_track_and_roadway_by_mode`