### PR TITLE
Update parse_elavon dag to use new sftp bucket

### DIFF
--- a/airflow/dags/parse_elavon/elavon_to_gcs_jsonl.py
+++ b/airflow/dags/parse_elavon/elavon_to_gcs_jsonl.py
@@ -62,16 +62,13 @@ def process_elavon_data_to_jsonl():
 
     # List raw files available from GCS
     file_and_dir_list = fs.ls(f"{CALITP_BUCKET__ELAVON_RAW}/", detail=False)
-    dir_list = [x for x in file_and_dir_list if fs.isdir(x)]
+    file_list = [x for x in file_and_dir_list if fs.isfile(x) and x.endswith(".zip")]
 
-    if not dir_list:
+    if not file_list:
         logger.warning("No extracts were found in GCS")
         return
 
-    # Drill down to the latest export (folders are "ts=" format)
-    target_dir = max(dir_list)
-    logger.info(f"Using latest export directory: {target_dir}")
-    file_list = [x for x in fs.ls(f"{target_dir}/", detail=False) if fs.isfile(x)]
+    logger.info(f"Found {len(file_list)} zip files to process")
 
     execution_ts = pendulum.now()
     for file in file_list:

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -75,7 +75,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         "CALITP_BUCKET__DBT_ARTIFACTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-dbt-artifacts_name}",
         "CALITP_BUCKET__DBT_DOCS"                              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-dbt-docs_name}",
         "CALITP_BUCKET__ELAVON_PARSED"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-elavon-parsed_name}",
-        "CALITP_BUCKET__ELAVON_RAW"                            = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-elavon-raw_name}",
+        "CALITP_BUCKET__ELAVON_RAW"                            = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-elavon-raw-v2_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG"                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_PROD_SOURCE"      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_TEST_DESTINATION" = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-download-config-test_name}",

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -192,7 +192,7 @@ resource "google_composer_environment" "calitp-staging-composer3" {
         "CALITP_BUCKET__DBT_ARTIFACTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-dbt-artifacts_name}",
         "CALITP_BUCKET__DBT_DOCS"                              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-dbt-docs_name}",
         "CALITP_BUCKET__ELAVON_PARSED"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-elavon-parsed_name}",
-        "CALITP_BUCKET__ELAVON_RAW"                            = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-elavon-raw_name}",
+        "CALITP_BUCKET__ELAVON_RAW"                            = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-elavon-raw-v2_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG"                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_PROD_SOURCE"      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_TEST_DESTINATION" = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-download-config-test_name}",

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -75,7 +75,7 @@ resource "google_composer_environment" "calitp-composer" {
         "CALITP_BUCKET__DBT_ARTIFACTS"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-dbt-artifacts_name}",
         "CALITP_BUCKET__DBT_DOCS"                              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-dbt-docs_name}",
         "CALITP_BUCKET__ELAVON_PARSED"                         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-elavon-parsed_name}",
-        "CALITP_BUCKET__ELAVON_RAW"                            = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-elavon-raw_name}",
+        "CALITP_BUCKET__ELAVON_RAW"                            = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-elavon-raw-v2_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG"                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_PROD_SOURCE"      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_TEST_DESTINATION" = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-download-config-test_name}",


### PR DESCRIPTION
# Description

https://github.com/cal-itp/data-infra/pull/5026 added sftp endpoint with gcs_fuse. This results in a flat structure in the bucket instead of the daily sync. This change points the parse_elavon code at the new bucket and removes the need to parse that latest directory and instead reparses the contents of the bucket. No other behavior changed.

ref: #4420, #4872


## How has this been tested?

Ran on staging and verified that the output of the parsed data was identical.

## Post-merge follow-ups

This needs to be merged at the same time as PR: xxx
The latest sync from the old bucket needs to be seeded into the new bucket.
