### PR TITLE
Add product_type to final CTE for fct_payment_rides

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -78,6 +78,8 @@ models:
         description: '{{ doc("lp_product_description") }}'
       - name: product_type
         description: '{{ doc("lp_product_type") }}'
+      - name: activation_type
+        description: '{{ doc("lp_activation_type") }}'
       - name: route_id
         description: '{{ doc("lp_paired_transaction_route_id") }}'
       - name: route_long_name

--- a/warehouse/models/mart/payments/fct_payments_rides_v2.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_v2.sql
@@ -105,6 +105,7 @@ fct_payments_rides_v2 AS (
         products.product_code,
         products.product_description,
         products.product_type,
+        products.activation_type,
 
         -- Common transaction info
         routes.route_long_name,


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #4897 

Adds `products.activation_type` (from model `int_payments__dim_product_data`) to `fct_payments_rides_v2`. Adds column to final CTE of model, and adds column doc to model yml configuration.

A `build` / `test` raises some errors noted under the testing header. 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

Ran `uv run dbt build -s fct_payments_rides_v2+` against both `main` and this branch and got errors below. `uv run dbt run` works fine though. 

<details><summary>Model test failure present on both branches</summary> 

```sh
(data-infra-airflow) ss@366KPB4-P5690:~/data-infra/warehouse$ uv run dbt build -s fct_payments_rides_v2+
14:07:16  Running with dbt=1.10.8
14:07:18  Registered adapter: bigquery=1.10.2
14:07:22  Found 628 models, 178 data tests, 16 seeds, 227 sources, 4 exposures, 1088 macros
14:07:22  
14:07:22  Concurrency: 8 threads (target='staging')
14:07:22  
14:07:26  1 of 15 START sql table model mart_payments.fct_payments_rides_v2 .............. [RUN]
14:07:44  1 of 15 OK created sql table model mart_payments.fct_payments_rides_v2 ......... [CREATE TABLE (136.4k rows, 152.1 MiB processed) in 17.94s]
14:07:44  2 of 15 START test dbt_utils_not_null_proportion_fct_payments_rides_v2_0_998__littlepay_transaction_id  [RUN]
14:07:44  3 of 15 START test not_null_fct_payments_rides_v2_aggregation_id ............... [RUN]
14:07:44  4 of 15 START test not_null_fct_payments_rides_v2_micropayment_id .............. [RUN]
14:07:44  5 of 15 START test relationships_fct_payments_rides_v2_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [RUN]
14:07:44  6 of 15 START test unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id  [RUN]
14:07:44  7 of 15 START test unique_proportion_fct_payments_rides_v2_0_999__micropayment_id  [RUN]
14:07:45  4 of 15 PASS not_null_fct_payments_rides_v2_micropayment_id .................... [PASS in 1.41s]
14:07:45  2 of 15 PASS dbt_utils_not_null_proportion_fct_payments_rides_v2_0_998__littlepay_transaction_id  [PASS in 1.44s]
14:07:46  3 of 15 PASS not_null_fct_payments_rides_v2_aggregation_id ..................... [PASS in 1.50s]
14:07:46  6 of 15 FAIL 1 unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id  [FAIL 1 in 1.51s]
14:07:46  7 of 15 PASS unique_proportion_fct_payments_rides_v2_0_999__micropayment_id .... [PASS in 1.59s]
14:07:46  8 of 15 SKIP relation mart_payments.elavon_littlepay__daily_history_transactions_deposits_billing due to ephemeral model status 'skipped'  [ERROR SKIP]
14:07:46  9 of 15 SKIP relation mart_payments.v2_payments_daily_transaction_deltas due to ephemeral model status 'skipped'  [ERROR SKIP]
14:07:46  10 of 15 SKIP relation mart_payments.v2_payments_monthly_transaction_deltas due to ephemeral model status 'skipped'  [ERROR SKIP]
14:07:46  11 of 15 SKIP relation mart_payments.v2_payments_reliability_monthly_unlabeled_routes due to ephemeral model status 'skipped'  [ERROR SKIP]
14:07:46  12 of 15 SKIP relation mart_payments.v2_payments_reliability_weekly_unlabeled_routes due to ephemeral model status 'skipped'  [ERROR SKIP]
14:07:46  13 of 15 SKIP relation mart_payments.v2_payments_weekly_transaction_deltas due to ephemeral model status 'skipped'  [ERROR SKIP]
14:07:46  14 of 15 SKIP test dbt_utils_expression_is_true_v2_payments_reliability_monthly_unlabeled_routes_n_all_rides_n_route_z_rides_n_null_rides_  [SKIP]
14:07:46  15 of 15 SKIP test dbt_utils_expression_is_true_v2_payments_reliability_weekly_unlabeled_routes_n_all_rides_n_route_z_rides_n_null_rides_  [SKIP]
14:07:46  5 of 15 PASS relationships_fct_payments_rides_v2_aggregation_id__aggregation_id__ref_fct_payments_aggregations_  [PASS in 1.97s]
14:07:46  
14:07:46  Finished running 7 table models, 8 data tests in 0 hours 0 minutes and 24.02 seconds (24.02s).
14:07:47  
14:07:47  Completed with 7 errors, 0 partial successes, and 0 warnings:
14:07:47  
14:07:47  Failure in test unique_proportion_fct_payments_rides_v2_0_999__littlepay_transaction_id (models/mart/payments/_payments.yml)
14:07:47    Got 1 result, configured to fail if != 0
14:07:47  
14:07:47    compiled code at target/compiled/calitp_warehouse/models/mart/payments/_payments.yml/unique_proportion_fct_payments_5ae765bfa0adf9c27b77002bb886a2c5.sql
14:07:47  
```

</details>

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)

This adds a new column to a model rendered as a table. i don't think it requires a full refresh on incremental models, but this column may be useful in a different downstream model that does. Not familiar enough here. 