### PR TITLE
fix(jupyterhub): correct new image path

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -43,14 +43,14 @@ jupyterhub:
       - display_name: "Prototype Image - 2026.1.28, Python 3.11"
         description: "Changes introduced with this image include package management is switched from Poetry to uv and dask[dataframe] is installed. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.1.28
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2026.1.28
       - display_name: "Power Prototype Image - 2026.1.28, Python 3.11"
         description: "Changes introduced with this image include package management is switched from Poetry to uv and dask[dataframe] is installed. Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.1.28
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2026.1.28
       - display_name: "Legacy Image - 2025.12.12, Python 3.11"
         description: "This is the previous default image version. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:


### PR DESCRIPTION
# Description

Fixes typo in #4740 that caused JupyterHub Helm deployment to fail due to `hook-image-puller` not being able to pull all the images

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
