### PR TITLE
Promote JH prototype image to default

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -9,7 +9,7 @@ jupyterhub:
     startTimeout: 300
     image:
       name: ghcr.io/cal-itp/data-infra/jupyter-singleuser
-      tag: 2025.8.28
+      tag: 2025.9.25
     memory:
       # Much more than 10 and we risk bumping up against the actual capacity of e2-highmem-2
       limit: 10G
@@ -31,26 +31,15 @@ jupyterhub:
               mkdir -p -- /home/jovyan/.jupyter;
               cp /tmp/jupyter_notebook_config.py /home/jovyan/.jupyter/jupyter_notebook_config.py;
     profileList:
-      - display_name: "Default Image - 2025.8.28, Python 3.11"
+      - display_name: "Default Image - 2025.9.25, Python 3.11"
         description: "Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         default: true
-      - display_name: "Power Default Image - 2025.8.28, Python 3.11"
+      - display_name: "Power Default Image - 2025.9.25, Python 3.11"
         description: "Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-      - display_name: "Prototype Image - 2025.9.25, Python 3.11"
-        description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
-        kubespawner_override:
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.9.25
-      - display_name: "Power Prototype Image - 2025.9.25, Python 3.11"
-        description: "This is the newer environment proposed for promotion to default. Recommended for analysts to use and report any issues. Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
-        kubespawner_override:
-          mem_limit: "12G"
-          mem_guarantee: "10G"
-          cpu_guarantee: 1.5
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.9.25
       - display_name: "Legacy Image - 2025.6.10, Python 3.11"
         description: "This is the older environment from before the dependency updates work. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:


### PR DESCRIPTION
# Description

This PR bumps the JH image profiles so that default is 2025.9.25 (this version includes adding voila back to the image) and removes the prototype image profile for now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and `poetry run dbt test -s CHANGED_MODEL`, then include the output in this section of the PR._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Post-deploy actions 
- [ ]  Confirm deployment of new image profile
