### PR TITLE
Replace yaml tests with data_tests

### DIFF
--- a/warehouse/models/intermediate/gtfs_quality/_int_gtfs_quality.yml
+++ b/warehouse/models/intermediate/gtfs_quality/_int_gtfs_quality.yml
@@ -5,7 +5,7 @@ models:
   # "Final" combined guideline checks table
   - name: int_gtfs_quality__guideline_checks_long
     description: '{{ doc("int_gtfs_quality__guideline_checks_long") }}'
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: 'status != {{ guidelines_to_be_assessed_status() }}'
@@ -13,14 +13,14 @@ models:
     #TODO: use these anchors below
       - &key
         name: key
-        tests: &primary_key_tests
+        data_tests: &primary_key_tests
           - unique
           - not_null
         meta: &pk_meta
           metabase.semantic_type: type/PK
       - &date
         name: date
-        tests:
+        data_tests:
           - not_null
       - name: organization_name
         description: |
@@ -58,7 +58,7 @@ models:
           Foreign key to `dim_schedule_feeds`.
       - &check
         name: check
-        tests:
+        data_tests:
           - not_null
           # This is a useful test but dbt-metabase fails since
           # Metabase does not sync the staging schema
@@ -67,13 +67,13 @@ models:
           #     to: ref('stg_gtfs_quality__intended_checks')
           #     field: check
       - name: status
-        tests:
+        data_tests:
           - not_null
       - name: feature
       - name: is_manual
         description: |
           Boolean flag for whether the associated check was performed by hand (via Airtable) or automatically.
-        tests:
+        data_tests:
           - not_null
       - name: reports_order
         description: |
@@ -86,7 +86,7 @@ models:
       Daily index of all potentially assessed entities with all possible checks.
       Index against which individual checks are meant to be defined.
       All entity-related columns are inherited from `int_gtfs_quality__daily_assessment_candidate_entities`.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -101,7 +101,7 @@ models:
       Unioned, incremental table of RT validation outcomes.
     columns:
       - name: key
-        tests:
+        data_tests:
           - not_null
           - unique
 
@@ -110,7 +110,7 @@ models:
       List of codes and their severity in the GTFS validator.
       TODO: this will need additional work when we deploy
       a new GTFS validator version.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -124,20 +124,20 @@ models:
       at some point used within the GTFS data pipeline.)
     columns:
       - name: key
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: code
-        tests:
+        data_tests:
           - not_null
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: int_gtfs_quality__naive_organization_service_dataset_full_join
@@ -162,7 +162,7 @@ models:
       to represent this service)
 
       Entities that fail any of the criteria will *not* be included as `assessed` for the given date.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -173,7 +173,7 @@ models:
         description: |
           Synthetic key from `organization_key`, `service_key`, `gtfs_service_data_key`, `gtfs_dataset_key`,
           and `schedule_feed_key`.
-        tests:
+        data_tests:
           - not_null
       - name: date
         description: |
@@ -250,7 +250,7 @@ models:
       so that if this organization/dataset relationship is customer facing or assessed
       for any service, the entire relationship is marked as customer facing or assessed
       in this table.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -261,7 +261,7 @@ models:
   - name: int_gtfs_quality__feed_version_history
     description: |
       Describes attributes of the previous and following versions of each feed.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -274,7 +274,7 @@ models:
   - name: int_gtfs_quality__outcome_validator_versions
     description: |
       Unique observed validator versions for each extract.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         arguments:
           combination_of_columns:
@@ -286,7 +286,7 @@ models:
     description: |
       Summary of a schedule feed's stops and stop times by trip and (calendar) service, to support the GTFS guideline
       check about sufficient lead time for schedule updates.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         arguments:
           combination_of_columns:

--- a/warehouse/models/intermediate/ntd_validation/int_ntd_validation.yml
+++ b/warehouse/models/intermediate/ntd_validation/int_ntd_validation.yml
@@ -12,7 +12,7 @@ models:
     description: |
       Setting up the RR-20 data for comparing fare revenues to previous year
       NOTE: This model uses dynamic variables for "this_year" and "last_year" which are based on the timestamp that this run started.
-    # tests:
+    # data_tests:
     #   - dbt_utils.expression_is_true:
     #       arguments:
     #         expression: 'status != {{ guidelines_to_be_assessed_status() }}'

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -11,12 +11,12 @@ models:
       that all rows dropped do in fact have a duplicate and no authorisations are lost.)
     columns:
       - name: request_type
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: ['AUTHORISATION', 'DEBT_RECOVERY_AUTHCHECK', 'DEBT_RECOVERY_REVERSAL', 'CARD_CHECK']
       - name: aggregation_id
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('int_payments__latest_authorisations_by_aggregation')
@@ -38,11 +38,11 @@ models:
           ID of the aggregation being summarized. An aggregation can contain or be associated with multiple
           micropayment, authorisation, and settlement events. It represents the unit at which settlement occurs
           (so multiple settlement events only occur for a single aggregation if there are refunds against the original settlement.)
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: currency_code
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: [840]
@@ -54,7 +54,7 @@ models:
   - name: int_payments__settlements_to_aggregations
     description: |
       This model contains Littlepay settlements aggregated to the `aggregation_id + retrieval_reference_number` level.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -69,7 +69,7 @@ models:
     columns:
       - *aggregation_pk
       - name: retrieval_reference_number
-        tests:
+        data_tests:
           - not_null
           - unique
       - &participant_id
@@ -83,7 +83,7 @@ models:
         description: '{{ doc("lp_settlement_latest_update_timestamp") }}'
       - name: net_settled_amount_dollars
         description: '{{ doc("lp_net_settled_amount_dollars") }}'
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               arguments:
                 min_value: 0
@@ -101,7 +101,7 @@ models:
   - name: int_payments__micropayments_to_aggregations
     description: |
       Littlepay micropayments grouped to the aggregation (`aggregation_id`) level.
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "total_nominal_amount_dollars >= net_micropayment_amount_dollars"
@@ -289,7 +289,7 @@ models:
     description: |
       Summarizing micropayment information across the source micropayment,
       any applied adjustments (ex. fare capping), and any associated refunds.
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "micropayment_refund_amount <= charge_amount"
@@ -298,7 +298,7 @@ models:
       - &micropayment_id
         name: micropayment_id
         description: '{{ doc("lp_micropayment_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique:
               arguments:
@@ -353,7 +353,7 @@ models:
       - *micropayment_id
       - name: littlepay_transaction_id
         description: '{{ doc("lp_paired_first_transaction_id") }}'
-        tests:
+        data_tests:
           - not_null
           # refunds cause duplicates; ignore them here
           - unique:
@@ -430,7 +430,7 @@ models:
       erroneous micropayment records.
       It also annotates micropayment device transactions with the type and charge type
       of the associated micropayment to assist in later modeling.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -442,7 +442,7 @@ models:
       - *participant_id
       - name: littlepay_transaction_id
         description: '{{ doc("lp_littlepay_transaction_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique:
               arguments:
@@ -508,7 +508,7 @@ models:
       Derived from customer_funding_source records.
       funding_source_vault_id values can appear across multiple participants, so this
       table is unique at the funding_source_vault_id + participant_id level.
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           arguments:
             lower_bound_column: calitp_valid_at
@@ -523,7 +523,7 @@ models:
               - funding_source_id
     columns:
       - name: funding_source_id
-        tests:
+        data_tests:
           - not_null
       - name: customer_id
         description: '{{ doc("customer_funding_source_customer_id") }}'
@@ -555,7 +555,7 @@ models:
       should only have one principal_customer_id.
       customer_id values can appear across multiple participants, so this
       table is unique at the customer_id + participant_id level.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -564,11 +564,11 @@ models:
     columns:
       - name: customer_id
         description: '{{ doc("customer_funding_source_customer_id") }}'
-        tests:
+        data_tests:
           - not_null
       - name: principal_customer_id
         description: '{{ doc("customer_funding_source_principal_customer_id") }}'
-        tests:
+        data_tests:
           - not_null
       - name: earliest_tap
 
@@ -759,7 +759,7 @@ models:
       - *participant_id
       - name: aggregation_id
         description: '{{ doc("lp_aggregation_id") }}'
-        tests:
+        data_tests:
         - unique_proportion:
             arguments:
               at_least: 0.999

--- a/warehouse/models/intermediate/transit_database/_int_transit_database.yml
+++ b/warehouse/models/intermediate/transit_database/_int_transit_database.yml
@@ -6,7 +6,7 @@ models:
     description: |
       Version of `stg_transit_database__service_components` with all
       service, product, and component keys unnested.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -38,7 +38,7 @@ models:
       the January 1 download from www.calitp.org/gtfs.zip will still be mapped to GTFS dataset record `123`,
       even though it was downloaded outside the record's validity window, to facilitate some assignment of the
       GTFS feed data to organizations, services, etc.
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           arguments:
             lower_bound_column: _valid_from
@@ -47,10 +47,10 @@ models:
             gaps: required
     columns:
       - name: base64_url
-        tests:
+        data_tests:
           - not_null
       - name: gtfs_dataset_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_gtfs_datasets')

--- a/warehouse/models/intermediate/transit_database/dimensions/_int_transit_database_dimensions.yml
+++ b/warehouse/models/intermediate/transit_database/dimensions/_int_transit_database_dimensions.yml
@@ -6,7 +6,7 @@ models:
     description: |
       Organizations data in slowly-changing-dimension format.
       For detailed data definitions, see: https://docs.google.com/document/d/1KvlYRYB8cnyTOkT1Q0BbBmdQNguK_AMzhSV5ELXiZR4/edit/.
-    tests: &mutually_exclusive_ranges
+    data_tests: &mutually_exclusive_ranges
       - dbt_utils.mutually_exclusive_ranges:
           arguments:
             lower_bound_column: _valid_from
@@ -18,76 +18,76 @@ models:
         name: key
         description: |
           Synthetic primary key constructed from incoming record ID and `_valid_from`.
-        tests: &primary_key_tests
+        data_tests: &primary_key_tests
           - unique
           - not_null
   - name: int_transit_database__services_dim
     description: |
       Services data in slowly-changing-dimension format.
       For detailed data definitions, see: https://docs.google.com/document/d/1KvlYRYB8cnyTOkT1Q0BbBmdQNguK_AMzhSV5ELXiZR4/edit/.
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__gtfs_service_data_dim
     description: |
       GTFS service data in slowly-changing-dimension format.
       For detailed data definitions, see: https://docs.google.com/document/d/1KvlYRYB8cnyTOkT1Q0BbBmdQNguK_AMzhSV5ELXiZR4/edit/.
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__gtfs_datasets_dim
     description: |
       GTFS datasets data in slowly-changing-dimension format.
       For detailed data definitions, see: https://docs.google.com/document/d/1KvlYRYB8cnyTOkT1Q0BbBmdQNguK_AMzhSV5ELXiZR4/edit/.
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__components_dim
     description: |
       Components data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__products_dim
     description: |
       Products data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__properties_and_features_dim
     description: |
       Properties and features data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__contracts_dim
     description: |
       Contracts data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__data_schemas_dim
     description: |
       Data schemas data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__fare_systems_dim
     description: |
       Fare systems data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__funding_programs_dim
     description: |
       Funding programs data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__service_components_dim
     description: |
       Service components data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -100,13 +100,13 @@ models:
   - name: int_transit_database__ntd_agency_info_dim
     description: |
       NTD agency information data in *artificial* slowly-changing-dimension format (current-only data with effective dates).
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__modes_dim
     description: |
       Slowly-changing modes data.
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
   - name: int_transit_database__county_geography_dim

