### PR TITLE
Fixing Staging error 'None has no element 0' when the table is empty

### DIFF
--- a/warehouse/macros/incremental_max_date.sql
+++ b/warehouse/macros/incremental_max_date.sql
@@ -1,14 +1,24 @@
 {% macro incremental_max_date(default_start_var, this_dt_column = 'dt', filter_dt_column = 'dt', dev_lookback_days = 7) -%}
-{# BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
-{# save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
+{#- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
+{#- save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
 
 {%- if is_incremental() -%}
     {%- if var('INCREMENTAL_MAX_DT') -%}
         {% set max_dt = var('INCREMENTAL_MAX_DT') %}
     {%- else -%}
         {% set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
-        {% set max_dt = dates[0] %}
+        {%- if dates -%}
+            {% set max_dt = dates[0] %}
+        {%- else -%}
+            {# the table is empty #}
+            {%- if target.name.startswith('prod') or not dev_lookback_days %}
+                {% set max_dt = var(default_start_var) %}
+            {%- else %}
+                {% set max_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
+            {%- endif -%}
+        {%- endif -%}
     {%- endif -%}
+
     {%- if target.name.startswith('prod') or not dev_lookback_days -%}
         {% set start_dt = max_dt %}
     {%- else -%}
@@ -25,4 +35,4 @@
     {%- endif -%}
 {%- endif -%}
 {{ start_dt }}
-{% endmacro %}
+{%- endmacro %}

--- a/warehouse/macros/incremental_where.sql
+++ b/warehouse/macros/incremental_where.sql
@@ -1,20 +1,30 @@
 {% macro incremental_where(default_start_var, this_dt_column = 'dt', filter_dt_column = 'dt', dev_lookback_days = 7) -%}
-{# BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
-{# save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
+{#- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
+{#- save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
 
 {%- if is_incremental() -%}
-    {% if var('INCREMENTAL_MAX_DT') %}
+    {%- if var('INCREMENTAL_MAX_DT') -%}
         {% set max_dt = var('INCREMENTAL_MAX_DT') %}
-    {% else %}
+    {%- else -%}
         {% set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
-        {% set max_dt = dates[0] %}
-    {% endif %}
+        {%- if dates -%}
+            {% set max_dt = dates[0] %}
+        {%- else -%}
+            {# the table is empty #}
+            {%- if target.name.startswith('prod') or not dev_lookback_days %}
+                {% set max_dt = var(default_start_var) %}
+            {%- else %}
+                {% set max_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endif -%}
+
     {%- if target.name.startswith('prod') or not dev_lookback_days -%}
         {% set start_dt = max_dt %}
     {%- else -%}
         {% set start_dt = [max_dt, (modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days))] | max %}
     {%- endif -%}
-{% endif %}
+{%- endif -%}
 
 {%- if not start_dt -%}
     {# full refresh, or the table was empty #}
@@ -25,4 +35,4 @@
     {%- endif -%}
 {%- endif -%}
 {{ filter_dt_column }} >= '{{ start_dt }}'
-{% endmacro %}
+{%- endmacro %}


### PR DESCRIPTION
# Description

This PR fixes error `None has no element 0` when running or compiling an empty Incremental table that uses `incremental_where` macro.
The logic `set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1)` when the table is empty returns `None`, then the next line was `set max_dt = dates[0]` that tries to get the first number out of this None value retuning the error `None has no element 0`.

I fixed by testing if there are values on `dates`. When there are no values I follow the same logic on `if not start_dt` to set the max date.

There were some annoying empty lines returning from the `incremental_where` and `incremental_max_date` macros that we would need to use `trim` to display nicely:

For this example code:
```
WHERE {{ incremental_where(default_start_var='PROD_GTFS_RT_START') }}
```
It was previously compiling as:
```
    WHERE
dt >= '2026-01-05'

```

Removing the empty lines using the minus sign (-) inside the macro fixes and it will now return:
```
WHERE dt >= '2026-01-05'
```

The `incremental_max_date` macro is a copy of `incremental_where` but returning only a date (for example: '2026-01-05'). I will merge them on another PR for ticket https://github.com/cal-itp/data-infra/issues/4271.

Resolves #4133

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested using Poetry compile and Poetry run locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor any building error on tables running on `dbt_all` or `dbt_daily` DAGs.