### PR TITLE
Deduplicating the organization name

### DIFF
--- a/warehouse/models/mart/transit_database/fct_create_expiring_gtfs_issues.sql
+++ b/warehouse/models/mart/transit_database/fct_create_expiring_gtfs_issues.sql
@@ -71,15 +71,26 @@ expiring_datasets AS (
     dwe.gtfs_dataset_source_record_id,
     dwe.max_end_date,
     dwe.expiration_status,
-    dp.service_name,
-    dp.service_source_record_id,
-    dp.organization_name
+    ARRAY_AGG(
+      STRUCT(
+        dp.service_name,
+        dp.service_source_record_id,
+        dp.organization_name
+      )
+      ORDER BY dp.service_source_record_id
+      LIMIT 1
+    )[OFFSET(0)] AS service_info
   FROM datasets_with_expiration dwe
   INNER JOIN {{ ref('dim_provider_gtfs_data') }} dp
     ON dwe.gtfs_dataset_key = dp.schedule_gtfs_dataset_key
   WHERE dwe.expiration_status != 'OK'
     AND dp._is_current = TRUE
     AND dp.public_customer_facing_or_regional_subfeed_fixed_route
+  GROUP BY
+    dwe.name,
+    dwe.gtfs_dataset_source_record_id,
+    dwe.max_end_date,
+    dwe.expiration_status
 ),
 
 airtable_services_latest AS (
@@ -110,42 +121,16 @@ expiring_datasets_with_airtable_ids AS (
     ed.gtfs_dataset_source_record_id,
     ed.max_end_date,
     ed.expiration_status,
-    ed.service_name,
-    ed.service_source_record_id,
+    ed.service_info.service_name AS service_name,
+    ed.service_info.service_source_record_id AS service_source_record_id,
+    ed.service_info.organization_name AS organization_name,
     s.id AS service_record_id,
-    d.id AS gtfs_dataset_record_id,
-    ed.organization_name
+    d.id AS gtfs_dataset_record_id
   FROM expiring_datasets ed
   INNER JOIN airtable_services_latest s
-    ON ed.service_source_record_id = s.source_record_id
+    ON ed.service_info.service_source_record_id = s.source_record_id
   INNER JOIN airtable_datasets_latest d
     ON ed.gtfs_dataset_source_record_id = d.source_record_id
-),
-
-aggregated_expiring_datasets AS (
-  SELECT
-    name,
-    gtfs_dataset_source_record_id,
-    max_end_date,
-    expiration_status,
-    gtfs_dataset_record_id,
-    organization_name,
-    ARRAY_AGG(
-      STRUCT(
-        service_name,
-        service_record_id
-      )
-      ORDER BY service_record_id
-      LIMIT 1
-    )[OFFSET(0)] AS service_info
-  FROM expiring_datasets_with_airtable_ids
-  GROUP BY
-    name,
-    gtfs_dataset_source_record_id,
-    max_end_date,
-    expiration_status,
-    gtfs_dataset_record_id,
-    organization_name
 ),
 
 expiring_open_issues AS (
@@ -165,16 +150,16 @@ expiring_open_issues AS (
 
 fct_create_expiring_gtfs_issues AS (
   SELECT
-    aed.name AS gtfs_dataset_name,
-    aed.max_end_date,
-    aed.expiration_status,
-    aed.gtfs_dataset_record_id,
-    aed.service_info.service_name AS service_name,
-    aed.service_info.service_record_id AS service_record_id,
-    aed.organization_name
-  FROM aggregated_expiring_datasets aed
+    edwai.name AS gtfs_dataset_name,
+    edwai.max_end_date,
+    edwai.expiration_status,
+    edwai.gtfs_dataset_record_id,
+    edwai.service_name,
+    edwai.service_record_id,
+    edwai.organization_name
+  FROM expiring_datasets_with_airtable_ids edwai
   LEFT JOIN expiring_open_issues i
-    ON aed.gtfs_dataset_source_record_id = i.gtfs_dataset_source_record_id
+    ON edwai.gtfs_dataset_source_record_id = i.gtfs_dataset_source_record_id
   WHERE i.issue_number IS NULL
 )
 

--- a/warehouse/models/mart/transit_database/fct_create_expiring_gtfs_issues.sql
+++ b/warehouse/models/mart/transit_database/fct_create_expiring_gtfs_issues.sql
@@ -71,26 +71,23 @@ expiring_datasets AS (
     dwe.gtfs_dataset_source_record_id,
     dwe.max_end_date,
     dwe.expiration_status,
-    ARRAY_AGG(
-      STRUCT(
-        dp.service_name,
-        dp.service_source_record_id,
-        dp.organization_name
-      )
-      ORDER BY dp.service_source_record_id
-      LIMIT 1
-    )[OFFSET(0)] AS service_info
+    dp.service_name,
+    dp.service_source_record_id,
+    dp.organization_name
   FROM datasets_with_expiration dwe
   INNER JOIN {{ ref('dim_provider_gtfs_data') }} dp
     ON dwe.gtfs_dataset_key = dp.schedule_gtfs_dataset_key
   WHERE dwe.expiration_status != 'OK'
     AND dp._is_current = TRUE
     AND dp.public_customer_facing_or_regional_subfeed_fixed_route
-  GROUP BY
-    dwe.name,
-    dwe.gtfs_dataset_source_record_id,
-    dwe.max_end_date,
-    dwe.expiration_status
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY
+      dwe.name,
+      dwe.gtfs_dataset_source_record_id,
+      dwe.max_end_date,
+      dwe.expiration_status
+    ORDER BY dp.service_source_record_id
+  ) = 1
 ),
 
 airtable_services_latest AS (
@@ -121,14 +118,14 @@ expiring_datasets_with_airtable_ids AS (
     ed.gtfs_dataset_source_record_id,
     ed.max_end_date,
     ed.expiration_status,
-    ed.service_info.service_name AS service_name,
-    ed.service_info.service_source_record_id AS service_source_record_id,
-    ed.service_info.organization_name AS organization_name,
+    ed.service_name,
+    ed.service_source_record_id,
+    ed.organization_name,
     s.id AS service_record_id,
     d.id AS gtfs_dataset_record_id
   FROM expiring_datasets ed
   INNER JOIN airtable_services_latest s
-    ON ed.service_info.service_source_record_id = s.source_record_id
+    ON ed.service_source_record_id = s.source_record_id
   INNER JOIN airtable_datasets_latest d
     ON ed.gtfs_dataset_source_record_id = d.source_record_id
 ),


### PR DESCRIPTION
# Description

This PR refactors the `fct_create_expiring_gtfs_issues` model to deduplicate records earlier in the pipeline.

Previously, duplicate rows introduced in `expiring_datasets `were carried forward and later resolved in `aggregated_expiring_datasets`. This change moves the deduplication logic upstream by using `ARRAY_AGG(... LIMIT 1)` directly in `expiring_datasets`, eliminating the need for the additional aggregation step.

The update also includes `organization_name `in the aggregation to ensure it remains aligned with the selected service record.

ref. https://github.com/cal-itp/data-infra/issues/4992

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
(cal-itp-data-infra-airflow) jovyan@jupyter-fsalemi:~/data-infra/warehouse$ ./.venv/bin/dbt run -s fct_create_expiring_gtfs_issues
20:56:36  Running with dbt=1.10.8
20:56:50  Registered adapter: bigquery=1.10.2
20:56:52  Unable to do partial parsing because a project config has changed
20:57:19  Found 633 models, 178 data tests, 16 seeds, 226 sources, 4 exposures, 1088 macros
20:57:19  
20:57:19  Concurrency: 8 threads (target='dev')
20:57:19  
20:57:23  1 of 1 START sql table model farhad_mart_transit_database.fct_create_expiring_gtfs_issues  [RUN]
20:57:27  1 of 1 OK created sql table model farhad_mart_transit_database.fct_create_expiring_gtfs_issues  [CREATE TABLE (0.0 rows, 1.1 GiB processed) in 4.08s]
20:57:27  
20:57:27  Finished running 1 table model in 0 hours 0 minutes and 8.34 seconds (8.34s).
20:57:29  
20:57:29  Completed successfully
20:57:29  
20:57:29  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)
