### PR TITLE
Add service account for enghouse sftp access

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra/iam/us/outputs.tf
@@ -517,3 +517,15 @@ output "google_service_account_composer-service-account_email" {
 output "google_service_account_composer-service-account_name" {
   value = google_service_account.composer-service-account.name
 }
+
+output "google_service_account_enghouse-sftp-service-account_name" {
+  value = google_service_account.enghouse-sftp-service-account.name
+}
+
+output "google_service_account_enghouse-sftp-service-account_email" {
+  value = google_service_account.enghouse-sftp-service-account.email
+}
+
+output "google_service_account_enghouse-sftp-service-account_id" {
+  value = google_service_account.enghouse-sftp-service-account.id
+}

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -283,3 +283,11 @@ resource "google_service_account" "eldorado-payments-user" {
   disabled   = "false"
   project    = "cal-itp-data-infra"
 }
+
+resource "google_service_account" "enghouse-sftp-service-account" {
+  account_id   = "enghouse-sftp-service-account"
+  description  = "Service account for enghouse sftp server"
+  disabled     = "false"
+  display_name = "enghouse-sftp-service-account"
+  project      = "cal-itp-data-infra"
+}

--- a/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
@@ -45,3 +45,9 @@ resource "google_service_account_iam_member" "github-actions-service-account_ana
   service_account_id = google_service_account.github-actions-service-account.id
   role               = "roles/iam.workloadIdentityUser"
 }
+
+resource "google_service_account_iam_member" "enghouse-sftp-service-account" {
+  service_account_id = google_service_account.enghouse-sftp-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:cal-itp-data-infra.svc.id.goog[default/enghouse-sftp-service-account]"
+}


### PR DESCRIPTION
ref: #4048

Adds service account for enghouse sftp to access bucket storage

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

