### PR TITLE
Configure Airflow Slack URL using Terraform

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -95,6 +95,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         "CALITP_BUCKET__PUBLISH"                               = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-publish_name}",
         "CALITP_BUCKET__SENTRY_EVENTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-sentry_name}",
         "CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-state-geoportal-scrape_name}",
+        "CALITP_SLACK_URL_KEY"                                 = data.google_secret_manager_secret_version.slack-airflow-url.secret_data
       })
     }
   }

--- a/iac/cal-itp-data-infra-staging/composer/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/variables.tf
@@ -34,6 +34,10 @@ data "kubernetes_secret" "composer" {
   }
 }
 
+data "google_secret_manager_secret_version" "slack-airflow-url" {
+  # The secret name is case sensitive
+  secret = "SLACK_AIRFLOW_WEBHOOK_URL"
+}
 
 data "google_client_config" "default" {}
 

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -95,6 +95,7 @@ resource "google_composer_environment" "calitp-composer" {
         "CALITP_BUCKET__PUBLISH"                               = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-publish_name}",
         "CALITP_BUCKET__SENTRY_EVENTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-sentry_name}",
         "CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-state-geoportal-scrape_name}",
+        "CALITP_SLACK_URL_KEY"                                 = data.google_secret_manager_secret_version.slack-airflow-url.secret_data
       })
     }
   }

--- a/iac/cal-itp-data-infra/composer/us/variables.tf
+++ b/iac/cal-itp-data-infra/composer/us/variables.tf
@@ -2,6 +2,7 @@ locals {
   namespace            = "airflow-jobs"
   secret               = "jobs-data"
   service_account_name = "composer-service-account"
+
   # This regular expression corresponds to the Python package name specification
   # https://packaging.python.org/en/latest/specifications/name-normalization/
   python_package_regex  = "(?P<name>[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])(?P<version>.*)"
@@ -33,6 +34,10 @@ data "kubernetes_secret" "composer" {
   }
 }
 
+data "google_secret_manager_secret_version" "slack-airflow-url" {
+  # The secret name is case sensitive
+  secret = "SLACK_AIRFLOW_WEBHOOK_URL"
+}
 
 data "google_client_config" "default" {}
 


### PR DESCRIPTION
# Description

This PR configures Airflow Slack URL using Terraform, so the variable is not removed anymore. 

Resolves [#4363]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running "terraform plan" and "terraform apply" on staging.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
