### PR TITLE
Add 'secretmanager.versions.access' to Terraform service account

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -232,6 +232,7 @@ resource "google_project_iam_member" "github-actions-terraform" {
     "roles/resourcemanager.projectIamAdmin",
     "roles/run.admin",
     "roles/storage.admin",
+    "roles/secretmanager.secretAccessor",
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.github-actions-terraform.email}"

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -558,7 +558,8 @@ resource "google_project_iam_member" "github-actions-terraform" {
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/editor",
     "roles/storage.admin",
-    "roles/logging.configWriter"
+    "roles/logging.configWriter",
+    "roles/secretmanager.secretAccessor",
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.github-actions-terraform.email}"


### PR DESCRIPTION
# Description

This PR adds 'secretmanager.versions.access' permission to github-actions-terraform service account in order to set up Composer variables for PR https://github.com/cal-itp/data-infra/pull/4440.

[#4363]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running "terraform plan" locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Rebase PR https://github.com/cal-itp/data-infra/pull/4440 and see if Terraform account is able to build the plan.