### PR TITLE
Fix Slack env variable name to send DAG notifications

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -95,7 +95,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         "CALITP_BUCKET__PUBLISH"                               = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-publish_name}",
         "CALITP_BUCKET__SENTRY_EVENTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-sentry_name}",
         "CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-state-geoportal-scrape_name}",
-        "CALITP_SLACK_URL_KEY"                                 = data.google_secret_manager_secret_version.slack-airflow-url.secret_data
+        "CALITP_SLACK_URL"                                     = data.google_secret_manager_secret_version.slack-airflow-url.secret_data
       })
     }
   }

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -95,7 +95,7 @@ resource "google_composer_environment" "calitp-composer" {
         "CALITP_BUCKET__PUBLISH"                               = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-publish_name}",
         "CALITP_BUCKET__SENTRY_EVENTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-sentry_name}",
         "CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-state-geoportal-scrape_name}",
-        "CALITP_SLACK_URL_KEY"                                 = data.google_secret_manager_secret_version.slack-airflow-url.secret_data
+        "CALITP_SLACK_URL"                                     = data.google_secret_manager_secret_version.slack-airflow-url.secret_data
       })
     }
   }


### PR DESCRIPTION
# Description

This PR fixes the name of the environment variable that DAGs use to send Slack notifications (added on https://github.com/cal-itp/data-infra/pull/4440)

[4363]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running Airflow locally. It didn't send message but was able to read the variable.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor to see error messages on Slack alerts-data-infra channel.