### PR TITLE
Bump development and staging composer to composer-2.13.1-airflow-2.9.3

### DIFF
--- a/airflow/Makefile
+++ b/airflow/Makefile
@@ -5,7 +5,7 @@ COMPOSER_ENVIRONMENT_NAME := calitp-development-composer
 COMPOSER_PATH := composer
 COMPOSER_ENVIRONMENT_PATH := $(COMPOSER_PATH)/$(COMPOSER_ENVIRONMENT_NAME)
 
-COMPOSER_VERSION := composer-2.11.1-airflow-2.9.3
+COMPOSER_VERSION := composer-2.13.1-airflow-2.9.3
 COMPOSER_PROJECT := cal-itp-data-infra-staging
 COMPOSER_LOCATION := us-west2
 

--- a/docs/airflow/dags-maintenance.md
+++ b/docs/airflow/dags-maintenance.md
@@ -90,7 +90,7 @@ We use Terraform to manage the Composer environment. To tell Terraform to make t
 +    environment_size = "ENVIRONMENT_SIZE_LARGE"
 
      software_config {
-       image_version = "composer-2.11.1-airflow-2.9.3"
+       image_version = "composer-2.13.1-airflow-2.9.3"
 
        airflow_config_overrides = {
 -        celery-worker_concurrency                  = 4

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -36,7 +36,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
     environment_size = "ENVIRONMENT_SIZE_SMALL"
 
     software_config {
-      image_version = "composer-2.11.1-airflow-2.9.3"
+      image_version = "composer-2.13.1-airflow-2.9.3"
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4


### PR DESCRIPTION
# Description

This PR bumps the development and staging composer images to `composer-2.13.1-airflow-2.9.3`

Relates to #4465 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` and staging DAG runs