### PR TITLE
fix(k8s): update bitnami Docker image for 2nd zookeeper

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -126,6 +126,8 @@ sentry:
       enabled: false
     zookeeper:
       enabled: true
+      image:
+        repository: bitnamilegacy/zookeeper
 
   clickhouse:
     clickhouse:


### PR DESCRIPTION
# Description

Updates a 2nd zookeeper instance that the Sentry helm chart deploys to use the `bitnamilegacy` container repository

Resolves #4371

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Ran the command below to verify the rendered manifests:

```bash
helm template sentry kubernetes/apps/charts/sentry \
  --namespace sentry \
  --values kubernetes/apps/charts/sentry/values.yaml 
```

## Post-merge follow-ups

Ensure no pods in the Sentry namespace enter an error state