--- a/warehouse/models/mart/audit/_mart_audit.yml
+++ b/warehouse/models/mart/audit/_mart_audit.yml
@@ -8,23 +8,23 @@ models:
       for more details.
     columns:
       - name: timestamp
-        tests:
+        data_tests:
           - not_null
       - name: date
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
       - name: resource_name
-        tests:
+        data_tests:
           - not_null
       - name: principal_email
       - name: email
-        tests:
+        data_tests:
           - not_null
       - name: job_name
-        tests:
+        data_tests:
           - not_null
           # uniqueness test removed in order to investigate underlying behavior
           # - unique:
@@ -32,7 +32,7 @@ models:
           #       # the only known dupe, with unclear origin
           #       where: job_name != 'projects/cal-itp-data-infra/jobs/job_whFNQ0oGxCM2ejXkfMAk5QA41Vcv'
       - name: job_type
-        tests:
+        data_tests:
           - not_null
       - name: dbt_invocation_id
       - name: create_disposition
@@ -43,19 +43,19 @@ models:
       - name: statement_type
       - name: write_disposition
       - name: duration_in_seconds
-        tests:
+        data_tests:
           - not_null
       - name: referenced_tables
-        tests:
+        data_tests:
           - not_null
       - name: total_billed_bytes
       - name: estimated_cost_usd
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 where: duration_in_seconds > 0 and job_type != 'IMPORT' and statement_type != 'CREATE_EXTERNAL_TABLE' and create_disposition != 'CREATE_IF_NEEDED'
       - name: total_slots_seconds
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 where: duration_in_seconds > 0 and job_type != 'IMPORT' and statement_type != 'CREATE_EXTERNAL_TABLE' and create_disposition != 'CREATE_IF_NEEDED'
@@ -66,7 +66,7 @@ models:
       - name: payload
       - name: metadata
       - name: job
-        tests:
+        data_tests:
           - not_null
 
   - name: fct_bigquery_data_access_referenced_tables
@@ -81,23 +81,23 @@ models:
       entries in the original table that have an empty referenced_tables array.
     columns:
       - name: timestamp
-        tests:
+        data_tests:
           - not_null
       - name: date
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
       - name: resource_name
-        tests:
+        data_tests:
           - not_null
       - name: principal_email
       - name: email
-        tests:
+        data_tests:
           - not_null
       - name: job_name
-        tests:
+        data_tests:
           - not_null
           # uniqueness test removed in order to investigate underlying behavior
           # - unique:
@@ -105,7 +105,7 @@ models:
           #       # the only known dupe, with unclear origin
           #       where: job_name != 'projects/cal-itp-data-infra/jobs/job_whFNQ0oGxCM2ejXkfMAk5QA41Vcv'
       - name: job_type
-        tests:
+        data_tests:
           - not_null
       - name: dbt_invocation_id
       - name: create_disposition
@@ -116,16 +116,16 @@ models:
       - name: statement_type
       - name: write_disposition
       - name: duration_in_seconds
-        tests:
+        data_tests:
           - not_null
       - name: total_billed_bytes
       - name: estimated_cost_usd
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 where: duration_in_seconds > 0 and job_type != 'IMPORT' and statement_type != 'CREATE_EXTERNAL_TABLE' and create_disposition != 'CREATE_IF_NEEDED'
       - name: total_slots_seconds
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 where: duration_in_seconds > 0 and job_type != 'IMPORT' and statement_type != 'CREATE_EXTERNAL_TABLE' and create_disposition != 'CREATE_IF_NEEDED'
@@ -136,8 +136,8 @@ models:
       - name: payload
       - name: metadata
       - name: job
-        tests:
+        data_tests:
           - not_null
       - name: referenced_table
-        tests:
+        data_tests:
           - not_null

--- a/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_dims.yml
@@ -13,7 +13,7 @@ x-common-fields:
       natural (i.e. GTFS) keys.
       This column is tested to be majority false (i.e. sanity-check that most
       records are unique).
-    tests:
+    data_tests:
       - not_null
       - dbt_expectations.expect_column_most_common_value_to_be_in_set:
           arguments:
@@ -30,7 +30,7 @@ x-common-fields:
       This key is intended to identify an actual _row_ in the GTFS source data,
       rather than a GTFS entity described in that row. See _gtfs_key as a single
       key derived from the "natural" key of the entity.
-    tests:
+    data_tests:
       - not_null
       - unique
   - &schedule_dim_gtfs_key
@@ -38,7 +38,7 @@ x-common-fields:
     description: |
       Synthetic primary natural key constructed from the model's GTFS
       specification uniqueness.
-    tests:
+    data_tests:
       - not_null
       - unique:
           arguments:
@@ -50,7 +50,7 @@ x-common-fields:
             where: "feed_key != '6368fe701bdd68c4f521751a9a222a10'"
   - &schedule_dim_gtfs_key_with_dupe_flag
     <<: *schedule_dim_gtfs_key
-    tests:
+    data_tests:
       - not_null
       - unique:
           arguments:
@@ -62,19 +62,19 @@ x-common-fields:
     description: |
       Date of the feed version (i.e. date from _feed_valid_from in UTC); used for
       upstream partition elimination.
-    tests:
+    data_tests:
       - not_null
   - &schedule_dim_line_number
     name: _line_number
     description: |
       Line number of this record in the original Schedule file; used for
       incremental materialization.
-    tests:
+    data_tests:
       - not_null
   - &feed_key
     name: feed_key
     description: '{{ doc("gtfs_schedule_feed_key") }}'
-    tests:
+    data_tests:
       - not_null
       - relationships:
           arguments:
@@ -101,7 +101,7 @@ models:
       what was in effect on January 2.
       This table should be used to understand "versions" of constituent data like
       routes, trips, etc.
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           arguments:
             lower_bound_column: _valid_from
@@ -112,7 +112,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `base64_url` and `_valid_from`.
-        tests:
+        data_tests:
           - unique:
               arguments:
                 # TODO: remove this once we deal with Auburn feed that has
@@ -137,7 +137,7 @@ models:
         description: '{{ doc("column_is_current") }}'
       - name: feed_timezone
         description: '{{ doc("gtfs_schedule_feed_timezone") }}'
-        tests:
+        data_tests:
           - not_null
       - *schedule_dim_dt
 
@@ -157,17 +157,17 @@ models:
         description: '{{ doc("gtfs_agency__agency_id") }}'
       - name: agency_name
         description: '{{ doc("gtfs_agency__agency_name") }}'
-        tests: &not_null_warn_99_threshold
+        data_tests: &not_null_warn_99_threshold
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
                 severity: warn
       - name: agency_url
         description: '{{ doc("gtfs_agency__agency_url") }}'
-        tests: *not_null_warn_99_threshold
+        data_tests: *not_null_warn_99_threshold
       - name: agency_timezone
         description: '{{ doc("gtfs_agency__agency_timezone") }}'
-        tests: &not_null_warn
+        data_tests: &not_null_warn
         - not_null:
             arguments:
               # TODO: remove feed_key filter once we deal with Auburn feed that has
@@ -205,7 +205,7 @@ models:
       - *base64_url
       - name: area_id
         description: '{{ doc("gtfs_areas__area_id") }}'
-        tests: &not_null_error
+        data_tests: &not_null_error
           - not_null:
               arguments:
                 # TODO: remove feed_key filter once we deal with Auburn feed that has
@@ -224,7 +224,7 @@ models:
     columns:
       - *schedule_dim_pk
       - <<: *schedule_dim_gtfs_key
-        tests:
+        data_tests:
           - not_null
           - unique:
               arguments:
@@ -232,7 +232,7 @@ models:
       # attribution_id is optional in the GTFS spec, so the flag is present
       # on most/all rows
       - <<: *warning_duplicate_gtfs_key
-        tests:
+        data_tests:
           - not_null
       - *schedule_dim_dt
       - *schedule_dim_line_number
@@ -248,7 +248,7 @@ models:
         description: '{{ doc("gtfs_attributions__trip_id") }}'
       - name: organization_name
         description: '{{ doc("gtfs_attributions__organization_name") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: is_producer
         description: '{{ doc("gtfs_attributions__is_producer") }}'
       - name: is_operator
@@ -277,19 +277,19 @@ models:
       - *feed_key
       - name: fare_id
         description: '{{ doc("gtfs_fare_attributes__fare_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: price
         description: '{{ doc("gtfs_fare_attributes__price") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: currency_type
         description: '{{ doc("gtfs_fare_attributes__currency_type") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: payment_method
         description: '{{ doc("gtfs_fare_attributes__payment_method") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: transfers
         description: '{{ doc("gtfs_fare_attributes__transfers") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: agency_id
         description: '{{ doc("gtfs_fare_attributes__agency_id") }}'
       - name: transfer_duration
@@ -358,17 +358,17 @@ models:
       - *base64_url
       - name: fare_product_id
         description: '{{ doc("gtfs_fare_products__fare_product_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: fare_product_name
         description: '{{ doc("gtfs_fare_products__fare_product_name") }}'
       - name: fare_media_id
         description: '{{ doc("gtfs_fare_products__fare_media_id") }}'
       - name: amount
         description: '{{ doc("gtfs_fare_products__amount") }}'
-        tests: *not_null_warn_99_threshold
+        data_tests: *not_null_warn_99_threshold
       - name: currency
         description: '{{ doc("gtfs_fare_products__currency") }}'
-        tests: *not_null_warn_99_threshold
+        data_tests: *not_null_warn_99_threshold
       - *_feed_valid_from
       - *feed_timezone_no_tests
 
@@ -387,7 +387,7 @@ models:
       - *base64_url
       - name: fare_id
         description: '{{ doc("gtfs_fare_rules__fare_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: route_id
         description: '{{ doc("gtfs_fare_rules__route_id") }}'
       - name: origin_id
@@ -424,7 +424,7 @@ models:
         description: '{{ doc("gtfs_fare_transfer_rules__duration_limit_type") }}'
       - name: fare_transfer_type
         description: '{{ doc("gtfs_fare_transfer_rules__fare_transfer_type") }}'
-        tests: *not_null_warn_99_threshold
+        data_tests: *not_null_warn_99_threshold
       - name: fare_product_id
         description: '{{ doc("gtfs_fare_transfer_rules__fare_product_id") }}'
       - *_feed_valid_from
@@ -445,13 +445,13 @@ models:
       - *base64_url
       - name: feed_publisher_name
         description: '{{ doc("gtfs_feed_info__feed_publisher_name") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: feed_publisher_url
         description: '{{ doc("gtfs_feed_info__feed_publisher_url") }}'
-        tests: *not_null_warn_99_threshold
+        data_tests: *not_null_warn_99_threshold
       - name: feed_lang
         description: '{{ doc("gtfs_feed_info__feed_lang") }}'
-        tests: *not_null_warn_99_threshold
+        data_tests: *not_null_warn_99_threshold
       - name: default_lang
         description: '{{ doc("gtfs_feed_info__default_lang") }}'
       - name: feed_start_date
@@ -481,16 +481,16 @@ models:
       - *base64_url
       - name: trip_id
         description: '{{ doc("gtfs_frequencies__trip_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: start_time
         description: '{{ doc("gtfs_frequencies__start_time") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: end_time
         description: '{{ doc("gtfs_frequencies__end_time") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: headway_secs
         description: '{{ doc("gtfs_frequencies__headway_secs") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: exact_times
         description: '{{ doc("gtfs_frequencies__exact_times") }}'
       - *_feed_valid_from
