### PR TITLE
Point `int_gtfs_rt__trip_updates_trip_stop_day_map_grouping` at `fct_stop_time_updates`

### DIFF
--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_stop_day_map_grouping.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_stop_day_map_grouping.sql
@@ -13,7 +13,7 @@
 WITH stop_time_updates AS (
     SELECT *
     FROM {{ ref('fct_stop_time_updates') }}
-    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }} AND dt >= "2025-06-01"
+    WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }} AND dt >= "2025-12-01"
 ),
 
 prediction_arrays AS (


### PR DESCRIPTION
# Description

* Limited production deployment of this intermediate table.
* Intermediate table now is pointing at a materialized sample of 2 weeks. Incremental model is working and we can point it back at the view and remove date filters and it works fine!
   * For now, we'll go with June 2025 onward and use the DAG to continue to populate.
* Add new columns to this model (`arrival_time`, `departure_time`, `_extract_ts`) and store as arrays to benefit `fct_stop_time_metrics` (downstream model).
   * TODO: The way [fct_stop_time_metrics](https://github.com/cal-itp/data-infra/blob/918258d24b845a4ab541c5e4770ddc12afad355b/warehouse/models/mart/gtfs/fct_stop_time_metrics.sql) starts is that it scans the view a second time. Work what's needed from this downstream model into this intermediate table so we don't need this computationally and cost intensive step!
* Progress on productionizing tables needed for #4101. 
* This will allow us to also us to remove #4598. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested this in staging to make sure incremental model is adding a day at a time.
Post changing it to December, tested it with `WHERE dt = "2025-12-11"` to play nicely with the default in `dev_lookback_days`, any earlier will get 0 rows and throw an error. 

```
jovyan@jupyter-tiffanychu90 ~/data-infra/warehouse (expand-incremental-intermediate-tu) $ poetry run dbt run -s int_gtfs_rt__trip_updates_trip_stop_day_map_grouping --full-refresh --target staging
21:18:34  Concurrency: 8 threads (target='staging')
21:18:38  1 of 1 START sql incremental model staging.int_gtfs_rt__trip_updates_trip_stop_day_map_grouping  [RUN]
/home/jovyan/.cache/pypoetry/virtualenvs/calitp-warehouse-rrNmZ0ll-py3.11/lib/python3.11/site-packages/dbt/adapters/bigquery/impl.py:520: PendingDeprecationWarning: This method will be deprecated in future versions. Please use Table.time_partitioning.type_ instead.
21:19:27  1 of 1 OK created sql incremental model staging.int_gtfs_rt__trip_updates_trip_stop_day_map_grouping  [CREATE TABLE (8.0m rows, 420.6 GiB processed) in 48.85s]
21:19:27  Finished running 1 incremental model in 0 hours 0 minutes and 52.48 seconds (52.48s).
21:19:28  Completed successfully
21:19:28  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required 
   - [ ] go into production, staging, dev sections to remove `fct_stop_time_updates_sample` from BQ
   - [x] run in `dbt_manual` DAG in subsequent days to make sure incremental model is working as expected in prod
