### PR TITLE
Fix partition adding Timestamp to Fare Media outcomes configuration

### DIFF
--- a/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
+++ b/airflow/dags/create_external_tables/gtfs_schedule_v2/gtfs_schedule_json_outcomes/gtfs_schedule_fare_media_txt_json_outcomes.yml
@@ -8,7 +8,7 @@ use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "fare_media.txt_parsing_results/{dt:DATE}/"
+  source_uri_prefix: "fare_media.txt_parsing_results/{dt:DATE}/{ts:TIMESTAMP}/"
 schema_fields:
   - name: success
     type: BOOLEAN


### PR DESCRIPTION
# Description

This PR fixes the configuration for Fare Media outcomes that was missing the `Timestamp` partition  #4708.
Once `create_external_table` DAG runs and re-configure this external table, we can join the table results on  [stg_gtfs_schedule__file_parse_outcomes](https://github.com/cal-itp/data-infra/blob/09080a91dd09a322e8f86d2afc507afef30e51a7/warehouse/models/staging/gtfs/stg_gtfs_schedule__file_parse_outcomes.sql) and [dim_gtfs_schedule_file_parse_outcomes](https://github.com/cal-itp/data-infra/blob/09080a91dd09a322e8f86d2afc507afef30e51a7/warehouse/models/mart/gtfs_audit/dim_gtfs_schedule_file_parse_outcomes.sql) in a second PR to then close the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on Staging:
<img width="1990" height="833" alt="image" src="https://github.com/user-attachments/assets/4e92da1b-6e13-46dd-8e3a-e55029756ff3" />


## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Recreate the table through `create_external_table` DAG  and join result tables on a new PR.