### PR TITLE
Update workflow service account and remove cloud function bucket

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -150,10 +150,6 @@ output "google_storage_bucket_calitp-staging-analysis-output-models_name" {
   value = google_storage_bucket.calitp-staging["calitp-staging-analysis-output-models"].name
 }
 
-output "google_storage_bucket_calitp-staging-cloud-functions_name" {
-  value = google_storage_bucket.calitp-staging["calitp-staging-cloud-functions"].name
-}
-
 output "google_storage_bucket_calitp-staging-elavon-parsed_name" {
   value = google_storage_bucket.calitp-staging["calitp-staging-elavon-parsed"].name
 }

--- a/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
@@ -4,7 +4,6 @@ locals {
     "calitp-staging-airtable",
     "calitp-staging-amplitude-benefits-events",
     "calitp-staging-analysis-output-models",
-    "calitp-staging-cloud-functions",
     "calitp-staging-elavon-parsed",
     "calitp-staging-elavon-raw",
     "calitp-staging-gtfs-download-config",

--- a/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
@@ -174,8 +174,8 @@ output "google_service_account_composer-service-account_name" {
   value = google_service_account.composer-service-account.name
 }
 
-output "google_service_account_workflow-service-account_email" {
-  value = google_service_account.workflow-service-account.email
+output "google_service_account_gtfs-rt-archiver-service-account_email" {
+  value = google_service_account.gtfs-rt-archiver-service-account.email
 }
 
 output "google_service_account_sftp-pod-service-account_id" {

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -266,7 +266,7 @@ resource "google_project_iam_member" "composer-service-account" {
   project = "cal-itp-data-infra-staging"
 }
 
-resource "google_project_iam_member" "workflow-service-account" {
+resource "google_project_iam_member" "gtfs-rt-archiver-service-account" {
   for_each = toset([
     "roles/storage.objectUser",
     "roles/bigquery.dataViewer",
@@ -277,7 +277,7 @@ resource "google_project_iam_member" "workflow-service-account" {
     "roles/iam.serviceAccountTokenCreator"
   ])
   role    = each.key
-  member  = "serviceAccount:${google_service_account.workflow-service-account.email}"
+  member  = "serviceAccount:${google_service_account.gtfs-rt-archiver-service-account.email}"
   project = "cal-itp-data-infra-staging"
 }
 

--- a/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
@@ -66,9 +66,9 @@ resource "google_service_account" "composer-service-account" {
   project      = "cal-itp-data-infra-staging"
 }
 
-resource "google_service_account" "workflow-service-account" {
-  account_id   = "workflow-service-account"
-  description  = "Service account for Workflow"
+resource "google_service_account" "gtfs-rt-archiver-service-account" {
+  account_id   = "gtfs-rt-service-account"
+  description  = "Service account for the GTFS-RT archiver"
   disabled     = "false"
   display_name = "workflow"
   project      = "cal-itp-data-infra-staging"


### PR DESCRIPTION
# Description

This PR updates the workflow service account to gtfs-rt-archiver and removes the cloud functions storage bucket.

Relates to #4488 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`