### PR TITLE
Reduce analysis staging site caching

### DIFF
--- a/iac/cal-itp-data-infra-staging/cdn/us/backend_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/cdn/us/backend_bucket.tf
@@ -49,8 +49,8 @@ resource "google_compute_backend_bucket" "calitp-analysis-staging" {
   enable_cdn  = true
   cdn_policy {
     cache_mode        = "CACHE_ALL_STATIC"
-    client_ttl        = 3600
-    default_ttl       = 3600
+    client_ttl        = 300
+    default_ttl       = 300
     max_ttl           = 86400
     negative_caching  = true
     serve_while_stale = 86400


### PR DESCRIPTION
# Description

Reduce caching for the analysis staging sites so that you get fresh content after deploys. 

Relates to https://github.com/cal-itp/data-analyses/issues/1854

Related documentation https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_bucket#nested_cdn_policy

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Configuration change

## How has this been tested?

Will need to test by deploying

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
- [ ] Deploy a site and see how this performs
