### PR TITLE
Hotfix to stop duplicates on dim_stop_latest

### DIFF
--- a/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
+++ b/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
@@ -29,8 +29,9 @@ current_stops AS (
 
 
 stops_on_shn AS (
-    SELECT
-        current_stops.*
+    SELECT distinct
+    current_stops._gtfs_key
+    -- current_stops.* old code, hotfix since we are getting duplicates here
     FROM buffer_geometry_table, current_stops
     WHERE ST_DWITHIN(
             buffer_geometry_table.buffer_geometry,current_stops.pt_geom, 0)


### PR DESCRIPTION
# Description

Hotfix to stop duplicates on dim_stop_latest.

Tons of fanout from the geometry work due to duplicates.  This at least stops the duplicates.

Thanks for the help @lauriemerrell 


Work towards #4691

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
When querying inside dim_stops_latest, 
`select * from dim_stops_latest_with_shn_boolean` produces 139972 rows
which is the same as 
`select count(*) from dim_stops_latest`

## Post-merge follow-ups

Someone should properly work on #4691