### PR TITLE
Include Fare Media in join tables

### DIFF
--- a/warehouse/models/mart/gtfs_audit/dim_gtfs_schedule_file_parse_outcomes.sql
+++ b/warehouse/models/mart/gtfs_audit/dim_gtfs_schedule_file_parse_outcomes.sql
@@ -9,6 +9,7 @@ WITH unioned_outcomes AS (
         "calendar_dates_txt_parse_outcomes",
         "fare_attributes_txt_parse_outcomes",
         "fare_leg_rules_txt_parse_outcomes",
+        "fare_media_txt_parse_outcomes",
         "fare_products_txt_parse_outcomes",
         "fare_rules_txt_parse_outcomes",
         "fare_transfer_rules_txt_parse_outcomes",

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__file_parse_outcomes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__file_parse_outcomes.sql
@@ -7,6 +7,7 @@ WITH unioned_outcomes AS (
         "calendar_dates_txt_parse_outcomes",
         "fare_attributes_txt_parse_outcomes",
         "fare_leg_rules_txt_parse_outcomes",
+        "fare_media_txt_parse_outcomes",
         "fare_products_txt_parse_outcomes",
         "fare_rules_txt_parse_outcomes",
         "fare_transfer_rules_txt_parse_outcomes",


### PR DESCRIPTION
# Description

This PR includes Fare Media parse results to `stg_gtfs_schedule__file_parse_outcomes` and `dim_gtfs_schedule_file_parse_outcomes` that joins all txt parse results.
The fix for the Fare Media parse results external table was done on PR https://github.com/cal-itp/data-infra/pull/4709 that needs to be merged first.

Resolves #4708 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running tables locally:
```
❯ poetry run dbt run -s stg_gtfs_schedule__file_parse_outcomes dim_gtfs_schedule_file_parse_outcomes --target staging
01:09:48  Running with dbt=1.10.1
01:09:49  Registered adapter: bigquery=1.10.0
01:09:55  Found 619 models, 1230 data tests, 15 seeds, 223 sources, 4 exposures, 1080 macros
01:09:55
01:09:55  Concurrency: 8 threads (target='staging')
01:09:55
01:09:59  1 of 2 START sql table model mart_gtfs_audit.dim_gtfs_schedule_file_parse_outcomes  [RUN]
01:09:59  2 of 2 START sql view model staging.stg_gtfs_schedule__file_parse_outcomes ..... [RUN]
01:10:00  2 of 2 OK created sql view model staging.stg_gtfs_schedule__file_parse_outcomes  [CREATE VIEW (0 processed) in 1.67s]
01:10:23  1 of 2 OK created sql table model mart_gtfs_audit.dim_gtfs_schedule_file_parse_outcomes  [CREATE TABLE (142.9k rows, 136.4 MiB processed) in 24.62s]
01:10:23
01:10:23  Finished running 1 table model, 1 view model in 0 hours 0 minutes and 28.64 seconds (28.64s).
01:10:24
01:10:24  Completed successfully
01:10:24
01:10:24  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=2
```

and tests:
```
 ❯ poetry run dbt test -s stg_gtfs_schedule__file_parse_outcomes dim_gtfs_schedule_file_parse_outcomes --target staging
02:07:43  Running with dbt=1.10.1
02:07:45  Registered adapter: bigquery=1.10.0
02:07:46  Found 619 models, 1230 data tests, 15 seeds, 223 sources, 4 exposures, 1080 macros
02:07:46
02:07:46  Concurrency: 8 threads (target='staging')
02:07:46
02:07:48  1 of 2 START test dbt_utils_equal_rowcount_int_gtfs_schedule__keyed_parse_outcomes_ref_stg_gtfs_schedule__file_parse_outcomes_  [RUN]
02:07:48  2 of 2 START test dbt_utils_unique_combination_of_columns_stg_gtfs_schedule__file_parse_outcomes_base64_url__ts__filename  [RUN]
02:07:55  2 of 2 PASS dbt_utils_unique_combination_of_columns_stg_gtfs_schedule__file_parse_outcomes_base64_url__ts__filename  [PASS in 6.30s]
02:08:00  1 of 2 PASS dbt_utils_equal_rowcount_int_gtfs_schedule__keyed_parse_outcomes_ref_stg_gtfs_schedule__file_parse_outcomes_  [PASS in 12.10s]
02:08:00
02:08:00  Finished running 2 data tests in 0 hours 0 minutes and 14.34 seconds (14.34s).
02:08:01
02:08:01  Completed successfully
02:08:01
02:08:01  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=2
```

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor the next `dbt_all` to see it running successfully.