### PR TITLE
Grant Terraform Cloud SQL admin role for Cal-B/C staging

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -230,7 +230,8 @@ resource "google_project_iam_member" "github-actions-terraform" {
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/iam.serviceAccountAdmin",
     "roles/logging.configWriter",
-    "roles/run.admin"
+    "roles/run.admin",
+    "roles/cloudsql.admin",
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.github-actions-terraform.email}"


### PR DESCRIPTION
# Description

This PR allows the staging terraform service account to administer cloud sql resources for Cal-B/C staging

Relates to https://github.com/cal-itp/cal-bc/issues/37

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` output
