### PR TITLE
Made an audit column that's easier to read

### DIFF
--- a/warehouse/models/mart/audit/_mart_audit.yml
+++ b/warehouse/models/mart/audit/_mart_audit.yml
@@ -59,6 +59,7 @@ models:
       - name: table_data_read_job_name
       - name: dbt_header
       - name: dbt_node
+      - name: dbt_node_short_name
       - name: payload
       - name: metadata
       - name: job
@@ -125,6 +126,7 @@ models:
       - name: table_data_read_job_name
       - name: dbt_header
       - name: dbt_node
+      - name: dbt_node_short_name
       - name: payload
       - name: metadata
       - name: job

--- a/warehouse/models/mart/audit/fct_bigquery_data_access.sql
+++ b/warehouse/models/mart/audit/fct_bigquery_data_access.sql
@@ -36,6 +36,11 @@ WITH fct_bigquery_data_access AS (
         table_data_read_job_name,
         dbt_header,
         dbt_node,
+        -- Short name from dbt_node or fallback to destination_table_short_name
+        COALESCE(
+            SPLIT(dbt_node, '.')[SAFE_OFFSET(ARRAY_LENGTH(SPLIT(dbt_node, '.')) - 1)],
+            SPLIT(destination_table, '/')[SAFE_OFFSET(ARRAY_LENGTH(SPLIT(destination_table, '/')) - 1)]
+        ) AS dbt_node_short_name,
         payload,
         metadata,
         job


### PR DESCRIPTION
# Description

Some tiny column edits to make prettier tables in metabase.

Extra touches to  #4142 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

```
➜  warehouse git:(audit_minor_update) ✗ poetry run dbt run -s stg_audit__cloudaudit_googleapis_com_data_access fct_bigquery_data_access_referenced_tables fct_bigquery_data_access --full-refresh --ta
rget staging
02:22:39  Running with dbt=1.10.1
02:22:40  Registered adapter: bigquery=1.10.0
02:22:41  Unable to do partial parsing because config vars, config profile, or config target have changed
02:22:41  Unable to do partial parsing because profile has changed
/Users/vivek/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-1QJyB9-Z-py3.11/lib/python3.11/site-packages/jinja2/lexer.py:654: DeprecationWarning: invalid escape sequence '\w'
/Users/vivek/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-1QJyB9-Z-py3.11/lib/python3.11/site-packages/jinja2/lexer.py:654: DeprecationWarning: invalid escape sequence '\?'
02:22:46  Found 620 models, 1241 data tests, 14 seeds, 225 sources, 4 exposures, 1053 macros
02:22:46  
02:22:46  Concurrency: 8 threads (target='staging')
02:22:46  
02:22:48  1 of 3 START sql incremental model staging.stg_audit__cloudaudit_googleapis_com_data_access  [RUN]
/Users/vivek/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-1QJyB9-Z-py3.11/lib/python3.11/site-packages/dbt/adapters/bigquery/impl.py:520: PendingDeprecationWarning: This method will be deprecated in future versions. Please use Table.time_partitioning.type_ instead.
02:22:57  1 of 3 OK created sql incremental model staging.stg_audit__cloudaudit_googleapis_com_data_access  [CREATE TABLE (0.0 rows, 0 processed) in 8.93s]
02:22:57  2 of 3 START sql incremental model mart_audit.fct_bigquery_data_access ......... [RUN]
/Users/vivek/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-1QJyB9-Z-py3.11/lib/python3.11/site-packages/dbt/adapters/bigquery/impl.py:520: PendingDeprecationWarning: This method will be deprecated in future versions. Please use Table.time_partitioning.type_ instead.
02:22:59  2 of 3 OK created sql incremental model mart_audit.fct_bigquery_data_access .... [CREATE TABLE (0.0 rows, 0 processed) in 2.37s]
02:22:59  3 of 3 START sql incremental model mart_audit.fct_bigquery_data_access_referenced_tables  [RUN]
/Users/vivek/Library/Caches/pypoetry/virtualenvs/calitp-warehouse-1QJyB9-Z-py3.11/lib/python3.11/site-packages/dbt/adapters/bigquery/impl.py:520: PendingDeprecationWarning: This method will be deprecated in future versions. Please use Table.time_partitioning.type_ instead.
02:23:02  3 of 3 OK created sql incremental model mart_audit.fct_bigquery_data_access_referenced_tables  [CREATE TABLE (0.0 rows, 0 processed) in 2.30s]
02:23:02  
02:23:02  Finished running 3 incremental models in 0 hours 0 minutes and 15.47 seconds (15.47s).
02:23:02  
02:23:02  Completed successfully
02:23:02  
02:23:02  Done. PASS=3 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=3
```
## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
