### PR TITLE
Bug: fix typo and add `where` back into SQL

### DIFF
--- a/warehouse/models/mart/gtfs/fct_stop_time_metrics.sql
+++ b/warehouse/models/mart/gtfs/fct_stop_time_metrics.sql
@@ -16,8 +16,8 @@ WITH int_tu_trip_stop AS (
     WHERE {{ incremental_where(
         default_start_var='PROD_GTFS_RT_START',
         this_dt_column="service_date",
-        filter_dt_column="dt",
-    ) }} 
+        filter_dt_column="dt"
+    ) }}
 ),
 
 tu_trip_keys AS (


### PR DESCRIPTION
# Description

* Somehow deleted `WHERE` in earlier #4627 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
