### PR TITLE
Create GTFS download config view

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__gtfs_datasets_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__gtfs_datasets_dim.sql
@@ -1,49 +1,7 @@
 {{ config(materialized='table') }}
 
 WITH int_transit_database__gtfs_datasets_dim AS (
-    SELECT key,
-           source_record_id,
-           name,
-           data,
-           data_quality_pipeline,
-           manual_check__link_to_dataset_on_website,
-           manual_check__accurate_shapes,
-           manual_check__data_license,
-           manual_check__authentication_acceptable,
-           manual_check__stable_url,
-           manual_check__localized_stop_tts,
-           manual_check__grading_scheme_v1,
-           regional_feed_type,
-           fares_v2_status,
-           fares_notes,
-           pathways_status,
-           schedule_comments,
-           uri,
-           future_uri,
-           pipeline_url,
-           aggregated_to_gtfs_dataset_key,
-           provider_gtfs_capacity,
-           notes,
-           provider,
-           operator,
-           gtfs_service_mapping,
-           dataset_producers,
-           schedule_to_use_for_rt_validation_gtfs_dataset_key,
-           dataset_publisher,
-           deprecated_date,
-           authorization_url_parameter_name,
-           url_secret_key_name,
-           authorization_header_parameter_name,
-           header_secret_key_name,
-           url_to_encode,
-           base64_url,
-           type,
-           private_dataset,
-           analysis_name,
-           _is_current,
-           _valid_from,
-           _valid_to
-      FROM {{ ref('int_gtfs_datasets') }}
+    SELECT * FROM {{ ref('stg_gtfs_schedule__download_configs') }}
 )
 
 SELECT * FROM int_transit_database__gtfs_datasets_dim

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -1,6 +1,21 @@
 version: 2
 
 models:
+  - name: stg_gtfs_schedule__download_configs
+    description: GTFS datasets data
+    tests:
+      - dbt_utils.mutually_exclusive_ranges:
+          lower_bound_column: _valid_from
+          upper_bound_column: _valid_to
+          partition_by: source_record_id
+          gaps: required
+    columns:
+      - name: key
+        description: |
+          Synthetic primary key constructed from incoming record ID and `_valid_from`.
+        tests:
+          - unique
+          - not_null
   - name: stg_gtfs_schedule__download_outcomes
     description: Outcomes from download attempts of GTFS schedule data.
     tests:

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__download_configs.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__download_configs.sql
@@ -1,0 +1,59 @@
+WITH dim AS (
+    {{ transit_database_make_historical_dimension(
+        once_daily_staging_table = 'stg_transit_database__gtfs_datasets',
+        date_col = 'dt',
+        record_id_col = 'id',
+        array_cols = ['fares_v2_status', 'provider', 'operator',
+        'gtfs_service_mapping', 'dataset_producers', 'dataset_publisher'],
+        ignore_cols = ['ts']
+        ) }}
+),
+
+stg_gtfs_schedule__download_configs AS (
+    SELECT
+        {{ dbt_utils.generate_surrogate_key(['id', '_valid_from']) }} AS key,
+        id AS source_record_id,
+        name,
+        data,
+        data_quality_pipeline,
+        manual_check__link_to_dataset_on_website,
+        manual_check__accurate_shapes,
+        manual_check__data_license,
+        manual_check__authentication_acceptable,
+        manual_check__stable_url,
+        manual_check__localized_stop_tts,
+        manual_check__grading_scheme_v1,
+        regional_feed_type,
+        fares_v2_status,
+        fares_notes,
+        pathways_status,
+        schedule_comments,
+        uri,
+        future_uri,
+        pipeline_url,
+        aggregated_to_gtfs_dataset_key,
+        provider_gtfs_capacity,
+        notes,
+        provider,
+        operator,
+        gtfs_service_mapping,
+        dataset_producers,
+        schedule_to_use_for_rt_validation_gtfs_dataset_key,
+        dataset_publisher,
+        deprecated_date,
+        authorization_url_parameter_name,
+        url_secret_key_name,
+        authorization_header_parameter_name,
+        header_secret_key_name,
+        url_to_encode,
+        base64_url,
+        type,
+        private_dataset,
+        analysis_name,
+        _is_current,
+        _valid_from,
+        _valid_to
+    FROM dim
+)
+
+SELECT * FROM stg_gtfs_schedule__download_configs


