### PR TITLE
Create Littlepay parse audit table

### DIFF
--- a/warehouse/models/mart/payments_audit/_mart_payments_audit.yml
+++ b/warehouse/models/mart/payments_audit/_mart_payments_audit.yml
@@ -2,4 +2,6 @@ version: 2
 
 models:
   - name: dim_littlepay_sync_job_results
-    description: Summary of Sync Littlepay Files
+    description: Summary of Downloaded Littlepay Files
+  - name: dim_littlepay_parse_job_results
+    description: Summary of Parsed Littlepay Files

--- a/warehouse/models/mart/payments_audit/dim_littlepay_parse_job_results.sql
+++ b/warehouse/models/mart/payments_audit/dim_littlepay_parse_job_results.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+# For data security, do not show the bucket name or file path.
+
+WITH dim_littlepay_sync_job_results AS (
+    SELECT
+        {{ trim_make_empty_string_null('instance') }} AS instance,
+        {{ trim_make_empty_string_null('filename') }} AS filename,
+        {{ trim_make_empty_string_null('`extract`.filename') }} AS extract_filename,
+        {{ trim_make_empty_string_null('`extract`.instance') }} AS extract_instance,
+        SAFE_CAST(`extract`.ts AS TIMESTAMP) AS extract_ts,
+        {{ trim_make_empty_string_null('`extract`.s3object.ETag') }} AS extract_s3object_etag,
+        SAFE_CAST(`extract`.s3object.LastModified AS TIMESTAMP) AS extract_s3object_last_modified,
+        SAFE_CAST(`extract`.s3object.Size AS INTEGER) AS extract_s3object_size,
+        {{ trim_make_empty_string_null('`extract`.s3object.StorageClass') }} AS extract_s3object_storage_class,
+        SAFE_CAST(ts AS TIMESTAMP) AS ts
+    FROM {{ source('external_littlepay_v3', 'littlepay_parse_job_results') }}
+)
+
+SELECT * FROM dim_littlepay_sync_job_results


### PR DESCRIPTION
# Description

This PR creates a mart table to visualize Littlepay parsed file results to build query checks and audit dashboards in Metabase.

To audit results for #4384

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally:
```
❯ uv run dbt run -s dim_littlepay_sync_job_results --target staging
19:31:04  Found 627 models, 178 data tests, 16 seeds, 227 sources, 4 exposures, 1088 macros
19:31:04
19:31:04  Concurrency: 8 threads (target='staging')
19:31:04
19:31:08  1 of 1 START sql table model mart_payments_audit.dim_littlepay_sync_job_results  [RUN]
19:31:12  1 of 1 OK created sql table model mart_payments_audit.dim_littlepay_sync_job_results  [CREATE TABLE (7.4k rows, 3.1 MiB processed) in 4.74s]
19:31:12
19:31:12  Finished running 1 table model in 0 hours 0 minutes and 8.66 seconds (8.66s).
19:31:13
19:31:13  Completed successfully
19:31:13
19:31:13  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
