### PR TITLE
[images/jupyter-singleuser] Update folium 0.12.0 to 0.20.0

### DIFF
--- a/images/jupyter-singleuser/poetry.lock
+++ b/images/jupyter-singleuser/poetry.lock
@@ -1782,21 +1782,22 @@ test = ["aiohttp", "fiona[s3]", "fsspec", "pytest (>=7)", "pytest-cov", "pytz"]
 
 [[package]]
 name = "folium"
-version = "0.13.0"
+version = "0.20.0"
 description = "Make beautiful maps with Leaflet.js & Python"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "folium-0.13.0-py2.py3-none-any.whl", hash = "sha256:6219350c4303b556e5c80f8379714374ebe8b14312a97add4c89bae4daaa3d9f"},
-    {file = "folium-0.13.0.tar.gz", hash = "sha256:9eee35961cd9a3234948efe47bcd0ef9729a278768ae90685c24922beafb53dd"},
+    {file = "folium-0.20.0-py2.py3-none-any.whl", hash = "sha256:f0bc2a92acde20bca56367aa5c1c376c433f450608d058daebab2fc9bf8198bf"},
+    {file = "folium-0.20.0.tar.gz", hash = "sha256:a0d78b9d5a36ba7589ca9aedbd433e84e9fcab79cd6ac213adbcff922e454cb9"},
 ]
 
 [package.dependencies]
-branca = ">=0.3.0"
+branca = ">=0.6.0"
 jinja2 = ">=2.9"
 numpy = "*"
 requests = "*"
+xyzservices = "*"
 
 [package.extras]
 testing = ["pytest"]
@@ -8881,4 +8882,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0, <3.12.0"
-content-hash = "512643029e820d97c35f31163b266e71886da2a6302e07490d44c2e731ae11ca"
+content-hash = "99cc107b0f86b498b1f7f7f8c9a871ccf2f8456a13c522a9f547e02b78011706"

--- a/images/jupyter-singleuser/pyproject.toml
+++ b/images/jupyter-singleuser/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "csvkit==1.0.7",
     "dask (>=2024.5.0, <2024.6.0)",
     "dask-geopandas (>=0.2.0, <0.3.0)",
-    "folium>=0.12.1.post1",
+    "folium (>=0.20.0, <0.21.0)",
     "intake-dcat==0.4.0",
     "intake-geopandas>=0.3.0",
     "intake-parquet>=0.2.3",


### PR DESCRIPTION
# Description

This PR updates folium from 0.12.0 to 0.20.0. After reviewing folium's [release log](https://github.com/python-visualization/branca/releases), it looks like there's one function that may be impacted and that we use. I've reached out to analysts whose code use this function and have asked them to take a look once this goes out to prototype. Otherwise, it doesn't appear folium introduced any other breaking changes that would impact how we're currently using it.

Relates to https://github.com/cal-itp/data-infra/issues/4237

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Dependency update

## How has this been tested?
I will need to deploy and ask analysts to test this on JH for the specific notebooks using folium.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
- [ ] Coordinate with analysts on testing  the update
