### PR TITLE
Add default variable to set Airflow Catchup to False

### DIFF
--- a/airflow/.development.env
+++ b/airflow/.development.env
@@ -1,5 +1,6 @@
 AIRFLOW__CORE__PARALLELISM=4
 AIRFLOW__CORE__EXECUTOR=LocalExecutor
+AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT=false
 AIRFLOW_CONN_HTTP_BLACKCAT=https://services.blackcattransit.com
 AIRFLOW_CONN_HTTP_MOBILITY_DATABASE=https://bit.ly/catalogs-csv
 AIRFLOW_CONN_HTTP_NTD=https://data.transportation.gov

--- a/airflow/.test.env
+++ b/airflow/.test.env
@@ -1,4 +1,5 @@
 AIRFLOW__CORE__EXECUTOR=SequentialExecutor
+AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT=false
 AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT='google-cloud-platform://'
 CALITP_BUCKET__AGGREGATOR_SCRAPER=gs://calitp-staging-pytest
 CALITP_BUCKET__AIRTABLE=gs://calitp-staging-pytest


### PR DESCRIPTION
# Description

This PR sets Airflow Catchup as default to false using environment variable `AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT` as requested in issue #4389.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running Airflow locally:

When starting DAGs, it only created the latest run for today:
<img width="1470" height="848" alt="Screenshot 2025-10-21 at 3 54 01 PM" src="https://github.com/user-attachments/assets/ff98d4dc-aa50-4bdf-91eb-87dbb6e833be" />

For this DAG that was set to `catchup: True` in the `METADATA.yml` file, all dates since start date were created:

<img width="1477" height="841" alt="Screenshot 2025-10-21 at 3 54 16 PM" src="https://github.com/user-attachments/assets/7430596d-82e3-46af-978d-b5c13ffcf7da" />

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
