### PR TITLE
NTD: 2024 XLSX external tables

### DIFF
--- a/airflow/dags/create_external_tables/ntd_data_products/2024__annual_database_agency_information.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2024__annual_database_agency_information.yml
@@ -1,0 +1,15 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
+post_hook: |
+  SELECT *
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.2024__annual_database_agency_information
+  LIMIT 1;
+source_objects:
+  - "annual_database_agency_information/2024/agency_information/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__annual_reporting.2024__annual_database_agency_information"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "annual_database_agency_information/2024/agency_information/"

--- a/airflow/dags/create_external_tables/ntd_data_products/2024__annual_database_contractual_relationships.yml
+++ b/airflow/dags/create_external_tables/ntd_data_products/2024__annual_database_contractual_relationships.yml
@@ -1,0 +1,15 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__NTD_XLSX_DATA_PRODUCTS__CLEAN') }}"
+post_hook: |
+  SELECT *
+  FROM `{{ env_var('GOOGLE_CLOUD_PROJECT') }}`.external_ntd__annual_reporting.2024__annual_database_contractual_relationships
+  LIMIT 1;
+source_objects:
+  - "annual_database_contractual_relationship/2024/contractual_relationship/*.jsonl.gz"
+destination_project_dataset_table: "external_ntd__annual_reporting.2024__annual_database_contractual_relationships"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: AUTO
+  require_partition_filter: false
+  source_uri_prefix: "annual_database_contractual_relationship/2024/contractual_relationship/"


### PR DESCRIPTION
# Description
This PR follows up on #4485, this PR creates the external tables needed to populate the 2024 NTD XLSX tables in the warehouse (continued in #4486)

Resolves #4493 

## Type of change
- [x] New feature

## How has this been tested?
<img width="692" height="43" alt="Screenshot 2025-11-10 at 12 44 51" src="https://github.com/user-attachments/assets/da58f989-5ec7-46ea-9bed-fea5039691a0" />

## Post-merge follow-ups
- [x] Actions required (specified below)
#4486 