### PR TITLE
Use bignumeric on `track_and_roadway_by_agency. sum_total_miles` to fix INVALID number

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_agency.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/multi_year__track_and_roadway_by_agency.yml
@@ -72,6 +72,6 @@ schema_fields:
   - name: sum_slip_switch
     type: NUMERIC
   - name: sum_total_miles
-    type: NUMERIC
+    type: BIGNUMERIC
   - name: sum_total_track_miles
     type: BIGNUMERIC

--- a/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_agency.sql
+++ b/warehouse/models/staging/ntd_annual_reporting/stg_ntd__track_and_roadway_by_agency.sql
@@ -43,7 +43,7 @@ stg_ntd__track_and_roadway_by_agency AS (
         SAFE_CAST(sum_single_crossover AS NUMERIC) AS sum_single_crossover,
         SAFE_CAST(sum_single_turnout AS NUMERIC) AS sum_single_turnout,
         SAFE_CAST(sum_slip_switch AS NUMERIC) AS sum_slip_switch,
-        SAFE_CAST(sum_total_miles AS NUMERIC) AS sum_total_miles,
+        SAFE_CAST(sum_total_miles AS BIGNUMERIC) AS sum_total_miles,
         SAFE_CAST(sum_total_track_miles AS BIGNUMERIC) AS sum_total_track_miles,
         dt,
         execution_ts


### PR DESCRIPTION
# Description

This PR changes the data type from `NUMERIC` to `BIGNUMERIC` to fix `Invalid NUMERIC value` error accepting longer values on `track_and_roadway_by_agency.sum_total_miles`.

[#4276]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Compiled external table on Airflow Staging:


Running models:



## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm if `dbt_all` is able to run successfully `fct_track_and_roadway_by_agency`