### PR TITLE
Add default `to` email for failure notifications

### DIFF
--- a/airflow/.development.env
+++ b/airflow/.development.env
@@ -56,3 +56,4 @@ SENTRY_DSN=https://0fc56e5e8a96482da63b8d9dd3955ee7@sentry.k8s.calitp.jarv.us/2
 SENTRY_ENVIRONMENT=cal-itp-data-infra-staging
 GTFS_RT_VALIDATOR_JAR=gtfs-realtime-validator-lib-1.0.0-20220223.003525-2.jar
 GTFS_RT_VALIDATOR_VERSION=v1.0.0
+CALITP_NOTIFY_EMAIL=test-notify@example.com

--- a/airflow/dags/airtable_loader_v2/METADATA.yml
+++ b/airflow/dags/airtable_loader_v2/METADATA.yml
@@ -7,9 +7,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-06-01"
     catchup: False
-    email:
-      - "hunter.owens@dot.ca.gov"
-      - "evan.siroky@dot.ca.gov"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/copy_production_to_staging/METADATA.yml
+++ b/airflow/dags/copy_production_to_staging/METADATA.yml
@@ -7,8 +7,6 @@ default_args:
   depends_on_past: False
   start_date: "2025-08-22"
   catchup: False
-  email:
-    - "hello@calitp.org"
   email_on_failure: True
   pool: default_pool
   max_active_dag_runs: 1

--- a/airflow/dags/create_external_tables/METADATA.yml
+++ b/airflow/dags/create_external_tables/METADATA.yml
@@ -8,8 +8,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: False
     email_on_retry: False
     retries: 0

--- a/airflow/dags/dags.py
+++ b/airflow/dags/dags.py
@@ -8,6 +8,7 @@ import airflow  # noqa
 
 # pointed at #alerts-data-infra as of 2024-02-05
 CALITP_SLACK_URL = os.environ.get("CALITP_SLACK_URL")
+CALITP_NOTIFY_EMAIL = os.environ.get("CALITP_NOTIFY_EMAIL")
 
 # DAG Directories =============================================================
 
@@ -63,6 +64,7 @@ for dag_directory in dag_directories:
         },
         default_args={
             "on_failure_callback": log_failure_to_slack,
+            "email": CALITP_NOTIFY_EMAIL
             # "on_retry_callback": log_failure_to_slack,
         },
     )

--- a/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
+++ b/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
@@ -8,8 +8,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "evan.siroky@dot.ca.gov"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
+++ b/airflow/dags/download_gtfs_schedule_v2/download_schedule_feeds.py
@@ -164,13 +164,13 @@ def download_all(task_instance, execution_date, **kwargs):
                 str(f.exception) or str(type(f.exception)) for f in result.failures
             ),
         )
-        # Commenting out since it is used only for email_download_failures.py (temporarily disabled)
-        # task_instance.xcom_push(
-        #     key="download_failures",
-        #     value=[
-        #         json.loads(f.json()) for f in result.failures
-        #     ],  # use the Pydantic serializer
-        # )
+
+        task_instance.xcom_push(
+            key="download_failures",
+            value=[
+                json.loads(f.json()) for f in result.failures
+            ],  # use the Pydantic serializer
+        )
 
     success_rate = len(result.successes) / len(configs)
     if success_rate < GTFS_FEED_LIST_ERROR_THRESHOLD:

--- a/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
+++ b/airflow/dags/download_gtfs_schedule_v2/email_download_failures.py
@@ -32,6 +32,9 @@ def email_failures(task_instance: TaskInstance, execution_date, **kwargs):
     {html_report}
     """  # noqa: E231,E241
 
+    email_to = kwargs["dag_run"].conf.get(
+        "email", kwargs["dag"].default_args.get("email")
+    )
     if os.environ["AIRFLOW_ENV"] == "development":
         print(
             f"Skipping since in development mode! Would have emailed {failures_df.shape[0]} failures."
@@ -39,9 +42,7 @@ def email_failures(task_instance: TaskInstance, execution_date, **kwargs):
         print(html_content)
     else:
         send_email(
-            to=[
-                "evan.siroky@dot.ca.gov",
-            ],
+            to=email_to,
             html_content=html_content,
             subject=(
                 f"Operator GTFS Errors for {datetime.datetime.now().strftime('%Y-%m-%d')}"

--- a/airflow/dags/ntd_report_from_blackcat/METADATA.yml
+++ b/airflow/dags/ntd_report_from_blackcat/METADATA.yml
@@ -8,9 +8,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "christian.suyat@dot.ca.gov"
-      - "katrina.kaiser@dot.ca.gov"
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/parse_elavon/METADATA.yml
+++ b/airflow/dags/parse_elavon/METADATA.yml
@@ -8,8 +8,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "dds.app.notify@dot.ca.gov"
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/parse_littlepay_v3/METADATA.yml
+++ b/airflow/dags/parse_littlepay_v3/METADATA.yml
@@ -8,8 +8,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: False
     email_on_retry: False
     max_active_dag_runs: 6

--- a/airflow/dags/scrape_feed_aggregators/METADATA.yml
+++ b/airflow/dags/scrape_feed_aggregators/METADATA.yml
@@ -7,8 +7,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: False
     email_on_retry: False
     retries: 2

--- a/airflow/dags/scrape_state_geoportal/METADATA.yml
+++ b/airflow/dags/scrape_state_geoportal/METADATA.yml
@@ -7,8 +7,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/sync_elavon/METADATA.yml
+++ b/airflow/dags/sync_elavon/METADATA.yml
@@ -8,8 +8,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "dds.app.notify@dot.ca.gov"
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/sync_kuba/METADATA.yml
+++ b/airflow/dags/sync_kuba/METADATA.yml
@@ -7,8 +7,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-14"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/sync_littlepay_v3/METADATA.yml
+++ b/airflow/dags/sync_littlepay_v3/METADATA.yml
@@ -8,8 +8,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: False
     email_on_retry: False
     retries: 0

--- a/airflow/dags/sync_ntd_data_api/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_api/METADATA.yml
@@ -7,8 +7,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_xlsx/METADATA.yml
@@ -7,8 +7,6 @@ default_args:
     depends_on_past: False
     start_date: "2025-07-06"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
@@ -7,8 +7,6 @@ default_args:
     depends_on_past: False
     start_date: "2024-01-01"
     catchup: False
-    email:
-      - "hello@calitp.org"
     email_on_failure: False
     email_on_retry: False
     max_active_dag_runs: 6

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -45,11 +45,11 @@ resource "google_composer_environment" "calitp-staging-composer" {
         core-dags_are_paused_at_creation           = true
         email-email_backend                        = "airflow.utils.email.send_email_smtp"
         email-email_conn_id                        = "smtp_postmark"
-        email-from_email                           = "bot@calitp.org"
+        email-from_email                           = "airflow-bot@calitp.org"
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
-        smtp-smtp_mail_from                        = "bot@calitp.org"
+        smtp-smtp_mail_from                        = "airflow-bot@calitp.org"
         smtp-smtp_starttls                         = true
         smtp-smtp_host                             = "smtp.postmarkapp.com"
         smtp-smtp_port                             = 587

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -45,11 +45,11 @@ resource "google_composer_environment" "calitp-composer" {
         core-dags_are_paused_at_creation           = true
         email-email_backend                        = "airflow.utils.email.send_email_smtp"
         email-email_conn_id                        = "smtp_postmark"
-        email-from_email                           = "bot@calitp.org"
+        email-from_email                           = "airflow-bot@calitp.org"
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
-        smtp-smtp_mail_from                        = "bot@calitp.org"
+        smtp-smtp_mail_from                        = "airflow-bot@calitp.org"
         smtp-smtp_starttls                         = true
         smtp-smtp_host                             = "smtp.postmarkapp.com"
         smtp-smtp_port                             = 587
@@ -98,6 +98,7 @@ resource "google_composer_environment" "calitp-composer" {
         "CALITP_BUCKET__SENTRY_EVENTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-sentry_name}",
         "CALITP_BUCKET__STATE_GEOPORTAL_DATA_PRODUCTS"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-state-geoportal-scrape_name}",
         "CALITP_SLACK_URL"                                     = data.google_secret_manager_secret_version.slack-airflow-url.secret_data
+        "CALITP_NOTIFY_EMAIL"                                  = "dds.app.notify@dot.ca.gov"
       })
     }
   }


### PR DESCRIPTION
ref: #4364
enable outputs for download_gtfs_schedule #4381

Adds default mail to: `dds.app.notify@dot.ca.gov`