@@ -550,10 +550,10 @@ models:
       - *base64_url
       - name: level_id
         description: '{{ doc("gtfs_levels__level_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: level_index
         description: '{{ doc("gtfs_levels__level_index") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: level_name
         description: '{{ doc("gtfs_levels__level_name") }}'
       - *_feed_valid_from
@@ -573,19 +573,19 @@ models:
       - *base64_url
       - name: pathway_id
         description: '{{ doc("gtfs_pathways__pathway_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: from_stop_id
         description: '{{ doc("gtfs_pathways__from_stop_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: to_stop_id
         description: '{{ doc("gtfs_pathways__to_stop_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: pathway_mode
         description: '{{ doc("gtfs_pathways__pathway_mode") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: is_bidirectional
         description: '{{ doc("gtfs_pathways__is_bidirectional") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: length
         description: '{{ doc("gtfs_pathways__length") }}'
       - name: traversal_time
@@ -617,7 +617,7 @@ models:
       - *base64_url
       - name: route_id
         description: '{{ doc("gtfs_routes__route_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: agency_id
         description: '{{ doc("gtfs_routes__agency_id") }}'
       - name: route_short_name
@@ -628,7 +628,7 @@ models:
         description: '{{ doc("gtfs_routes__route_desc") }}'
       - name: route_type
         description: '{{ doc("gtfs_routes__route_type") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: route_url
         description: '{{ doc("gtfs_routes__route_url") }}'
       - name: route_color
@@ -660,10 +660,10 @@ models:
       - *base64_url
       - name: shape_id
         description: '{{ doc("gtfs_shapes__shape_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: shape_pt_lat
         description: '{{ doc("gtfs_shapes__shape_pt_lat") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
         meta:
           metabase.semantic_type: type/Latitude
           ckan.type: FLOAT
@@ -671,7 +671,7 @@ models:
           ckan.precision: 3
       - name: shape_pt_lon
         description: '{{ doc("gtfs_shapes__shape_pt_lon") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
         meta:
           metabase.semantic_type: type/Longitude
           ckan.type: FLOAT
@@ -679,7 +679,7 @@ models:
           ckan.precision: 3
       - name: shape_pt_sequence
         description: '{{ doc("gtfs_shapes__shape_pt_sequence") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: shape_dist_traveled
         description: '{{ doc("gtfs_shapes__shape_dist_traveled") }}'
       - *_feed_valid_from
@@ -699,10 +699,10 @@ models:
       - *base64_url
       - name: area_id
         description: '{{ doc("gtfs_stop_areas__area_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: stop_id
         description: '{{ doc("gtfs_stop_areas__stop_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - *_feed_valid_from
       - *feed_timezone_no_tests
 
@@ -721,7 +721,7 @@ models:
       - *base64_url
       - name: stop_id
         description: '{{ doc("gtfs_stops__stop_id") }}'
-        tests: &not_null_error_99_threshold
+        data_tests: &not_null_error_99_threshold
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
@@ -773,7 +773,7 @@ models:
           they cannot be referenced by a foreign key elsewhere.
       - name: stop_timezone_coalesced
         description: '{{ doc("gtfs_schedule_stop_timezone_coalesced") }}'
-        tests:
+        data_tests:
           - not_null
       - *_feed_valid_from
       - *feed_timezone_no_tests
@@ -793,19 +793,19 @@ models:
       - *base64_url
       - name: from_stop_id
         description: '{{ doc("gtfs_transfers__from_stop_id") }}'
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 error_if: "> 5"
       - name: to_stop_id
         description: '{{ doc("gtfs_transfers__to_stop_id") }}'
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 error_if: "> 5"
       - name: transfer_type
         description: '{{ doc("gtfs_transfers__transfer_type") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: min_transfer_time
         description: '{{ doc("gtfs_transfers__min_transfer_time") }}'
       - name: from_route_id
@@ -833,16 +833,16 @@ models:
       - *base64_url
       - name: table_name
         description: '{{ doc("gtfs_translations__table_name") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: field_name
         description: '{{ doc("gtfs_translations__field_name") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: language
         description: '{{ doc("gtfs_translations__language") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: translation
         description: '{{ doc("gtfs_translations__translation") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: record_id
         description: '{{ doc("gtfs_translations__record_id") }}'
       - name: record_sub_id
@@ -867,13 +867,13 @@ models:
       - *base64_url
       - name: route_id
         description: '{{ doc("gtfs_trips__route_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: service_id
         description: '{{ doc("gtfs_trips__service_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: trip_id
         description: '{{ doc("gtfs_trips__trip_id") }}'
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 error_if: ">1"
@@ -914,34 +914,34 @@ models:
       - *base64_url
       - name: service_id
         description: '{{ doc("gtfs_calendar__service_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: monday
         description: '{{ doc("gtfs_calendar__monday") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: tuesday
         description: '{{ doc("gtfs_calendar__tuesday") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: wednesday
         description: '{{ doc("gtfs_calendar__wednesday") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: thursday
         description: '{{ doc("gtfs_calendar__thursday") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: friday
         description: '{{ doc("gtfs_calendar__friday") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: saturday
         description: '{{ doc("gtfs_calendar__saturday") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: sunday
         description: '{{ doc("gtfs_calendar__sunday") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: start_date
         description: '{{ doc("gtfs_calendar__start_date") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: end_date
         description: '{{ doc("gtfs_calendar__end_date") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - *_feed_valid_from
       - *feed_timezone_no_tests
 
@@ -959,13 +959,13 @@ models:
       - *base64_url
       - name: service_id
         description: '{{ doc("gtfs_calendar_dates__service_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: date
         description: '{{ doc("gtfs_calendar_dates__date") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: exception_type
         description: '{{ doc("gtfs_calendar_dates__exception_type") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - *_feed_valid_from
       - *feed_timezone_no_tests
 
@@ -978,7 +978,7 @@ models:
       status in the Cal-ITP data warehouse and
       https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md
       for the Flex v2 specification.
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "EXTRACT(DAY FROM arrival_time_interval) = 0"
@@ -997,20 +997,20 @@ models:
       - *base64_url
       - name: trip_id
         description: '{{ doc("gtfs_stop_times__trip_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: arrival_time
         description: '{{ doc("gtfs_stop_times__arrival_time") }}'
       - name: departure_time
         description: '{{ doc("gtfs_stop_times__departure_time") }}'
       - name: stop_id
         description: '{{ doc("gtfs_stop_times__stop_id") }}'
-        tests:
+        data_tests:
         - not_null:
             arguments:
               where: "not warning_missing_foreign_key_stop_id"
       - name: stop_sequence
         description: '{{ doc("gtfs_stop_times__stop_sequence") }}'
-        tests: *not_null_warn
+        data_tests: *not_null_warn
       - name: stop_headsign
         description: '{{ doc("gtfs_stop_times__stop_headsign") }}'
       - name: pickup_type
@@ -1169,7 +1169,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `feed_key` and `shape_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
       - *schedule_dim_dt
@@ -1177,9 +1177,9 @@ models:
       - *base64_url
       - name: shape_id
         description: '{{ doc("gtfs_shapes__shape_id") }}'
-        tests: *not_null_error
+        data_tests: *not_null_error
       - name: pt_array
         description: Ordered array of WKT points that describe this shape.
-        tests: *not_null_error
+        data_tests: *not_null_error
       - *_feed_valid_from
       - *feed_timezone_no_tests

--- a/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
+++ b/warehouse/models/mart/gtfs/_mart_gtfs_fcts.yml
@@ -10,7 +10,7 @@ x-common-fields:
   - &feed_key
     name: feed_key
     description: '{{ doc("gtfs_schedule_feed_key") }}'
-    tests:
+    data_tests:
       - not_null
       - relationships:
           arguments:
@@ -26,7 +26,7 @@ x-common-fields:
     name: gtfs_dataset_key
     description: &gtfs_dataset_key_desc |
       '{{ doc("gtfs_schedule_gtfs_dataset_key") }}'
-    tests:
+    data_tests:
       - not_null:
           arguments:
             config:
@@ -45,7 +45,7 @@ x-common-fields:
     name: gtfs_dataset_key
     description: |
       Foreign key to the associated GTFS dataset record.
-    tests:
+    data_tests:
       - not_null:
           arguments:
             config:
@@ -68,7 +68,7 @@ x-common-fields:
   - &gtfs_dataset_key
     name: gtfs_dataset_key
     description: *gtfs_dataset_key_desc
-    tests:
+    data_tests:
       - dbt_utils.not_null_proportion:
           arguments:
             # TODO: raise back to .999 after some time getting new data -
@@ -87,7 +87,7 @@ x-common-fields:
   - &gtfs_rt_schedule_dataset_key
     name: schedule_gtfs_dataset_key
     description: '{{ doc("column_rt_schedule_dataset_key") }}'
-    tests:
+    data_tests:
       - relationships:
           arguments:
             to: ref('dim_gtfs_datasets')
@@ -100,7 +100,7 @@ x-common-fields:
   - &gtfs_rt_schedule_feed_key
     name: schedule_feed_key
     description: '{{ doc("column_rt_schedule_feed_key") }}'
-    tests:
+    data_tests:
       - relationships:
           arguments:
             to: ref('dim_schedule_feeds')
@@ -125,7 +125,7 @@ x-common-fields:
       - service date
       - trip_id
       - iteration number, which attempts to normalize trip start times
-    tests:
+    data_tests:
       - not_null
       - unique_proportion:
           arguments:
@@ -134,7 +134,7 @@ x-common-fields:
     name: key
     description: |
       Composite of calculated service date, URL, trip ID, and trip start time.
-    tests:
+    data_tests:
       - not_null
       - unique_proportion:
           arguments:
@@ -497,7 +497,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `date` and `feed_key`.
-        tests: &primary_key_tests
+        data_tests: &primary_key_tests
           - unique
           - not_null
       - name: date
@@ -516,9 +516,9 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `base64_url` and `ts`.
-        tests: *primary_key_tests
+        data_tests: *primary_key_tests
       - <<: *feed_key
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 config:
@@ -564,7 +564,7 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`, `vehicle_id`, and `trip_id`.
-        tests: &almost_unique_rt_key_tests
+        data_tests: &almost_unique_rt_key_tests
           - unique_proportion:
               arguments:
                 at_least: 0.999
@@ -614,7 +614,7 @@ models:
       Unnested and de-duped stop time updates.
     columns:
       - name: key
-        tests: *almost_unique_rt_key_tests
+        data_tests: *almost_unique_rt_key_tests
       - *gtfs_dataset_key_errorif_sampled
       - *gtfs_rt_dt
       - *gtfs_rt_hour
@@ -679,7 +679,7 @@ models:
           Synthetic primary key constructed from `service_date`, `base64_url`,
           `location_timestamp`, `vehicle_id`, `vehicle_label`,
           `trip_id`, and `trip_start_time`.
-        tests: *almost_unique_rt_key_tests
+        data_tests: *almost_unique_rt_key_tests
       - name: gtfs_dataset_key
         description: *gtfs_dataset_key_desc
       - *gtfs_rt_dt
