### PR TITLE
Pipeline: run NTD API dag every Wednesday

### DIFF
--- a/airflow/dags/sync_ntd_data_api/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_api/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Scrape NTD endpoints from DOT API monthly"
-schedule_interval: "0 11 1 * *" # 11am UTC first day of every month
+schedule_interval: "0 11 * * 3" # 11am UTC every Wednesday
 tags:
   - ntd
 default_args:


### PR DESCRIPTION
# Description
During this month's NTD ridership report generation, it was discovered that the most recent data wasn't available in the warehouse due to an order of operations conflict related to the scheduling of the `sync_ntd_api` dag – It was previously only running on the first of the month. 

This PR modifies the schedule to run every Wednesday, as per @csuyat-dot's recommendation, so that data is more likely to be available when expected.

Resolves #4533 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
n/a

## Post-merge follow-ups
- [x] No action required
