### PR TITLE
Payments(vctc): create elavon row access policy

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -188,6 +188,12 @@ filter using (
 ) }};
 
 {{ create_row_access_policy(
+    filter_column = 'organization_name',
+    filter_value = 'Ventura County Transportation Commission',
+    principals = ['serviceAccount:vctc-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
     principals = [
         'serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
         'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',


### PR DESCRIPTION
# Description
This PR creates the Elavon row access policy for the VCTC data feed in the payments pipeline

Resolves #4697 

## Type of change
- [x] New feature

## How has this been tested?
n/a

## Post-merge follow-ups
Generate key for metabase connection