### PR TITLE
Analyst sees that the CKAN hook gets the correct URL

### DIFF
--- a/airflow/plugins/hooks/ckan_hook.py
+++ b/airflow/plugins/hooks/ckan_hook.py
@@ -20,7 +20,7 @@ class CKANHook(BaseHook):
     def remote_ckan(self) -> RemoteCKAN:
         if not self._remote_ckan:
             self._remote_ckan = RemoteCKAN(
-                self.connection.host,
+                f"{self.connection.conn_type}://{self.connection.host}",
                 apikey=self.connection.password,
                 user_agent=self.user_agent,
             )

--- a/airflow/tests/conftest.py
+++ b/airflow/tests/conftest.py
@@ -153,7 +153,7 @@ def setup_module():
     add_connection(
         session,
         conn_id="http_ckan",
-        conn_type="http",
-        host="https://test-data.technology.ca.gov",
+        conn_type="https",
+        host="test-data.technology.ca.gov",
         password=os.environ.get("CKAN_API_KEY"),
     )


### PR DESCRIPTION
# Description

This PR changes how the CKANHook resolves the host when connecting to the Open Data portal to incorporate the configured `conn_type` (i.e., https), rather than leaving it unspecified.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`pytest`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor execution on staging