### PR TITLE
Decrease size of GTFS monthly scheduled models, correctly implement GTFS `fct_vehicle_locations_path` as incremental

### DIFF
--- a/warehouse/macros/define_day_of_week.sql
+++ b/warehouse/macros/define_day_of_week.sql
@@ -1,0 +1,10 @@
+-- Transit is typically Weekday / Saturday / Sunday service
+-- Big Query has Sunday as 1 (https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#extract)
+{% macro generate_day_type(date_column) %}
+    CASE
+        WHEN EXTRACT(DAYOFWEEK FROM {{ date_column }}) = 1 THEN "Sunday"
+        WHEN EXTRACT(DAYOFWEEK FROM {{ date_column }}) = 7 THEN "Saturday"
+        ELSE 'Weekday'
+    END
+
+{% endmacro %}

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2489,7 +2489,7 @@ models:
       An monthly aggregation of GTFS scheduled trips by month-day_type (weekday/Sat/Sun).
       Keeps the trip grain in `fct_scheduled_trips`, joins this with the shape_id present
       in `fct_daily_scheduled_shapes`.
-      Each row is unique on gtfs_dataset_key-month-year-day_type-trip_id.
+      Each row is unique on gtfs_dataset_key-month-year-day_type-trip_id-iteration_num.
       It can be interpreted as:
       In a typical month, we observed weekday Trip 1 service (across 20+ days),
       Saturday Trip 1 service (across 4 days that month),
@@ -2533,7 +2533,6 @@ models:
       - &n_days
         name: n_days
         description: Count of distinct service_dates in this month for this day_type.
-      - *shape_pt_array
 
   - name: fct_monthly_routes
     description: |

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -2489,18 +2489,21 @@ models:
       An monthly aggregation of GTFS scheduled trips by month-day_type (weekday/Sat/Sun).
       Keeps the trip grain in `fct_scheduled_trips`, joins this with the shape_id present
       in `fct_daily_scheduled_shapes`.
-      Each row is unique on gtfs_dataset_key-month-year-day_type-trip_id-iteration_num.
+      Each row is unique on name-month-year-day_type-trip_id-iteration_num.
       It can be interpreted as:
       In a typical month, we observed weekday Trip 1 service (across 20+ days),
       Saturday Trip 1 service (across 4 days that month),
       and Sunday Trip 1 service (across 4 days that month).
     columns:
-      - name: gtfs_dataset_key
-        description: '{{ doc("column_rt_schedule_dataset_key") }}'
       - name: name
         description: *gtfs_dataset_name_desc
       - *month
       - *year
+      - &month_first_day
+        name: month_first_day
+        description: |
+          First day of the month saved as a date.
+          Service_date of 2025-09-15 would become 2025-09-01.
       - *day_type
       - *time_of_day
       - name: direction_id
@@ -2543,6 +2546,7 @@ models:
         description: *gtfs_dataset_name_desc
       - *year
       - *month
+      - *month_first_day
       - name: route_short_name
         description: '{{ doc("gtfs_routes__route_short_name") }}'
       - name: route_long_name

--- a/warehouse/models/mart/gtfs/fct_monthly_routes.sql
+++ b/warehouse/models/mart/gtfs/fct_monthly_routes.sql
@@ -1,4 +1,7 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='table',
+    cluster_by=['month_first_day', 'name']
+) }}
 
 WITH fct_scheduled_trips AS (
     SELECT * FROM {{ ref('fct_monthly_scheduled_trips') }}
@@ -16,6 +19,7 @@ trip_counts AS (
         name,
         year,
         month,
+        month_first_day,
         route_short_name,
         route_long_name,
         route_name,
@@ -26,9 +30,9 @@ trip_counts AS (
         COUNT(*) AS n_trips,
 
     FROM fct_scheduled_trips
-    GROUP BY name, year, month, route_short_name, route_long_name, route_name, direction_id, shape_id, shape_array_key
+    GROUP BY name, year, month, month_first_day, route_short_name, route_long_name, route_name, direction_id, shape_id, shape_array_key
     QUALIFY ROW_NUMBER() OVER (PARTITION BY
-                               name, year, month, route_short_name, route_long_name, route_name, direction_id
+                               name, year, month, month_first_day, route_short_name, route_long_name, route_name, direction_id
                                ORDER BY n_trips DESC) = 1
 ),
 

--- a/warehouse/models/mart/gtfs/fct_monthly_scheduled_trips.sql
+++ b/warehouse/models/mart/gtfs/fct_monthly_scheduled_trips.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='table',
-        cluster_by=['month_first_day', 'gtfs_dataset_key', 'name']
+        cluster_by=['month_first_day', 'name']
     )
 }}
 
