### PR TITLE
Replace enghouse bucket on production with the correct bucket name

### DIFF
--- a/airflow/dags/parse_enghouse/README.md
+++ b/airflow/dags/parse_enghouse/README.md
@@ -2,7 +2,7 @@
 
 Type: [Now / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
 
-This DAG converts Enghouse semicolon-delimited CSV files from the raw GCS bucket (`cal-itp-data-infra-enghouse-raw`) into gzipped JSONL files written to the parsed bucket (`calitp-enghouse-parsed`), using `agency={agency}/dt={date}/` Hive partition paths. Downstream BigQuery external tables and dbt models read from the parsed bucket.
+This DAG converts Enghouse semicolon-delimited CSV files from the raw GCS bucket (`calitp-enghouse-raw`) into gzipped JSONL files written to the parsed bucket (`calitp-enghouse-parsed`), using `agency={agency}/dt={date}/` Hive partition paths. Downstream BigQuery external tables and dbt models read from the parsed bucket.
 
 Each run scans all files in the raw bucket and skips any already present in the parsed bucket, making it safe to re-run. Late or re-delivered files are automatically picked up on the next scheduled run. This scan-all approach was chosen because Enghouse delivery timing is not guaranteed to be consistent relative to the DAG schedule.
 

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -186,19 +186,6 @@ resource "google_storage_bucket" "calitp-staging-enghouse-parsed" {
   uniform_bucket_level_access = "true"
 }
 
-# TODO: Delete once is totally replaced by calitp-staging-enghouse-raw
-resource "google_storage_bucket" "cal-itp-data-infra-enghouse-raw" {
-  default_event_based_hold    = "false"
-  force_destroy               = "true"
-  location                    = "US-WEST2"
-  name                        = "cal-itp-data-infra-staging-enghouse-raw"
-  project                     = "cal-itp-data-infra-staging"
-  public_access_prevention    = "inherited"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "true"
-}
-
 resource "google_storage_bucket" "calitp-staging" {
   for_each                    = local.environment_buckets
   name                        = each.key

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -95,7 +95,7 @@ resource "google_composer_environment" "calitp-composer" {
         "CALITP_BUCKET__LITTLEPAY_PARSED_V3"                   = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-payments-littlepay-parsed-v3_name}",
         "CALITP_BUCKET__LITTLEPAY_RAW"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-payments-littlepay-raw_name}",
         "CALITP_BUCKET__LITTLEPAY_RAW_V3"                      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-payments-littlepay-raw-v3_name}",
-        "CALITP_BUCKET__ENGHOUSE_RAW"                          = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_cal-itp-data-infra-enghouse-raw_name}",
+        "CALITP_BUCKET__ENGHOUSE_RAW"                          = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-enghouse-raw_name}",
         "CALITP_BUCKET__ENGHOUSE_PARSED"                       = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-enghouse-parsed_name}",
         "CALITP_BUCKET__NTD_API_DATA_PRODUCTS"                 = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-ntd-api-products_name}",
         "CALITP_BUCKET__NTD_REPORT_VALIDATION"                 = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-ntd-report-validation_name}",

--- a/iac/cal-itp-data-infra/enghouse-sftp/us/kubernetes.tf
+++ b/iac/cal-itp-data-infra/enghouse-sftp/us/kubernetes.tf
@@ -198,7 +198,7 @@ resource "kubernetes_deployment_v1" "enghouse-sftp" {
             driver    = "gcsfuse.csi.storage.gke.io"
 
             volume_attributes = {
-              bucketName   = data.terraform_remote_state.gcs.outputs.google_storage_bucket_cal-itp-data-infra-enghouse-raw_name
+              bucketName   = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-enghouse-raw_name
               mountOptions = "uid=2222,gid=2222,file-mode=777,dir-mode=777"
             }
           }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -617,7 +617,7 @@ resource "google_storage_bucket_iam_member" "calitp-analysis" {
 }
 
 resource "google_storage_bucket_iam_member" "enghouse-raw-sftp-service-account" {
-  bucket = google_storage_bucket.cal-itp-data-infra-enghouse-raw.name
+  bucket = google_storage_bucket.calitp-enghouse-raw.name
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${data.terraform_remote_state.iam.outputs.google_service_account_enghouse-sftp-service-account_email}"
 }

--- a/runbooks/workflow/payments/how-to/onboard-enghouse-agency.md
+++ b/runbooks/workflow/payments/how-to/onboard-enghouse-agency.md
@@ -51,7 +51,7 @@ Enghouse delivers data daily via SFTP server directly to our GCS bucket. This di
 
 **Implementation Details:**
 
