### PR TITLE
Merge `incremental_where` and `incremental_max_dt` macros code

### DIFF
--- a/warehouse/macros/incremental_where.sql
+++ b/warehouse/macros/incremental_where.sql
@@ -1,38 +1,6 @@
 {% macro incremental_where(default_start_var, this_dt_column = 'dt', filter_dt_column = 'dt', dev_lookback_days = 7) -%}
 {#- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
 {#- save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
-
-{%- if is_incremental() -%}
-    {%- if var('INCREMENTAL_MAX_DT') -%}
-        {% set max_dt = var('INCREMENTAL_MAX_DT') %}
-    {%- else -%}
-        {% set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
-        {%- if dates -%}
-            {% set max_dt = dates[0] %}
-        {%- else -%}
-            {# the table is empty #}
-            {%- if target.name.startswith('prod') or not dev_lookback_days %}
-                {% set max_dt = var(default_start_var) %}
-            {%- else %}
-                {% set max_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
-            {%- endif -%}
-        {%- endif -%}
-    {%- endif -%}
-
-    {%- if target.name.startswith('prod') or not dev_lookback_days -%}
-        {% set start_dt = max_dt %}
-    {%- else -%}
-        {% set start_dt = [max_dt, (modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days))] | max %}
-    {%- endif -%}
-{%- endif -%}
-
-{%- if not start_dt -%}
-    {# full refresh, or the table was empty #}
-    {%- if target.name.startswith('prod') or not dev_lookback_days -%}
-        {% set start_dt = var(default_start_var) %}
-    {%- else -%}
-        {% set start_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
-    {%- endif -%}
-{%- endif -%}
-{{ filter_dt_column }} >= '{{ start_dt }}'
-{%- endmacro %}
+{#- code moved to incremental_max_date in order to have only one source of truth #}
+{{ filter_dt_column }} >= '{{ incremental_max_date(default_start_var=default_start_var, this_dt_column=this_dt_column, filter_dt_column=filter_dt_column, dev_lookback_days=dev_lookback_days) }}'
+{% endmacro %}


### PR DESCRIPTION
# Description

This PR moves the code from `incremental_where` to `incremental_max_dt` in order to have only one source of truth since both have the same code and need to return the same date (but in different format).

The code was kept on  `incremental_max_dt` since it only returns a date (for example `'2026-01-05'`) and `incremental_where` concatenates the date with the column name (for example `dt >= '2026-01-05'`).

Resolves #4271

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running poetry compile locally and comparing results.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor any building error on tables running on `dbt_all` or `dbt_daily` DAGs.