### PR TITLE
Add secret accessor role to calbc service account

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -270,6 +270,7 @@ resource "google_project_iam_member" "github-actions-service-account" {
 resource "google_project_iam_member" "cal-bc-service-account" {
   for_each = toset([
     "roles/cloudsql.client",
+    "roles/secretmanager.secretAccessor",
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.cal-bc-service-account.email}"


### PR DESCRIPTION
# Description

This PR adds the Secret Accessor role to the Cal-B/C service account

Relates to https://github.com/cal-itp/cal-bc/issues/37

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` output