### PR TITLE
[images/jupyter-singleuser] Remove data-analyses specific packages

### DIFF
--- a/images/jupyter-singleuser/pyproject.toml
+++ b/images/jupyter-singleuser/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-singleuser"
-version = "2026.2.5"
+version = "2026.2.6"
 description = "This is the notebook image that individual users are served via JupyterHub."
 requires-python = ">=3.11.0, <3.12.0"
 classifiers = [

--- a/images/jupyter-singleuser/uv.lock
+++ b/images/jupyter-singleuser/uv.lock
@@ -1798,7 +1798,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-singleuser"
-version = "2026.2.5"
+version = "2026.2.6"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
# Description

Remove data-analyses specific package groups from the manifest and instead install them in the respective areas in data-analyses.

Relates to https://github.com/cal-itp/data-analyses/issues/1854 and https://github.com/cal-itp/data-infra/issues/4651

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Dependency cleanup

## How has this been tested?

No need to test. Dependencies were moved to where they're needed instead of being installed here.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
- [ ] Confirm image published to GHCR
