### PR TITLE
Add slack notification to Cosmos DAGs

### DIFF
--- a/airflow/dags/dbt_all_dag.py
+++ b/airflow/dags/dbt_all_dag.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 
 from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig, RenderConfig
+from src.dbt_utils import log_group_failure_to_slack
 
 from airflow import DAG
 from airflow.operators.latest_only import LatestOnlyOperator
@@ -44,7 +45,10 @@ with DAG(
         operator_args={
             "install_deps": True,
         },
-        default_args={"retries": 1},
+        default_args={
+            "on_failure_callback": log_group_failure_to_slack,
+            "retries": 1,
+        },
     )
 
     latest_only >> dbt_all

--- a/airflow/dags/dbt_daily_dag.py
+++ b/airflow/dags/dbt_daily_dag.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import TestBehavior
+from src.dbt_utils import log_group_failure_to_slack
 
 from airflow import DAG
 from airflow.operators.latest_only import LatestOnlyOperator
@@ -47,7 +48,10 @@ with DAG(
         operator_args={
             "install_deps": True,
         },
-        default_args={"retries": 1},
+        default_args={
+            "on_failure_callback": log_group_failure_to_slack,
+            "retries": 1,
+        },
     )
 
     latest_only >> dbt_daily

--- a/airflow/dags/dbt_manual_dag.py
+++ b/airflow/dags/dbt_manual_dag.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import TestBehavior
+from src.dbt_utils import log_group_failure_to_slack
 
 from airflow import DAG
 from airflow.operators.latest_only import LatestOnlyOperator
@@ -44,7 +45,10 @@ with DAG(
         operator_args={
             "install_deps": True,
         },
-        default_args={"retries": 0},
+        default_args={
+            "on_failure_callback": log_group_failure_to_slack,
+            "retries": 0,
+        },
     )
 
     latest_only >> dbt_manual

--- a/airflow/plugins/src/dag_utils.py
+++ b/airflow/plugins/src/dag_utils.py
@@ -1,0 +1,33 @@
+import os
+
+import requests
+
+
+def log_group_failure_to_slack(context):
+    # pointed at #alerts-data-infra as of 2024-02-05
+    CALITP_SLACK_URL = os.environ.get("CALITP_SLACK_URL")
+
+    if not CALITP_SLACK_URL:
+        print("Skipping email to slack channel. No CALITP_SLACK_URL in environment")
+    else:
+        try:
+            task_instance = context.get("task_instance")
+            dag_id = context.get("dag").dag_id
+            task_id = task_instance.task_id
+            log_url = task_instance.log_url
+            execution_date = context.get("execution_date")
+
+            message = f"""
+            Task Failed: {dag_id}.{task_id}
+            Execution Date: {execution_date}
+
+            <{log_url}| Check Log >
+            """
+            requests.post(CALITP_SLACK_URL, json={"text": message})
+            print(f"Slack notification sent: {message}")
+        except Exception as e:
+            # This is very broad but we want to try to log _any_ exception to slack
+            print(f"Slack notification failed: {type(e)}")
+            requests.post(
+                CALITP_SLACK_URL, json={"text": f"failed to log {type(e)} to slack"}
+            )


### PR DESCRIPTION
# Description

This PR adds slack notification to Cosmos DAGs (`dbt_all`, `dbt_daily`, and `dbt_manual`).
I created `log_group_failure_to_slack` based on `log_failure_to_slack` from [dags.py](https://github.com/cal-itp/data-infra/blob/f5909bd42f46ab8f5abde6f1c37e5bcf935888be/airflow/dags/dags.py#L27).

Once we have Airflow 2.10 we will be able to use [send_slack_notification](https://airflow.apache.org/docs/apache-airflow-providers-slack/stable/notifications/slack_notifier_howto_guide.html) from Airflow.

Resolves #4363 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running Airflow local.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
