### PR TITLE
Upgrade altair to 6.0 to fix data-analyses repo error

### DIFF
--- a/packages/calitp-data-analysis/poetry.lock
+++ b/packages/calitp-data-analysis/poetry.lock
@@ -188,28 +188,28 @@ typing-extensions = {version = ">=4.2", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "altair"
-version = "5.3.0"
+version = "6.0.0"
 description = "Vega-Altair: A declarative statistical visualization library for Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "altair-5.3.0-py3-none-any.whl", hash = "sha256:7084a1dab4d83c5e7e5246b92dc1b4451a6c68fd057f3716ee9d315c8980e59a"},
-    {file = "altair-5.3.0.tar.gz", hash = "sha256:5a268b1a0983b23d8f9129f819f956174aa7aea2719ed55a52eba9979b9f6675"},
+    {file = "altair-6.0.0-py3-none-any.whl", hash = "sha256:09ae95b53d5fe5b16987dccc785a7af8588f2dca50de1e7a156efa8a461515f8"},
+    {file = "altair-6.0.0.tar.gz", hash = "sha256:614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4"},
 ]
 
 [package.dependencies]
 jinja2 = "*"
 jsonschema = ">=3.0"
-numpy = "*"
+narwhals = ">=1.27.1"
 packaging = "*"
-pandas = ">=0.25"
-toolz = "*"
+typing-extensions = {version = ">=4.12.0", markers = "python_version < \"3.15\""}
 
 [package.extras]
-all = ["altair-tiles (>=0.3.0)", "anywidget (>=0.9.0)", "pyarrow (>=11)", "vega-datasets (>=0.9.0)", "vegafusion[embed] (>=1.6.6)", "vl-convert-python (>=1.3.0)"]
-dev = ["geopandas", "hatch", "ipython", "m2r", "mypy", "pandas-stubs", "pytest", "pytest-cov", "ruff (>=0.3.0)", "types-jsonschema", "types-setuptools"]
-doc = ["docutils", "jinja2", "myst-parser", "numpydoc", "pillow (>=9,<10)", "pydata-sphinx-theme (>=0.14.1)", "scipy", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinxext-altair"]
+all = ["altair-tiles (>=0.3.0)", "anywidget (>=0.9.0)", "numpy", "pandas (>=1.1.3)", "pyarrow (>=11)", "vegafusion (>=2.0.3)", "vl-convert-python (>=1.8.0)"]
+dev = ["duckdb (>=1.0) ; python_version < \"3.14\"", "geopandas (>=0.14.3) ; python_version < \"3.14\"", "hatch (>=1.13.0)", "ipykernel", "ipython", "mistune", "mypy", "pandas (>=1.1.3)", "pandas-stubs", "polars (>=0.20.3)", "pyarrow-stubs", "pytest", "pytest-cov", "pytest-xdist[psutil] (>=3.5,<4.0)", "ruff (>=0.9.5)", "taskipy (>=1.14.1)", "tomli (>=2.2.1)", "types-jsonschema", "types-setuptools"]
+doc = ["docutils", "jinja2", "myst-parser", "numpydoc", "pillow", "pydata-sphinx-theme (>=0.14.1)", "scipy", "scipy-stubs ; python_version >= \"3.10\"", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinxext-altair"]
+save = ["vl-convert-python (>=1.8.0)"]
 
 [[package]]
 name = "annotated-types"
@@ -2385,6 +2385,32 @@ files = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.17.0"
+description = "Extremely lightweight compatibility layer between dataframe libraries"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "narwhals-2.17.0-py3-none-any.whl", hash = "sha256:2ac5307b7c2b275a7d66eeda906b8605e3d7a760951e188dcfff86e8ebe083dd"},
+    {file = "narwhals-2.17.0.tar.gz", hash = "sha256:ebd5bc95bcfa2f8e89a8ac09e2765a63055162837208e67b42d6eeb6651d5e67"},
+]
+
+[package.extras]
+cudf = ["cudf-cu12 (>=24.10.0)"]
+dask = ["dask[dataframe] (>=2024.8)"]
+duckdb = ["duckdb (>=1.1)"]
+ibis = ["ibis-framework (>=6.0.0)", "packaging", "pyarrow-hotfix", "rich"]
+modin = ["modin"]
+pandas = ["pandas (>=1.1.3)"]
+polars = ["polars (>=0.20.4)"]
+pyarrow = ["pyarrow (>=13.0.0)"]
+pyspark = ["pyspark (>=3.5.0)"]
+pyspark-connect = ["pyspark[connect] (>=3.5.0)"]
+sql = ["duckdb (>=1.1)", "sqlparse"]
+sqlframe = ["sqlframe (>=3.22.0,!=3.39.3)"]
+
+[[package]]
 name = "numpy"
 version = "1.26.4"
 description = "Fundamental package for array computing in Python"
@@ -4507,4 +4533,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0, <3.12.0"
-content-hash = "4ca673b1b81bbba1617750698c218788d249d2e5791cf6eeb483bd38bb2170c5"
+content-hash = "44b1ddc299d7e83b5895363e2d353fb364d8d8b9704f9e147005344bcb3cf194"

--- a/packages/calitp-data-analysis/pyproject.toml
+++ b/packages/calitp-data-analysis/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "calitp-data-analysis"
-version = "2026.2.27"
+version = "2026.3.5"
 description = "Shared code for querying Cal-ITP data in notebooks, primarily."
 authors = [{ name = "Cal-ITP" }, { name = "Erika Pacheco" }, { name = "Rae Bonfanti" }]
 requires-python = ">=3.11.0, <3.12.0"
 
 dependencies = [
-    "altair (>=5.1.1, <6.0.0)",
+    "altair (>=5.1.1)",
     "black==24.10.0",
     "dask (>=2024.10.0, <2025.4.0)", # breaking changes introduced with 2025.4.0 https://docs.dask.org/en/stable/changelog.html#v2025-4-0
     "dask-geopandas (>=0.2.0, <0.3.0)",


### PR DESCRIPTION
# Description

The [pytest workflow](https://github.com/cal-itp/data-analyses/actions/workflows/pytest.yml) is failing when tries to install shared_utils dependencies in `data-analyses` repo.

Error:
```
The conflict is caused by:
    The user requested altair==6.0.0
    altair-transform 0.2.0 depends on altair>=3.0
    calitp-data-analysis 2025.12.17 depends on altair<6.0.0 and >=5.1.1
```

It started when a new version 6.0 for altair was set on shared_utils (see [commit](https://github.com/cal-itp/data-analyses/commit/5e8b212309c8e749da1f39730153adc05872cf66))

Resolves [#1951](https://github.com/cal-itp/data-analyses/issues/1951)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running Github Actions through this PR.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Re-run failing workflows from current PRs.