### PR TITLE
use teal-bold for apps/maps download link

### DIFF
--- a/apps/maps/src/routes/+page.svelte
+++ b/apps/maps/src/routes/+page.svelte
@@ -623,7 +623,7 @@
         {/if}
       </div>
       {#if (state)}
-        <a class="navbar-item has-text-teal" href="{state.layers.slice(-1)[0].url}">
+        <a class="navbar-item has-text-teal-bold" href="{state.layers.slice(-1)[0].url}">
           <div class="icon-text">
             <span class="icon">
               <i class="fas fa-file-arrow-down"></i>


### PR DESCRIPTION
# Description

Use a darker color for the map app download link to provide sufficient contrast to meet accessibility standards.

Resolves #4338

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested, in conversation with @vevetron we're willing to see if/how the post-merge deployment process picks this up. Isolated to `apps/maps` and highly unlikely to break anything.

## Post-merge follow-ups

- [ ] No action required
- [ ] Actions required (specified below)

Check if deployment succeeds. 
