### PR TITLE
Full refreshes only changed Models

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -162,13 +162,10 @@ jobs:
         run: |
           echo "List changed files: $CHANGED_FILES"
 
-  models_and_metabase:
-    name: Sync Models and Metabase
+  models:
+    name: Run dbt Models
     runs-on: ubuntu-latest
-
-    needs:
-      - compile
-      - dbt-changed
+    needs: [compile, dbt-changed]
 
     if: ${{ needs.dbt-changed.outputs.has-changed == 'true' }}
 
@@ -256,6 +253,80 @@ jobs:
       - name: Run downstream models
         working-directory: warehouse
         run: poetry run dbt run --select "${{ needs.dbt-changed.outputs.changed-downstream }}" --target ${{ env.DBT_TARGET }} --exclude "${{ needs.dbt-changed.outputs.changed-models }}"
+
+  metabase:
+    name: Sync Metabase
+    runs-on: ubuntu-latest
+
+    needs: [models]
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download compilation artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dbt
+          path: warehouse/target
+
+      - name: Authenticate Google Service Account
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: 'true'
+          project_id: ${{ env.PROJECT_ID }}
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Setup GCloud utilities
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Cache Poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-cache-${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-poetry-${{ env.POETRY_VERSION }}
+
+      - name: Setup Poetry
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
+
+      - name: Cache Python packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.local
+          key: python-cache-${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-lock-${{ hashFiles('warehouse/poetry.lock') }}-${{ hashFiles('.github/workflows/*.yml') }}
+
+      - name: Install dependencies
+        working-directory: warehouse
+        run: poetry install
+
+      - name: Cache dbt packages
+        uses: actions/cache@v3
+        with:
+          path: warehouse/dbt_packages
+          key: python-cache-${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-lock-${{ hashFiles('warehouse/poetry.lock') }}-dbt-packages-${{ hashFiles('warehouse/packages.yml') }}
+
+      - name: Install dbt dependencies
+        working-directory: warehouse
+        run: poetry run dbt deps
+
+      - name: Print dbt environment
+        working-directory: warehouse
+        run: poetry run dbt debug --target ${{ env.DBT_TARGET }}
 
       - name: Synchronize Metabase
         working-directory: warehouse


### PR DESCRIPTION
# Description

This PR makes some changes to `deploy-dbt` workflow in order to improve the rebuild process and reduce re-run the waiting time when sync Metabase fails:

* Use `full-refresh` to rebuild ONLY changed models
* Downstream models are rebuilt with regular run (without `full-refresh`)
* Remove `--exclude source:external_gtfs_rt+ source:gtfs_rt_external_tables+`
* Move sync Metabase to a dedicated job, when it fails we can re-run only this part and avoid rebuilding changed models again

Resolves #4531 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running workflow through this PR, making temporary changes to seeds and models.
See full logs on: https://github.com/cal-itp/data-infra/actions/runs/19926205424?pr=4556

<img width="1147" height="1092" alt="image" src="https://github.com/user-attachments/assets/278de2cc-b436-4307-8990-b8a36eb07d18" />

<img width="1152" height="651" alt="image" src="https://github.com/user-attachments/assets/7ef537bd-b3ba-4d6c-a1f9-43124b77582e" />

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor workflow behavior.