### PR TITLE
Staging/add run invoker to composer sa

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -259,7 +259,7 @@ resource "google_project_iam_member" "composer-service-account" {
     "roles/composer.serviceAgent",
     "roles/composer.worker",
     "roles/secretmanager.secretAccessor",
-    "roles/secretmanager.viewer"
+    "roles/secretmanager.viewer",
     "roles/run.invoker"
   ])
   role    = each.key

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -559,7 +559,7 @@ resource "google_project_iam_member" "composer-service-account" {
     "roles/cloudbuild.builds.viewer",
     "roles/composer.worker",
     "roles/secretmanager.secretAccessor",
-    "roles/secretmanager.viewer"
+    "roles/secretmanager.viewer",
     "roles/run.invoker"
   ])
   role    = each.key


### PR DESCRIPTION
# Description

Add `roles/run.invoker` to the Composer service account via Terraform so Airflow can invoke the existing Gen2 Cloud Function (Cloud Run–backed) used for the “Update Expired Airtable Issues” automation.

Refs #4799

## Changes
- Add `roles/run.invoker` to Composer service account IAM roles in:
  - `iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf`
  - `iac/cal-itp-data-infra/iam/us/project_iam_member.tf`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?


- Verified Terraform plan output reflects addition of `roles/run.invoker` to the Composer service account.
- Confirmed no unrelated Terraform changes are included in the plan.
- Staging apply will run automatically upon push to `staging/...` branch.
- Production apply will run upon merge to `main`.

(No dbt changes in this PR.)

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [X] No action required
- [ ] Actions required (specified below)
