### PR TITLE
Remove any empty line and space from macros to fix `dim_translations`

### DIFF
--- a/warehouse/macros/incremental_max_date.sql
+++ b/warehouse/macros/incremental_max_date.sql
@@ -4,34 +4,34 @@
 
 {%- if is_incremental() -%}
     {%- if var('INCREMENTAL_MAX_DT') -%}
-        {% set max_dt = var('INCREMENTAL_MAX_DT') %}
+        {%- set max_dt = var('INCREMENTAL_MAX_DT') %}
     {%- else -%}
-        {% set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
+        {%- set dates = dbt_utils.get_column_values(table=this, column=this_dt_column, order_by = this_dt_column + ' DESC', max_records = 1) %}
         {%- if dates -%}
             {% set max_dt = dates[0] %}
         {%- else -%}
-            {# the table is empty #}
+            {#- the table is empty #}
             {%- if target.name.startswith('prod') or not dev_lookback_days %}
-                {% set max_dt = var(default_start_var) %}
+                {%- set max_dt = var(default_start_var) %}
             {%- else %}
-                {% set max_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
+                {%- set max_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
             {%- endif -%}
         {%- endif -%}
     {%- endif -%}
 
     {%- if target.name.startswith('prod') or not dev_lookback_days -%}
-        {% set start_dt = max_dt %}
+        {%- set start_dt = max_dt %}
     {%- else -%}
-        {% set start_dt = [max_dt, (modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days))] | max %}
+        {%- set start_dt = [max_dt, (modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days))] | max %}
     {%- endif -%}
 {%- endif -%}
 
 {%- if not start_dt -%}
-    {# full refresh, or the table was empty #}
+    {#- full refresh, or the table was empty #}
     {%- if target.name.startswith('prod') or not dev_lookback_days -%}
-        {% set start_dt = var(default_start_var) %}
+        {%- set start_dt = var(default_start_var) %}
     {%- else -%}
-        {% set start_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
+        {%- set start_dt = modules.datetime.date.today() - modules.datetime.timedelta(days=dev_lookback_days) %}
     {%- endif -%}
 {%- endif -%}
 {{ start_dt }}

--- a/warehouse/macros/incremental_where.sql
+++ b/warehouse/macros/incremental_where.sql
@@ -1,6 +1,6 @@
-{% macro incremental_where(default_start_var, this_dt_column = 'dt', filter_dt_column = 'dt', dev_lookback_days = 7) -%}
-{#- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost #}
-{#- save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination #}
-{#- code moved to incremental_max_date in order to have only one source of truth #}
-{{ filter_dt_column }} >= '{{ incremental_max_date(default_start_var=default_start_var, this_dt_column=this_dt_column, filter_dt_column=filter_dt_column, dev_lookback_days=dev_lookback_days) }}'
-{% endmacro %}
+{%- macro incremental_where(default_start_var, this_dt_column = 'dt', filter_dt_column = 'dt', dev_lookback_days = 7) -%}
+{#- BigQuery does not do partition elimination when using a subquery: https://stackoverflow.com/questions/54135893/using-subquery-for-partitiontime-in-bigquery-does-not-limit-cost -#}
+{#- save max timestamp in a variable instead so it can be referenced in incremental logic and still use partition elimination -#}
+{#- code moved to incremental_max_date in order to have only one source of truth -#}
+{{ filter_dt_column }} >= '{{ incremental_max_date(default_start_var=default_start_var, this_dt_column=this_dt_column, filter_dt_column=filter_dt_column, dev_lookback_days=dev_lookback_days) | trim }}'
+{%- endmacro %}


### PR DESCRIPTION
# Description

This PR removes all empty spaces from `incremental_where` and `incremental_max_date` macros in order to fix error on `dim_translations` table.

`dim_translations` is the only table so far that creates line breaks before the date:

Before the change:
```
WITH dim_schedule_feeds AS (
    SELECT *
    FROM `cal-itp-data-infra-staging`.`erikap_mart_gtfs`.`dim_schedule_feeds`
    WHERE
_dt >= '
                2021-04-16'

),

stg_gtfs_schedule__translations AS (
    SELECT *
    FROM `cal-itp-data-infra-staging`.`erikap_staging`.`stg_gtfs_schedule__translations`
    WHERE
_dt >= '
                2021-04-16'

)
```

After the change:
```
WITH dim_schedule_feeds AS (
    SELECT *
    FROM `cal-itp-data-infra-staging`.`mart_gtfs`.`dim_schedule_feeds`
    WHERE _dt >= '2021-04-16'
),

stg_gtfs_schedule__translations AS (
    SELECT *
    FROM `cal-itp-data-infra-staging`.`staging`.`stg_gtfs_schedule__translations`
    WHERE _dt >= '2021-04-16'
)
```

Related to PR https://github.com/cal-itp/data-infra/pull/4681 and https://github.com/cal-itp/data-infra/issues/4271

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally:
```
❯ poetry run dbt run -s dim_translations --target staging
23:34:25  Running with dbt=1.10.8
23:34:26  Registered adapter: bigquery=1.10.2
23:34:27  Found 624 models, 1237 data tests, 16 seeds, 223 sources, 4 exposures, 1086 macros
23:34:27
23:34:27  Concurrency: 8 threads (target='staging')
23:34:27
23:34:30  1 of 1 START sql incremental model mart_gtfs.dim_translations .................. [RUN]
23:34:35  1 of 1 OK created sql incremental model mart_gtfs.dim_translations ............. [MERGE (0.0 rows, 268.6 KiB processed) in 4.96s]
23:34:35
23:34:35  Finished running 1 incremental model in 0 hours 0 minutes and 7.85 seconds (7.85s).
23:34:36
23:34:36  Completed successfully
23:34:36
23:34:36  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

Tested on Airflow Staging running `dbt_all` DAG and all models are green again:
<img width="1891" height="1173" alt="image" src="https://github.com/user-attachments/assets/864d7f29-f4bc-448f-afbc-dce3ad2c4154" />


## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
