### PR TITLE
Run build Metabase only on data or configuration changes

### DIFF
--- a/.github/workflows/build-metabase.yml
+++ b/.github/workflows/build-metabase.yml
@@ -1,6 +1,13 @@
 name: Metabase Docker image
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-metabase.yml'
+      - 'services/metabase/**'
+      - 'iac/cal-itp-data-infra-staging/metabase/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-metabase


### PR DESCRIPTION
# Description

This PR include rules to run `Metabase Docker image` workflow only when there are changes on Terraform configuration and docker files. 

[#3694]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on this PR.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
