### PR TITLE
Cal B/C service account is authorized as a workload identity user

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
@@ -10,6 +10,12 @@ resource "google_service_account_iam_member" "github-actions-service-account" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
 }
 
+resource "google_service_account_iam_member" "github-actions-service-account_cal-bc" {
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.cal-bc_github_repository_name}"
+}
+
 resource "google_service_account_iam_member" "custom_service_account" {
   service_account_id = google_service_account.composer-service-account.id
   role               = "roles/composer.ServiceAgentV2Ext"


### PR DESCRIPTION
# Description

This PR attaches the Cal B/C service account to the workload identity federation mechanism. This addresses a permissions issue identified during this Github Actions run: https://github.com/cal-itp/cal-bc/actions/runs/18597892883/job/53028785415

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` output