### PR TITLE
Payments (El Dorado Transit): create row-based access policy for Littlepay and Elavon data

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -87,6 +87,12 @@ filter using (
 ) }};
 
 {{ create_row_access_policy(
+    filter_column = 'participant_id',
+    filter_value = 'eldorado-transit',
+    principals = ['serviceAccount:eldorado-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
     principals = [
         'serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
         'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
@@ -173,6 +179,12 @@ filter using (
     filter_column = 'organization_name',
     filter_value = 'Ventura County Transportation Commission',
     principals = ['serviceAccount:vctc-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'El Dorado County Transit Authority',
+    principals = ['serviceAccount:eldorado-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
 ) }};
 
 {{ create_row_access_policy(


### PR DESCRIPTION
# Description
The PR implements our row-based access controls for El Dorado transit for both their Littlepay and Elavon data, using the service account created in #4374.

Resolves #4348

## Type of change
- [x] New feature

## How has this been tested?
n/a

## Post-merge follow-ups
- [x] Actions required (specified below)
Create Metabase connection as described in #4349 