### PR TITLE
Add staging GCS workload identity provider for data-analyses tests

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
@@ -35,3 +35,20 @@ resource "google_iam_workload_identity_pool_provider" "cal-bc" {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
+
+resource "google_iam_workload_identity_pool_provider" "data-analyses" {
+  workload_identity_pool_provider_id = "data-analyses"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.data-analyses_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
@@ -33,3 +33,9 @@ resource "google_service_account_iam_member" "enghouse-raw-sftp-service-account"
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:cal-itp-data-infra-staging.svc.id.goog[default/sftp-pod-service-account]"
 }
+
+resource "google_service_account_iam_member" "github-actions-service-account_data-analyses" {
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-analyses_github_repository_name}"
+}

--- a/iac/cal-itp-data-infra-staging/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/variables.tf
@@ -1,5 +1,6 @@
 locals {
-  project_id                        = "473674835135"
-  data-infra_github_repository_name = "cal-itp/data-infra"
-  cal-bc_github_repository_name     = "cal-itp/cal-bc"
+  project_id                           = "473674835135"
+  data-infra_github_repository_name    = "cal-itp/data-infra"
+  cal-bc_github_repository_name        = "cal-itp/cal-bc"
+  data-analyses_github_repository_name = "cal-itp/data-analyses"
 }


### PR DESCRIPTION
# Description

We want to[ run data-analyses repo shared_utils tests in a GH Action](https://github.com/cal-itp/data-analyses/actions/runs/18891529217/job/53920065575) and needed to setup a new identity provider for the parts that need to authenticate with GCS.

Relates to https://github.com/cal-itp/data-analyses/issues/1553

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Push terraform changes to GH and saw them setup IdP as expected. Used IdP in data-analyses test and saw the tests passing as expected.

## Post-merge follow-ups


- [x] No action required
- [ ] Actions required (specified below)
