### PR TITLE
Make the publish_gtfs dag weekly

### DIFF
--- a/airflow/dags/publish_gtfs.py
+++ b/airflow/dags/publish_gtfs.py
@@ -16,8 +16,8 @@ from airflow.operators.latest_only import LatestOnlyOperator
 with DAG(
     dag_id="publish_gtfs",
     tags=["gtfs", "open-data"],
-    # Every month
-    schedule="0 0 1 * *",
+    # Every Monday at 4pm Pacific (midnight UTC Tuesday), after the dbt_all runs
+    schedule="0 0 * * 2",
     start_date=datetime(2025, 10, 1),
     catchup=False,
     default_args={


### PR DESCRIPTION
# Description

Changes publish_gtfs dag from once a month to once weekly.

Work on #4956 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
