### PR TITLE
Bump production composer to composer-2.15.2-airflow-2.9.3

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -36,7 +36,7 @@ resource "google_composer_environment" "calitp-composer" {
     environment_size = "ENVIRONMENT_SIZE_MEDIUM"
 
     software_config {
-      image_version = "composer-2.14.2-airflow-2.9.3"
+      image_version = "composer-2.15.2-airflow-2.9.3"
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4


### PR DESCRIPTION
# Description

This PR updates the production composer image to `composer-2.15.2-airflow-2.9.3`

Resolves #4576

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Ran DAGs on staging

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor production Airflow