### PR TITLE
Add Airflow variables to Prod

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -43,6 +43,8 @@ resource "google_composer_environment" "calitp-composer" {
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true
+        core-max_templated_field_length            = 25000
+        cosmos-use_dataset_airflow3_uri_standard   = true
         email-email_backend                        = "airflow.utils.email.send_email_smtp"
         email-email_conn_id                        = "smtp_postmark"
         email-from_email                           = "bot+airflow@calitp.org"
@@ -75,10 +77,10 @@ resource "google_composer_environment" "calitp-composer" {
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG"                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_PROD_SOURCE"      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-download-config_name}",
         "CALITP_BUCKET__GTFS_DOWNLOAD_CONFIG_TEST_DESTINATION" = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-download-config-test_name}",
-        "CALITP_BUCKET__GTFS_SCHEDULE_MANUAL"                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-manual_name}",
         "CALITP_BUCKET__GTFS_RT_PARSED"                        = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-rt-parsed_name}",
         "CALITP_BUCKET__GTFS_RT_RAW"                           = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-rt-raw-v2_name}",
         "CALITP_BUCKET__GTFS_RT_VALIDATION"                    = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-rt-validation_name}",
+        "CALITP_BUCKET__GTFS_SCHEDULE_MANUAL"                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-manual_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_PARSED"                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-parsed_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_PARSED_HOURLY"           = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-parsed-hourly_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_RAW"                     = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-schedule-raw-v2_name}",


### PR DESCRIPTION
# Description

This PR is a production follow up from PR https://github.com/cal-itp/data-infra/pull/4941, adding the variable `cosmos-use_dataset_airflow3_uri_standard = true` already in Airflow Staging to remove warning bellow:
```
WARNING - 
                    Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs (standard used by Cosmos) will no longer be valid.
                    Therefore, if using Cosmos with Airflow 3, the Airflow Dataset URIs will be changed to <bigquery/cal-itp-data-infra/staging/stg_littlepay__settlements>.
                    Previously, with Airflow 2.x, the URI was <bigquery/cal-itp-data-infra.staging.stg_littlepay__settlements>.
                    If you want to use the Airflow 3 URI standard while still using Airflow 2, please, set:
                        export AIRFLOW__COSMOS__USE_DATASET_AIRFLOW3_URI_STANDARD=1
                    Remember to update any DAGs that are scheduled using this dataset.
```

And sets `core-max_templated_field_length = 25000` to show more information on each task field.

Resolves #4357

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested Airflow Staging.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
