### PR TITLE
Make sure to create/update models on Staging when creating a PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Resolves #\[issue\]
 
 _Include commands/logs/screenshots as relevant._
 
-_If making changes to dbt models, please run the command `poetry run dbt run -s CHANGED_MODEL` and `poetry run dbt test -s CHANGED_MODEL`, then include the output in this section of the PR._
+_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `poetry run dbt run -s CHANGED_MODEL --target staging` and `poetry run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._
 
 ## Post-merge follow-ups
 


### PR DESCRIPTION
# Description

This PR adds instructions to create/update models on **Staging** when creating a PR to reduce errors on sync Metabase.

[#4531]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Just documentation.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
