### PR TITLE
Make `unzip_and_validate_gtfs_schedule_hourly` and `download_gtfs_schedule_v2` DAGs run only Manually

### DIFF
--- a/airflow/dags/README.md
+++ b/airflow/dags/README.md
@@ -5,17 +5,17 @@
 |  0:00 AM    | 4 PM<br>previous day | 5 PM<br>previous day | [publish_gtfs](#publish_gtfs)                                                                                                    | Mondays    |
 |  0:00 AM    | 4 PM<br>previous day | 5 PM<br>previous day | [sync_elavon](./sync_elavon)(<br>[sync_kuba](./sync_kuba)<br>[scrape_feed_aggregators](./scrape_feed_aggregators)<br>[copy_production_to_staging](./copy_production_to_staging) | Every day  |
 |  2:00 AM    | 6 PM<br>previous day | 7 PM<br>previous day | [airtable_loader_v2](./airtable_loader_v2)<br>[parse_elavon](./parse_elavon)                                                     | Every Day  |
-|  3:00 AM    | 7 PM<br>previous day | 8 PM<br>previous day | [download_gtfs_schedule_v2](./download_gtfs_schedule_v2)                                                                         | Every Day  |
-|  4:00 AM    | 8 PM<br>previous day | 9 PM<br>previous day | [scrape_state_geoportal](./scrape_state_geoportal)<br>[download_parse_and_validate_gtfs](#download_parse_and_validate_gtfs)      | 1st Day of the month |
+|  3:00 AM    | 7 PM<br>previous day | 8 PM<br>previous day | [download_parse_and_validate_gtfs](#download_parse_and_validate_gtfs)                                                            | Every Day  |
+|  4:00 AM    | 8 PM<br>previous day | 9 PM<br>previous day | [scrape_state_geoportal](./scrape_state_geoportal)                                                                               | 1st Day of the month |
 |  9:00 AM    | 1:00 AM              | 2:00 AM              | [sync_ntd_data_api](./sync_ntd_data_api)                                                                                         | Wednesdays |
 | 10:00 AM    | 2:00 AM              | 3:00 AM              | [ntd_report_from_blackcat](./ntd_report_from_blackcat)<br>[sync_ntd_data_xlsx](./sync_ntd_data_xlsx)                             | Mondays    |
 | 11:00 AM    | 3:00 AM              | 4:00 AM              | [create_external_tables](./create_external_tables)                                                                               | Every Day  |
-|             | Every Hour           |                      | [sync_littlepay_v3](./sync_littlepay_v3)<br>[unzip_and_validate_gtfs_schedule_hourly](./unzip_and_validate_gtfs_schedule_hourly) | Every Day  |
+|             | Every Hour           |                      | [sync_littlepay_v3](./sync_littlepay_v3)                                                                                         | Every Day  |
 |             | Every<br>Hour:30 min                       || [parse_littlepay_v3](./parse_littlepay_v3)                                                                                       | Every Day  |
 |             | Every<br>Hour:15 min                       || [parse_and_validate_rt](#parse_and_validate_rt)                                                                                  | Every Day  |
 |  2:00 PM    | 6:00 AM              | 7:00 AM              | [dbt_all](#dbt_all)                                                                                                              | Monday and Thursday |
 |  2:00 PM    | 6:00 AM              | 7:00 AM              | [dbt_daily](#dbt_daily)                                                                                                          | Sunday, Tuesday, Wednesday, Friday, and Saturday |
-|  -          | -                    | -                    | [dbt_manual](#dbt_manual)                                                                                                        | Runs Only Manually |
+|  -          | -                    | -                    | [dbt_manual](#dbt_manual)<br>[download_gtfs_schedule_v2](./download_gtfs_schedule_v2)<br>[unzip_and_validate_gtfs_schedule_hourly](./unzip_and_validate_gtfs_schedule_hourly)| Runs Only Manually |
 
 
 ## dbt_all

--- a/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
+++ b/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Download GTFS Schedule feeds as specified in Airtable"
-schedule_interval: "0 3 * * *"
+schedule_interval: null
 tags:
   - gtfs
   - airtable
@@ -10,8 +10,6 @@ default_args:
     catchup: False
     email_on_failure: True
     email_on_retry: False
-    retries: 1
-    retry_delay: !timedelta 'minutes: 2'
+    retries: 0
     concurrency: 50
-    #sla: !timedelta 'hours: 2'
 latest_only: True

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Unzips and validates GTFS Schedule data"
-schedule_interval: "0 * * * *"
+schedule_interval: null
 tags:
   - gtfs
 default_args:
@@ -10,8 +10,7 @@ default_args:
     email_on_failure: False
     email_on_retry: False
     max_active_dag_runs: 6
-    retries: 1
-    retry_delay: !timedelta 'minutes: 2'
+    retries: 0
     concurrency: 50
     pool: schedule_unzip_pool
 latest_only: False


### PR DESCRIPTION
# Description

As part of the deprecation of the previous GTFS DAGs (#4814), we are turning off schedules for `unzip_and_validate_gtfs_schedule_hourly` and `download_gtfs_schedule_v2` so it will only run when manually triggered.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on Airflow locally.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
