### PR TITLE
Create output references to new Enghouse buckets

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -258,6 +258,10 @@ output "google_storage_bucket_cal-itp-data-infra-enghouse-raw_name" {
   value = google_storage_bucket.cal-itp-data-infra-enghouse-raw.name
 }
 
+output "google_storage_bucket_calitp-staging-enghouse-raw_name" {
+  value = google_storage_bucket.calitp-staging-enghouse-raw.name
+}
+
 output "google_storage_bucket_calitp-reports-staging_name" {
   value = google_storage_bucket.calitp-reports-staging.name
 }

--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2897,3 +2897,7 @@ output "google_storage_bucket_cal-itp-data-infra-cf-source_name" {
 output "google_storage_bucket_cal-itp-data-infra-enghouse-raw_name" {
   value = google_storage_bucket.cal-itp-data-infra-enghouse-raw.name
 }
+
+output "google_storage_bucket_calitp-enghouse-raw_name" {
+  value = google_storage_bucket.calitp-enghouse-raw.name
+}


### PR DESCRIPTION
# Description

In order to replace Enghouse buckets (to fix names) I need to create the output first so I can point variables and SFTP server to the new buckets (created on previous PR https://github.com/cal-itp/data-infra/pull/4672).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested with `terraform plan`.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Following PRs will be replacing the buckets on Staging https://github.com/cal-itp/data-infra/pull/4673 and then on Production https://github.com/cal-itp/data-infra/pull/4759.