### PR TITLE
Add `fct_schedule_feed_files` to `dbt_daily` Airflow job to support monitoring 

### DIFF
--- a/airflow/dags/dbt_daily_dag.py
+++ b/airflow/dags/dbt_daily_dag.py
@@ -82,6 +82,7 @@ with DAG(
             select=[
                 "models/mart/gtfs_audit",
                 "+fct_schedule_feed_downloads",
+                "+fct_schedule_feed_files",
             ],
             test_behavior=None,
         ),


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Supports #4769 (does not resolve it but supports it)

Adds `fct_schedule_feed_files` to the `dbt_daily` Airflow job to facilitate addition of a monitoring card in #4769 looking at files downloaded but not parsed

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `poetry run dbt run -s CHANGED_MODEL --target staging` and `poetry run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

I am having issues running local Composer but I verified that the model is added to the `dbt_daily` DAG task and that no other models are (there's nothing new in the dependency tree besides the one model, but I added `+` just in case.) 

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
