### PR TITLE
Fix object_path order for all tasks on `sync_ntd_data_api`

### DIFF
--- a/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/breakdowns/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: breakdowns/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: amkt-4ehs

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/breakdowns_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/breakdowns_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: breakdowns_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: fk8n-qvag

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_capital_use.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_capital_use.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/capital_expenses_by_capital_use/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: capital_expenses_by_capital_use/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: fphd-jyyj

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_by_mode.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/capital_expenses_by_mode/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: capital_expenses_by_mode/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 2667-vitc

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_existing_service.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_existing_service.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/capital_expenses_for_existing_service/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: capital_expenses_for_existing_service/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 7kqv-yqbn

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_expansion_of_service.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/capital_expenses_for_expansion_of_service.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/capital_expenses_for_expansion_of_service/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: capital_expenses_for_expansion_of_service/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: nvgd-g6pj

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/employees_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: employees_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: brbd-9azc

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/employees_by_mode/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: employees_by_mode/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: wsxw-2rpq

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode_and_employee_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/employees_by_mode_and_employee_type.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/employees_by_mode_and_employee_type/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: employees_by_mode_and_employee_type/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: uyv8-9jek

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/fuel_and_energy/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: fuel_and_energy/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 8ehq-7his

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/fuel_and_energy_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/fuel_and_energy_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: fuel_and_energy_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: wwem-ata9

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_by_expense_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_by_expense_type.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/funding_sources_by_expense_type/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: funding_sources_by_expense_type/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 4tmr-gwuu

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_directly_generated.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_directly_generated.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/funding_sources_directly_generated/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: funding_sources_directly_generated/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: yuaq-zdvc

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_federal.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_federal.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/funding_sources_federal/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: funding_sources_federal/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: qpjk-b3zw

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_local.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_local.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/funding_sources_local/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: funding_sources_local/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 8tvb-ywj3

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_state.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_state.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/funding_sources_state/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: funding_sources_state/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: dd43-h6wv

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_taxes_levied_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/funding_sources_taxes_levied_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/funding_sources_taxes_levied_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: funding_sources_taxes_levied_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: c8k8-y2cj

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/maintenance_facilities/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: maintenance_facilities/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 9yj4-fiiz

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/maintenance_facilities_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/maintenance_facilities_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: maintenance_facilities_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: s68b-wvgx

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/metrics.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/metrics.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/metrics/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: metrics/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: ekg5-frzt

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/operating_expenses_by_function/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: operating_expenses_by_function/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: dkxx-zjd6

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function_and_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_function_and_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/operating_expenses_by_function_and_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: operating_expenses_by_function_and_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: i5ki-dc58

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/operating_expenses_by_type/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: operating_expenses_by_type/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: j5uj-anzx

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type_and_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/operating_expenses_by_type_and_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/operating_expenses_by_type_and_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: operating_expenses_by_type_and_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: i4ua-cjx4

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/service_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: service_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 6y83-7vuw

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/service_by_mode/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: service_by_mode/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 4fir-qbim

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode_and_time_period.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/service_by_mode_and_time_period.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/service_by_mode_and_time_period/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: service_by_mode_and_time_period/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: wwdp-t4re

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/stations_and_facilities_by_agency_and_facility_type.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/stations_and_facilities_by_agency_and_facility_type.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/stations_and_facilities_by_agency_and_facility_type/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: stations_and_facilities_by_agency_and_facility_type/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: aqct-knjk

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/stations_by_mode_and_age.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/stations_by_mode_and_age.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/stations_by_mode_and_age/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: stations_by_mode_and_age/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: wfz2-eft6

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/track_and_roadway_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: track_and_roadway_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: pvgq-a73e

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_mode.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_by_mode.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/track_and_roadway_by_mode/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: track_and_roadway_by_mode/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: fzbb-f6kc

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_guideway_age_distribution.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/track_and_roadway_guideway_age_distribution.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/track_and_roadway_guideway_age_distribution/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: track_and_roadway_guideway_age_distribution/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: j9q7-53ae

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_age_distribution.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_age_distribution.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/vehicles_age_distribution/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: vehicles_age_distribution/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 6abt-uhgq

--- a/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_type_count_by_agency.yml
+++ b/airflow/dags/sync_ntd_data_api/annual_reporting/vehicles_type_count_by_agency.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: multi_year/vehicles_type_count_by_agency/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: vehicles_type_count_by_agency/multi_year/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: nimp-626k

--- a/airflow/dags/sync_ntd_data_api/ridership/complete_monthly_ridership_with_adjustments_and_estimates.yml
+++ b/airflow/dags/sync_ntd_data_api/ridership/complete_monthly_ridership_with_adjustments_and_estimates.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: historical/complete_monthly_ridership_with_adjustments_and_estimates/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: complete_monthly_ridership_with_adjustments_and_estimates/historical/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 8bui-9xvu

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/fra_regulated_mode_major_security_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/fra_regulated_mode_major_security_events.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: historical/fra_regulated_mode_major_security_events/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: fra_regulated_mode_major_security_events/historical/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 65fa-qbkf

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/major_safety_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/major_safety_events.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: historical/major_safety_events/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: major_safety_events/historical/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 9ivb-8ae9

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/monthly_modal_time_series_safety_and_service.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/monthly_modal_time_series_safety_and_service.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: historical/monthly_modal_time_series_safety_and_service/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: monthly_modal_time_series_safety_and_service/historical/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: 5ti2-5uiv

--- a/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/nonmajor_safety_and_security_events.yml
+++ b/airflow/dags/sync_ntd_data_api/safety_service_and_security_historical/nonmajor_safety_and_security_events.yml
@@ -1,5 +1,5 @@
 operator: operators.soda_to_gcs_operator.SODAToGCSOperator
 
-object_path: historical/nonmajor_safety_and_security_events/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
+object_path: nonmajor_safety_and_security_events/historical/dt={{ dag_run.logical_date.date().isoformat() }}/execution_ts={{ dag_run.logical_date.isoformat() }}
 bucket_name: "{{ env_var('CALITP_BUCKET__NTD_API_DATA_PRODUCTS') }}"
 resource: urir-txqm


### PR DESCRIPTION
# Description

Some params to define where json files would be stored when synchronizing NTD API data were combined in a single `object_path`. The order for `multi_year` and `historical` were inverted so external tables were not able to read new files.

This PR is fixing the path.

Resolves [#4387]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on Staging Airflow:
<img width="1784" height="1108" alt="image" src="https://github.com/user-attachments/assets/1bac27d5-a666-47f9-b089-dd49260fdb0a" />

<img width="1779" height="968" alt="image" src="https://github.com/user-attachments/assets/b7dfc846-2315-4349-b062-a81c65d434bb" />

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

1. Re-run `sync_ntd_data_api` for `2025-09-01` and `2025-10-01`.
2. Delete files in the incorrect path: `calitp-ntd-api-products/historical`, `calitp-ntd-api-products/multi_year`