### PR TITLE
Payments: add composer service account to row access policy macro

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -100,6 +100,7 @@ filter using (
         'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
         'serviceAccount:github-actions-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
         'serviceAccount:github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com',
+        'serviceAccount:composer-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
         'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DDS_Cloud_Admins',
         'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DOT_DDS_Data_Pipeline_and_Warehouse_Users'
     ]
@@ -195,6 +196,7 @@ filter using (
         'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
         'serviceAccount:github-actions-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
         'serviceAccount:github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com',
+        'serviceAccount:composer-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
         'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DDS_Cloud_Admins',
         'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DOT_DDS_Data_Pipeline_and_Warehouse_Users'
     ]


### PR DESCRIPTION
# Description
Following refactoring of composer and the dbt transformations pipeline, the date spines used for payments reliability tables were no longer generating correctly and the payments reliability tables were no longer being populated with data.

Because the tables were running but not populating, the most obvious culprit appears to be the row access policy which needs to access `fct_payments_rides_v2` at compile and runtime.

This PR adds the new composer service account to the row access policy to hopefully appropriately query `fct_payments_rides_2` during the transformations process.

Resolves #4453 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
This works locally via this command: 
`poetry run dbt run -s --select mart.payments.reliability --vars 'GOOGLE_CLOUD_PROJECT: cal-itp-data-infra'`

but we won't know until it attemps to run in production.

## Post-merge follow-ups
- [x] Actions required (specified below)
We need to ensure that the tables populate after a production run, and we also need to investigate whether we're able to deprecate this service account: `bq-transform-svcacct`, which may no longer be needed in the row access policy (or anywhere). Captured in this issue: #4478 