### PR TITLE
Remove fct_stop_time_updates_sample from DAGs

### DIFF
--- a/airflow/dags/dbt_all_dag.py
+++ b/airflow/dags/dbt_all_dag.py
@@ -36,7 +36,6 @@ with DAG(
             exclude=[
                 "models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_stop_day_map_grouping.sql",
                 "models/mart/gtfs/fct_stop_time_metrics.sql",
-                "models/mart/gtfs/fct_stop_time_updates_sample.sql",
                 "models/mart/gtfs/fct_trip_updates_stop_metrics.sql",
                 "models/mart/gtfs/fct_trip_updates_trip_metrics.sql",
             ],

--- a/airflow/dags/dbt_manual_dag.py
+++ b/airflow/dags/dbt_manual_dag.py
@@ -36,7 +36,6 @@ with DAG(
             select=[
                 "models/intermediate/gtfs/int_gtfs_rt__trip_updates_trip_stop_day_map_grouping.sql",
                 "models/mart/gtfs/fct_stop_time_metrics.sql",
-                "models/mart/gtfs/fct_stop_time_updates_sample.sql",
                 "models/mart/gtfs/fct_trip_updates_stop_metrics.sql",
                 "models/mart/gtfs/fct_trip_updates_trip_metrics.sql",
             ],


### PR DESCRIPTION
# Description

This PR removes `fct_stop_time_updates_sample` from dbt_manual and dbt_all DAG.

To be merged after PR https://github.com/cal-itp/data-infra/pull/4627.

Resolves [#4598]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally.
Not showing on dbt_manual DAG anymore:

<img width="709" height="497" alt="image" src="https://github.com/user-attachments/assets/9f21be8e-1cf0-4b2f-9069-227cbd3bcce0" />

Not showing on dbt_all DAG either:


## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `dbt_all` to make sure it is able to run successfully.