### PR TITLE
Remove skipped bandit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: 1.8.6
     hooks:
       - id: bandit
-        args: ["-ll", "--skip=B608,B113"]
+        args: ["-ll", "--skip=B608"]
         files: .py$
   - repo: https://github.com/sqlfluff/sqlfluff
     rev: 3.0.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: 1.8.6
     hooks:
       - id: bandit
-        args: ["-ll", "--skip=B608,B324,B113"]
+        args: ["-ll", "--skip=B608,B113"]
         files: .py$
   - repo: https://github.com/sqlfluff/sqlfluff
     rev: 3.0.6

--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -39,11 +39,13 @@ def log_failure_to_slack(context):
 
     <{ti.log_url}| Check Log >
     """  # noqa: E221, E222
-        requests.post(slack_url, json={"text": message})
+        requests.post(slack_url, json={"text": message}, timeout=5)
 
     # This is very broad but we want to try to log _any_ exception to slack
     except Exception as e:
-        requests.post(slack_url, json={"text": f"failed to log {type(e)} to slack"})
+        requests.post(
+            slack_url, json={"text": f"failed to log {type(e)} to slack"}, timeout=5
+        )
 
 
 for dag_directory in dag_directories:

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/unzip_gtfs_schedule.py
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/unzip_gtfs_schedule.py
@@ -120,7 +120,7 @@ def process_feed_files(
     pbar=None,
 ) -> Tuple[List[GTFSScheduleFeedFileHourly], str]:
     zipfile_files = []
-    md5hash = hashlib.md5()
+    md5hash = hashlib.md5(usedforsecurity=False)
     if not is_valid:
         raise ValueError(
             "Unparseable zip: File/directory structure within zipfile cannot be unpacked"

--- a/airflow/plugins/operators/scrape_state_geoportal.py
+++ b/airflow/plugins/operators/scrape_state_geoportal.py
@@ -57,7 +57,7 @@ class StateGeoportalAPIExtract(PartitionedGCSArtifact):
         """Make API request with proper error handling."""
         try:
             params["resultOffset"] = offset
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=5)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.HTTPError as e:

--- a/airflow/plugins/scripts/gtfs_rt_parser.py
+++ b/airflow/plugins/scripts/gtfs_rt_parser.py
@@ -138,7 +138,7 @@ class RTHourlyAggregation(PartitionedGCSArtifact):
 
     @property
     def name_hash(self) -> str:
-        return hashlib.md5(self.name.encode("utf-8")).hexdigest()
+        return hashlib.md5(self.name.encode("utf-8"), usedforsecurity=False).hexdigest()
 
     @property
     def unique_filename(self):
@@ -324,7 +324,7 @@ class AggregationExtract:
         with open(
             os.path.join(self.path, self.extract.timestamped_filename), "rb"
         ) as f:
-            file_hash = hashlib.md5()
+            file_hash = hashlib.md5(usedforsecurity=False)
             while chunk := f.read(8192):
                 file_hash.update(chunk)
         return file_hash.digest()

--- a/apps/maps/calitp_map_utils/__init__.py
+++ b/apps/maps/calitp_map_utils/__init__.py
@@ -81,7 +81,7 @@ def validate_geojson(
     is_compressed = path.endswith(".gz")
 
     if path.startswith("https://"):
-        resp = requests.get(path)
+        resp = requests.get(path, timeout=5)
         resp.raise_for_status()
         d = json.loads(
             gzip.decompress(resp.content).decode() if is_compressed else resp.text
@@ -155,7 +155,7 @@ class State(BaseModel):
                 typer.secho(
                     f"Checking that {typer.style(layer.url, fg=typer.colors.CYAN)} exists..."
                 )
-            resp = requests.head(layer.url)
+            resp = requests.head(layer.url, timeout=5)
 
             try:
                 resp.raise_for_status()

--- a/packages/calitp-data-analysis/calitp_data_analysis/utils.py
+++ b/packages/calitp-data-analysis/calitp_data_analysis/utils.py
@@ -267,6 +267,7 @@ def upload_file_to_github(
         f"{BASE}/repos/{repo}/contents/{os.path.dirname(path)}",
         params={"ref": branch},
         headers={"Authorization": f"token {token}"},
+        timeout=5,
     )
     r.raise_for_status()
     item = next(i for i in r.json() if i["path"] == path)
@@ -286,6 +287,7 @@ def upload_file_to_github(
             "sha": sha,
             "content": base64.b64encode(contents).decode("utf-8"),
         },
+        timeout=5,
     )
     r.raise_for_status()
     return

--- a/warehouse/scripts/publish.py
+++ b/warehouse/scripts/publish.py
@@ -176,6 +176,7 @@ def upload_to_ckan(
             f"{url}/api/action/{action}",
             data=encoder,
             headers={"Content-Type": encoder.content_type, "X-CKAN-API-Key": API_KEY},  # type: ignore
+            timeout=5,
         )
 
     if fsize <= CHUNK_SIZE:
@@ -185,6 +186,7 @@ def upload_to_ckan(
             data={"id": resource_id},
             headers={"Authorization": API_KEY},  # type: ignore
             files={"upload": file},
+            timeout=5,
         )
         try:
             response.raise_for_status()


### PR DESCRIPTION
# Description

This PR removes skipped bandit checks so they can be validated in new commits to avoid problems instead of always skipped.

Checks removed:
- [B113:request_without_timeout] Call to requests without timeout Severity: Medium Confidence: Low
- [B324:hashlib] Use of weak MD5 hash for security. Consider usedforsecurity=False Severity: High Confidence: High

This issue were found when fixing #4408.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally running:

1. `pre-commit install`
2. `pre-commit run --show-diff-on-failure --color=always --all-files`

Changes on code to fix issues tested on Staging:

TESTING....

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
