### PR TITLE
Set Terraform to auto approve when merging to Main

### DIFF
--- a/.github/workflows/composer-apply-files.yml
+++ b/.github/workflows/composer-apply-files.yml
@@ -99,7 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: iac/cal-itp-data-infra-staging/airflow/us
-          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}
+          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') || github.ref == 'refs/heads/main' }}
 
   composer-staging:
     name: Staging Composer
@@ -128,7 +128,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: iac/cal-itp-data-infra-staging/composer/us
-          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}
+          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') || github.ref == 'refs/heads/main' }}
 
   airflow-production:
     name: Production Airflow
@@ -157,6 +157,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: iac/cal-itp-data-infra/airflow/us
+          auto_approve: ${{ github.ref == 'refs/heads/main' }}
 
   composer-production:
     name: Production Composer
@@ -185,3 +186,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: iac/cal-itp-data-infra/composer/us
+          auto_approve: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: ${{ matrix.path }}
-          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}
+          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') || github.ref == 'refs/heads/main' }}
 
   production:
     name: Production
@@ -120,3 +120,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: ${{ matrix.path }}
+          auto_approve: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
# Description

Sometimes `Terraform Apply` process fail when changes applied from a different PR affects the `Terraform Plan`.
<img width="1582" height="813" alt="image" src="https://github.com/user-attachments/assets/b9b043dd-4f35-440f-a1a0-533de953e3e9" />

When it happens we need to wait for a new PR to be merged in order to apply the changes.
To avoid pending changes I included the `auto-approve` rule when merging to the Main branch.

The `auto-approve` rule was already used to apply Staging changes when branch starts with `staging/` and still valid.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running Terraform workflows through this PR.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
