### PR TITLE
Set schema change behavior for trip updates message age model & move event_time into SQL files

### DIFF
--- a/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
@@ -101,8 +101,6 @@ models:
       what was in effect on January 2.
       This table should be used to understand "versions" of constituent data like
       routes, trips, etc.
-    config:
-      event_time: _valid_from
     tests:
       - dbt_utils.mutually_exclusive_ranges:
           arguments:
@@ -859,8 +857,6 @@ models:
       Each row is a cleaned row from a trips.txt file.
       Definitions for the original GTFS fields are available at:
       https://gtfs.org/reference/static#tripstxt.
-    config:
-      event_time: _feed_valid_from
     columns:
       - *schedule_dim_pk
       - *schedule_dim_gtfs_key_with_dupe_flag

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -612,8 +612,6 @@ models:
   - name: fct_stop_time_updates
     description: |
       Unnested and de-duped stop time updates.
-    config:
-      event_time: dt
     columns:
       - name: key
         tests: *almost_unique_rt_key_tests
@@ -762,8 +760,6 @@ models:
       Due to data size, this table **must** be queried with a date filter
       (like `WHERE dt = 'YYYY-MM-DD'`).
       Hour filters will also further improve performance.
-    config:
-      event_time: dt
     columns:
       - name: key
         description: |
@@ -1026,8 +1022,6 @@ models:
       Due to data size, this table **must** be queried with a date filter
       (like `WHERE dt = 'YYYY-MM-DD'`).
       Hour filters will also further improve performance.
-    config:
-      event_time: dt
     columns:
       - name: key
         description: |
@@ -1094,8 +1088,6 @@ models:
       distinct.)
       See: https://gtfs.org/realtime/reference/#message-alert for
       field definitions.
-    config:
-      event_time: dt
     tests:
       - dbt_utils.expression_is_true:
           arguments:
@@ -1792,8 +1784,6 @@ models:
     description: |
       Incrementally materialize trip update messages without stop times;
       this reduces the data size by about 90%.
-    config:
-      event_time: dt
     columns:
       - name: key
         tests: *almost_unique_rt_key_tests

--- a/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
+++ b/warehouse/models/mart/gtfs/dim_schedule_feeds.sql
@@ -1,4 +1,4 @@
-{{ config(materialized='table') }}
+{{ config(materialized='table', event_time='_valid_from') }}
 
 {%- set timestamps = dbt_utils.get_column_values(
         table = ref('int_gtfs_schedule__joined_feed_outcomes'),

--- a/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_messages.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='dt') }}
+
 WITH stg_gtfs_rt__service_alerts AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__service_alerts') }}

--- a/warehouse/models/mart/gtfs/fct_service_alerts_messages_unnested.sql
+++ b/warehouse/models/mart/gtfs/fct_service_alerts_messages_unnested.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized='incremental',
+    event_time='dt',
     incremental_strategy='insert_overwrite',
     partition_by = {
         'field': 'dt',

--- a/warehouse/models/mart/gtfs/fct_stop_time_updates.sql
+++ b/warehouse/models/mart/gtfs/fct_stop_time_updates.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='dt') }}
+
 WITH fct_trip_updates_messages AS (
     SELECT * FROM {{ ref('fct_trip_updates_messages') }}
     -- TODO: these have duplicate rows down to the stop level, maybe should exclude

--- a/warehouse/models/mart/gtfs/fct_trip_updates_no_stop_times.sql
+++ b/warehouse/models/mart/gtfs/fct_trip_updates_no_stop_times.sql
@@ -2,6 +2,7 @@
     config(
         materialized='incremental',
         incremental_strategy='insert_overwrite',
+        event_time='dt',
         partition_by = {
             'field': 'dt',
             'data_type': 'date',

--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_messages.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='dt') }}
+
 WITH stg_gtfs_rt__vehicle_positions AS (
     SELECT *
     FROM {{ ref('stg_gtfs_rt__vehicle_positions') }}

--- a/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_trip_updates_message_age_summary.sql
@@ -12,6 +12,7 @@
             'granularity': 'day',
         },
         full_refresh=false,
+        on_schema_change='sync_all_columns'
     )
 }}
 

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -141,8 +141,6 @@ models:
     description: |
       Cleaned GTFS schedule agency data.
       See https://gtfs.org/reference/static#agencytxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -166,8 +164,6 @@ models:
     description: |
       Cleaned GTFS schedule area data.
       See https://gtfs.org/schedule/reference/#areastxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -179,8 +175,6 @@ models:
     description: |
       Cleaned GTFS schedule attribution data.
       See https://gtfs.org/reference/static#attributionstxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -210,8 +204,6 @@ models:
     description: |
       Cleaned GTFS schedule fare attribute data.
       See https://gtfs.org/reference/static#fare_attributestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -233,8 +225,6 @@ models:
     description: |
       Cleaned GTFS schedule fare leg rule data.
       See https://gtfs.org/schedule/reference/#fare_leg_rulestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -252,8 +242,6 @@ models:
     description: |
       Cleaned GTFS schedule fare media data.
       See https://gtfs.org/schedule/reference/#fare_mediatxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -267,8 +255,6 @@ models:
     description: |
       Cleaned GTFS schedule fare products data.
       See https://gtfs.org/schedule/reference/#fare_productstxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -286,8 +272,6 @@ models:
     description: |
       Cleaned GTFS schedule fare rules data.
       See https://gtfs.org/reference/static#fare_rulestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -305,8 +289,6 @@ models:
     description: |
       Cleaned GTFS schedule fare transfer rules data.
       See https://gtfs.org/schedule/reference/#fare_transfer_rulestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -328,8 +310,6 @@ models:
     description: |
       Cleaned GTFS schedule feed info data.
       See https://gtfs.org/reference/static#feed_infotxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -355,8 +335,6 @@ models:
     description: |
       Cleaned GTFS schedule frequency data.
       See https://gtfs.org/reference/static#frequenciestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -374,8 +352,6 @@ models:
     description: |
       Cleaned GTFS schedule level data.
       See https://gtfs.org/reference/static#levelstxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -386,8 +362,6 @@ models:
       - name: level_name
         description: '{{ doc("gtfs_levels__level_name") }}'
   - name: stg_gtfs_schedule__pathways
