### PR TITLE
Audit tables update so they become easier to use

### DIFF
--- a/warehouse/models/mart/audit/_mart_audit.yml
+++ b/warehouse/models/mart/audit/_mart_audit.yml
@@ -20,6 +20,7 @@ models:
         tests:
           - not_null
       - name: principal_email
+      - name: email
         tests:
           - not_null
       - name: job_name
@@ -35,6 +36,7 @@ models:
       - name: dbt_invocation_id
       - name: create_disposition
       - name: destination_table
+      - name: destination_table_short_name
       - name: priority
       - name: query
       - name: statement_type
@@ -87,6 +89,7 @@ models:
         tests:
           - not_null
       - name: principal_email
+      - name: email
         tests:
           - not_null
       - name: job_name
@@ -102,6 +105,7 @@ models:
       - name: dbt_invocation_id
       - name: create_disposition
       - name: destination_table
+      - name: destination_table_short_name
       - name: priority
       - name: query
       - name: statement_type

--- a/warehouse/models/mart/audit/fct_bigquery_data_access.sql
+++ b/warehouse/models/mart/audit/fct_bigquery_data_access.sql
@@ -1,4 +1,12 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='incremental',
+    partition_by={
+        'field': 'date',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+    on_schema_change='append_new_columns'
+) }}
 
 WITH fct_bigquery_data_access AS (
     SELECT
@@ -8,11 +16,14 @@ WITH fct_bigquery_data_access AS (
         resource_name,
         principal_email,
         principal_subject,
+        -- Use principal_email if present, otherwise principal_subject
+        COALESCE(NULLIF(principal_email, ''), principal_subject) AS email,
         job_name,
         job_type,
         dbt_invocation_id,
         create_disposition,
         destination_table,
+        SPLIT(destination_table, '/')[SAFE_OFFSET(ARRAY_LENGTH(SPLIT(destination_table, '/')) - 1)] AS destination_table_short_name,
         priority,
         query,
         statement_type,
@@ -29,6 +40,9 @@ WITH fct_bigquery_data_access AS (
         metadata,
         job
     FROM {{ ref('stg_audit__cloudaudit_googleapis_com_data_access') }}
+    {% if is_incremental() %}
+        WHERE date > (SELECT MAX(date) FROM {{ this }})
+    {% endif %}
 )
 
 SELECT * FROM fct_bigquery_data_access

--- a/warehouse/models/mart/audit/fct_bigquery_data_access_referenced_tables.sql
+++ b/warehouse/models/mart/audit/fct_bigquery_data_access_referenced_tables.sql
@@ -1,4 +1,12 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='incremental',
+    partition_by={
+        'field': 'date',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+    on_schema_change='append_new_columns'
+) }}
 
 WITH fct_bigquery_data_access_unnested AS (
     SELECT *
@@ -8,10 +16,7 @@ WITH fct_bigquery_data_access_unnested AS (
 
 fct_bigquery_data_access_referenced_tables AS (
     SELECT
-    * EXCEPT(referenced_tables),
-        -- Use principal_email if present, otherwise principal_subject
-        COALESCE(NULLIF(principal_email, ''), principal_subject) AS email,
-        SPLIT(destination_table, '/')[SAFE_OFFSET(ARRAY_LENGTH(SPLIT(destination_table, '/')) - 1)] AS destination_table_name
+    * EXCEPT(referenced_tables)
     FROM fct_bigquery_data_access_unnested
 )
 

--- a/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
+++ b/warehouse/models/staging/audit/stg_audit__cloudaudit_googleapis_com_data_access.sql
@@ -9,6 +9,7 @@
             'granularity': 'day',
         },
         cluster_by='job_type',
+        on_schema_change='append_new_columns'
     )
 }}
 -- we should use https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#parse_json when available


### PR DESCRIPTION
# Description

Minor updates to the audit tables to make them more useful and accounting for that we've moved to SSO
- Break out emails
- Pull out table name
- Update the costs

Resolves #4142 

## Type of change

- [x] New feature

## How has this been tested?

```
➜  warehouse git:(audit_update) ✗ poetry run dbt run -s stg_audit__cloudaudit_googleapis_com_data_access fct_bigquery_data_access_referenced_tables fct_bigquery_data_access              
23:20:18  Running with dbt=1.10.1
23:20:19  Registered adapter: bigquery=1.10.0
23:20:21  Found 617 models, 1238 data tests, 14 seeds, 224 sources, 4 exposures, 1052 macros
23:20:21  
23:20:21  Concurrency: 8 threads (target='dev')
23:20:21  
23:20:23  1 of 3 START sql incremental model vb_staging.stg_audit__cloudaudit_googleapis_com_data_access  [RUN]
23:20:29  1 of 3 OK created sql incremental model vb_staging.stg_audit__cloudaudit_googleapis_com_data_access  [SCRIPT (0 processed) in 5.84s]
23:20:29  2 of 3 START sql table model vb_mart_audit.fct_bigquery_data_access ............ [RUN]
23:20:31  2 of 3 OK created sql table model vb_mart_audit.fct_bigquery_data_access ....... [CREATE TABLE (0.0 rows, 0 processed) in 1.99s]
23:20:31  3 of 3 START sql table model vb_mart_audit.fct_bigquery_data_access_referenced_tables  [RUN]
23:20:33  3 of 3 OK created sql table model vb_mart_audit.fct_bigquery_data_access_referenced_tables  [CREATE TABLE (0.0 rows, 0 processed) in 2.06s]
23:20:33  
23:20:33  Finished running 1 incremental model, 2 table models in 0 hours 0 minutes and 12.11 seconds (12.11s).
23:20:33  
23:20:33  Completed successfully
23:20:33  
23:20:33  Done. PASS=3 WARN=0 ERROR=0 SKIP=0 NO-OP=0
```
## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
Update Mart tables accordingly