### PR TITLE
Adjust dbt_short_name so it can handle…

### DIFF
--- a/warehouse/models/mart/audit/fct_bigquery_data_access.sql
+++ b/warehouse/models/mart/audit/fct_bigquery_data_access.sql
@@ -43,7 +43,8 @@ WITH fct_bigquery_data_access AS (
                 SPLIT(destination_table, '/')[SAFE_OFFSET(ARRAY_LENGTH(SPLIT(destination_table, '/')) - 1)]
             ),
             '__dbt_tmp'
-        )[OFFSET(0)] AS dbt_node_short_name,
+        )[OFFSET(0)] AS dbt_node_short_name, # Remove __dbt_tmp* suffix if present, helps with microbatches especially for incremental models
+        payload,
         metadata,
         job
     FROM {{ ref('stg_audit__cloudaudit_googleapis_com_data_access') }}


### PR DESCRIPTION
# Description

It's hard to monitor certain dbt job costs because strings might look like "dim_stop_arrivals__dbt_tmp_20260305" - this will strip out things like '__dbt_tmp_20260305` moving forward.

Cost audit work for #4295 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested in bigquery.

`poetry run dbt run -s fct_bigqury_data_access` and `poetry run dbt run -s fct_bigqury_data_access --target prod` didn't do anything.  

Maybe because this incremental model is a little different and doesn't exist in staging.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Check - https://dashboards.calitp.org/question/4060-how-much-do-dbt-runs-cost-per-table-per-day - monday and see if costs for dim_stop_arrivals show up.