@@ -712,7 +712,7 @@ models:
       - *rt_vehicle_license_plate
       - *rt_vehicle_wheelchair_accessible
       - <<: *rt_trip_id
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 config:
@@ -765,7 +765,7 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`, `vehicle_id`, and `trip_id`.
-        tests: *almost_unique_rt_key_tests
+        data_tests: *almost_unique_rt_key_tests
       - *gtfs_dataset_key_errorif_sampled
       - *gtfs_rt_dt
       - *gtfs_rt_hour
@@ -819,34 +819,34 @@ models:
       Each row is a date / URL pair with a summary of data aggregation outcomes.
     columns:
     - name: key
-      tests: *primary_key_tests
+      data_tests: *primary_key_tests
     - name: date
       description: Date that data was downloaded.
     - <<: *base64_url
-      tests:
+      data_tests:
         - not_null
     - *feed_type
     - name: parse_success_file_count
       description: |
         Count of files successfully parsed. Target is 4,320 (one file every
         20 seconds.)
-      tests:
+      data_tests:
         - not_null
     - name: parse_failure_file_count
       description: Count of files where parsing failed, but a file was present.
-      tests:
+      data_tests:
         - not_null
     - *gtfs_dataset_key
     - name: schedule_to_use_for_rt_validation_gtfs_dataset_key
       description: '{{ doc("column_rt_schedule_dataset_key") }}'
-      tests:
+      data_tests:
           - relationships:
               arguments:
                 to: ref('dim_gtfs_datasets')
                 field: key
     - name: schedule_feed_key
       description: '{{ doc("column_rt_schedule_feed_key") }}'
-      tests:
+      data_tests:
           - relationships:
               arguments:
                 to: ref('dim_schedule_feeds')
@@ -860,7 +860,7 @@ models:
       Service summary is based on `fct_scheduled_trips`, grouped to the feed
       level (a feed with no trips in `fct_scheduled_trips` will have 0s here for
       the summary columns.)
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -927,7 +927,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `dt` and `base64_url`.
-        tests: *primary_key_tests
+        data_tests: *primary_key_tests
       - name: dt
         description: |
           Date on which the download attempt was made.
@@ -973,7 +973,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `dt` and `base64_url`.
-        tests: *primary_key_tests
+        data_tests: *primary_key_tests
       - name: dt
         description: |
           Date on which the download attempt was made.
@@ -1027,7 +1027,7 @@ models:
         description: |
           Synthetic primary key constructed from `base64_url`, `extract_ts`,
           entity `id`.
-        tests: &rt_primary_key_tests
+        data_tests: &rt_primary_key_tests
           - unique:
               arguments:
                 where: '__rt_sampled__'
@@ -1088,7 +1088,7 @@ models:
       distinct.)
       See: https://gtfs.org/realtime/reference/#message-alert for
       field definitions.
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "active_period_start <= active_period_end"
@@ -1098,11 +1098,11 @@ models:
         description: |
           Synthetic primary key constructed from `service_alerts_message_key`
           along with the active period and informed entities.
-        tests: *rt_primary_key_tests
+        data_tests: *rt_primary_key_tests
       - name: service_alert_message_key
         description: |
           The primary key for the message in `fct_service_alerts_messages`.
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 config:
@@ -1200,7 +1200,7 @@ models:
         description: |
           Synthetic primary key constructed from `active_date`,
           `base64_url`, `id`, entity selectors, and alert active period.
-        tests:
+        data_tests:
           - unique_proportion:
               arguments:
                 at_least: 0.999
@@ -1260,7 +1260,7 @@ models:
         description: |
           Synthetic primary key constructed from `activity_date`, `shape_id`,
           and `shape_array_key`.
-        tests:
+        data_tests:
           - unique:
               arguments:
                 where: "not contains_warning_duplicate_trip_primary_key"
@@ -1331,7 +1331,7 @@ models:
         description: |
           Synthetic primary key constructed from `stop_arrival_date_pacific` and
           `stop_key`.
-        tests:
+        data_tests:
           - unique:
               arguments:
                 where: "not contains_warning_duplicate_trip_primary_key AND not contains_warning_duplicate_stop_times_primary_key AND not contains_warning_duplicate_stop_primary_key"
@@ -1448,7 +1448,7 @@ models:
           Treat these rows with caution.
       - name: stop_key
         description: Foreign key to the `dim_stops` table.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_stops')
@@ -1504,7 +1504,7 @@ models:
           feed.
           This field is provided for convenience and should not be used as a
           join key.
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 config:
@@ -1516,7 +1516,7 @@ models:
           positions feed.
           This field is provided for convenience and should not be used as a
           join key.
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 config:
@@ -1556,7 +1556,7 @@ models:
       # foreign keys
       - name: tu_gtfs_dataset_key
         description: *gtfs_dataset_key_desc
-        tests:
+        data_tests:
           - dbt_utils.relationships_where:
               arguments:
                 to: ref('dim_gtfs_datasets')
@@ -1566,7 +1566,7 @@ models:
         name: tu_base64_url
       - name: vp_gtfs_dataset_key
         description: *gtfs_dataset_key_desc
-        tests:
+        data_tests:
           - dbt_utils.relationships_where:
               arguments:
                 to: ref('dim_gtfs_datasets')
@@ -1574,7 +1574,7 @@ models:
                 to_condition: "type = 'vehicle_positions'"
       - name: schedule_gtfs_dataset_key
         description: *gtfs_dataset_key_desc
-        tests:
+        data_tests:
           - dbt_utils.relationships_where:
               arguments:
                 to: ref('dim_gtfs_datasets')
@@ -1786,7 +1786,7 @@ models:
       this reduces the data size by about 90%.
     columns:
       - name: key
-        tests: *almost_unique_rt_key_tests
+        data_tests: *almost_unique_rt_key_tests
       - *gtfs_dataset_key_errorif_sampled
       - *gtfs_rt_dt
       - *gtfs_rt_hour
@@ -1852,7 +1852,7 @@ models:
     # as of May 2023 this test would fail because we have Flex feeds that use incorrect column names so both fields are null
     columns:
       - name: key
-        tests:
+        data_tests:
           - unique:
               arguments:
                 where: "not contains_warning_duplicate_trip_primary_key"
@@ -1893,7 +1893,7 @@ models:
           trip has service on this date.
       - name: trip_key
         description: Foreign key to dim_trips.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_trips')
@@ -1907,7 +1907,7 @@ models:
       - name: block_id
         description: '{{ doc("gtfs_trips__block_id") }}'
       - <<: *trip_instance_key
-        tests:
+        data_tests:
           - not_null
           - unique:
               arguments:
@@ -1915,7 +1915,7 @@ models:
                   where: "not contains_warning_duplicate_trip_primary_key"
       - name: route_key
         description: Foreign key to dim_routes.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_routes')
@@ -1944,7 +1944,7 @@ models:
         description: '{{ doc("gtfs_routes__continuous_drop_off") }}'
       - name: shape_array_key
         description: Foreign key to dim_shapes_arrays.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_shapes_arrays')
@@ -2217,7 +2217,7 @@ models:
       applies to that trip.
       So, for example, if there is a service alert for Route A on a given date,
       this table will *not* include all trips on Route A for that date.
-    tests:
+    data_tests:
       - &warn_rt_trip_hours_past_midnight_no_start_date
         dbt_utils.expression_is_true:
           arguments:
@@ -2315,12 +2315,12 @@ models:
       `trip_instance_key` and `key` values, specifically they can occur on days
       where the URL or time zone for a given  feed change because of how the keys
       are generated upstream.
-    tests:
+    data_tests:
       - *warn_rt_trip_hours_past_midnight_no_start_date
     columns:
       - *rt_trip_summary_key
       - <<: *trip_instance_key
-        tests:
+        data_tests:
           - not_null
           - unique_proportion:
               arguments:
@@ -2425,12 +2425,12 @@ models:
       `trip_instance_key` and `key` values, specifically they can occur on days
       where the URL or time zone for a given feed change because of how the keys
       are generated upstream.
-    tests:
+    data_tests:
       - *warn_rt_trip_hours_past_midnight_no_start_date
     columns:
       - *rt_trip_summary_key
       - <<: *trip_instance_key
-        tests:
+        data_tests:
           - not_null
           - unique_proportion:
               arguments:

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -10,34 +10,34 @@ models:
       is filled in so there is always a count of notices per day
       per feed, even if that count is zero; null counts indicate
       a lack of validation for that feed on that day.
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: 'validated_extracts = validation_successes + validation_exceptions'
     columns:
       - &key
         name: key
-        tests: &primary_key_tests
+        data_tests: &primary_key_tests
           - unique
           - not_null
         meta: &pk_meta
           metabase.semantic_type: type/PK
       - &date
         name: date
-        tests:
+        data_tests:
           - not_null
       - name: code
-        tests:
+        data_tests:
           - not_null
       - name: description
         description: A plain language description of the issue indicated by the code
-        tests:
+        data_tests:
           - not_null
       - name: is_critical
-        tests:
+        data_tests:
           - not_null
       - name: parsed_files
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
@@ -45,7 +45,7 @@ models:
               arguments:
                 expression: '<= 4320'
       - name: validated_extracts
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
@@ -53,7 +53,7 @@ models:
               arguments:
                 expression: '<= 4320'
       - name: validation_successes
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
@@ -61,7 +61,7 @@ models:
               arguments:
                 expression: '<= 4320'
       - name: validation_exceptions
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
@@ -79,7 +79,7 @@ models:
     columns:
       - *key
       - name: date
-        tests:
+        data_tests:
           - not_null
           # These tests ensure we only display notices during
           # the "range" of validator versions.
@@ -119,7 +119,7 @@ models:
                 where: validation_validator_version = 'v7.1.0'
       - &schedule_feed_key
         name: feed_key
-        tests:
+        data_tests:
           - not_null
           - relationships:
               arguments:
@@ -127,10 +127,10 @@ models:
                 field: key
       - &base64_url
         name: base64_url
-        tests:
+        data_tests:
           - not_null
       - name: outcome_extract_dt
-        tests:
+        data_tests:
           - dbt_utils.expression_is_true:
               arguments:
                 # outcomes only count for the outcomes's date and onwards
@@ -140,7 +140,7 @@ models:
         description: |
           The version of the GTFS schedule canonical validator that these notices are from.
           See version and release history at https://github.com/MobilityData/gtfs-validator/releases.
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -151,19 +151,19 @@ models:
           Code from the GTFS schedule canonical validator.
           See https://github.com/MobilityData/gtfs-validator/blob/master/RULES.md for
           documentation of individual codes.
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
       - name: validation_success
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
       - name: validation_exception
       - name: total_notices
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.99
@@ -173,7 +173,7 @@ models:
       Contains the actually implemented checks, i.e. checks that
       show up in the underlying daily checks model. Tested against
       the "intended checks" to verify checks are actually implemented.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -224,18 +224,18 @@ models:
           Array of schedule_feed_key values for schedule feed versions included in this organization's assessment.
       - &check
         name: check
-        tests:
+        data_tests:
           - not_null
       - &status
         name: status
-        tests:
+        data_tests:
           - not_null
       - name: feature
       - &is_manual
         name: is_manual
         description: |
           Boolean flag for whether the associated check was performed by hand (via Airtable) or automatically.
-        tests:
+        data_tests:
           - not_null
       - &reports_order
         name: reports_order
@@ -299,7 +299,7 @@ models:
         description:
           Foreign key to `dim_schedule_feeds`.
           This may be null if the unzip operation failed.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_schedule_feeds')
@@ -309,13 +309,13 @@ models:
           The original full file path to this file in the zipfile.
           This may include directory names that were part of
           the zipfile's original internal structure.
-        tests:
+        data_tests:
           - not_null
       - name: original_filename
         description: |
           The file name portion of the original file path
           (i.e., directories have been stripped away.)
-        tests:
+        data_tests:
           - not_null
       - name: gtfs_filename
         description: |
@@ -340,14 +340,14 @@ models:
           If not `parse_success`, the exception that was encountered when
           converting this file to JSONL.
       - name: base64_url
-        tests:
+        data_tests:
           - not_null
       - name: string_url
         description: |
           Human readable string URL.
           Will not contain authorization parameters.
       - name: gtfs_dataset_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_gtfs_datasets')
@@ -387,7 +387,7 @@ models:
       - name: organization_itp_id
       - name: organization_source_record_id
       - name: organization_key
-        tests:
+        data_tests:
           - not_null
           - relationships:
               arguments:
@@ -499,13 +499,13 @@ models:
         name: publish_date
         description: |
           See `idx_monthly_reports_site` table; intended to be used to join this data with the index.
-        tests:
+        data_tests:
           - not_null
       - *schedule_validator_code
       - name: severity
       - *schedule_validation_validator_version
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
   - name: fct_monthly_reports_site_organization_file_checks
     description: |
@@ -594,7 +594,7 @@ models:
         that the `header_timestamp` was later than `_extract_ts`.
       - `pX` refers to a percentile, so `p25` refers to 25th percentile.
       - `avg` refers to the mean.
-    tests: &message_age_summary_tests
+    data_tests: &message_age_summary_tests
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -602,10 +602,10 @@ models:
               - base64_url
     columns: &message_age_summary_cols
       - name: dt
-        tests:
+        data_tests:
           - not_null
       - name: base64_url
-        tests:
+        data_tests:
           - not_null
 
   - name: fct_daily_trip_updates_message_age_summary
@@ -619,7 +619,7 @@ models:
         that the `header_timestamp` was later than `_extract_ts`.
       - `pX` refers to a percentile, so `p25` refers to 25th percentile.
       - `avg` refers to the mean.
-    tests: *message_age_summary_tests
+    data_tests: *message_age_summary_tests
     columns: *message_age_summary_cols
 
   - name: fct_daily_service_alerts_message_age_summary
@@ -632,7 +632,7 @@ models:
         that the `header_timestamp` was later than `_extract_ts`.
       - `pX` refers to a percentile, so `p25` refers to 25th percentile.
       - `avg` refers to the mean.
-    tests: *message_age_summary_tests
+    data_tests: *message_age_summary_tests
     columns: *message_age_summary_cols
 
   - name: fct_monthly_reports_site_organization_gtfs_vendors

--- a/warehouse/models/mart/gtfs_rollup/_mart_gtfs_rollup.yml
+++ b/warehouse/models/mart/gtfs_rollup/_mart_gtfs_rollup.yml
@@ -8,7 +8,7 @@ x-common-fields:
   - &feed_key
     name: feed_key
     description: '{{ doc("gtfs_schedule_feed_key") }}'
-    tests:
+    data_tests:
       - not_null
       - relationships:
           arguments:

--- a/warehouse/models/mart/ntd/_mart_ntd.yml
+++ b/warehouse/models/mart/ntd/_mart_ntd.yml
@@ -3,13 +3,13 @@ version: 2
 x-common-fields:
   - &key
     name: key
-    tests:
+    data_tests:
       - not_null
       - unique
   - &ntd_id
     name: ntd_id
     description: '{{ doc("ntd_id") }}'
-    tests:
+    data_tests:
       - not_null
   - &agency
     name: agency
@@ -302,7 +302,7 @@ models:
       and then choose which year to look up.
 
       Use _is_current to find the latest version for each set of year, ntd_id, and state_parent_ntd_id.
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           arguments:
             lower_bound_column: _valid_from
@@ -313,18 +313,18 @@ models:
       - *key
       - <<: *report_year
         name: year
-        tests:
+        data_tests:
           - not_null
       - *ntd_id
       - name: _valid_from
-        tests:
+        data_tests:
           - not_null
       - name: _valid_to
-        tests:
+        data_tests:
           - not_null
       - name: _is_current
         description: Indicates the latest report version for each year, ntd_id, and state_parent_ntd_id.
-        tests:
+        data_tests:
           - not_null
       - *state_parent_ntd_id
       - *agency_name
@@ -380,7 +380,7 @@ models:
         description: |
           The table that originated the funding source information.
           The options are: `federal`, `state`, and `local`.
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -472,7 +472,7 @@ models:
           Local and State funding sources reported by agencies that do not report funding sources in specific categories because they have reduced reporting requirements.
           *ONLY for Local and State Funding Sources (funding_source IN ("local", "state"))
       - <<: *report_year
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -503,7 +503,7 @@ models:
     columns:
       - *key
       - <<: *report_year
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -550,7 +550,7 @@ models:
     columns:
       - *key
       - <<: *report_year
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -563,7 +563,7 @@ models:
       - *mode
       - *mode_name
       - <<: *time_period
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: ["Average Weekday - AM Peak", "Average Weekday - Midday", "Average Weekday - PM Peak", "Average Weekday - Other", "Average Typical Weekday", "Average Typical Saturday", "Average Typical Sunday"]
@@ -656,7 +656,7 @@ models:
     columns:
       - *key
       - <<: *report_year
-        tests:
+        data_tests:
           - not_null
           - accepted_values:
               arguments:
@@ -672,7 +672,7 @@ models:
         description: |
           The time period for which data was collected.
           This table displays only "Annual Total".
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: ["Annual Total"]

--- a/warehouse/models/mart/ntd_annual_reporting/_mart_ntd_annual_reporting.yml
+++ b/warehouse/models/mart/ntd_annual_reporting/_mart_ntd_annual_reporting.yml
@@ -4,7 +4,7 @@ x-common-fields:
   - &ntd_id
     name: ntd_id
     description: '{{ doc("ntd_id") }}'
-    tests:
+    data_tests:
       - not_null
   - &agency_name
     name: agency_name
@@ -147,7 +147,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `year`, 'ntd_id', 'state_parent_ntd_id', and 'execution_ts'.
-        tests:
+        data_tests:
           - not_null
           - unique
       - *ntd_id
@@ -205,7 +205,7 @@ models:
       - name: _content_hash
         description: |
           Synthetic primary key constructed from hashing all row values (aside from internally-created columns `dt` and `execution_ts`).
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_breakdowns
@@ -215,7 +215,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `type_of_service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_breakdowns_by_agency
@@ -225,7 +225,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_capital_expenses_by_capital_use
@@ -235,7 +235,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, `type_of_service`, and `form_type`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_capital_expenses_by_mode
@@ -245,7 +245,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, and `mode`, and `type_of_service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_capital_expenses_for_existing_service
@@ -255,7 +255,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_capital_expenses_for_expansion_of_service
@@ -265,7 +265,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_employees_by_agency
@@ -275,7 +275,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_employees_by_mode
@@ -285,7 +285,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, 'mode', 'type_of_service'.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_employees_by_mode_and_employee_type
@@ -295,7 +295,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, 'mode', 'type_of_service', and 'full_or_part_time'.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_fuel_and_energy
@@ -305,7 +305,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, and `mode`, and `type_of_service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_fuel_and_energy_by_agency
@@ -315,7 +315,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_funding_sources_by_expense_type
@@ -325,7 +325,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, and `fund_expenditure_type`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_funding_sources_directly_generated
@@ -335,7 +335,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_funding_sources_federal
@@ -345,7 +345,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_funding_sources_local
@@ -355,7 +355,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_funding_sources_state
@@ -365,7 +365,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_funding_sources_taxes_levied_by_agency
@@ -375,7 +375,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_maintenance_facilities
@@ -385,7 +385,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `type_of_service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_maintenance_facilities_by_agency
@@ -395,7 +395,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_metrics
@@ -405,7 +405,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `type_of_service.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_expenses_by_function
@@ -415,7 +415,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `type_of_service.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_expenses_by_function_and_agency
@@ -425,7 +425,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_expenses_by_type
@@ -435,7 +435,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `type_of_service.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_expenses_by_type_and_agency
@@ -445,7 +445,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_by_agency
@@ -455,7 +455,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_by_mode
@@ -465,7 +465,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `type_of_service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_by_mode_and_time_period
@@ -475,7 +475,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, `type_of_service`, and `time_period`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_stations_and_facilities_by_agency_and_facility_type
@@ -485,7 +485,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_stations_by_mode_and_age
@@ -495,7 +495,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `facility_type`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_track_and_roadway_by_agency
@@ -505,7 +505,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_track_and_roadway_by_mode
@@ -515,7 +515,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, and `type_of_service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_track_and_roadway_guideway_age_distribution
@@ -525,7 +525,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, `mode`, `type_of_service`, and `guideway_element`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_vehicles_age_distribution
@@ -535,7 +535,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `report_year`, and `vehicle_type`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_vehicles_type_count_by_agency
@@ -545,6 +545,6 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id` and `report_year`.
-        tests:
+        data_tests:
           - not_null
           - unique

--- a/warehouse/models/mart/ntd_assets/_mart_assets.yml
+++ b/warehouse/models/mart/ntd_assets/_mart_assets.yml
@@ -8,7 +8,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_asset_inventory_time_series_ada_fleet
@@ -18,7 +18,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_asset_inventory_time_series_avg_fleet_age
@@ -28,7 +28,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_asset_inventory_time_series_avg_seating_capacity
@@ -38,7 +38,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_asset_inventory_time_series_avg_standing_capacity
@@ -48,6 +48,6 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique

--- a/warehouse/models/mart/ntd_funding_and_expenses/_mart_ntd_funding_and_expenses.yml
+++ b/warehouse/models/mart/ntd_funding_and_expenses/_mart_ntd_funding_and_expenses.yml
@@ -8,7 +8,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, and `mode`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_capital_expenditures_time_series_other
@@ -18,7 +18,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, and `mode`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_capital_expenditures_time_series_rolling_stock
@@ -28,7 +28,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, and `mode`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_capital_expenditures_time_series_total
@@ -38,7 +38,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, and `mode`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_capital_federal
@@ -48,7 +48,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_capital_local
@@ -58,7 +58,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_capital_other
@@ -68,7 +68,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_capital_state
@@ -78,7 +78,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_capital_total
@@ -88,7 +88,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_operating_federal
@@ -98,7 +98,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_operating_local
@@ -108,7 +108,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_operating_other
@@ -118,7 +118,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_operating_state
@@ -128,7 +128,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_operating_total
@@ -138,7 +138,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_summary_total
@@ -149,7 +149,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_operating_and_capital_funding_time_series_decommissioned_operatingother
@@ -159,7 +159,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, and `legacy_ntd_id`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_drm
@@ -169,7 +169,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_fares
@@ -179,7 +179,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_opexp_ga
@@ -189,7 +189,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_opexp_nvm
@@ -199,7 +199,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_opexp_total
@@ -209,7 +209,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vm
@@ -219,7 +219,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_opexp_vo
@@ -229,7 +229,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_pmt
@@ -239,7 +239,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_upt
@@ -249,7 +249,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_voms
@@ -259,7 +259,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_vrh
@@ -269,7 +269,7 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique
   - name: fct_service_data_and_operating_expenses_time_series_by_mode_vrm
@@ -279,6 +279,6 @@ models:
       - name: key
         description: |
           Synthetic primary key constructed from `ntd_id`, `year`, `legacy_ntd_id`, `mode`, and `service`.
-        tests:
+        data_tests:
           - not_null
           - unique

--- a/warehouse/models/mart/ntd_ridership/_mart_ntd_ridership.yml
+++ b/warehouse/models/mart/ntd_ridership/_mart_ntd_ridership.yml
@@ -60,7 +60,7 @@ models:
       - name: key
         description: |
           Surrogate key generated from ntd_id, mode, tos, period_month, and period_year.
-        tests:
+        data_tests:
           - not_null
           - unique
       - *ntd_id

--- a/warehouse/models/mart/ntd_safety_and_security/_mart_ntd_safety_and_security.yml
+++ b/warehouse/models/mart/ntd_safety_and_security/_mart_ntd_safety_and_security.yml
@@ -6,7 +6,7 @@ models:
     columns:
       - name: key
         description: Synthetic primary key constructed from ntd_id, year, and incident_number
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: ntd_id
@@ -223,7 +223,7 @@ models:
     columns:
       - name: key
         description: Synthetic primary key constructed from ntd_id, year, and incident_number
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: ntd_id
@@ -505,7 +505,7 @@ models:
     columns:
       - name: key
         description: Synthetic primary key constructed from ntd_id, year, month, mode, and type_of_service
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: ntd_id
@@ -655,7 +655,7 @@ models:
     columns:
       - name: key
         description: Synthetic primary key constructed from ntdid, yr, mo, modecd, typeofservicecd, eventtype, and location
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: ntd_id

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -7,14 +7,14 @@ models:
     columns:
       - name: micropayment_id
         description: '{{ doc("lp_micropayment_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique_proportion:
               arguments:
                 at_least: 0.999
       - name: aggregation_id
         description: '{{ doc("lp_aggregation_id") }}'
-        tests:
+        data_tests:
           - not_null
           - relationships:
               arguments:
@@ -22,7 +22,7 @@ models:
                 field: aggregation_id
       - name: littlepay_transaction_id
         description: '{{ doc("lp_paired_first_transaction_id") }}'
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               arguments:
                 at_least: 0.998
@@ -179,7 +179,7 @@ models:
           The last day of the month of the aggregation_datetime in Pacific Time (involves conversion of aggregation_datetime to Pacific Time).
           This column is primarily for use in BI tooling to support consistent dates across activity types.
           Aggregation activity happens throughout the month.
-        tests:
+        data_tests:
           - not_null
       - name: end_of_month_date_utc
         description: |
@@ -187,12 +187,12 @@ models:
           This column preserves the end of month date value for the original UTC date as received by Littlepay, however,
           `end_of_month_date_pacific` is primarily used in BI tooling instead to support consistent dates across activity types.
           Aggregation activity happens throughout the month.
-        tests:
+        data_tests:
           - not_null
       - name: aggregation_id
         description: |
           Aggregation ID that uniquely identifies this aggregation.
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: aggregation_datetime
@@ -311,7 +311,7 @@ models:
           The last day of the month of the aggregation_datetime in Pacific Time (involves conversion of aggregation_datetime to Pacific Time).
           This column is primarily for use in BI tooling to support consistent dates across activity types.
           Aggregation activity happens throughout the month.
-        tests:
+        data_tests:
           - not_null
       - name: end_of_month_date_utc
         description: |
@@ -319,12 +319,12 @@ models:
           This column preserves the end of month date value for the original UTC date as received by Littlepay, however,
           `end_of_month_date_pacific` is primarily used in BI tooling instead to support consistent dates across activity types.
           Aggregation activity happens throughout the month.
-        tests:
+        data_tests:
           - not_null
       - name: aggregation_id
         description: |
           Aggregation ID that uniquely identifies this aggregation.
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: aggregation_datetime
@@ -427,7 +427,7 @@ models:
       - *participant_id
       - name: aggregation_id
         description: '{{ doc("lp_aggregation_id") }}'
-        tests:
+        data_tests:
             - relationships:
                 arguments:
                   to: ref('fct_payments_aggregations')
@@ -446,7 +446,7 @@ models:
         description: Settlement amount in dollars. Negative for credit (refund) settlements.
       - name: retrieval_reference_number
         description: '{{ doc("lp_retrieval_reference_number") }}'
-        tests:
+        data_tests:
             - relationships:
                 arguments:
                   to: ref('fct_payments_aggregations')
@@ -482,7 +482,7 @@ models:
           This column is primarily for use in BI tooling to support consistent dates across activity types.
           Billing activity generally occurs only once per month, at the end of the month, while deposit
           activity happens throughout the month.
-        tests:
+        data_tests:
           - not_null
       - &elavon_lp_participant_id
         name: littlepay_participant_id
@@ -614,7 +614,7 @@ models:
         name: trn_ref_num
         description: |
           Elavon system assigned transaction reference tag
-        tests:
+        data_tests:
           - unique
       - &settlement_method
         name: settlement_method

--- a/warehouse/models/mart/payments/reliability/_payments_views_tests.yml
+++ b/warehouse/models/mart/payments/reliability/_payments_views_tests.yml
@@ -32,7 +32,7 @@ models:
       - name: relative_difference
         description: The relative change in a participant's ridership count as compared to the previous day
   - name: v2_payments_reliability_monthly_unlabeled_routes
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "n_all_rides >= (n_route_z_rides + n_null_rides)"
@@ -54,7 +54,7 @@ models:
       - name: recency_rank
         description: Used to identify a month's recency (for help with filtering)
   - name: v2_payments_reliability_weekly_unlabeled_routes
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "n_all_rides >= (n_route_z_rides + n_null_rides)"
@@ -76,7 +76,7 @@ models:
       - name: recency_rank
         description: Used to identify a month's recency (for help with filtering)
   - name: v2_payments_reliability_weekly_unlabeled_routes_enghouse
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "n_all_rides >= total_unlabeled_rides"

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: dim_components
     description: '{{ doc("components_table") }}'
-    tests: &mutually_exclusive_ranges
+    data_tests: &mutually_exclusive_ranges
       - dbt_utils.mutually_exclusive_ranges:
           arguments:
             lower_bound_column: _valid_from
@@ -13,7 +13,7 @@ models:
     columns:
       - &key
         name: key
-        tests:
+        data_tests:
           - not_null
           - unique
         meta:
@@ -40,14 +40,14 @@ models:
           this will always be True.
   - name: dim_contracts
     description: '{{ doc("contracts_table") }}'
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - name: contract_holder_organization_key
         description: |
           Unversioned Airtable record ID for contract holder organization; versioned bridge
           table to come later.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
@@ -56,7 +56,7 @@ models:
         description: |
           Unversioned Airtable record ID for contract vendor organization; versioned bridge
           table to come later.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
@@ -70,7 +70,7 @@ models:
       - *is_current_placeholder
   - name: dim_data_schemas
     description: '{{ doc("data_schemas_table") }}'
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - *valid_from_placeholder
@@ -78,7 +78,7 @@ models:
       - *is_current_placeholder
   - name: dim_organizations
     description: '{{ doc("organizations_table") }}'
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - &org_ntd_id
@@ -189,7 +189,7 @@ models:
             Council of Governments
   - name: dim_services
     description: '{{ doc("services_table") }}'
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - name: name
@@ -269,7 +269,7 @@ models:
       - *valid_to_actual
       - *is_current_actual
   - name: dim_products
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     description: '{{ doc("products_table") }}'
     columns:
       - *key
@@ -284,7 +284,7 @@ models:
       - *valid_to_placeholder
       - *is_current_placeholder
   - name: dim_properties_and_features
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - *valid_from_placeholder
@@ -294,11 +294,11 @@ models:
     description: |
       Attachment links to images of contracts.
       One contract can have multiple attachments.
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - name: contract_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_contracts')
@@ -308,7 +308,7 @@ models:
       - *is_current_placeholder
   - name: dim_gtfs_datasets
     description: '{{ doc("gtfs_datasets_table") }}'
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - name: type
@@ -358,13 +358,13 @@ models:
       - *is_current_actual
   - name: dim_gtfs_service_data
     description: '{{ doc("gtfs_service_data_table") }}'
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - name: service_key
         description: |
           Service record key for this service / dataset relationship.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
@@ -372,7 +372,7 @@ models:
       - name: gtfs_dataset_key
         description: |
           GTFS dataset record key for this service / dataset relationship.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_gtfs_datasets')
@@ -393,7 +393,7 @@ models:
       - name:  fares_v2_status
         # self relationship test breaks metabase connector: https://github.com/JarvusInnovations/dbt-metabase/blob/master/dbtmetabase/parsers/dbt_manifest.py#L202
         # TODO: make an aliased version of the relationship test
-        # tests:
+        # data_tests:
         #   - relationships:
         #       arguments:
         #         to: ref('dim_gtfs_service_data')
@@ -403,7 +403,7 @@ models:
       - *is_current_actual
   - name: dim_fare_systems
     description: '{{ doc("fare_systems_table") }}'
-    tests: *mutually_exclusive_ranges
+    data_tests: *mutually_exclusive_ranges
     columns:
       - *key
       - *valid_from_placeholder
@@ -414,25 +414,25 @@ models:
     columns:
       - *key
       - name: component_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_components')
                 field: key
       - name: product_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_products')
                 field: key
       - name: service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
                 field: key
       - name: product_vendor_organization_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
@@ -460,7 +460,7 @@ models:
       Currently, this is not a genuinely historical table because component and product data is current-only.
       Versioning columns are provided for future schema consistency.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -468,13 +468,13 @@ models:
               - product_key
     columns:
       - name: component_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_components')
                 field: key
       - name: product_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_products')
@@ -497,7 +497,7 @@ models:
     columns:
       - *key
       - name: service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
@@ -508,7 +508,7 @@ models:
           #       config:
           #         where: gtfs_service_data_customer_facing
       - name: schedule_gtfs_dataset_key
-        tests:
+        data_tests:
           - &ref_gtfs_datasets_key
             relationships:
               arguments:
@@ -521,16 +521,16 @@ models:
         description: |
           If "Yes", this service should be considered "assessed" by Cal-ITP for the reports site.
       - name: service_alerts_gtfs_dataset_key
-        tests:
+        data_tests:
           - *ref_gtfs_datasets_key
       - name: vehicle_positions_gtfs_dataset_key
-        tests:
+        data_tests:
           - *ref_gtfs_datasets_key
       - name: trip_updates_gtfs_dataset_key
-        tests:
+        data_tests:
           - *ref_gtfs_datasets_key
       - name: organization_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
@@ -601,7 +601,7 @@ models:
       - name: agency_name
         description: The name of the TA as specified in NTD.
       - <<: *org_ntd_id
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: hq_city
@@ -634,7 +634,7 @@ models:
       Currently, this is not a genuinely historical table because component and properties and features data is current-only.
       Versioning columns are provided for future schema consistency.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -642,13 +642,13 @@ models:
               - property_feature_key
     columns:
       - name: component_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_components')
                 field: key
       - name: property_feature_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_properties_and_features')
@@ -662,7 +662,7 @@ models:
       Currently, this is not a genuinely historical table because data schema and product data is current-only.
       Versioning columns are provided for future schema consistency.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -670,13 +670,13 @@ models:
               - product_key
     columns:
       - name: data_schema_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_data_schemas')
                 field: key
       - name: product_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_products')
@@ -690,7 +690,7 @@ models:
       Currently, this is not a genuinely historical table because data schema and product data is current-only.
       Versioning columns are provided for future schema consistency.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -698,13 +698,13 @@ models:
               - product_key
     columns:
       - name: data_schema_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_data_schemas')
                 field: key
       - name: product_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_products')
@@ -716,7 +716,7 @@ models:
       the given mobility service.
       This is a versioned, many-to-many relationship.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -724,13 +724,13 @@ models:
               - service_key
     columns:
       - name: organization_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
                 field: key
       - name: service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
@@ -741,7 +741,7 @@ models:
       (map between two organization records.)
       This is a versioned, many-to-many relationship.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -749,13 +749,13 @@ models:
               - parent_organization_key
     columns:
       - name: organization_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
                 field: key
       - name: parent_organization_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
@@ -767,7 +767,7 @@ models:
       (map between two service records.)
       This is a versioned, many-to-many relationship.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -775,13 +775,13 @@ models:
               - paratransit_for_service_key
     columns:
       - name: service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
                 field: key
       - name: paratransit_for_service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
@@ -794,7 +794,7 @@ models:
       For the organization that manages the service represented in a dataset, see dim_provider_gtfs_data.
       This is a versioned, many-to-many relationship.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -802,13 +802,13 @@ models:
               - gtfs_dataset_key
     columns:
       - name: organization_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
                 field: key
       - name: gtfs_dataset_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_gtfs_datasets')
@@ -824,7 +824,7 @@ models:
       Organizations that have been deleted will not have their funding programs present in
       this table.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -832,13 +832,13 @@ models:
               - funding_program_key
     columns:
       - name: organization_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_organizations')
                 field: key
       - name: funding_program_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_funding_programs')
@@ -855,7 +855,7 @@ models:
       Services that have been deleted will not have their fare systems present in
       this table.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -863,13 +863,13 @@ models:
               - service_key
     columns:
       - name: fare_system_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_fare_systems')
                 field: key
       - name: service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
@@ -880,7 +880,7 @@ models:
       Relationship indicates that contract covers the given component.
       This is a versioned, many-to-many relationship.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -888,13 +888,13 @@ models:
               - component_key
     columns:
       - name: contract_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_contracts')
                 field: key
       - name: component_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_components')
@@ -905,7 +905,7 @@ models:
       Relationship indicates that contract covers the given service.
       This is a versioned, many-to-many relationship.
       Joins via this table can result in fanout.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -913,13 +913,13 @@ models:
               - service_key
     columns:
       - name: contract_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_contracts')
                 field: key
       - name: service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
@@ -932,7 +932,7 @@ models:
       While an RT dataset can only use one schedule at a time, because the records are versioned independently,
       a given `gtfs_dataset_key` can appear multiple times in this table with different versions of its accompanying schedule.
       Thus, joins via this table can result in fanout if they don't limit to validity on a specific date.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -940,14 +940,14 @@ models:
               - schedule_to_use_for_rt_validation_gtfs_dataset_key
     columns:
       - name: gtfs_dataset_key
-        tests:
+        data_tests:
           - dbt_utils.relationships_where:
               arguments:
                 to: ref('dim_gtfs_datasets')
                 field: key
                 to_condition: "type != 'schedule'"
       - name: schedule_to_use_for_rt_validation_gtfs_dataset_key
-        tests:
+        data_tests:
           - dbt_utils.relationships_where:
               arguments:
                 to: ref('dim_gtfs_datasets')
@@ -959,7 +959,7 @@ models:
       modes records.
       This is a versioned relationship, with one service having one primary mode.
       Joins via this table can result in fanout because of versioning.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -967,13 +967,13 @@ models:
               - mode_key
     columns:
       - name: service_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_services')
                 field: key
       - name: mode_key
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('dim_modes')

--- a/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
+++ b/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
@@ -25,7 +25,7 @@ models:
         description: |
           GTFS data type ("schedule", "trip_updates",
           "vehicle_positions", or "service_alerts")
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: ["trip_updates", "vehicle_positions", "service_alerts"]
@@ -62,7 +62,7 @@ models:
         description: |
           Base64-encoded URL of the GTFS schedule feed associated with the row, only
           filled with a value for rows representing non-schedule-type feeds
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: [NULL]

--- a/warehouse/models/staging/gtfs/_stg_gtfs.yml
+++ b/warehouse/models/staging/gtfs/_stg_gtfs.yml
@@ -3,7 +3,7 @@ version: 2
 models:
   - name: stg_gtfs_schedule__download_outcomes
     description: Outcomes from download attempts of GTFS schedule data.
-    tests:
+    data_tests:
       - &schedule_outcome_uniqueness
         dbt_utils.unique_combination_of_columns:
           arguments:
@@ -25,7 +25,7 @@ models:
       - name: ts
   - name: stg_gtfs_schedule__unzip_outcomes
     description: Outcomes from unzip attempts on downloaded GTFS schedule data.
-    tests:
+    data_tests:
       - *schedule_outcome_uniqueness
     columns:
       - name: dt
@@ -45,7 +45,7 @@ models:
       - name: ts
   - name: stg_gtfs_schedule__file_parse_outcomes
     description: Outcomes from parse (.txt --> .jsonl conversion) attempts on files within GTFS feeds.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:

--- a/warehouse/models/staging/gtfs_quality/_stg_gtfs_quality.yml
+++ b/warehouse/models/staging/gtfs_quality/_stg_gtfs_quality.yml
@@ -5,7 +5,7 @@ models:
     description: |
       Index model listing all intended-to-have-been-implemented
       GTFS guideline checks.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -16,16 +16,17 @@ models:
             combination_of_columns:
               - reports_order
               - feature
-          where: 'reports_order IS NOT null'
+          config:
+            where: 'reports_order IS NOT null'
     columns:
       - name: check
-        tests:
+        data_tests:
           - not_null
       - name: feature
-        tests:
+        data_tests:
           - not_null
       - name: entity
-        tests:
+        data_tests:
           - not_null
 
   - name: stg_gtfs_quality__rt_validation_code_descriptions
@@ -33,14 +34,14 @@ models:
       Metadata for codes that come from the GTFS RT validator.
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: description
-        tests:
+        data_tests:
           - not_null
       - name: is_critical
-        tests:
+        data_tests:
           - not_null
 
   - name: stg_gtfs_rt__service_alerts_validation_notices
@@ -50,7 +51,7 @@ models:
     columns:
       - &rt_key
         name: key
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 where: '__rt_sampled__'
@@ -124,7 +125,7 @@ models:
       validator against GTFS Schedule zipfiles; not the actual
       output notices, but the "execution" results i.e. did we get
       output written to GCS.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -144,7 +145,7 @@ models:
       - name: extract_ts
 
   - name: stg_gtfs_quality__scraped_urls
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -156,7 +157,7 @@ models:
       - name: dt
       - name: ts
       - name: aggregator
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values:
@@ -168,7 +169,7 @@ models:
           for detecting fanout, etc.
       - name: name
       - name: feed_url_str
-        tests:
+        data_tests:
           - not_null
       - name: feed_type
       - name: raw_record

--- a/warehouse/models/staging/ntd_annual_reporting/_src.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_src.yml
@@ -4,7 +4,7 @@ x-common-fields:
   - &ntd_id
     name: ntd_id
     description: '{{ doc("ntd_id") }}'
-    tests:
+    data_tests:
       - not_null
   - &agency
     name: agency
@@ -21,7 +21,7 @@ x-common-fields:
   - &report_year
     name: report_year
     description: '{{ doc("ntd_report_year") }}'
-    tests:
+    data_tests:
       - not_null
       - accepted_values:
           arguments:
@@ -567,7 +567,7 @@ sources:
             description: |
               The time period for which data was collected.
               This table displays only "Annual Total".
-            tests:
+            data_tests:
               - accepted_values:
                   arguments:
                     values: ["Annual Total"]
@@ -665,7 +665,7 @@ sources:
           - *mode
           - *mode_name
           - <<: *time_period
-            tests:
+            data_tests:
               - accepted_values:
                   arguments:
                     values: [

--- a/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
+++ b/warehouse/models/staging/ntd_annual_reporting/_stg_ntd_annual_reporting.yml
@@ -4,7 +4,7 @@ x-common-fields:
   - &ntd_id
     name: ntd_id
     description: '{{ doc("ntd_id") }}'
-    tests:
+    data_tests:
       - not_null
   - &agency
     name: agency
@@ -21,7 +21,7 @@ x-common-fields:
   - &report_year
     name: report_year
     description: '{{ doc("ntd_report_year") }}'
-    tests:
+    data_tests:
       - not_null
       - accepted_values:
           arguments:
@@ -562,7 +562,7 @@ models:
         description: |
           The time period for which data was collected.
           This table displays only "Annual Total".
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: ["Annual Total"]
@@ -660,7 +660,7 @@ models:
       - *mode
       - *mode_name
       - <<: *time_period
-        tests:
+        data_tests:
           - accepted_values:
               arguments:
                 values: [

--- a/warehouse/models/staging/ntd_ridership/_stg_ntd_ridership.yml
+++ b/warehouse/models/staging/ntd_ridership/_stg_ntd_ridership.yml
@@ -4,7 +4,7 @@ x-common-fields:
   - &ntd_id
     name: ntd_id
     description: '{{ doc("ntd_id") }}'
-    tests:
+    data_tests:
       - not_null
   - &legacy_ntd_id
     name: legacy_ntd_id

--- a/warehouse/models/staging/payments/elavon/_elavon.yml
+++ b/warehouse/models/staging/payments/elavon/_elavon.yml
@@ -141,7 +141,7 @@ models:
       - name: trn_aci
       - name: card_scheme_ref
       - name: trn_ref_num
-        tests:
+        data_tests:
           - unique
       - name: settlement_method
       - name: currency_code
@@ -191,7 +191,7 @@ models:
       - name: trn_aci
       - name: card_scheme_ref
       - name: trn_ref_num
-        tests:
+        data_tests:
           - unique
       - name: settlement_method
       - name: currency_code
@@ -241,7 +241,7 @@ models:
       - name: trn_aci
       - name: card_scheme_ref
       - name: trn_ref_num
-        tests:
+        data_tests:
           - unique
       - name: settlement_method
       - name: currency_code

--- a/warehouse/models/staging/payments/littlepay/_stg_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_stg_littlepay.yml
@@ -43,13 +43,13 @@ models:
         name: _key
         description: |
           Synthetic key composed of Littlepay file date and line number to uniquely identify a row within source data.
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: _payments_key
         description: |
           Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
-        tests:
+        data_tests:
           - not_null
           - unique_proportion:
               arguments:
@@ -68,7 +68,7 @@ models:
     columns:
       - name: littlepay_export_ts
         description: Export timestamp parsed from filename.
-        tests:
+        data_tests:
           - not_null
       - name: masked_pan
         description: First six and last four numbers of the PAN.
@@ -111,7 +111,7 @@ models:
         name: _payments_key
         description: |
           Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
-        tests:
+        data_tests:
           - not_null
           - unique
       - *_content_hash
@@ -166,7 +166,7 @@ models:
           If the device does not support GPS, then this field will not be included.
       - name: littlepay_transaction_id
         description: '{{ doc("lp_littlepay_transaction_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: location_id
@@ -248,7 +248,7 @@ models:
       which were not actually applied (for example, if a micropayment
       is eligible for multiple products, adjustments will be present for
       each applicable product but only one will be applied.)
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -268,7 +268,7 @@ models:
         description: '{{ doc("lp_adjustment_id") }}'
       - name: micropayment_id
         description: '{{ doc("lp_micropayment_id") }}'
-        tests:
+        data_tests:
           - unique:
               arguments:
                 where: applied
@@ -316,7 +316,7 @@ models:
       - *_content_hash
 
   - name: stg_littlepay__micropayments
-    tests:
+    data_tests:
       - &littlepay_uniqueness
         dbt_utils.unique_combination_of_columns:
           arguments:
@@ -329,7 +329,7 @@ models:
     columns:
       - name: micropayment_id
         description: '{{ doc("lp_micropayment_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: aggregation_id
@@ -365,7 +365,7 @@ models:
       - *participant_id
       - name: product_id
         description: '{{ doc("lp_product_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: previous_version_id
@@ -452,7 +452,7 @@ models:
       - *_content_hash
 
   - name: stg_littlepay__refunds
-    tests:
+    data_tests:
       - *littlepay_uniqueness
     columns:
       - name: refund_id
@@ -465,7 +465,7 @@ models:
           authorisations that are submitted depend on the scheme and the result
           of the initial authorisation. For example, if an authorisation is declined,
           then a debt recovery authorisation may be performed.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('int_payments__refunds_deduped')
@@ -502,7 +502,7 @@ models:
           Uniquely identifies a card transaction, based on the ISO 8583 standard. The value is generated during authorisation.
 
           If the acquirer is Elavon, this value will be split between `littlepay_reference_number` and `external_reference_number`.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('int_payments__refunds_deduped')
@@ -550,7 +550,7 @@ models:
       - *payments_key_full_uniqueness
 
   - name: stg_littlepay__settlements
-    tests:
+    data_tests:
       - *littlepay_uniqueness
     columns:
       - name: settlement_id

--- a/warehouse/models/staging/payments/littlepay_v3/_stg_littlepay_v3.yml
+++ b/warehouse/models/staging/payments/littlepay_v3/_stg_littlepay_v3.yml
@@ -43,13 +43,13 @@ models:
         name: _key
         description: |
           Synthetic key composed of Littlepay file date and line number to uniquely identify a row within source data.
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: _payments_key
         description: |
           Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
-        tests:
+        data_tests:
           - not_null
           - unique_proportion:
               arguments:
@@ -68,7 +68,7 @@ models:
     columns:
       - name: littlepay_export_ts
         description: Export timestamp parsed from filename.
-        tests:
+        data_tests:
           - not_null
       - name: masked_pan
         description: First six and last four numbers of the PAN.
@@ -111,7 +111,7 @@ models:
         name: _payments_key
         description: |
           Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
-        tests:
+        data_tests:
           - not_null
           - unique
       - *_content_hash
@@ -166,7 +166,7 @@ models:
           If the device does not support GPS, then this field will not be included.
       - name: littlepay_transaction_id
         description: '{{ doc("lp_littlepay_transaction_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: location_id
@@ -248,7 +248,7 @@ models:
       which were not actually applied (for example, if a micropayment
       is eligible for multiple products, adjustments will be present for
       each applicable product but only one will be applied.)
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -268,7 +268,7 @@ models:
         description: '{{ doc("lp_adjustment_id") }}'
       - name: micropayment_id
         description: '{{ doc("lp_micropayment_id") }}'
-        tests:
+        data_tests:
           - unique:
               arguments:
                 where: applied
@@ -316,7 +316,7 @@ models:
       - *_content_hash
 
   - name: stg_littlepay__micropayments_v3
-    tests:
+    data_tests:
       - &littlepay_uniqueness
         dbt_utils.unique_combination_of_columns:
           arguments:
@@ -329,7 +329,7 @@ models:
     columns:
       - name: micropayment_id
         description: '{{ doc("lp_micropayment_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: aggregation_id
@@ -365,7 +365,7 @@ models:
       - *participant_id
       - name: product_id
         description: '{{ doc("lp_product_id") }}'
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: previous_version_id
@@ -452,7 +452,7 @@ models:
       - *_content_hash
 
   - name: stg_littlepay__refunds_v3
-    tests:
+    data_tests:
       - *littlepay_uniqueness
     columns:
       - name: refund_id
@@ -465,7 +465,7 @@ models:
           authorisations that are submitted depend on the scheme and the result
           of the initial authorisation. For example, if an authorisation is declined,
           then a debt recovery authorisation may be performed.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('int_payments__refunds_deduped')
@@ -499,7 +499,7 @@ models:
           Uniquely identifies a card transaction, based on the ISO 8583 standard. The value is generated during authorisation.
 
           If the acquirer is Elavon, this value will be split between `littlepay_reference_number` and `external_reference_number`.
-        tests:
+        data_tests:
           - relationships:
               arguments:
                 to: ref('int_payments__refunds_deduped')
@@ -544,7 +544,7 @@ models:
       - *payments_key_full_uniqueness
 
   - name: stg_littlepay__settlements_v3
-    tests:
+    data_tests:
       - *littlepay_uniqueness
     columns:
       - name: settlement_id

--- a/warehouse/models/staging/rt/_stg_rt.yml
+++ b/warehouse/models/staging/rt/_stg_rt.yml
@@ -6,7 +6,7 @@ models:
     columns:
       - &rt_key
         name: key
-        tests:
+        data_tests:
           - not_null:
               arguments:
                 where: date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)

--- a/warehouse/models/staging/transit_database/_stg_transit_database.yml
+++ b/warehouse/models/staging/transit_database/_stg_transit_database.yml
@@ -14,7 +14,7 @@ models:
     description: |
       Each row is an individual row from an individual download (snapshot) of the
       Contracts table in Airtable.
-    tests:
+    data_tests:
       - dbt_utils.equal_rowcount:
           arguments:
             compare_model: ref('base_tts_contracts_idmap')
@@ -33,7 +33,7 @@ models:
       Each row is an individual row from an individual download (snapshot) of the
       Service Components table in Airtable.
       IDs have been translated from the Transit Technology Service base to the California Transit base.
-    tests:
+    data_tests:
       - dbt_utils.equal_rowcount:
           arguments:
             compare_model: ref('base_tts_service_components_idmap')

--- a/warehouse/models/staging/transit_database/base/_base_transit_database.yml
+++ b/warehouse/models/staging/transit_database/base/_base_transit_database.yml
@@ -8,7 +8,7 @@ models:
       Transit Data Quality Issues base. Different Airtable internal record IDs
       are assigned in each instance so this table maps the IDs between
       instances, using `name` (Airtable primary field) to join.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -26,7 +26,7 @@ models:
       Transit Data Quality Issues base. Different Airtable internal record IDs
       are assigned in each instance so this table maps the IDs between
       instances, using `name` (Airtable primary field) to join.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -44,7 +44,7 @@ models:
       Technology Stacks base. Different Airtable internal record IDs
       are assigned in each instance so this table maps the IDs between
       instances, using `name` (Airtable primary field) to join.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -62,7 +62,7 @@ models:
       Technology Stacks base. Different Airtable internal record IDs
       are assigned in each instance so this table maps the IDs between
       instances, using `name` (Airtable primary field) to join.
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:

--- a/warehouse/seeds/_seeds.yml
+++ b/warehouse/seeds/_seeds.yml
@@ -11,11 +11,11 @@ seeds:
     columns:
       - name: location_name
         description: On location in the O/D pair
-        tests:
+        data_tests:
           - unique
       - name: off_location_name
         description: Off location in the O/D pair
-        tests:
+        data_tests:
           - unique
       - name: distance_miles
         description: Distance in miles between location_name and off_location_name.
@@ -30,7 +30,7 @@ seeds:
     columns:
       - name: ntd_mode_abbreviation
         description: The two letter abbreviation mode
-        tests:
+        data_tests:
           - unique
       - name: ntd_mode_full_name
         description: The mode's full name
@@ -45,20 +45,20 @@ seeds:
         description: Unversioned key to dim_gtfs_datasets natural key from Airtable.
       - name: littlepay_participant_id
         description: Littlepay-assigned Participant ID.
-        tests:
+        data_tests:
           - unique
       - name: elavon_customer_name
         description: Elavon-assigned Customer Name.
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: _in_use_from
         description: Start date from which this mapping is valid (inclusive). Used to handle cases where the same littlepay_participant_id maps to different elavon customer_name and customer_id over time.
-        tests:
+        data_tests:
           - not_null
       - name: _in_use_until
         description: End date until which this mapping is valid (inclusive). Used to handle cases where the same littlepay_participant_id maps to different elavon customer_name and customer_id over time.
-        tests:
+        data_tests:
           - not_null
 
   - name: payments_entity_mapping_enghouse
@@ -75,20 +75,20 @@ seeds:
         description: To-do.
       - name: enghouse_operator_id
         description: Enghouse-assigned operator ID.
-        tests:
+        data_tests:
           - unique
       - name: elavon_customer_name
         description: Elavon-assigned Customer Name.
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: _in_use_from
         description: Start date from which this mapping is valid (inclusive). Used to handle cases where the same enghouse_operator_id maps to different elavon customer_name and customer_id over time.
-        tests:
+        data_tests:
           - not_null
       - name: _in_use_until
         description: End date until which this mapping is valid (inclusive). Used to handle cases where the same enghouse_operator_id maps to different elavon customer_name and customer_id over time.
-        tests:
+        data_tests:
           - not_null
 
   - name: gtfs_rt_validation_code_descriptions
@@ -101,7 +101,7 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
 
@@ -116,7 +116,7 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: name
-        tests:
+        data_tests:
           - not_null
           - unique
 
@@ -131,17 +131,17 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: gtfs_schedule_validator_rule_details_v3_1_1
@@ -155,17 +155,17 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: gtfs_schedule_validator_rule_details_v4_0_0
@@ -179,17 +179,17 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: gtfs_schedule_validator_rule_details_v4_1_0
@@ -203,17 +203,17 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: gtfs_schedule_validator_rule_details_v4_2_0
@@ -227,17 +227,17 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: gtfs_schedule_validator_rule_details_v5_0_0
@@ -251,17 +251,17 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: gtfs_schedule_validator_rule_details_v7_1_0
@@ -275,17 +275,17 @@ seeds:
         dataset: gtfs_quality
     columns:
       - name: code
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: human_readable_description
-        tests:
+        data_tests:
           - not_null
       - name: version
-        tests:
+        data_tests:
           - not_null
       - name: severity
-        tests:
+        data_tests:
           - not_null
 
   - name: _deprecated__ntd_agency_to_organization
@@ -310,7 +310,7 @@ seeds:
       labels:
         domain: seeds
         dataset: transit_database
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -318,17 +318,17 @@ seeds:
               - organization_name
     columns:
       - name: ntd_id
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: legacy_ntd_id
-        tests:
+        data_tests:
           - unique
       - name: organization_record_id
-        tests:
+        data_tests:
           - unique
       - name: organization_name
-        tests:
+        data_tests:
           - unique
 
   - name: transit_facilities
@@ -342,28 +342,28 @@ seeds:
     columns:
       - name: id
         description: "Unique identifier for the transit facility feature."
-        tests:
+        data_tests:
           - not_null
           - unique
       - name: agency_name
         description: "Agency name that manages the facility."
-        tests:
+        data_tests:
           - not_null
       - name: facility_id
         description: "Id of the transit center."
-        tests:
+        data_tests:
           - not_null
       - name: facility_name
         description: "Name of the transit facility."
-        tests:
+        data_tests:
           - not_null
       - name: facility_type
         description: "Type of the facility."
-        tests:
+        data_tests:
           - not_null
       - name: ntd_id
         description: "NTD id of the facility."
-        tests:
+        data_tests:
           - not_null
       - name: geojson_geometry
         description: "GeoJSON string representation of the transit facility's location."
@@ -381,17 +381,17 @@ seeds:
     columns:
       - name: gtfs_dataset_name
         description: The GTFS schedule name from dim_gtfs_datasets
-        tests:
+        data_tests:
           - not_null
       - name: route_id
         description: GTFS trips route_id value
-        tests:
+        data_tests:
           - not_null
       - name: direction_id
         description: GTFS trips direction_id value (0 or 1)
-        tests:
+        data_tests:
           - not_null
       - name: shape_id
         description: Derived shape_id based on combination of route_id and direction_id.
-        tests:
+        data_tests:
           - not_null


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #4096. Replaces `tests` with `data_tests` throughout model config yml files to silence deprecation warnings. `tests` is deprecated syntax. This touches a lot of files but in very very minor ways. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

Successfully ran `dbt run` and `dbt test` without errors. Ran `uv run dbt parse --show-all-deprecations` without any deprecations. 

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
