### PR TITLE
Create enghouse buckets following the correct name convention

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -150,6 +150,19 @@ resource "google_storage_bucket" "calitp-staging-pytest" {
   uniform_bucket_level_access = "true"
 }
 
+resource "google_storage_bucket" "calitp-staging-enghouse-raw" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-staging-enghouse-raw"
+  project                     = "cal-itp-data-infra-staging"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
+# TODO: Delete once is totally replaced by calitp-staging-enghouse-raw
 resource "google_storage_bucket" "cal-itp-data-infra-enghouse-raw" {
   default_event_based_hold    = "false"
   force_destroy               = "true"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -2123,6 +2123,19 @@ resource "google_storage_bucket" "calitp-analysis" {
   }
 }
 
+resource "google_storage_bucket" "calitp-enghouse-raw" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-enghouse-raw"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
+# TODO: Delete once is totally replaced by calitp-enghouse-raw
 resource "google_storage_bucket" "cal-itp-data-infra-enghouse-raw" {
   default_event_based_hold    = "false"
   force_destroy               = "true"


### PR DESCRIPTION
# Description

This PR creates enghouse buckets following the correct name convention on Staging (`calitp-staging-enghouse-raw`) and on Production (`calitp-enghouse-raw`).

After the creation we can move the data to `cal-itp-data-infra-enghouse-raw` and `cal-itp-data-infra-staging-enghouse-raw` new buckets and replace all references to these new ones.

This issue was found during review of https://github.com/cal-itp/data-infra/issues/4051.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running Terraform.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After the creation move all the data to `cal-itp-data-infra-enghouse-raw` and `cal-itp-data-infra-staging-enghouse-raw` new buckets and replace all references to these new ones.
