### PR TITLE
Add CloudSQL permissions to github action service account

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -231,7 +231,6 @@ resource "google_project_iam_member" "github-actions-terraform" {
     "roles/iam.serviceAccountAdmin",
     "roles/logging.configWriter",
     "roles/run.admin",
-    "roles/cloudsql.admin",
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.github-actions-terraform.email}"
@@ -256,6 +255,8 @@ resource "google_project_iam_member" "github-actions-service-account" {
     "roles/bigquery.metadataViewer",
     "roles/composer.admin",
     "roles/storage.objectAdmin",
+    "roles/run.admin",
+    "roles/cloudsql.admin",
     google_project_iam_custom_role.calitp-dds-analyst.id,
     google_project_iam_custom_role.tfer--projects-002F-cal-itp-data-infra-staging-002F-roles-002F-CustomGCSPublisher.id
   ])


### PR DESCRIPTION
# Description

This PR moves CloudSQL permissions from the terraform service account mainly used in the data-infra repo to the github actions service account mainly used in external repositories

Relates to [cal-bc#37](https://github.com/cal-itp/cal-bc/issues/37)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` output