### PR TITLE
Payments (Littlepay): make participant_id in union tables not explicit

### DIFF
--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_authorisations.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_authorisations.sql
@@ -14,7 +14,7 @@ authorisations_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_customer_funding_source.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_customer_funding_source.sql
@@ -14,7 +14,7 @@ customer_funding_source_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_device_transaction_purchases.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_device_transaction_purchases.sql
@@ -14,7 +14,7 @@ device_transaction_purchases_v3 AS (
         -- Keep all records for Nevada County Connects and SacRT, these agencies didn't have a competing feed v1 so we keep it all
         instance NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             instance IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_device_transactions.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_device_transactions.sql
@@ -14,7 +14,7 @@ device_transactions_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayment_adjustments.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayment_adjustments.sql
@@ -14,7 +14,7 @@ micropayment_adjustments_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayment_device_transactions.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayment_device_transactions.sql
@@ -14,7 +14,7 @@ micropayment_device_transactions_v3 AS (
         -- Keep all records for Nevada County Connects and SacRT, these agencies didn't have a competing feed v1 so we keep it all
         instance NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             instance IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayments.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayments.sql
@@ -14,7 +14,7 @@ micropayments_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_product_data.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_product_data.sql
@@ -14,7 +14,7 @@ product_data_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_refunds.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_refunds.sql
@@ -14,7 +14,7 @@ refunds_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_settlements.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_settlements.sql
@@ -14,7 +14,7 @@ settlements_v3 AS (
         -- Keep all records for agencies that didn't have a competing feed v1
         participant_id NOT IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
 
-        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had both feeds at some point)
+        -- For the following participants only, keep records including and after 5/17/2025 (cutover date for agencies that had a feed v1)
         OR (
             participant_id IN ('clean-air-express', 'mendocino-transit-authority', 'ccjpa', 'atn', 'mst', 'lake-transit-authority', 'sbmtd', 'humboldt-transit-authority', 'redwood-coast-transit')
             AND littlepay_export_date >= '2025-05-17'


### PR DESCRIPTION
# Description
This PR simplifies the process of unioning our intermediate Littlepay v1 + v3 tables by making the date filtering of participant_id not explicit

Resolves #4397 

## Type of change
- [x] New feature

## How has this been tested?
`poetry run dbt run -s +mart.payments --vars 'GOOGLE_CLOUD_PROJECT: cal-itp-data-infra'`
<img width="976" height="175" alt="Screenshot 2025-10-14 at 11 41 13" src="https://github.com/user-attachments/assets/bf44de84-e543-4610-88df-fee89d753aeb" />

## Post-merge follow-ups
- [x] No action required
