### PR TITLE
Promotes 2026.2.6 JupyterHub image to default

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -51,6 +51,17 @@ jupyterhub:
           mem_guarantee: "10G"
           cpu_guarantee: 1.5
           image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2026.1.12
+      - display_name: "Legacy Image - 2025.12.12, Python 3.11"
+        description: "This is a previous image version with siuba. Your code will run on a shared machine with 3–10G of memory and 0.7–1.9 CPU cores."
+        kubespawner_override:
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.12.12
+      - display_name: "Power Legacy Image - 2025.12.12, Python 3.11"
+        description: "This is a previous image version with siuba. Your code will run on a shared machine with 10–12G of memory and 1.5–1.9 CPU cores."
+        kubespawner_override:
+          mem_limit: "12G"
+          mem_guarantee: "10G"
+          cpu_guarantee: 1.5
+          image: ghcr.io/cal-itp/data-infra/jupyter-singleuser:2025.12.12
   scheduling:
     userPods:
       nodeAffinity:


### PR DESCRIPTION
# Description

This PR promotes the 2026.2.6 JupyterHub image to default.
Changes introduced with this image include package management is switched from Poetry to uv, dask[dataframe] is installed, and dependencies upgrade on calitp-data-analysis==2026.1.30.
Resolves #4907

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Image was tested by the Analysts.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm the changes on JupyterHub.