-    config:
-      event_time: ts
     description: |
       Cleaned GTFS schedule pathway data.
       See https://gtfs.org/reference/static#pathwaystxt for specification.
@@ -422,8 +396,6 @@ models:
     description: |
       Cleaned GTFS schedule route data.
       See https://gtfs.org/schedule/reference/#routestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -455,8 +427,6 @@ models:
     description: |
       Cleaned GTFS schedule shape data.
       See https://gtfs.org/reference/static#shapestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -485,8 +455,6 @@ models:
     description: |
       Cleaned GTFS schedule stop area data.
       See https://gtfs.org/schedule/reference/#stop_areastxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -498,8 +466,6 @@ models:
     description: |
       Cleaned GTFS schedule stop data.
       See https://gtfs.org/reference/static#stopstxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -551,8 +517,6 @@ models:
     description: |
       Cleaned GTFS schedule transfer data.
       See https://gtfs.org/reference/static#transferstxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -572,8 +536,6 @@ models:
     description: |
       Cleaned GTFS schedule translation data.
       See https://gtfs.org/reference/static#translationstxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -595,8 +557,6 @@ models:
     description: |
       Cleaned GTFS schedule trip data.
       See https://gtfs.org/schedule/reference/#tripstxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -628,8 +588,6 @@ models:
     description: |
       Cleaned GTFS schedule calendar data.
       See https://gtfs.org/schedule/reference/#calendartxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -657,8 +615,6 @@ models:
     description: |
       Cleaned GTFS schedule calendar_dates data.
       See https://gtfs.org/schedule/reference/#calendar_datestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts
@@ -672,8 +628,6 @@ models:
     description: |
       Cleaned GTFS schedule stop_times data.
       See https://gtfs.org/schedule/reference/#calendar_datestxt for specification.
-    config:
-      event_time: ts
     columns:
       - name: base64_url
       - name: ts

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__agency.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__agency.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_agency AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'agency') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__areas.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__areas.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_areas AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'areas') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__attributions.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__attributions.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_attributions AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'attributions') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__calendar.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__calendar.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_calendar AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'calendar') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__calendar_dates.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__calendar_dates.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_calendar_dates AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'calendar_dates') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_attributes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_attributes.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_fare_attributes AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'fare_attributes') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_leg_rules.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_leg_rules.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_fare_leg_rules AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'fare_leg_rules') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_media.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_media.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_fare_media AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'fare_media') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_products.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_products.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_fare_products AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'fare_products') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_rules.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_rules.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_fare_rules AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'fare_rules') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_transfer_rules.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__fare_transfer_rules.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_fare_transfer_rules AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'fare_transfer_rules') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__feed_info.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__feed_info.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_feed_info AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'feed_info') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__frequencies.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__frequencies.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_frequencies AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'frequencies') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__levels.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__levels.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_levels AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'levels') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__pathways.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__pathways.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_pathways AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'pathways') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__routes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__routes.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_routes AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'routes') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__shapes.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__shapes.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_shapes AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'shapes') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__stop_areas.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__stop_areas.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_stop_areas AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'stop_areas') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__stop_times.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__stop_times.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_stop_times AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'stop_times') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__stops.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__stops.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_stops AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'stops') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__transfers.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__transfers.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_transfers AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'transfers') }}

--- a/warehouse/models/staging/gtfs/stg_gtfs_schedule__translations.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_schedule__translations.sql
@@ -1,3 +1,5 @@
+{{ config(event_time='ts') }}
+
 WITH external_translations AS (
     SELECT *
     FROM {{ source('external_gtfs_schedule', 'translations') }}


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Follow up on #4881 

This job: https://github.com/cal-itp/data-infra/actions/runs/24413529340/job/71316976052 failed in prod because the schema change (deleted columns) was not handled. Not sure why this didn't fire in staging (in my personal schema it was because the table didn't exist prior)

Also moved `event_time` config into SQL files rather than YAML (something @vevetron asked about a while ago) because @erikamov pointed out that setting it in YAML means that if it's changed it doesn't trigger CI/CD runs (which means that the fix in #5075 wasn't actually deployed into prod dbt). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Confirm that the message age models ran as expected 