### PR TITLE
Enhance app/maps linestring and point display

### DIFF
--- a/apps/maps/src/routes/+page.svelte
+++ b/apps/maps/src/routes/+page.svelte
@@ -439,9 +439,14 @@
                     data: fetchGeoJSON(layer.url),
                     pickable: true,
                     autoHighlight: true,
-                    getPointRadius: 10,
+                    getPointRadius: 12,
+                    pointRadiusUnits: "pixels", // point radius is less zoom dependendent
+                    pointRadiusScale: 0.3, //slows growth of points when zooming out
+                    getLineWidth: 3,
+                    lineWidthUnits: "pixels",
                     ...layerProperties,
                     getFillColor: (feature) => getColor(feature, layer, 1, 200),
+                    getLineColor: (feature) => getColor(feature, layer, 1, 200),
                     highlightColor: ({ object, layer }) => getColor(object, layer, layerProperties.highlight_saturation_multiplier || 0.7),
                     onDataLoad: (data) => {
                       console.log("Finished loading", layer);


### PR DESCRIPTION
ref: #4461
Use pixel scaling to display points so that they are visible at all zoom levels #4515 
Add width to line rendering and use pixel scaling so that lines are more easily visible #4514 
Add color to lines #4516

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

