### PR TITLE
JupyterHub - Allow hidden files to show in the file browser

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -95,6 +95,7 @@ jupyterhub:
       Spawner:
         args:
           - '--NotebookApp.tornado_settings={"headers":{"Content-Security-Policy": "frame-ancestors *"}}'
+          - '--ContentsManager.allow_hidden=True'
     # holds github OAuth creds
     existingSecret: jupyterhub-github-config
   ingress:


### PR DESCRIPTION
# Description

This is my attempt to allow hidden files to appear in the JupyterLab file browser. In order to enable it, the user will also need to check this setting. 

<img width="957" height="484" alt="Screenshot 2026-02-05 at 10 26 08 AM" src="https://github.com/user-attachments/assets/2a5681b9-1959-4df3-bdab-f187e99ba27f" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Will need to test by deploying to see if this works.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
- [ ] Confirm that the image value updates deploy and it's possible to see dotfiles