@@ -18,7 +18,6 @@ monthly_trips AS (
 
     SELECT
 
-        gtfs_dataset_key,
         name,
 
         EXTRACT(month FROM service_date) AS month,
@@ -46,7 +45,7 @@ monthly_trips AS (
         ARRAY_AGG(DISTINCT route_id IGNORE NULLS) AS route_id_array
 
     FROM trips
-    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17
 
 )
 

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations.sql
@@ -26,7 +26,7 @@ vp_trips AS (
         schedule_base64_url,
         trip_id,
         trip_start_time,
-        trip_instance_key
+        trip_instance_key,
     FROM {{ ref('fct_vehicle_positions_trip_summaries') }}
 ),
 

--- a/warehouse/models/mart/gtfs/fct_vehicle_locations_path.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_locations_path.sql
@@ -7,13 +7,19 @@
             'data_type': 'date',
             'granularity': 'day',
         },
-        cluster_by='base64_url',
+        cluster_by=['base64_url', 'schedule_base64_url'],
     )
 }}
 
 WITH fct_vehicle_locations AS (
     SELECT *
     FROM {{ ref('fct_vehicle_locations') }}
+    WHERE {{ incremental_where(
+        default_start_var='PROD_GTFS_RT_START',
+        this_dt_column='dt',
+        filter_dt_column='dt',
+        dev_lookback_days=14)
+    }}
 ),
 
 -- collect points into an array
@@ -26,6 +32,7 @@ initial_pt_array AS (
         schedule_gtfs_dataset_key,
         schedule_name,
         schedule_feed_key,
+        schedule_base64_url,
         trip_id,
         trip_instance_key,
         -- don't try to make LINESTRING because of this issue:
@@ -52,7 +59,7 @@ initial_pt_array AS (
         COUNT(*) AS n_vp,
 
     FROM fct_vehicle_locations
-    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 ),
 
 fct_vehicle_locations_path AS (


### PR DESCRIPTION
# Description

Follow-up to #3994 
* For monthly scheduled trips, drop the `shape` geometry column, this table is huge with it. Instead, that join will occur in `fct_monthly_routes`
* `fct_vehicle_locations_path` was doing full refresh each time, so use macro to support #4109 
* see if this model can be used for #4034

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (tweak-gtfs-models) $ poetry run dbt run -s fct_vehicle_locations  --full-refresh
19:11:58  Running with dbt=1.10.1
19:12:03  Registered adapter: bigquery=1.10.0
19:12:07  Found 624 models, 1241 data tests, 14 seeds, 225 sources, 4 exposures, 1053 macros
19:12:07  
19:12:07  Concurrency: 8 threads (target='dev')
19:12:07  
19:12:09  1 of 1 START sql incremental model tiffany_mart_gtfs.fct_vehicle_locations ..... [RUN]
/home/jovyan/.cache/pypoetry/virtualenvs/calitp-warehouse-rrNmZ0ll-py3.11/lib/python3.11/site-packages/dbt/adapters/bigquery/impl.py:520: PendingDeprecationWarning: This method will be deprecated in future versions. Please use Table.time_partitioning.type_ instead.
19:12:41  1 of 1 OK created sql incremental model tiffany_mart_gtfs.fct_vehicle_locations  [CREATE TABLE (46.2m rows, 97.2 GiB processed) in 31.31s]
19:12:41  
19:12:41  Finished running 1 incremental model in 0 hours 0 minutes and 34.10 seconds (34.10s).
19:12:42  
19:12:42  Completed successfully
19:12:42  
19:12:42  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1


jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (tweak-gtfs-models) $ poetry run dbt run -s fct_vehicle_locations_path --full-refresh
19:15:35  Running with dbt=1.10.1
19:15:39  Registered adapter: bigquery=1.10.0
19:15:44  Found 624 models, 1241 data tests, 14 seeds, 225 sources, 4 exposures, 1053 macros
19:15:44  
19:15:44  Concurrency: 8 threads (target='dev')
19:15:44  
19:15:47  1 of 1 START sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_path  [RUN]
19:16:02  1 of 1 OK created sql incremental model tiffany_mart_gtfs.fct_vehicle_locations_path  [CREATE TABLE (270.4k rows, 17.1 GiB processed) in 15.12s]
19:16:02  
19:16:02  Finished running 1 incremental model in 0 hours 0 minutes and 18.00 seconds (18.00s).
19:16:03  
19:16:03  Completed successfully
19:16:03  
19:16:03  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [ ] No action required
- [ ] Actions required (specified below)
