### PR TITLE
Payments (El Dorado Transit): create and add new service account for RBAC policy to terraform

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -64,6 +64,12 @@ resource "google_project_iam_member" "tfer--projects-002F-cal-itp-data-infra-002
   role    = "projects/cal-itp-data-infra/roles/AgencyPaymentsServiceReader"
 }
 
+resource "google_project_iam_member" "tfer--projects-002F-cal-itp-data-infra-002F-roles-002F-AgencyPaymentsServiceReaderserviceAccount-003A-eldorado-payments-user-0040-cal-itp-data-infra-002E-iam-002E-gserviceaccount-002E-com" {
+  member  = "serviceAccount:eldorado-payments-user@cal-itp-data-infra.iam.gserviceaccount.com"
+  project = "cal-itp-data-infra"
+  role    = "projects/cal-itp-data-infra/roles/AgencyPaymentsServiceReader"
+}
+
 resource "google_project_iam_member" "tfer--roles-002F-appengine-002E-serviceAgentserviceAccount-003A-service-1005246706141-0040-gcp-gae-service-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:service-1005246706141@gcp-gae-service.iam.gserviceaccount.com"
   project = "cal-itp-data-infra"

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -277,3 +277,9 @@ resource "google_service_account" "vctc-payments-user" {
   disabled   = "false"
   project    = "cal-itp-data-infra"
 }
+
+resource "google_service_account" "eldorado-payments-user" {
+  account_id = "eldorado-payments-user"
+  disabled   = "false"
+  project    = "cal-itp-data-infra"
+}


### PR DESCRIPTION
# Description
As we onboard El Dorado to the payments data pipeline, we need to add their new payments agency reader service account to Terraform so as to include their data in the pipeline via our row-based access control policy.

Resolves #4346 

## Type of change
- [x] New feature

## How has this been tested?
n/a

## Post-merge follow-ups
- [x] Actions required (specified below)
#4348 