-- Data is delivered directly to `gs://cal-itp-data-infra-enghouse-raw/` via SFTP
+- Data is delivered directly to `gs://calitp-enghouse-raw/` via SFTP
 - No sync DAG is needed (data arrives directly in GCS)
 - A daily parse DAG (`parse_enghouse`) converts the raw semicolon-delimited CSV files to JSONL.GZ in `gs://calitp-enghouse-parsed/`
 - External tables read from `gs://calitp-enghouse-parsed/` (the parsed bucket)
@@ -66,10 +66,10 @@ Enghouse delivers data daily via SFTP server directly to our GCS bucket. This di
 ### 1.1 Verify Raw Data in GCS
 
 1. Navigate to Google Cloud Storage
-2. Select the bucket `cal-itp-data-infra-enghouse-raw`
+2. Select the bucket `calitp-enghouse-raw`
 3. Select any table directory from the list, ex: `tap/`
 4. Select the directory of the agency whose sync task you are verifying, ex: `ventura/`
-5. You should see at least one file within that directory, ex: `cal-itp-data-infra-enghouse-raw/tap/ventura/VENTURA_TAPtaps-2025-12-14.csv`
+5. You should see at least one file within that directory, ex: `calitp-enghouse-raw/tap/ventura/VENTURA_TAPtaps-2025-12-14.csv`
 
 ## Step 2: Create Service Account
 
@@ -255,12 +255,12 @@ After the next scheduled run of the transform_warehouse DAG:
 
 ```sql
 -- Check staging table
-SELECT COUNT(*) 
+SELECT COUNT(*)
 FROM `cal-itp-data-infra.staging.stg_enghouse__taps`
 WHERE operator_id = '<enghouse-operator-id>'
 
 -- Check mart table
-SELECT 
+SELECT
   COUNT(*) as total_transactions,
 FROM `cal-itp-data-infra.mart_payments.fct_payments_rides_enghouse`
 WHERE operator_id = '<enghouse-operator-id>'

--- a/runbooks/workflow/payments/tutorials/02-understanding-data-flow.md
+++ b/runbooks/workflow/payments/tutorials/02-understanding-data-flow.md
@@ -17,26 +17,26 @@ graph TB
     B --> C[Littlepay S3 Bucket]
     B2 --> C2[Enghouse Direct to GCS]
     D["Payment Processed (Received from Littlepay or Elavon)"] --> E[Elavon SFTP Server]
-    
+
     C --> F[sync_littlepay_v3 DAG]
     C2 --> H2[GCS: calitp-enghouse-raw]
     E --> G[sync_elavon DAG]
-    
+
     F --> H[GCS: calitp-payments-littlepay-raw-v3]
     G --> I[GCS: calitp-elavon-raw]
-    
+
     H --> J[parse_littlepay_v3 DAG]
     H2 --> J2[No parse needed]
     I --> K[parse_elavon DAG]
-    
+
     J --> L[GCS: calitp-payments-littlepay-parsed-v3]
     J2 --> L2[Data already in GCS]
     K --> M[GCS: calitp-elavon-parsed]
-    
+
     L --> N[create_external_tables DAG]
     L2 --> N
     M --> N
-    
+
     N --> O[BigQuery External Tables]
     O --> P[dbt Staging Models]
     P --> Q[dbt Intermediate Models]
@@ -106,7 +106,7 @@ Enghouse provides data directly to our GCS buckets via SFTP server (no intermedi
 **File Format (Enghouse GCS Raw):**
 
 ```
-gs://cal-itp-data-infra-enghouse-raw/tap/ventura/VENTURA_TAPtaps-2026-01-28.csv
+gs://calitp-enghouse-raw/tap/ventura/VENTURA_TAPtaps-2026-01-28.csv
 ```
 
 Data is delivered directly to GCS by Enghouse as CSV files. The schema differs significantly from Littlepay.
@@ -459,7 +459,7 @@ Let's trace a specific transaction through the entire pipeline! This exercise us
 In BigQuery, run:
 
 ```sql
-SELECT 
+SELECT
   littlepay_transaction_id,
   participant_id,
   transaction_date_time_pacific,


### PR DESCRIPTION
# Description

This PR replaces references to `cal-itp-data-infra-enghouse-raw` by `calitp-enghouse-raw` in Production.

Remove the staging `cal-itp-data-infra-staging-enghouse-raw` already replaced and data moved to `calitp-staging-enghouse-raw`.

This is the last PR from a sequence of #4672 and  #4673 in order to correct the bucket name.

PR #4673 need to be merged first!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

The PR changing staging worked #4673, so this one follows the same changes for Prod.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Move data from previous bucket to the new one and create new PR to delete the old buckets.