### PR TITLE
Change back Sync Elavon code to use AutoAddPolicy()

### DIFF
--- a/airflow/dags/parse_elavon/METADATA.yml
+++ b/airflow/dags/parse_elavon/METADATA.yml
@@ -9,7 +9,7 @@ default_args:
     start_date: "2025-07-06"
     catchup: False
     email:
-      - "soren.s@jarv.us"
+      - "dds.app.notify@dot.ca.gov"
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/sync_elavon/METADATA.yml
+++ b/airflow/dags/sync_elavon/METADATA.yml
@@ -9,7 +9,7 @@ default_args:
     start_date: "2025-07-06"
     catchup: False
     email:
-      - "soren.s@jarv.us"
+      - "dds.app.notify@dot.ca.gov"
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/sync_elavon/elavon_to_gcs_raw.py
+++ b/airflow/dags/sync_elavon/elavon_to_gcs_raw.py
@@ -23,7 +23,7 @@ def mirror_raw_files_from_elavon():
 
     # Establish connection to SFTP server
     client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.RejectPolicy())
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # nosec B507
     client.connect(
         hostname=CALITP__ELAVON_SFTP_HOSTNAME,
         port=CALITP__ELAVON_SFTP_PORT,


### PR DESCRIPTION
# Description

In previous PR (https://github.com/cal-itp/data-infra/pull/4413) I changed the Sync Elavon code to be compliant with the security check, but the DAG failed. I am changing back to use `AutoAddPolicy` in `elavon_to_gcs_raw.py`and tagged to skip the check on this line.

I created a ticked to work on this issue and replace the entire code in https://github.com/cal-itp/data-infra/issues/4420.

Also replaced consultant email that is not on the project anymore by "dds.app.notify@dot.ca.gov".

[#4408]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running Airflow DAG locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After merging the code re-run the failing DAG.