### PR TITLE
Pipeline: try working headers on xlsx sync

### DIFF
--- a/airflow/plugins/operators/scrape_ntd_xlsx.py
+++ b/airflow/plugins/operators/scrape_ntd_xlsx.py
@@ -24,14 +24,17 @@ RAW_XLSX_BUCKET = os.environ["CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__RAW"]
 CLEAN_XLSX_BUCKET = os.environ["CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN"]
 
 headers = {
-    "User-Agent": "CalITP/1.0.0",
-    "Accept": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,*/*",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.5",
     "Accept-Encoding": "gzip, deflate, br",
     "Connection": "keep-alive",
-    "sec-ch-ua": '"CalITP";v="1"',
-    "sec-ch-ua-mobile": "?0",
-    "sec-ch-ua-platform": '"macOS"',
+    "Upgrade-Insecure-Requests": "1",
+    "sec-ch-ua": '"Not A;Brand"',
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "sec-fetch-user": "?1",
 }
 
 


### PR DESCRIPTION
# Description
The `sync_ntd_data_xlsx` dag stopped working in production for the most part recently, and we assumed that it was related to the NTD data portal detecting us as a bot, and the headers would likely need to be changed.

There was one task that was still working, however, `scrape_ntd_xlsx_urls`, and it utilized different headers because it was created separately as a custom python file.

This PR attempts to use the same (working) headers across the dag to see if that causes the downloads to succeed.

Resolves #4205 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Works in local airflow but it always does, we won't know until it's in production.
<img width="671" height="372" alt="Screenshot 2025-11-06 at 17 52 37" src="https://github.com/user-attachments/assets/796bae1b-d9c8-4236-90c3-68ce7c4e7aec" />

## Post-merge follow-ups
- [x] Actions required (specified below)
If this doesn't work, take the issue back out of 'for review' and turn the dag back off