### PR TITLE
NTD: adjust annual data configuration to allow 2024 values

### DIFF
--- a/warehouse/models/mart/ntd/_mart_ntd.yml
+++ b/warehouse/models/mart/ntd/_mart_ntd.yml
@@ -473,7 +473,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: [2022, 2023]
+              values: [2022, 2023, 2024]
               quote: false
       - *reporter_type
       - name: sales_tax
@@ -503,7 +503,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: [2022, 2023]
+              values: [2022, 2023, 2024]
               quote: false
       - *ntd_id
       - *agency
@@ -549,7 +549,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: [2022, 2023]
+              values: [2022, 2023, 2024]
               quote: false
       - *reporter_type
       - *ntd_id
@@ -731,7 +731,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: [2022, 2023]
+              values: [2022, 2023, 2024]
               quote: false
       - *ntd_id
       - *type_of_service

--- a/warehouse/models/staging/ntd_annual_reporting/_src.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_src.yml
@@ -24,7 +24,7 @@ x-common-fields:
     tests:
       - not_null
       - accepted_values:
-          values: [2022, 2023]
+          values: [2022, 2023, 2024]
   - &reporter_type
     name: reporter_type
     description: '{{ doc("ntd_reporter_type") }}'

--- a/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
@@ -24,7 +24,7 @@ x-common-fields:
     tests:
       - not_null
       - accepted_values:
-          values: [2022, 2023]
+          values: [2022, 2023, 2024]
           quote: false
   - &reporter_type
     name: reporter_type


### PR DESCRIPTION
# Description
With the recent release of the 2024 NTD annual data, we need to configure the accepted values in our warehouse configurations to allow the population of the new year of data.

Resolves #4433 

## Type of change
- [x] New feature

## How has this been tested?
`poetry run dbt run -s +staging.ntd_annual_reporting+ --vars 'GOOGLE_CLOUD_PROJECT: cal-itp-data-infra'`
<img width="1044" height="245" alt="Screenshot 2025-11-03 at 13 25 24" src="https://github.com/user-attachments/assets/ba708e24-6986-4a13-bd8b-cef8c8c09a7e" />

<img width="607" height="323" alt="Screenshot 2025-11-03 at 13 26 53" src="https://github.com/user-attachments/assets/1e81ab4a-3ee7-4f8f-9c6c-4a3312e9d206" />


## Post-merge follow-ups
Investigate whether 2024 data is available for other supporting XLSX datasets that we're currently using (agency information, contractual relationships, maybe more?
- [x] Actions required (specified below)
