### PR TITLE
Enable backups for Metabase CloudSQL instance

### DIFF
--- a/iac/cal-itp-data-infra/metabase/us/service.tf
+++ b/iac/cal-itp-data-infra/metabase/us/service.tf
@@ -12,6 +12,7 @@ resource "google_cloud_run_v2_service" "metabase" {
 
   scaling {
     min_instance_count = 1
+    max_instance_count = 100
   }
 
   template {

--- a/iac/cal-itp-data-infra/metabase/us/sql.tf
+++ b/iac/cal-itp-data-infra/metabase/us/sql.tf
@@ -1,12 +1,23 @@
 resource "google_sql_database_instance" "metabase" {
-  name             = "metabase"
-  database_version = "POSTGRES_18"
-  region           = "us-west2"
+  name                = "metabase"
+  database_version    = "POSTGRES_18"
+  region              = "us-west2"
+  deletion_protection = true
+
   settings {
     edition = "ENTERPRISE"
     tier    = "db-g1-small"
+
+    backup_configuration {
+      location = "us-west2"
+      enabled  = true
+
+      backup_retention_settings {
+        retained_backups = 7
+        retention_unit   = "COUNT"
+      }
+    }
   }
-  deletion_protection = true
 }
 
 resource "google_sql_database" "metabase" {

--- a/iac/cal-itp-data-infra/metabase/us/variables.tf
+++ b/iac/cal-itp-data-infra/metabase/us/variables.tf
@@ -6,6 +6,14 @@ data "terraform_remote_state" "iam" {
     prefix = "cal-itp-data-infra/iam"
   }
 }
+data "terraform_remote_state" "gcs" {
+  backend = "gcs"
+
+  config = {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/gcs"
+  }
+}
 
 resource "random_password" "metabase-secret-key" {
   special = false


### PR DESCRIPTION
# Description

This PR enables backups for the CloudSQL instance.

Relates to #4864 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`