### PR TITLE
Mount sftp data directory with ownership, Assign static ip

### DIFF
--- a/iac/cal-itp-data-infra-staging/networks/us/compute_address.tf
+++ b/iac/cal-itp-data-infra-staging/networks/us/compute_address.tf
@@ -1,0 +1,5 @@
+resource "google_compute_address" "enghouse-sftp-address" {
+  name         = "enghouse-sftp-address"
+  region       = "us-west2"
+  address_type = "EXTERNAL"
+}

--- a/iac/cal-itp-data-infra-staging/networks/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/networks/us/outputs.tf
@@ -5,3 +5,7 @@ output "google_compute_network_tfer--default_self_link" {
 output "google_compute_network_static-load-balancer-address_id" {
   value = google_compute_global_address.static-load-balancer-address.id
 }
+
+output "google_compute_address_enghouse-sftp-address_ip" {
+  value = google_compute_address.enghouse-sftp-address.address
+}


### PR DESCRIPTION
ref: #4048

Mount the sftp data directory such that it is owned by the sftp-user. This will allow `setstat` from sftp clients.
Assign a static ip to the deployment service so that it doesnt change when redeployed.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

