### PR TITLE
Make 2026.2.3 the JH Prototype image

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -40,17 +40,17 @@ jupyterhub:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-      - display_name: "Prototype Image - 2026.1.28, Python 3.11"
+      - display_name: "Prototype Image - 2026.2.3, Python 3.11"
         description: "Changes introduced with this image include package management is switched from Poetry to uv and dask[dataframe] is installed. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2026.1.28
-      - display_name: "Power Prototype Image - 2026.1.28, Python 3.11"
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2026.2.3
+      - display_name: "Power Prototype Image - 2026.2.3, Python 3.11"
         description: "Changes introduced with this image include package management is switched from Poetry to uv and dask[dataframe] is installed. Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
         kubespawner_override:
           mem_limit: "12G"
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
-          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2026.1.28
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2026.2.3
       - display_name: "Legacy Image - 2025.12.12, Python 3.11"
         description: "This is the previous default image version. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
         kubespawner_override:


### PR DESCRIPTION
# Description

Make jupyter-singleuser image 2026.2.3 the Prototype image on JupyterHub. 

Relates to https://github.com/cal-itp/data-infra/issues/4651 and https://github.com/cal-itp/data-infra/pull/4763

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Dependency changes

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `poetry run dbt run -s CHANGED_MODEL --target staging` and `poetry run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
- [x] Confirm image is available on JH
- [x] Make sure sentry-zookeeper pods are running or follow these instructions to relaunch them if needed https://github.com/cal-itp/data-infra/issues/4371#issuecomment-3825144125
