### PR TITLE
Create staging GTFS download configs view

### DIFF
--- a/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
+++ b/warehouse/models/staging/gtfs/_src_gtfs_schedule_external_tables.yml
@@ -14,6 +14,7 @@ sources:
     database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
     schema: external_gtfs_schedule
     tables:
+      - name: download_configs
       - name: download_outcomes
       - name: unzip_outcomes
       - name: agency

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -1,6 +1,28 @@
 version: 2
 
 models:
+  - name: stg_gtfs_schedule__download_configs
+    description: Displays all existing download configs with related schedule validation url
+    columns:
+      - name: name
+      - name: url
+      - name: base64_url
+      - name: feed_type
+      - name: auth_headers
+      - name: auth_query_params
+      - name: first_extracted_date
+        description: First date this configuration was extracted
+      - name: last_extracted_date
+        description: Last date this configuration was extracted
+      - name: schedule_url
+      - name: schedule_base64_url
+      - name: schedule_name
+      - name: schedule_auth_headers
+      - name: schedule_auth_query_params
+      - name: schedule_first_extracted_date
+        description: First date this configuration schedule was extracted
+      - name: schedule_last_extracted_date
+        description: Last date this configuration schedule was extracted
   - name: stg_gtfs_schedule__download_outcomes
     description: Outcomes from download attempts of GTFS schedule data.
     tests:

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__download_configs.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__download_configs.sql
@@ -1,0 +1,34 @@
+WITH stg_gtfs_schedule__download_configs AS (
+    SELECT configs.name,
+           configs.url,
+           {{ to_url_safe_base64('configs.url') }} AS base64_url,
+           configs.feed_type,
+           TO_JSON_STRING(configs.auth_headers) AS auth_headers,
+           TO_JSON_STRING(configs.auth_query_params) AS auth_query_params,
+           MIN(configs.dt) AS first_extracted_date,
+           MAX(configs.dt) AS last_extracted_date,
+           configs.schedule_url_for_validation AS schedule_url,
+           {{ to_url_safe_base64('schedules.url') }} AS schedule_base64_url,
+           schedules.name AS schedule_name,
+           TO_JSON_STRING(schedules.auth_headers) AS schedule_auth_headers,
+           TO_JSON_STRING(schedules.auth_query_params) AS schedule_auth_query_params,
+           MIN(schedules.dt) AS schedule_first_extracted_date,
+           MAX(schedules.dt) AS schedule_last_extracted_date
+      FROM {{ source('external_gtfs_schedule', 'download_configs') }} AS configs
+      LEFT JOIN {{ source('external_gtfs_schedule', 'download_configs') }} AS schedules
+             ON configs.schedule_url_for_validation = schedules.url
+            AND schedules.feed_type = 'schedule'
+     GROUP BY
+           configs.name,
+           configs.url,
+           configs.feed_type,
+           auth_headers,
+           auth_query_params,
+           configs.schedule_url_for_validation,
+           schedules.url,
+           schedules.name,
+           schedule_auth_query_params,
+           schedule_auth_headers
+)
+
+SELECT * FROM stg_gtfs_schedule__download_configs


### PR DESCRIPTION
# Description

This PR creates a staging view `stg_gtfs_schedule__download_configs`, to help test and visualize GTFS download configurations.

[#4379]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running Locally:

```
❯ poetry run dbt run -s +models/staging/gtfs/stg_gtfs_schedule__download_configs.sql --target staging
01:06:14  Running with dbt=1.10.1
01:06:15  Registered adapter: bigquery=1.10.0
01:06:21  Found 599 models, 1226 data tests, 14 seeds, 219 sources, 4 exposures, 1075 macros
01:06:21
01:06:21  Concurrency: 8 threads (target='staging')
01:06:21
01:06:24  1 of 1 START sql view model staging.stg_gtfs_schedule__download_configs ........ [RUN]
01:06:26  1 of 1 OK created sql view model staging.stg_gtfs_schedule__download_configs ... [CREATE VIEW (0 processed) in 1.66s]
01:06:26
01:06:26  Finished running 1 view model in 0 hours 0 minutes and 4.91 seconds (4.91s).
01:06:26
01:06:26  Completed successfully
01:06:26
01:06:26  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

```
❯ poetry run dbt test -s +models/staging/gtfs/stg_gtfs_schedule__download_configs.sql --target staging
01:06:33  Running with dbt=1.10.1
01:06:34  Registered adapter: bigquery=1.10.0
01:06:35  Found 599 models, 1226 data tests, 14 seeds, 219 sources, 4 exposures, 1075 macros
01:06:35  Nothing to do. Try checking your model configs and model specification args
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
