### PR TITLE
[images/jupyter-singleuser] Update calitp-data-analysis for dask compatibility

### DIFF
--- a/images/jupyter-singleuser/pyproject.toml
+++ b/images/jupyter-singleuser/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-singleuser"
-version = "2026.2.3"
+version = "2026.2.4"
 description = "This is the notebook image that individual users are served via JupyterHub."
 requires-python = ">=3.11.0, <3.12.0"
 classifiers = [

--- a/images/jupyter-singleuser/uv.lock
+++ b/images/jupyter-singleuser/uv.lock
@@ -1918,7 +1918,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-singleuser"
-version = "2026.2.3"
+version = "2026.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
# Description

Upgrading dask wasn't as simple as upgrading it in the image dependencies. We also needed to upgrade it in the calitp-data-analysis package.

Relates to https://github.com/cal-itp/data-analyses/issues/1854

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Dependency upgrade

## How has this been tested?

Ran the image locally to ensure no dependency clashing when installing dependencies from data-analyses.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
- [x] Ensure image publishes to GHCR 
