### PR TITLE
[images/jupyter-singleuser] Update branca 0.4.2 to 0.8.2

### DIFF
--- a/images/jupyter-singleuser/poetry.lock
+++ b/images/jupyter-singleuser/poetry.lock
@@ -648,18 +648,18 @@ crt = ["awscrt (==0.23.8)"]
 
 [[package]]
 name = "branca"
-version = "0.4.2"
+version = "0.8.2"
 description = "Generate complex HTML+JS pages with Python"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "branca-0.4.2-py3-none-any.whl", hash = "sha256:62c2e777f074fc1830cd40ba9e650beb941861075980babafead8d97856b1a4b"},
-    {file = "branca-0.4.2.tar.gz", hash = "sha256:c111453617b17ab2bda60a4cd71787d6f2b59c85cdf71ab160a737606ac66c31"},
+    {file = "branca-0.8.2-py3-none-any.whl", hash = "sha256:2ebaef3983e3312733c1ae2b793b0a8ba3e1c4edeb7598e10328505280cf2f7c"},
+    {file = "branca-0.8.2.tar.gz", hash = "sha256:e5040f4c286e973658c27de9225c1a5a7356dd0702a7c8d84c0f0dfbde388fe7"},
 ]
 
 [package.dependencies]
-jinja2 = "*"
+jinja2 = ">=3"
 
 [[package]]
 name = "cachetools"
@@ -8881,4 +8881,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0, <3.12.0"
-content-hash = "3bd2721d5a96f1b89a594be9d666b84e7c47c322a6bc75ae2812f44a18e46839"
+content-hash = "512643029e820d97c35f31163b266e71886da2a6302e07490d44c2e731ae11ca"

--- a/images/jupyter-singleuser/pyproject.toml
+++ b/images/jupyter-singleuser/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11.0, <3.12.0"
 
 dependencies = [
     "black==24.10.0",
-    "branca==0.4.2",
+    "branca (>=0.8.2, <0.9.0)",
     "calitp-data-analysis==2025.8.10",
     "csvkit==1.0.7",
     "dask (>=2024.5.0, <2024.6.0)",


### PR DESCRIPTION
# Description

This PR updates branca from 0.4.2 to 0.8.2. Based on their [release log](https://github.com/python-visualization/branca/releases), it doesn't appear they introduced any breaking changes between these versions, only new functionality. 

Relates to https://github.com/cal-itp/data-infra/issues/4236

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x]  Dependency update

## How has this been tested?

I did some very light testing of this by 
1. building the image with the branca update locally
2. downloading the data-analyses repo
3. cd data-analyses/_shared_utils/
4. make setup_env
5. Running python and importing modules that import branca

I will need to ask a analyst to test this on JH for a specific notebook.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
- [ ] Confirm updated version does not break existing branca usages