### PR DESCRIPTION
# Description

This PR creates a new view `stg_gtfs_schedule__download_configs` to be used on the GTFS Download DAG.
To keep the same source of truth, the code from the materialized view `int_transit_database__gtfs_datasets_dim` was moved to this new GTFS download config view `stg_gtfs_schedule__download_configs`.

[#4653]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally with poetry:

```
❯ poetry run dbt run -s stg_gtfs_schedule__download_configs int_transit_database__gtfs_datasets_dim --target staging
22:46:18  Running with dbt=1.10.1
22:46:20  Registered adapter: bigquery=1.10.0
22:46:26  Found 599 models, 1229 data tests, 14 seeds, 219 sources, 4 exposures, 1075 macros
22:46:26
22:46:26  Concurrency: 8 threads (target='staging')
22:46:26
22:46:29  1 of 2 START sql view model staging.stg_gtfs_schedule__download_configs ........ [RUN]
22:46:31  1 of 2 OK created sql view model staging.stg_gtfs_schedule__download_configs ... [CREATE VIEW (0 processed) in 2.29s]
22:46:31  2 of 2 START sql table model staging.int_transit_database__gtfs_datasets_dim ... [RUN]
22:46:37  2 of 2 OK created sql table model staging.int_transit_database__gtfs_datasets_dim  [CREATE TABLE (5.5k rows, 8.5 GiB processed) in 5.15s]
22:46:37
22:46:37  Finished running 1 table model, 1 view model in 0 hours 0 minutes and 10.93 seconds (10.93s).
22:46:37
22:46:37  Completed successfully
22:46:37
22:46:37  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=2
```

```
❯ poetry run dbt test -s stg_gtfs_schedule__download_configs int_transit_database__gtfs_datasets_dim --target staging
22:46:47  Running with dbt=1.10.1
22:46:48  Registered adapter: bigquery=1.10.0
22:46:49  Found 599 models, 1229 data tests, 14 seeds, 219 sources, 4 exposures, 1075 macros
22:46:49
22:46:49  Concurrency: 8 threads (target='staging')
22:46:49
22:46:51  1 of 6 START test dbt_utils_mutually_exclusive_ranges_int_transit_database__gtfs_datasets_dim_required___valid_from__source_record_id___valid_to  [RUN]
22:46:51  2 of 6 START test dbt_utils_mutually_exclusive_ranges_stg_gtfs_schedule__download_configs_required___valid_from__source_record_id___valid_to  [RUN]
22:46:51  3 of 6 START test not_null_int_transit_database__gtfs_datasets_dim_key ......... [RUN]
22:46:51  4 of 6 START test not_null_stg_gtfs_schedule__download_configs_key ............. [RUN]
22:46:51  5 of 6 START test unique_int_transit_database__gtfs_datasets_dim_key ........... [RUN]
22:46:51  6 of 6 START test unique_stg_gtfs_schedule__download_configs_key ............... [RUN]
22:46:53  5 of 6 PASS unique_int_transit_database__gtfs_datasets_dim_key ................. [PASS in 1.24s]
22:46:53  3 of 6 PASS not_null_int_transit_database__gtfs_datasets_dim_key ............... [PASS in 1.25s]
22:46:53  1 of 6 PASS dbt_utils_mutually_exclusive_ranges_int_transit_database__gtfs_datasets_dim_required___valid_from__source_record_id___valid_to  [PASS in 1.26s]
22:46:54  4 of 6 PASS not_null_stg_gtfs_schedule__download_configs_key ................... [PASS in 2.90s]
22:46:55  6 of 6 PASS unique_stg_gtfs_schedule__download_configs_key ..................... [PASS in 3.31s]
22:46:55  2 of 6 PASS dbt_utils_mutually_exclusive_ranges_stg_gtfs_schedule__download_configs_required___valid_from__source_record_id___valid_to  [PASS in 3.59s]
22:46:55
22:46:55  Finished running 6 data tests in 0 hours 0 minutes and 5.56 seconds (5.56s).
22:46:55
22:46:55  Completed successfully
22:46:55
22:46:55  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=6
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor the correct creation of the view and updated materialized view.