### PR TITLE
Adds new static ip for elavon sftp

### DIFF
--- a/iac/cal-itp-data-infra/networks/us/compute_address.tf
+++ b/iac/cal-itp-data-infra/networks/us/compute_address.tf
@@ -3,3 +3,9 @@ resource "google_compute_address" "enghouse-sftp-address" {
   region       = "us-west2"
   address_type = "EXTERNAL"
 }
+
+resource "google_compute_address" "elavon-sftp-address" {
+  name         = "elavon-sftp-address"
+  region       = "us-west2"
+  address_type = "EXTERNAL"
+}

--- a/iac/cal-itp-data-infra/networks/us/outputs.tf
+++ b/iac/cal-itp-data-infra/networks/us/outputs.tf
@@ -9,3 +9,7 @@ output "google_compute_network_static-load-balancer-address_id" {
 output "google_compute_address_enghouse-sftp-address_ip" {
   value = google_compute_address.enghouse-sftp-address.address
 }
+
+output "google_compute_address_elavon-sftp-address_ip" {
+  value = google_compute_address.elavon-sftp-address.address
+}


### PR DESCRIPTION
Adds new static ip for elavon sftp. I wasnt able to re-use the ip from the old deployment so we will have to ask elavon to update their IP


ref: #4420


- [x ] No action required

