### PR TITLE
Benefits: Add row-level security to benefits mart table

### DIFF
--- a/warehouse/macros/create_row_access_policy.sql
+++ b/warehouse/macros/create_row_access_policy.sql
@@ -266,3 +266,63 @@ filter using (
 ) }};
 -- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context
 {% endmacro %}
+
+
+{% macro benefits_row_access_policy() %}
+
+{{ create_row_access_policy(
+    filter_column = 'event_properties_transit_agency',
+    filter_value = 'Monterey-Salinas Transit',
+    principals = ['serviceAccount:mst-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'event_properties_transit_agency',
+    filter_value = 'Sacramento Regional Transit',
+    principals = ['serviceAccount:sacrt-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'event_properties_transit_agency',
+    filter_value = 'Santa Barbara MTD',
+    principals = ['serviceAccount:sbmtd-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'event_properties_transit_agency',
+    filter_value = 'Nevada County Connects',
+    principals = ['serviceAccount:nevada-county-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'event_properties_transit_agency',
+    filter_value = 'Ventura County Transportation Commission',
+    principals = ['serviceAccount:vctc-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'event_properties_transit_agency',
+    filter_value = 'El Dorado Transit',
+    principals = ['serviceAccount:eldorado-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    filter_column = 'event_properties_transit_agency',
+    filter_value = 'San Luis Obispo RTA',
+    principals = ['serviceAccount:slorta-payments-user@cal-itp-data-infra.iam.gserviceaccount.com']
+) }};
+
+{{ create_row_access_policy(
+    principals = [
+        'serviceAccount:metabase@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:metabase-payments-team@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-services-accoun@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
+        'serviceAccount:github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com',
+        'serviceAccount:composer-service-account@cal-itp-data-infra.iam.gserviceaccount.com',
+        'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DDS_Cloud_Admins',
+        'principalSet://iam.googleapis.com/locations/global/workforcePools/dot-ca-gov/group/DOT_DDS_Data_Pipeline_and_Warehouse_Users'
+    ]
+) }};
+-- TODO: In the last policy of the macro call above, see if we can get the prod warehouse service account out of context
+{% endmacro %}

--- a/warehouse/models/mart/benefits/fct_benefits_events.sql
+++ b/warehouse/models/mart/benefits/fct_benefits_events.sql
@@ -1,4 +1,5 @@
-{{ config(materialized='table') }}
+{{ config(materialized = 'table',
+    post_hook="{{ benefits_row_access_policy() }}") }}
 
 WITH fct_benefits_events_raw AS (
   -- fct_benefits_events_raw extracts JSON columns and


### PR DESCRIPTION
# Description

Agencies accessing benefits data through Metabase should only be able to see their own data. This PR adds a benefits_row_access_policy macro (following the same pattern used for payments data) and applies it as a post-hook on fct_benefits_events.

Each agency's service account is restricted to rows where event_properties_transit_agency matches their agency name. Internal team members retain full access as long as they are added to the DOT_DDS_Data_Pipeline_and_Warehouse_Users GCP group. Service accounts for CI, Composer, and Metabase team access are also included in the unrestricted policy.

**Changes**
Added benefits_row_access_policy() macro to create_row_access_policy.sql with per-agency filters for MST, SacRT, SBMTD, Nevada County Connects, VCTC, El Dorado Transit, and SLO RTA
Applied the macro as a post_hook on fct_benefits_events

Resolves #4789

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
The query below (and screenshot in the comment below) represents my investigation into existing queries, who is performing them, and whether they will inadvertently be unable to query the table directly in BigQuery (eg are outside of the existing `DOT_DDS_Data_Pipeline_and_Warehouse_Users` group). More tests will happen post-merge

```
SELECT
  user_email,
  COUNT(*) AS query_count,
  MAX(creation_time) AS last_queried
FROM `cal-itp-data-infra.region-us-west2`.INFORMATION_SCHEMA.JOBS_BY_PROJECT,
  UNNEST(referenced_tables) AS ref
WHERE
  creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
  AND ref.project_id = 'cal-itp-data-infra'
  AND ref.dataset_id = 'mart_benefits'
  AND ref.table_id = 'fct_benefits_events'
  AND state = 'DONE'
  AND error_result IS NULL
GROUP BY user_email
ORDER BY query_count DESC
```

**Post-Merge Testing** 
- [ ] Confirm fct_benefits_events builds successfully in dbt
- [ ] Verify an agency service account can only query its own rows
- [ ] Verify a DOT_DDS_Data_Pipeline_and_Warehouse_Users member can query all rows

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Configure agency database connections in Metabase so users can access their own benefits data
