### PR TITLE
Payments (enghouse): create external table fields as strings to cast downstream in warehouse

### DIFF
--- a/airflow/dags/create_external_tables/payments/enghouse/enghouse__pay_windows.yml
+++ b/airflow/dags/create_external_tables/payments/enghouse/enghouse__pay_windows.yml
@@ -16,20 +16,20 @@ schema_fields:
   - name: Token
     type: STRING
   - name: Amount_Settled
-    type: NUMERIC
+    type: STRING
   - name: Amount_To_Settle
-    type: NUMERIC
+    type: STRING
   - name: Debt_Settled
-    type: NUMERIC
+    type: STRING
   - name: Stage
     type: STRING
   - name: Payment_reference
     type: STRING
   - name: Terminal_Id
-    type: INTEGER
+    type: STRING
   - name: Open_Date
-    type: TIMESTAMP
+    type: STRING
   - name: Close_Date
-    type: TIMESTAMP
+    type: STRING
   - name: Operator_Id
-    type: INTEGER
+    type: STRING

--- a/airflow/dags/create_external_tables/payments/enghouse/enghouse__taps.yml
+++ b/airflow/dags/create_external_tables/payments/enghouse/enghouse__taps.yml
@@ -18,33 +18,33 @@ schema_fields:
   - name: Mapping_Merchant_ID
     type: STRING
   - name: terminal
-    type: INTEGER
+    type: STRING
   - name: Token
     type: STRING
   - name: Masked_Pan
     type: STRING
   - name: Expiry
-    type: INTEGER
+    type: STRING
   - name: Server_date
-    type: TIMESTAMP
+    type: STRING
   - name: Terminal_date
-    type: TIMESTAMP
+    type: STRING
   - name: Tx_number
-    type: INTEGER
+    type: STRING
   - name: Tx_status
-    type: INTEGER
+    type: STRING
   - name: Payment_Reference
     type: STRING
   - name: Operator_Id
-    type: INTEGER
+    type: STRING
   - name: Terminal_SPDH_code
-    type: INTEGER
+    type: STRING
   - name: Denylist_version
     type: STRING
   - name: Transit_data
     type: STRING
   - name: Currency
-    type: INTEGER
+    type: STRING
   - name: Par
     type: STRING
   - name: Fare_Mode
@@ -52,7 +52,7 @@ schema_fields:
   - name: Fare_Type
     type: STRING
   - name: Fare_Value
-    type: INTEGER
+    type: STRING
   - name: Fare_Description
     type: STRING
   - name: Fare_Linked_Id
@@ -60,15 +60,15 @@ schema_fields:
   - name: ID
     type: STRING
   - name: Gps_Latitude
-    type: FLOAT64
+    type: STRING
   - name: Gps_Altitude
-    type: FLOAT64
+    type: STRING
   - name: Vehicle_Public_Number
-    type: INTEGER
+    type: STRING
   - name: Vehicle_Name
     type: STRING
   - name: Stop_Id
-    type: INTEGER
+    type: STRING
   - name: Stop_Name
     type: STRING
   - name: Platform_Id
@@ -76,11 +76,11 @@ schema_fields:
   - name: Platform_Name
     type: STRING
   - name: Zone_Id
-    type: INTEGER
+    type: STRING
   - name: Zone_Name
     type: STRING
   - name: Line_Public_Number
-    type: INTEGER
+    type: STRING
   - name: Line_Name
     type: STRING
   - name: Line_Direction

--- a/airflow/dags/create_external_tables/payments/enghouse/enghouse__ticket_results.yml
+++ b/airflow/dags/create_external_tables/payments/enghouse/enghouse__ticket_results.yml
@@ -18,11 +18,11 @@ schema_fields:
   - name: Station_Name
     type: STRING
   - name: Amount
-    type: NUMERIC
+    type: STRING
   - name: Clearing_Id
     type: STRING
   - name: Operator_Id
-    type: INTEGER
+    type: STRING
   - name: Reason
     type: STRING
   - name: Tap_Id
@@ -30,7 +30,7 @@ schema_fields:
   - name: Ticket_Type
     type: STRING
   - name: Created_Dttm
-    type: TIMESTAMP
+    type: STRING
   - name: Line
     type: STRING
   - name: Start_Station
@@ -38,9 +38,9 @@ schema_fields:
   - name: End_Station
     type: STRING
   - name: Start_Dttm
-    type: TIMESTAMP
+    type: STRING
   - name: End_Dttm
-    type: TIMESTAMP
+    type: STRING
   - name: Ticket_Code
     type: STRING
   - name: Additional_Infos

--- a/airflow/dags/create_external_tables/payments/enghouse/enghouse__transactions.yml
+++ b/airflow/dags/create_external_tables/payments/enghouse/enghouse__transactions.yml
@@ -16,19 +16,19 @@ schema_fields:
   - name: Operation
     type: STRING
   - name: Terminal_ID
-    type: INTEGER
+    type: STRING
   - name: Mapping_Terminal_ID
     type: STRING
   - name: Mapping_Merchant_ID
     type: STRING
-  - name: Timestamp
-    type: TIMESTAMP
+  - name: timestamp
+    type: STRING
   - name: Amount
-    type: NUMERIC
+    type: STRING
   - name: Payment_Reference
     type: STRING
   - name: Spdh_Response
-    type: INTEGER
+    type: STRING
   - name: Response_Type
     type: STRING
   - name: Response_Message
@@ -38,9 +38,9 @@ schema_fields:
   - name: Issuer_Response
     type: STRING
   - name: Core_Response
-    type: INTEGER
+    type: STRING
   - name: Rrn
-    type: INTEGER
+    type: STRING
   - name: Authorization_Code
     type: STRING
   - name: Par
@@ -48,4 +48,4 @@ schema_fields:
   - name: Brand
     type: STRING
   - name: OperatorId
-    type: INTEGER
+    type: STRING


### PR DESCRIPTION
# Description
This PR configures the external data types as strings during the enghouse external table creation so as to work around some corrupted files enghouse is delivering. Typecasting from strings is then (already) taking place downstream in the staging tables, and deduping/corrupt line handling will be merged in #4658 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
<img width="961" height="94" alt="Screenshot 2026-01-09 at 13 58 26" src="https://github.com/user-attachments/assets/81ca12d0-4584-4e71-84f4-c103f5cdb6a3" />

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Make sure create external tables dag runs successfully
