### PR TITLE
Update helm charts to use bitnamilegacy while keeping the version the same

### DIFF
--- a/kubernetes/apps/charts/postgresql/.helmignore
+++ b/kubernetes/apps/charts/postgresql/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/apps/charts/postgresql/Chart.yaml
+++ b/kubernetes/apps/charts/postgresql/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: postgresql
+description: Postgres for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.4.2"
+dependencies:
+  - name: postgresql
+    version: 12.1.14
+    repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
# Description

Based on https://github.com/sentry-kubernetes/charts/blob/develop/charts/sentry/CHANGELOG.md, the bitnami legacy issue is resolved in more recent sentry versions.

But Chris suggests we just override the tag values.

A recent deployment accidentally took down sentry again.

Resolves #4371 at least for sentry

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Not tested
## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Watch the cluster