### PR TITLE
Add staging bucket and workload identity federation for Cal-B/C

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -102,6 +102,10 @@ output "google_storage_bucket_calitp-staging-dbt-docs_name" {
   value = google_storage_bucket.calitp-staging-dbt-docs.name
 }
 
+output "google_storage_bucket_calitp-staging-cal-bc_name" {
+  value = google_storage_bucket.calitp-staging-cal-bc.name
+}
+
 output "google_storage_bucket_calitp-staging-composer_name" {
   value = google_storage_bucket.calitp-staging-composer.name
 }

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -106,6 +106,22 @@ resource "google_storage_bucket" "calitp-staging-dbt-docs" {
   }
 }
 
+resource "google_storage_bucket" "calitp-staging-cal-bc" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-staging-cal-bc"
+  project                     = "cal-itp-data-infra-staging"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+
+  lifecycle {
+    ignore_changes = [labels]
+  }
+}
+
 resource "google_storage_bucket" "calitp-staging-composer" {
   default_event_based_hold    = "false"
   force_destroy               = "true"

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
@@ -40,6 +40,12 @@ resource "google_storage_bucket_iam_member" "calitp-staging-composer" {
   role   = "roles/storage.legacyBucketOwner"
 }
 
+resource "google_storage_bucket_iam_member" "cal-bc-service-account" {
+  bucket = google_storage_bucket.calitp-staging-cal-bc.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${data.terraform_remote_state.iam.outputs.google_service_account_cal-bc-service-account_email}"
+}
+
 resource "google_storage_bucket_iam_member" "enghouse-raw-sftp-service-account" {
   bucket = google_storage_bucket.cal-itp-data-infra-enghouse-raw.name
   role   = "roles/storage.objectAdmin"

--- a/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
@@ -18,3 +18,20 @@ resource "google_iam_workload_identity_pool_provider" "data-infra" {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
+
+resource "google_iam_workload_identity_pool_provider" "cal-bc" {
+  workload_identity_pool_provider_id = "cal-bc"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.cal-bc_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
@@ -166,6 +166,18 @@ output "google_service_account_tfer--111881979116192190399_id" {
   value = google_service_account.tfer--111881979116192190399.id
 }
 
+output "google_service_account_cal-bc-service-account_id" {
+  value = google_service_account.cal-bc-service-account.id
+}
+
+output "google_service_account_cal-bc-service-account_email" {
+  value = google_service_account.cal-bc-service-account.email
+}
+
+output "google_service_account_cal-bc-service-account_name" {
+  value = google_service_account.cal-bc-service-account.name
+}
+
 output "google_service_account_composer-service-account_id" {
   value = google_service_account.composer-service-account.id
 }

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -229,7 +229,8 @@ resource "google_project_iam_member" "github-actions-terraform" {
     "roles/iam.roleAdmin",
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/iam.serviceAccountAdmin",
-    "roles/logging.configWriter"
+    "roles/logging.configWriter",
+    "roles/run.admin"
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.github-actions-terraform.email}"
@@ -259,6 +260,15 @@ resource "google_project_iam_member" "github-actions-service-account" {
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.github-actions-service-account.email}"
+  project = "cal-itp-data-infra-staging"
+}
+
+resource "google_project_iam_member" "cal-bc-service-account" {
+  for_each = toset([
+    "roles/cloudsql.client",
+  ])
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.cal-bc-service-account.email}"
   project = "cal-itp-data-infra-staging"
 }
 

--- a/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
@@ -42,6 +42,14 @@ resource "google_service_account" "github-actions-service-account" {
   project      = "cal-itp-data-infra-staging"
 }
 
+resource "google_service_account" "cal-bc-service-account" {
+  account_id   = "cal-bc-service-account"
+  description  = "Service account for Cal B/C"
+  disabled     = "false"
+  display_name = "cal-bc"
+  project      = "cal-itp-data-infra-staging"
+}
+
 resource "google_service_account" "composer-service-account" {
   account_id   = "composer-service-account"
   description  = "Service account for Composer"

--- a/iac/cal-itp-data-infra-staging/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/variables.tf
@@ -1,4 +1,5 @@
 locals {
   project_id                        = "473674835135"
   data-infra_github_repository_name = "cal-itp/data-infra"
+  cal-bc_github_repository_name     = "cal-itp/cal-bc"
 }


### PR DESCRIPTION
# Description

This PR adds a bucket and workload identity federation for Cal-B/C.

Relates to https://github.com/cal-itp/cal-bc/issues/37

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` output