### PR TITLE
Set edition of production Metabase CloudSQL to enterprise

### DIFF
--- a/iac/cal-itp-data-infra/metabase/us/sql.tf
+++ b/iac/cal-itp-data-infra/metabase/us/sql.tf
@@ -3,7 +3,8 @@ resource "google_sql_database_instance" "metabase" {
   database_version = "POSTGRES_18"
   region           = "us-west2"
   settings {
-    tier = "db-f1-micro"
+    edition = "ENTERPRISE"
+    tier    = "db-g1-small"
   }
   deletion_protection = true
 }


### PR DESCRIPTION
# Description

This PR sets the edition of SQL to Enterprise.

Relates to #4707 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`