### PR TITLE
Stop temporarily dbt tests on Airflow dbt_all and dbt_payments DAGs

### DIFF
--- a/airflow/dags/dbt_all_dag.py
+++ b/airflow/dags/dbt_all_dag.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import TestBehavior
 
 from airflow import DAG
 from airflow.operators.latest_only import LatestOnlyOperator
@@ -40,7 +39,7 @@ with DAG(
                 "models/mart/gtfs/fct_trip_updates_stop_metrics.sql",
                 "models/mart/gtfs/fct_trip_updates_trip_metrics.sql",
             ],
-            test_behavior=TestBehavior.AFTER_ALL,
+            test_behavior=None,
         ),
         operator_args={
             "install_deps": True,

--- a/airflow/dags/dbt_payments_dag.py
+++ b/airflow/dags/dbt_payments_dag.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import TestBehavior
 
 from airflow import DAG
 from airflow.operators.latest_only import LatestOnlyOperator
@@ -38,7 +37,7 @@ with DAG(
                 "+path:models/intermediate/payments+",
                 "+path:models/mart/payments+",
             ],
-            test_behavior=TestBehavior.AFTER_ALL,
+            test_behavior=None,
         ),
         operator_args={
             "install_deps": True,


### PR DESCRIPTION
# Description

A lot of dbt tests are failing so we are not able to see all tasks in `dbt_all` and `dbt_payments` passing.
Until those tests are fixed, we want to see errors when building/running models they are really happening.

This PR stops temporarily dbt tests on those DAGs.

[#4361]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

It was tested running Airflow locally, Airflow and DAGs load successfully and dbt_all does not show tests anymore:
<img width="1265" height="916" alt="image" src="https://github.com/user-attachments/assets/2f6d1921-652d-411f-9434-1a21a312c686" />

<img width="1183" height="868" alt="image" src="https://github.com/user-attachments/assets/93a54e64-0043-4db8-ba66-a4eb5820ee16" />


Before the change on Airflow production:
<img width="1256" height="880" alt="image" src="https://github.com/user-attachments/assets/d6884b90-f5a6-4ded-8405-22b0e433c368" />

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm the DAGs are running and all tasks passing.