### PR TITLE
feat: Extract and materialize new properties from Benefits events

### DIFF
--- a/warehouse/models/mart/benefits/_mart_benefits.yml
+++ b/warehouse/models/mart/benefits/_mart_benefits.yml
@@ -59,6 +59,10 @@ models:
         description: The `enrollment_method` value from the `event_properties` column
       - name: event_properties_claims_provider
         description: The `claims_provider` value from the `event_properties` column (previously `event_properties_auth_provider`)
+      - name: event_properties_card_category
+        description: The `card_category` value from the `event_properties` column
+      - name: event_properties_card_scheme
+        description: The `card_scheme` value from the `event_properties` column
       - name: event_properties_card_tokenize_func
         description: The `card_tokenize_func` value from the `event_properties` column
       - name: event_properties_card_tokenize_url
@@ -87,6 +91,8 @@ models:
         description: The `status` value from the `event_properties` column
       - name: event_properties_transit_agency
         description: The `transit_agency` value from the `event_properties` column
+      - name: event_properties_transit_processor
+        description: The `transit_processor` value from the `event_properties` column
       - name: event_properties_enrollment_flows
         description: A semi-colon delimited list of `enrollment_flows` values from the `event_properties` column (previously `event_properties_eligibility_types`)
       - name: user_properties_enrollment_method


### PR DESCRIPTION
# Description

Extracts the existing event_properties.(card_category|card_scheme|transit_processor) JSON columns from raw Benefits events data for inclusion in the final mart table. This will allow users to e.g. filter and group on these fields in Metabase.

Resolves cal-itp/benefits#3209

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

I am not currently set up to be able to test this. I based the changes off of the example shown in #4166.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
