### PR TITLE
Fix: correct Netlify deploy args for Apps/Maps

### DIFF
--- a/.github/workflows/deploy-apps-maps.yml
+++ b/.github/workflows/deploy-apps-maps.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Deploy apps/maps production to Netlify
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
-        npm install -g netlify-cli
-        netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --prod
+        npm install --location=global netlify-cli@17.x.x
+        netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --prod --auth=${{ NETLIFY_AUTH_TOKEN }}
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
@@ -40,8 +40,8 @@ jobs:
     - name: Deploy apps/maps preview to Netlify
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        npm install -g netlify-cli
-        netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --alias=${GITHUB_REPOSITORY#*/}-${PR_NUMBER}
+        npm install --location=global netlify-cli@17.x.x
+        netlify deploy --site=embeddable-maps-calitp-org --dir=apps/maps/build --alias=${GITHUB_REPOSITORY#*/}-${PR_NUMBER} --auth=${{ NETLIFY_AUTH_TOKEN }}
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
# Description

`NETLIFY_AUTH_TOKEN` needs to be passed directly via the `--auth` arg.

Resolves #4353 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
