### PR TITLE
Set size of production Metabase CloudSQL

### DIFF
--- a/iac/cal-itp-data-infra/metabase/us/sql.tf
+++ b/iac/cal-itp-data-infra/metabase/us/sql.tf
@@ -3,7 +3,7 @@ resource "google_sql_database_instance" "metabase" {
   database_version = "POSTGRES_18"
   region           = "us-west2"
   settings {
-    tier = "db-g1-small"
+    tier = "db-f1-micro"
   }
   deletion_protection = true
 }


### PR DESCRIPTION
# Description

This PR sets the size of the Metabase CloudSQL to db-f1-micro.

Resolves #4707

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`