### PR TITLE
Adjust Littlepay Metadata format to match previous files

### DIFF
--- a/airflow/plugins/operators/littlepay_s3_to_gcs_operator.py
+++ b/airflow/plugins/operators/littlepay_s3_to_gcs_operator.py
@@ -147,8 +147,8 @@ class LittlepayS3ToGCSOperator(BaseOperator):
             "s3bucket": self.source_bucket_name(),
             "s3object": {
                 "Key": self.source_path,
-                "LastModified": str(self.source_object()["LastModified"]),
-                "ETag": self.source_object()["ETag"].replace('"', ""),
+                "LastModified": self.source_object()["LastModified"].isoformat(),
+                "ETag": self.source_object()["ETag"].replace('"', '"'),
                 "Size": self.source_object()["ContentLength"],
                 "StorageClass": self.source_object().get("StorageClass"),
             },
@@ -167,9 +167,9 @@ class LittlepayS3ToGCSOperator(BaseOperator):
     def exists(self) -> bool:
         return (
             self.prior_artifact().s3object_metadata() is not None
-            and str(self.source_object()["LastModified"])
+            and self.source_object()["LastModified"].isoformat()
             == self.prior_artifact().s3object_metadata().get("LastModified")
-            and self.source_object()["ETag"].replace('"', "")
+            and self.source_object()["ETag"]
             == self.prior_artifact().s3object_metadata().get("ETag")
         )
 

--- a/airflow/requirements-dev.txt
+++ b/airflow/requirements-dev.txt
@@ -1,5 +1,5 @@
 apache-airflow==2.10.5
-apache-airflow-providers-amazon>=8.15.0
+apache-airflow-providers-amazon>=9.17.0
 astronomer-cosmos
 beautifulsoup4==4.12.3
 boto3==1.41.2

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow-providers-amazon>=8.15.0
+apache-airflow-providers-amazon>=9.17.0
 astronomer-cosmos
 beautifulsoup4==4.12.3
 boto3==1.41.2

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute.yaml
@@ -13,17 +13,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/83a2d1ac-3649-404a-9dbc-a786a1d73cda
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/4224e17b-fe4c-4f83-9844-cb9435c7940e
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202510241114_authorisations.psv&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202510241114_authorisations.psv&prettyPrint=false
   response:
     body:
-      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776211646761908","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776211646761908&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776211646761908","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLSXgYLI7pMDEAE=","timeCreated":"2026-04-15T00:07:26.765Z","updated":"2026-04-15T00:07:26.765Z","timeStorageClassUpdated":"2026-04-15T00:07:26.765Z","timeFinalized":"2026-04-15T00:07:26.765Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776730490741333","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776730490741333&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776730490741333","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNXEjO7U/ZMDEAE=","timeCreated":"2026-04-21T00:14:50.745Z","updated":"2026-04-21T00:14:50.745Z","timeStorageClassUpdated":"2026-04-21T00:14:50.745Z","timeFinalized":"2026-04-21T00:14:50.745Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202510241114_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202510241114_authorisations.psv\",
-        \"LastModified\": \"2026-04-15 00:07:24+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-04-21T00:14:48+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}]}'
     headers:
       Alt-Svc:
@@ -31,20 +31,20 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1703'
+      - '1711'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:04 GMT
+      - Tue, 21 Apr 2026 00:29:03 GMT
       Expires:
-      - Wed, 15 Apr 2026 00:49:04 GMT
+      - Tue, 21 Apr 2026 00:29:03 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3jxiQ1FnSKjTlXwXzSa64kNFr2xlIqdAnW4Au1LZZHrSW_hgu_yKRtjFH-qFGsOT_G
+      - AMNfjG2dj7AaouyWlDCLUS1CS-VY3P86XuQmNFD9dzDX_YIlpfdufIX3WsXYfJqHgQ599dfT2H2O4II
     status:
       code: 200
       message: OK
@@ -64,7 +64,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/c83a0bb7-bae7-4c91-86bc-b346b14b5401
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/fbfbce84-8921-4830-aa5b-788c0f419e8d
       x-goog-user-project:
       - cal-itp-data-infra
     method: DELETE
@@ -82,7 +82,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Apr 2026 00:49:04 GMT
+      - Tue, 21 Apr 2026 00:29:03 GMT
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -93,7 +93,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3V0rY0WDdkCjjMVAyBCGRDcSU-4ZX5Ic2S5j465ku93Gpr9W4xGtcSQNknxmYqfkB1
+      - AMNfjG1aJan2CEsU4isteNJLv92w2-OzvooqlYmL4mcc9ACvHv839lQiEEstvxv5oB_ZWhrszJC8jKA
     status:
       code: 204
       message: No Content
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/91208e13-10cb-43b3-8fe4-0fe0b77b5a14
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/23c3e21a-d4e1-42e6-9033-185d735cde11
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
@@ -129,29 +129,29 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:06 GMT
+      - Tue, 21 Apr 2026 00:29:05 GMT
       Expires:
-      - Wed, 15 Apr 2026 00:49:06 GMT
+      - Tue, 21 Apr 2026 00:29:05 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1hIgPKc4-cIiPD3e8tpRCxFeMFXJmrNzT9zjv1A3q9ZrBxMK1YlQiJW9YBvEjHXeAT
+      - AMNfjG2_n1de0z0yzdGhFY9_wmXlezzqAqbACDC1Erf2Nej5OmuEEJ6NzY-vVGUtgSBz53Fh
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============1079911217541216513==\r\ncontent-type: application/json;
+    body: "--===============4497047128848704485==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202510241114_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\",
       \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
       \\\"atn/v3/authorisations/202510241114_authorisations.psv\\\", \\\"LastModified\\\":
-      \\\"2026-04-15 00:49:04+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
-      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============1079911217541216513==\r\ncontent-type:
-      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============1079911217541216513==--"
+      \\\"2026-04-21T00:29:04+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============4497047128848704485==\r\ncontent-type:
+      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============4497047128848704485==--"
     headers:
       Accept:
       - application/json
@@ -162,15 +162,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1227'
+      - '1235'
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/412c8c90-4aa2-43b1-b40d-c855e22836e8
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/162ff9e5-6ceb-42d6-a885-21a831abb38b
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0xMDc5OTExMjE3NTQx
-        MjE2NTEzPT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT00NDk3MDQ3MTI4ODQ4
+        NzA0NDg1PT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -179,21 +179,21 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776214147752407\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776731346327385\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776214147752407&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776731346327385&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776214147752407\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731346327385\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CNfDyarR7pMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-15T00:49:07.756Z\",\n  \"updated\": \"2026-04-15T00:49:07.756Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-15T00:49:07.756Z\",\n  \"timeFinalized\":
-        \"2026-04-15T00:49:07.756Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CNmuiYbY/ZMDEAE=\",\n  \"timeCreated\":
+        \"2026-04-21T00:29:06.331Z\",\n  \"updated\": \"2026-04-21T00:29:06.331Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-21T00:29:06.331Z\",\n  \"timeFinalized\":
+        \"2026-04-21T00:29:06.331Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202510241114_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202510241114_authorisations.psv\\\",
-        \\\"LastModified\\\": \\\"2026-04-15 00:49:04+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
+        \\\"LastModified\\\": \\\"2026-04-21T00:29:04+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
         \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"\n  }\n}\n"
     headers:
       Alt-Svc:
@@ -201,13 +201,13 @@ interactions:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '1753'
+      - '1761'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:07 GMT
+      - Tue, 21 Apr 2026 00:29:06 GMT
       ETag:
-      - CNfDyarR7pMDEAE=
+      - CNmuiYbY/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -218,18 +218,17 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2v40GV-pazYFB12msdAdpXJYS4jGZh_HntQAZCq8RhSxltb73gJuieqxYv7hPp7otf
+      - AMNfjG1kN0jgWvdasi7M_N4Kx4_7UYvuwlWJI1_A_o9zLkKygEydb1pkNhMrfYE_IYGqH5AH_SfrDA
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============8846399591051045076==\r\ncontent-type: application/json;
+    body: "--===============4885457531354250110==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"results_202510241114_authorisations.psv.jsonl\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"},
-      \"crc32c\": \"+sCzMg==\"}\r\n--===============8846399591051045076==\r\ncontent-type:
-      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{},\"extract\":{\"filename\":\"202510241114_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202510241114_authorisations.psv\",\"LastModified\":\"2026-04-15
-      00:49:04+00:00\",\"ETag\":\"5d46e84b9c9fa3cc87e4916c452c4de8\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============8846399591051045076==--"
+      \"crc32c\": \"zCxLLg==\"}\r\n--===============4885457531354250110==\r\ncontent-type:
+      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{},\"extract\":{\"filename\":\"202510241114_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202510241114_authorisations.psv\",\"LastModified\":\"2026-04-21T00:29:04+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============4885457531354250110==--"
     headers:
       Accept:
       - application/json
@@ -240,15 +239,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '902'
+      - '906'
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/1387506c-11b9-444e-89ef-7cf0adebce18
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/38e877ac-c8b2-4f3b-b587-1629becd45b4
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT04ODQ2Mzk5NTkxMDUx
-        MDQ1MDc2PT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT00ODg1NDU3NTMxMzU0
+        MjUwMTEwPT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -257,17 +256,17 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1776214148930875\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1776731347422100\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1776214148930875&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1776731347422100&alt=media\",\n
         \ \"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776214148930875\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731347422100\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
-        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"377\",\n  \"md5Hash\": \"M0Vr4OBNa/Fv4G/fisgbvQ==\",\n
-        \ \"crc32c\": \"+sCzMg==\",\n  \"etag\": \"CLu6kavR7pMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-15T00:49:08.940Z\",\n  \"updated\": \"2026-04-15T00:49:08.940Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-15T00:49:08.940Z\",\n  \"timeFinalized\":
-        \"2026-04-15T00:49:08.940Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"381\",\n  \"md5Hash\": \"RFR3tUEOSuiOzb6SZHRuEA==\",\n
+        \ \"crc32c\": \"zCxLLg==\",\n  \"etag\": \"CJSXzIbY/ZMDEAE=\",\n  \"timeCreated\":
+        \"2026-04-21T00:29:07.435Z\",\n  \"updated\": \"2026-04-21T00:29:07.435Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-21T00:29:07.435Z\",\n  \"timeFinalized\":
+        \"2026-04-21T00:29:07.435Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"results_202510241114_authorisations.psv.jsonl\\\",
         \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"\n
         \ }\n}\n"
@@ -281,9 +280,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:08 GMT
+      - Tue, 21 Apr 2026 00:29:07 GMT
       ETag:
-      - CLu6kavR7pMDEAE=
+      - CJSXzIbY/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -294,7 +293,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3pr1RpZAN4NYTEz-oSzbtY5pkMp2RYUQHqubZWvfcvbEYj_-MdhGVkfko4OVlvvVsl8P7tQYk
+      - AMNfjG2BotN2uU_gcxEMrj2C7pu-hEtEUDgrvQ4wtZ3lt-0pNioYRDKCzrgqLEkvTrsrTjRp
     status:
       code: 200
       message: OK
@@ -310,7 +309,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/d89f3dc5-b507-4ba9-b8fb-e6ec0bfb9b70
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/e30c4f67-5ff9-4702-a218-5ee50698f986
       accept-encoding:
       - gzip
       content-type:
@@ -340,13 +339,13 @@ interactions:
       Content-Type:
       - binary/octet-stream
       Date:
-      - Wed, 15 Apr 2026 00:49:09 GMT
+      - Tue, 21 Apr 2026 00:29:07 GMT
       ETag:
-      - CNfDyarR7pMDEAE=
+      - CNmuiYbY/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Last-Modified:
-      - Wed, 15 Apr 2026 00:49:07 GMT
+      - Tue, 21 Apr 2026 00:29:06 GMT
       Pragma:
       - no-cache
       Server:
@@ -355,9 +354,9 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1XZChSSiyHB55N20NP8P7-Ymr59P_UmxryRFkzAT1Jc5avOcAaoYbKZ-HKI0HeIKpU
+      - AMNfjG0e78Lyccu-bZKFCs9O3Q0bKTci0k_-8CybiUMdP2XfxPdhx-r6Rr0pkihKb_IkzvJb9K5FtFI
       X-Goog-Generation:
-      - '1776214147752407'
+      - '1776731346327385'
       X-Goog-Hash:
       - crc32c=hQqhOQ==,md5=XUboS5yfo8yH5JFsRSxN6A==
       X-Goog-Metageneration:
@@ -385,17 +384,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/0a0d90cd-5900-443e-9fed-ad17481daa89
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/2dcf0ef4-1e26-46a0-8652-c3308e6abb87
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202510241114_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202510241114_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776214147752407","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776214147752407&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214147752407","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNfDyarR7pMDEAE=","timeCreated":"2026-04-15T00:49:07.756Z","updated":"2026-04-15T00:49:07.756Z","timeStorageClassUpdated":"2026-04-15T00:49:07.756Z","timeFinalized":"2026-04-15T00:49:07.756Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776731346327385","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776731346327385&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731346327385","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNmuiYbY/ZMDEAE=","timeCreated":"2026-04-21T00:29:06.331Z","updated":"2026-04-21T00:29:06.331Z","timeStorageClassUpdated":"2026-04-21T00:29:06.331Z","timeFinalized":"2026-04-21T00:29:06.331Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202510241114_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202510241114_authorisations.psv\",
-        \"LastModified\": \"2026-04-15 00:49:04+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-04-21T00:29:04+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -403,22 +402,22 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1666'
+      - '1674'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:09 GMT
+      - Tue, 21 Apr 2026 00:29:07 GMT
       ETag:
-      - CNfDyarR7pMDEAE=
+      - CNmuiYbY/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:09 GMT
+      - Tue, 21 Apr 2026 00:29:07 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1HXLgWh7JxKui3b0hPdAkklRDgm4QNehFHbhO84YOyRKTOwxrTqAcJBwrEwZinDJUR
+      - AMNfjG2nO-LDIR02HtAqipPQMIutBJA8qH-79kM37Tb5UpMNjmYyiAYaES9916zU0bplImMKTVg2xS0
     status:
       code: 200
       message: OK
@@ -434,7 +433,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/202dcae1-2164-457a-8b40-8a7093a4cd70
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/4508268e-9b61-49b5-a659-6d6709382fb0
       accept-encoding:
       - gzip
       content-type:
@@ -447,8 +446,7 @@ interactions:
     uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202510241114_authorisations.jsonl?alt=media
   response:
     body:
-      string: '{"success":true,"exception":null,"prior":{},"extract":{"filename":"202510241114_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202510241114_authorisations.psv","LastModified":"2026-04-15
-        00:49:04+00:00","ETag":"5d46e84b9c9fa3cc87e4916c452c4de8","Size":429,"StorageClass":null}}}'
+      string: '{"success":true,"exception":null,"prior":{},"extract":{"filename":"202510241114_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202510241114_authorisations.psv","LastModified":"2026-04-21T00:29:04+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":null}}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -457,17 +455,17 @@ interactions:
       Content-Disposition:
       - attachment
       Content-Length:
-      - '377'
+      - '381'
       Content-Type:
       - application/jsonl
       Date:
-      - Wed, 15 Apr 2026 00:49:09 GMT
+      - Tue, 21 Apr 2026 00:29:07 GMT
       ETag:
-      - CLu6kavR7pMDEAE=
+      - CJSXzIbY/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Last-Modified:
-      - Wed, 15 Apr 2026 00:49:08 GMT
+      - Tue, 21 Apr 2026 00:29:07 GMT
       Pragma:
       - no-cache
       Server:
@@ -476,11 +474,11 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1OoPxfp4jptQ8pwvylAnu7qHQiaOs5WYwMGOiXSbfSZ3gtkeaaGoir0xHdUDhIrQqK
+      - AMNfjG1VtT9uyQZYiB7XQNMuPssdS3XrQnHvS_u9G6GbFXf7If9NNW2pCqB-l6cuDOMw0mx0409kMLg
       X-Goog-Generation:
-      - '1776214148930875'
+      - '1776731347422100'
       X-Goog-Hash:
-      - crc32c=+sCzMg==,md5=M0Vr4OBNa/Fv4G/fisgbvQ==
+      - crc32c=zCxLLg==,md5=RFR3tUEOSuiOzb6SZHRuEA==
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
@@ -488,7 +486,7 @@ interactions:
       X-Goog-Stored-Content-Encoding:
       - identity
       X-Goog-Stored-Content-Length:
-      - '377'
+      - '381'
     status:
       code: 200
       message: OK
@@ -506,14 +504,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/f55d5956-ef98-46f2-bc87-f6ce94ffac83
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/aaa165d1-d92c-43f2-b33e-bd9dda97847b
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202510241114_authorisations.jsonl?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1776214148930875","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1776214148930875&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1776214148930875","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"377","md5Hash":"M0Vr4OBNa/Fv4G/fisgbvQ==","crc32c":"+sCzMg==","etag":"CLu6kavR7pMDEAE=","timeCreated":"2026-04-15T00:49:08.940Z","updated":"2026-04-15T00:49:08.940Z","timeStorageClassUpdated":"2026-04-15T00:49:08.940Z","timeFinalized":"2026-04-15T00:49:08.940Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1776731347422100","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1776731347422100&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1776731347422100","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"381","md5Hash":"RFR3tUEOSuiOzb6SZHRuEA==","crc32c":"zCxLLg==","etag":"CJSXzIbY/ZMDEAE=","timeCreated":"2026-04-21T00:29:07.435Z","updated":"2026-04-21T00:29:07.435Z","timeStorageClassUpdated":"2026-04-21T00:29:07.435Z","timeFinalized":"2026-04-21T00:29:07.435Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"results_202510241114_authorisations.psv.jsonl\", \"instance\": \"atn\",
         \"ts\": \"2025-06-01T00:00:00+00:00\"}"}}'
     headers:
@@ -526,18 +524,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:09 GMT
+      - Tue, 21 Apr 2026 00:29:08 GMT
       ETag:
-      - CLu6kavR7pMDEAE=
+      - CJSXzIbY/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:09 GMT
+      - Tue, 21 Apr 2026 00:29:08 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2HN9XMPCi72iIlFaXNtrKFdpaMyovG6qZojjQ98zvf4kb0Sd34uNULNIIi07bz9JhK
+      - AMNfjG3VVIu-c2-gGQ6lbw4hnMAXGyf-v0tU9INkll4q-0pZ0yKawlbki-rSA4VEAl0zT3OjdP6YYBw
     status:
       code: 200
       message: OK

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_file_exists.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_file_exists.yaml
@@ -1,14 +1,14 @@
 interactions:
 - request:
-    body: "--===============0051638635154089499==\r\ncontent-type: application/json;
+    body: "--===============6863018647767187687==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202504291120_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\",
       \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
       \\\"atn/v3/authorisations/202504291120_authorisations.psv\\\", \\\"LastModified\\\":
-      \\\"2026-03-01 00:00:00+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
-      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============0051638635154089499==\r\ncontent-type:
-      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============0051638635154089499==--"
+      \\\"2026-03-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============6863018647767187687==\r\ncontent-type:
+      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============6863018647767187687==--"
     headers:
       Accept:
       - application/json
@@ -19,15 +19,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1227'
+      - '1235'
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/2a0ea634-16b3-4304-922a-f7143243dfd1
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/c4acc78f-ef00-4849-8187-d5d591b76b3f
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0wMDUxNjM4NjM1MTU0
-        MDg5NDk5PT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT02ODYzMDE4NjQ3NzY3
+        MTg3Njg3PT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -36,21 +36,21 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776214151290483\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776214151290483&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776214151290483\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731349823421\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CPO8oazR7pMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-15T00:49:11.300Z\",\n  \"updated\": \"2026-04-15T00:49:11.300Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-15T00:49:11.300Z\",\n  \"timeFinalized\":
-        \"2026-04-15T00:49:11.300Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CL3f3ofY/ZMDEAE=\",\n  \"timeCreated\":
+        \"2026-04-21T00:29:09.835Z\",\n  \"updated\": \"2026-04-21T00:29:09.835Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-21T00:29:09.835Z\",\n  \"timeFinalized\":
+        \"2026-04-21T00:29:09.835Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202504291120_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202504291120_authorisations.psv\\\",
-        \\\"LastModified\\\": \\\"2026-03-01 00:00:00+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
+        \\\"LastModified\\\": \\\"2026-03-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
         \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"\n  }\n}\n"
     headers:
       Alt-Svc:
@@ -58,13 +58,13 @@ interactions:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '1753'
+      - '1761'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:11 GMT
+      - Tue, 21 Apr 2026 00:29:09 GMT
       ETag:
-      - CPO8oazR7pMDEAE=
+      - CL3f3ofY/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -75,7 +75,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG13ZLUkkepZatflDmJVQvP0aVqNO8lh2IM3-s0M9dNRDzo3Ja3wqgCGAAUgqqggAiO3
+      - AMNfjG1in2oi8KVNJFIWIhZl5w_2FKWQwqWQeqLHOqtw5dNCc_NTW7rDVPwiMcD0VeYm4WQJqZW91yc
     status:
       code: 200
       message: OK
@@ -93,21 +93,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/e5b41963-dc06-4cef-8fc4-676e9ec74738
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/dd9a0e6d-6a62-488a-ba4a-a8b6bd016dfe
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202504291120_authorisations.psv&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv&prettyPrint=false
   response:
     body:
-      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776214151290483","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776214151290483&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214151290483","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CPO8oazR7pMDEAE=","timeCreated":"2026-04-15T00:49:11.300Z","updated":"2026-04-15T00:49:11.300Z","timeStorageClassUpdated":"2026-04-15T00:49:11.300Z","timeFinalized":"2026-04-15T00:49:11.300Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731349823421","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CL3f3ofY/ZMDEAE=","timeCreated":"2026-04-21T00:29:09.835Z","updated":"2026-04-21T00:29:09.835Z","timeStorageClassUpdated":"2026-04-21T00:29:09.835Z","timeFinalized":"2026-04-21T00:29:09.835Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
-        \"LastModified\": \"2026-03-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
-        \"Size\": 429, \"StorageClass\": null}}"}},{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2026-02-01T00:00:00+00:00/202504291120_authorisations.psv/1774649005909433","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2026-02-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2026-02-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1774649005909433&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2026-02-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1774649005909433","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLnL5NyKwZMDEAE=","timeCreated":"2026-03-27T22:03:25.918Z","updated":"2026-03-27T22:03:25.918Z","timeStorageClassUpdated":"2026-03-27T22:03:25.918Z","timeFinalized":"2026-03-27T22:03:25.918Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
-        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
-        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
-        \"LastModified\": \"2026-03-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}]}'
     headers:
       Alt-Svc:
@@ -115,20 +111,20 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '3370'
+      - '1711'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:12 GMT
+      - Tue, 21 Apr 2026 00:29:11 GMT
       Expires:
-      - Wed, 15 Apr 2026 00:49:12 GMT
+      - Tue, 21 Apr 2026 00:29:11 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG192fDoFpu8bXj0Aos5FhWBQBEYwzfSfWaSgq77nIQ_icGNcgxUVVCkJMq1zpvDlBYj
+      - AMNfjG0h_XniABDbpe0DtgywMdAfQSaio8EQyUBr4OXZ20Pzy050pH6cRt1vD6mU_A6BrqexURDlM_o
     status:
       code: 200
       message: OK
@@ -146,17 +142,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/b2b408ce-b811-4206-b1ce-ad5e7485fdd5
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/297a7cc8-891b-48ed-9eba-6595e41c63a1
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776214151290483","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776214151290483&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214151290483","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CPO8oazR7pMDEAE=","timeCreated":"2026-04-15T00:49:11.300Z","updated":"2026-04-15T00:49:11.300Z","timeStorageClassUpdated":"2026-04-15T00:49:11.300Z","timeFinalized":"2026-04-15T00:49:11.300Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731349823421","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CL3f3ofY/ZMDEAE=","timeCreated":"2026-04-21T00:29:09.835Z","updated":"2026-04-21T00:29:09.835Z","timeStorageClassUpdated":"2026-04-21T00:29:09.835Z","timeFinalized":"2026-04-21T00:29:09.835Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
-        \"LastModified\": \"2026-03-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -164,22 +160,22 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1666'
+      - '1674'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:12 GMT
+      - Tue, 21 Apr 2026 00:29:11 GMT
       ETag:
-      - CPO8oazR7pMDEAE=
+      - CL3f3ofY/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:12 GMT
+      - Tue, 21 Apr 2026 00:29:11 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3JkXwg2U703uvT_XzZGUXcWlNZoZZ02_oc1M2COBxCijDsDPHJdHpPVcC7HTWsa4ax
+      - AMNfjG10jfD0C5shKlut_GeDk9alh9JzVJO6mN5BTN0V_O1utglPVpjboqkB_UKGT88rzi43j77LIRQ
     status:
       code: 200
       message: OK
@@ -197,68 +193,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/5e43dd09-b7e7-435f-a155-10c50478d673
-      x-goog-user-project:
-      - cal-itp-data-infra
-    method: GET
-    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2026-02-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
-  response:
-    body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2026-02-01T00:00:00+00:00/202504291120_authorisations.psv/1774649005909433","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2026-02-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2026-02-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1774649005909433&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2026-02-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1774649005909433","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLnL5NyKwZMDEAE=","timeCreated":"2026-03-27T22:03:25.918Z","updated":"2026-03-27T22:03:25.918Z","timeStorageClassUpdated":"2026-03-27T22:03:25.918Z","timeFinalized":"2026-03-27T22:03:25.918Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
-        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
-        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
-        \"LastModified\": \"2026-03-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
-        \"Size\": 429, \"StorageClass\": null}}"}}'
-    headers:
-      Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Content-Length:
-      - '1666'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Wed, 15 Apr 2026 00:49:12 GMT
-      ETag:
-      - CLnL5NyKwZMDEAE=
-      Expires:
-      - Wed, 15 Apr 2026 00:49:12 GMT
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-      X-GUploader-UploadID:
-      - AMNfjG0L6Kp53pg1vXd9j02KKWDcp62j3-aGOdexE4VEsAYzVyFhINwEv1SHOJ9ki5k0Ayzc
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip
-      Authorization:
-      - FILTERED
-      Connection:
-      - keep-alive
-      User-Agent:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
-      X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/e4c28d2a-fd30-423b-8f4b-c6541649081e
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/efc343d4-9e86-441b-b961-b5260a5b23a3
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776214151290483","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776214151290483&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214151290483","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CPO8oazR7pMDEAE=","timeCreated":"2026-04-15T00:49:11.300Z","updated":"2026-04-15T00:49:11.300Z","timeStorageClassUpdated":"2026-04-15T00:49:11.300Z","timeFinalized":"2026-04-15T00:49:11.300Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731349823421","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CL3f3ofY/ZMDEAE=","timeCreated":"2026-04-21T00:29:09.835Z","updated":"2026-04-21T00:29:09.835Z","timeStorageClassUpdated":"2026-04-21T00:29:09.835Z","timeFinalized":"2026-04-21T00:29:09.835Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
-        \"LastModified\": \"2026-03-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -266,22 +211,22 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1666'
+      - '1674'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:13 GMT
+      - Tue, 21 Apr 2026 00:29:11 GMT
       ETag:
-      - CPO8oazR7pMDEAE=
+      - CL3f3ofY/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:13 GMT
+      - Tue, 21 Apr 2026 00:29:11 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3tcImIKkBdpA49gu6-wqUFcBdqXm8JmqKgt_o4a4HPvOKgGFTZTwj7jnozRUV6zSTc6jzNtbg
+      - AMNfjG3izm2i7DdWObfdUu8JgZbsoqmgFP-VkJwqSLCn9RMgVPK_D5HmpBcDKIK8THhIVe4A67bIYpo
     status:
       code: 200
       message: OK

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_old_file.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_old_file.yaml
@@ -1,14 +1,14 @@
 interactions:
 - request:
-    body: "--===============4298896113026035541==\r\ncontent-type: application/json;
+    body: "--===============1744729538959686207==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\",
       \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
       \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\", \\\"LastModified\\\":
-      \\\"2025-05-01 00:00:00+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
-      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============4298896113026035541==\r\ncontent-type:
-      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============4298896113026035541==--"
+      \\\"2025-05-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+      \\\"Size\\\": 429, \\\"StorageClass\\\": \\\"STANDARD\\\"}}\"}, \"crc32c\":
+      \"hQqhOQ==\"}\r\n--===============1744729538959686207==\r\ncontent-type: binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============1744729538959686207==--"
     headers:
       Accept:
       - application/json
@@ -19,15 +19,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1227'
+      - '1243'
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/35222954-0fbf-4fbc-aea5-f3ae27b8d507
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/ad2ba3a4-6f05-40c1-b3af-241c9b7a22a0
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT00Mjk4ODk2MTEzMDI2
-        MDM1NTQxPT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0xNzQ0NzI5NTM4OTU5
+        Njg2MjA3PT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -36,35 +36,35 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776214154337742\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776214154337742&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776214154337742\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731680545492\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CM67263R7pMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-15T00:49:14.346Z\",\n  \"updated\": \"2026-04-15T00:49:14.346Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-15T00:49:14.346Z\",\n  \"timeFinalized\":
-        \"2026-04-15T00:49:14.346Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CNS1uKXZ/ZMDEAE=\",\n  \"timeCreated\":
+        \"2026-04-21T00:34:40.556Z\",\n  \"updated\": \"2026-04-21T00:34:40.556Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-21T00:34:40.556Z\",\n  \"timeFinalized\":
+        \"2026-04-21T00:34:40.556Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\",
-        \\\"LastModified\\\": \\\"2025-05-01 00:00:00+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
-        \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"\n  }\n}\n"
+        \\\"LastModified\\\": \\\"2025-05-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+        \\\"Size\\\": 429, \\\"StorageClass\\\": \\\"STANDARD\\\"}}\"\n  }\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '1753'
+      - '1769'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:14 GMT
+      - Tue, 21 Apr 2026 00:34:40 GMT
       ETag:
-      - CM67263R7pMDEAE=
+      - CNS1uKXZ/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -75,7 +75,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG27aC4StN1zSJkKKr6RGwdP2J_X8ufDg7rkECOvQAML05wYU95tsWhnQilhfukI99gVu_uoKMc
+      - AMNfjG3D7jpnP9OTBG5xQrohIuPO5z4PdfpUmm9C2g7T9eFBHbk6S6irHfglq7YtpSH0Oel-6JJOQFM
     status:
       code: 200
       message: OK
@@ -93,21 +93,21 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/67e0fdee-4a11-47da-ae59-c53d30226b1b
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/6686fc87-03e2-42ab-b084-4071afdf21b7
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202504300000_authorisations.psv&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv&prettyPrint=false
   response:
     body:
-      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776214154337742","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776214154337742&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214154337742","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CM67263R7pMDEAE=","timeCreated":"2026-04-15T00:49:14.346Z","updated":"2026-04-15T00:49:14.346Z","timeStorageClassUpdated":"2026-04-15T00:49:14.346Z","timeFinalized":"2026-04-15T00:49:14.346Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731680545492","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNS1uKXZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:40.556Z","updated":"2026-04-21T00:34:40.556Z","timeStorageClassUpdated":"2026-04-21T00:34:40.556Z","timeFinalized":"2026-04-21T00:34:40.556Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2025-05-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
-        \"Size\": 429, \"StorageClass\": null}}"}},{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776211657953058","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776211657953058&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776211657953058","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CKKerIfI7pMDEAE=","timeCreated":"2026-04-15T00:07:37.962Z","updated":"2026-04-15T00:07:37.962Z","timeStorageClassUpdated":"2026-04-15T00:07:37.962Z","timeFinalized":"2026-04-15T00:07:37.962Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"LastModified\": \"2025-05-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": \"STANDARD\"}}"}},{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731561315918","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731561315918&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731561315918","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CM6cy+zY/ZMDEAE=","timeCreated":"2026-04-21T00:32:41.325Z","updated":"2026-04-21T00:32:41.325Z","timeStorageClassUpdated":"2026-04-21T00:32:41.325Z","timeFinalized":"2026-04-21T00:32:41.325Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2026-04-15 00:07:33+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-04-21T00:32:37+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}]}'
     headers:
       Alt-Svc:
@@ -115,20 +115,20 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '3370'
+      - '3394'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:15 GMT
+      - Tue, 21 Apr 2026 00:34:41 GMT
       Expires:
-      - Wed, 15 Apr 2026 00:49:15 GMT
+      - Tue, 21 Apr 2026 00:34:41 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2FUkZus_U7oG3ICy-BsIVbBKSQB6U56hHEadamkHaowaV4dMZ8HRcuGU5EqGuYylOk
+      - AMNfjG3GPha0ASS4H542x8-ifx93eExgUDReqvLZw7lDzMWsufktDlV1wMKNJiQUd9ssMlZVD8TDaxqjx-mW
     status:
       code: 200
       message: OK
@@ -146,40 +146,40 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/f3744869-6f96-4e28-987e-78d1c89846e8
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/3c4b653b-d8ab-4323-a879-510b138fcbc2
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776214154337742","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776214154337742&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214154337742","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CM67263R7pMDEAE=","timeCreated":"2026-04-15T00:49:14.346Z","updated":"2026-04-15T00:49:14.346Z","timeStorageClassUpdated":"2026-04-15T00:49:14.346Z","timeFinalized":"2026-04-15T00:49:14.346Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731680545492","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNS1uKXZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:40.556Z","updated":"2026-04-21T00:34:40.556Z","timeStorageClassUpdated":"2026-04-21T00:34:40.556Z","timeFinalized":"2026-04-21T00:34:40.556Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2025-05-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
-        \"Size\": 429, \"StorageClass\": null}}"}}'
+        \"LastModified\": \"2025-05-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": \"STANDARD\"}}"}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1666'
+      - '1682'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:15 GMT
+      - Tue, 21 Apr 2026 00:34:41 GMT
       ETag:
-      - CM67263R7pMDEAE=
+      - CNS1uKXZ/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:15 GMT
+      - Tue, 21 Apr 2026 00:34:41 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1skmXgD2QJyG99VBUDkp4NfRRqZYtCmuoyyLOr_RE9bo-aBIJOxXf1U03v-VB8fqcn
+      - AMNfjG0PlPJr8Z_PXsMkejNsH707aqlVCRDlHsjRNHHMuqGRLKtZwVlYWO544giz7D4UQJ1a9kFc4kNjzRsh
     status:
       code: 200
       message: OK
@@ -197,17 +197,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/53d17d18-acbf-4e44-9674-4a8665be95be
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/3b634cc6-cd4b-4703-adbb-a28769ccabcf
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776211657953058","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776211657953058&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776211657953058","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CKKerIfI7pMDEAE=","timeCreated":"2026-04-15T00:07:37.962Z","updated":"2026-04-15T00:07:37.962Z","timeStorageClassUpdated":"2026-04-15T00:07:37.962Z","timeFinalized":"2026-04-15T00:07:37.962Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731561315918","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731561315918&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731561315918","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CM6cy+zY/ZMDEAE=","timeCreated":"2026-04-21T00:32:41.325Z","updated":"2026-04-21T00:32:41.325Z","timeStorageClassUpdated":"2026-04-21T00:32:41.325Z","timeFinalized":"2026-04-21T00:32:41.325Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2026-04-15 00:07:33+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-04-21T00:32:37+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -215,22 +215,22 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1666'
+      - '1674'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:16 GMT
+      - Tue, 21 Apr 2026 00:34:41 GMT
       ETag:
-      - CKKerIfI7pMDEAE=
+      - CM6cy+zY/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:16 GMT
+      - Tue, 21 Apr 2026 00:34:41 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG0J6il9WwdOIapTQgBSb8tOrDgkffLFqhNcm85Fmo4aykaUhpNDZe_gQt0EFXQusyye
+      - AMNfjG3FXq1OoV7cTyU4nUBjv2vvlPXmSdVrlvJ0jqhXVYcEQgIeh4nwrK5ShjEcYFs_3Wsjm59UjuGguOoL
     status:
       code: 200
       message: OK
@@ -248,53 +248,53 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/a03ae97a-ed39-4053-8fe2-3639a69ff94a
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/5b7b8d5d-e661-498a-a3bb-9e67d1cccdbc
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776214154337742","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776214154337742&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214154337742","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CM67263R7pMDEAE=","timeCreated":"2026-04-15T00:49:14.346Z","updated":"2026-04-15T00:49:14.346Z","timeStorageClassUpdated":"2026-04-15T00:49:14.346Z","timeFinalized":"2026-04-15T00:49:14.346Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731680545492","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNS1uKXZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:40.556Z","updated":"2026-04-21T00:34:40.556Z","timeStorageClassUpdated":"2026-04-21T00:34:40.556Z","timeFinalized":"2026-04-21T00:34:40.556Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2025-05-01 00:00:00+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
-        \"Size\": 429, \"StorageClass\": null}}"}}'
+        \"LastModified\": \"2025-05-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": \"STANDARD\"}}"}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1666'
+      - '1682'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:16 GMT
+      - Tue, 21 Apr 2026 00:34:42 GMT
       ETag:
-      - CM67263R7pMDEAE=
+      - CNS1uKXZ/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:16 GMT
+      - Tue, 21 Apr 2026 00:34:42 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG08p35fCq6MQ_s8Hb6unhVw2xHR4-E96mNHzUnKkmJcCkygtywyiI0NASwdBEgL1_ud
+      - AMNfjG1NoQPw0xQJrJrNb2UTdlCTSdWhj81nU4btKvjfi597NaRQX6NojWU-DLhU-mHXkBmVo2sUA5YLpKum
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============3786139393092281104==\r\ncontent-type: application/json;
+    body: "--===============5233988074989703276==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\",
       \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
       \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\", \\\"LastModified\\\":
-      \\\"2026-04-15 00:49:13+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
-      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============3786139393092281104==\r\ncontent-type:
-      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============3786139393092281104==--"
+      \\\"2026-04-21T00:34:39+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============5233988074989703276==\r\ncontent-type:
+      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============5233988074989703276==--"
     headers:
       Accept:
       - application/json
@@ -305,15 +305,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1227'
+      - '1235'
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/ec5fe869-c74f-407a-8dde-0c18959a8310
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/2081e7ce-54e3-470a-9b27-79af624c679c
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0zNzg2MTM5MzkzMDky
-        MjgxMTA0PT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT01MjMzOTg4MDc0OTg5
+        NzAzMjc2PT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -322,21 +322,21 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776214157674879\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731683180353\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776214157674879&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731683180353&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776214157674879\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731683180353\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CP+Sp6/R7pMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-15T00:49:17.683Z\",\n  \"updated\": \"2026-04-15T00:49:17.683Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-15T00:49:17.683Z\",\n  \"timeFinalized\":
-        \"2026-04-15T00:49:17.683Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CMGe2abZ/ZMDEAE=\",\n  \"timeCreated\":
+        \"2026-04-21T00:34:43.189Z\",\n  \"updated\": \"2026-04-21T00:34:43.189Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-21T00:34:43.189Z\",\n  \"timeFinalized\":
+        \"2026-04-21T00:34:43.189Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\",
-        \\\"LastModified\\\": \\\"2026-04-15 00:49:13+00:00\\\", \\\"ETag\\\": \\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\",
+        \\\"LastModified\\\": \\\"2026-04-21T00:34:39+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
         \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"\n  }\n}\n"
     headers:
       Alt-Svc:
@@ -344,13 +344,13 @@ interactions:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '1753'
+      - '1761'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:17 GMT
+      - Tue, 21 Apr 2026 00:34:43 GMT
       ETag:
-      - CP+Sp6/R7pMDEAE=
+      - CMGe2abZ/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -361,19 +361,17 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3_4nyrWdyNuWra0UVH1ZV2wrezmAaxRB3I-N2mkP8DbWx9heYUNVj11_smo2CE6htK
+      - AMNfjG1tpxfQAf6QieWlnLzuIB9x4jchsQKepSxI6sAhb_Jio9LNDzAA8MmJOFfXZ81c6artiIG2gQ
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============2431343500386313113==\r\ncontent-type: application/json;
+    body: "--===============8265524489122910330==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"results_202504300000_authorisations.psv.jsonl\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"},
-      \"crc32c\": \"hWd0Rw==\"}\r\n--===============2431343500386313113==\r\ncontent-type:
-      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2025-05-01
-      00:00:00+00:00\",\"ETag\":\"5d46e84b9c9fa3cc87e4916c452c4de8\",\"Size\":429,\"StorageClass\":null},\"extract\":{\"filename\":\"202504300000_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2026-04-15
-      00:49:13+00:00\",\"ETag\":\"5d46e84b9c9fa3cc87e4916c452c4de8\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============2431343500386313113==--"
+      \"crc32c\": \"ZzMWRw==\"}\r\n--===============8265524489122910330==\r\ncontent-type:
+      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2025-05-01T00:00:00+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":\"STANDARD\"},\"extract\":{\"filename\":\"202504300000_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2026-04-21T00:34:39+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============8265524489122910330==--"
     headers:
       Accept:
       - application/json
@@ -384,15 +382,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1079'
+      - '1093'
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/f7e869ca-aa40-4aa9-9e95-72d5393c588a
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/1af6f77d-974f-45ab-88a4-8c766ac8f2cc
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0yNDMxMzQzNTAwMzg2
-        MzEzMTEzPT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT04MjY1NTI0NDg5MTIy
+        OTEwMzMwPT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -401,17 +399,17 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1776214158612966\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1776731684057929\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1776214158612966&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1776731684057929&alt=media\",\n
         \ \"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776214158612966\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731684057929\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
-        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"554\",\n  \"md5Hash\": \"Uh3IS1YMvUFSwjosffvWLQ==\",\n
-        \ \"crc32c\": \"hWd0Rw==\",\n  \"etag\": \"COaz4K/R7pMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-15T00:49:18.620Z\",\n  \"updated\": \"2026-04-15T00:49:18.620Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-15T00:49:18.620Z\",\n  \"timeFinalized\":
-        \"2026-04-15T00:49:18.620Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"568\",\n  \"md5Hash\": \"jr+xZimF399OukTsAs9S6g==\",\n
+        \ \"crc32c\": \"ZzMWRw==\",\n  \"etag\": \"CMnmjqfZ/ZMDEAE=\",\n  \"timeCreated\":
+        \"2026-04-21T00:34:44.066Z\",\n  \"updated\": \"2026-04-21T00:34:44.066Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-21T00:34:44.066Z\",\n  \"timeFinalized\":
+        \"2026-04-21T00:34:44.066Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"results_202504300000_authorisations.psv.jsonl\\\",
         \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"\n
         \ }\n}\n"
@@ -425,9 +423,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:18 GMT
+      - Tue, 21 Apr 2026 00:34:44 GMT
       ETag:
-      - COaz4K/R7pMDEAE=
+      - CMnmjqfZ/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -438,7 +436,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3pxwHy-0-GZnAiWYVHK9d4dZY1AD62axIIztkyJgPWk8Or4u5CT7dqDDTv4-RsAtXK
+      - AMNfjG3vytuIa1FmJD97oCTY8sCQ3-SqvdVTAlSfxMM9zZp63TXip4W8AfYNzH10YMoUIYIL
     status:
       code: 200
       message: OK
@@ -456,17 +454,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/bb7d9554-c134-47b3-8901-51c2c986592c
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/8f435d0a-b5ad-4270-a971-054e6a1097d6
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776214157674879","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776214157674879&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776214157674879","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CP+Sp6/R7pMDEAE=","timeCreated":"2026-04-15T00:49:17.683Z","updated":"2026-04-15T00:49:17.683Z","timeStorageClassUpdated":"2026-04-15T00:49:17.683Z","timeFinalized":"2026-04-15T00:49:17.683Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731683180353","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731683180353&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731683180353","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CMGe2abZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:43.189Z","updated":"2026-04-21T00:34:43.189Z","timeStorageClassUpdated":"2026-04-21T00:34:43.189Z","timeFinalized":"2026-04-21T00:34:43.189Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2026-04-15 00:49:13+00:00\", \"ETag\": \"5d46e84b9c9fa3cc87e4916c452c4de8\",
+        \"LastModified\": \"2026-04-21T00:34:39+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -474,22 +472,22 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1666'
+      - '1674'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:18 GMT
+      - Tue, 21 Apr 2026 00:34:44 GMT
       ETag:
-      - CP+Sp6/R7pMDEAE=
+      - CMGe2abZ/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:18 GMT
+      - Tue, 21 Apr 2026 00:34:44 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2-h0yqfzrieVibHmVVIkhPpf5Lk05yny1871T68OLki4N--vtsvAGpcYAQd6lNsR-h
+      - AMNfjG32CLImRCaYqKIWMbGA0gXkAVjk_M55GiIghOoVuTXz8hhj3rOSH4bXhIvNvedCkMOD
     status:
       code: 200
       message: OK
@@ -505,7 +503,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/1a9a1c33-a289-447e-8489-2309993bc7c2
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/54cf10f6-7e8f-403c-85b0-0611016b6ac4
       accept-encoding:
       - gzip
       content-type:
@@ -518,9 +516,7 @@ interactions:
     uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.jsonl?alt=media
   response:
     body:
-      string: '{"success":true,"exception":null,"prior":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2025-05-01
-        00:00:00+00:00","ETag":"5d46e84b9c9fa3cc87e4916c452c4de8","Size":429,"StorageClass":null},"extract":{"filename":"202504300000_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2026-04-15
-        00:49:13+00:00","ETag":"5d46e84b9c9fa3cc87e4916c452c4de8","Size":429,"StorageClass":null}}}'
+      string: '{"success":true,"exception":null,"prior":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2025-05-01T00:00:00+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":"STANDARD"},"extract":{"filename":"202504300000_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2026-04-21T00:34:39+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":null}}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -529,17 +525,17 @@ interactions:
       Content-Disposition:
       - attachment
       Content-Length:
-      - '554'
+      - '568'
       Content-Type:
       - application/jsonl
       Date:
-      - Wed, 15 Apr 2026 00:49:19 GMT
+      - Tue, 21 Apr 2026 00:34:44 GMT
       ETag:
-      - COaz4K/R7pMDEAE=
+      - CMnmjqfZ/ZMDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Last-Modified:
-      - Wed, 15 Apr 2026 00:49:18 GMT
+      - Tue, 21 Apr 2026 00:34:44 GMT
       Pragma:
       - no-cache
       Server:
@@ -548,11 +544,11 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG0JkJibRcIjFKDXB5_xWcnd1qZgYqSMJxN6wNGK_qcXWy3berp-ADVcxqk6Cyw3FN6G
+      - AMNfjG0GObiaNeFrEym9dIut55JM90Zcy0dytAphYIuCqaUZLUC-LXT2lKTAMVPh7mc9GMKq
       X-Goog-Generation:
-      - '1776214158612966'
+      - '1776731684057929'
       X-Goog-Hash:
-      - crc32c=hWd0Rw==,md5=Uh3IS1YMvUFSwjosffvWLQ==
+      - crc32c=ZzMWRw==,md5=jr+xZimF399OukTsAs9S6g==
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
@@ -560,7 +556,7 @@ interactions:
       X-Goog-Stored-Content-Encoding:
       - identity
       X-Goog-Stored-Content-Length:
-      - '554'
+      - '568'
     status:
       code: 200
       message: OK
@@ -578,14 +574,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/1d65d20b-45f2-4bc7-99b1-5fe87a009684
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/32b01654-00b8-45d8-a591-7a950e903894
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.jsonl?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1776214158612966","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1776214158612966&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1776214158612966","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"554","md5Hash":"Uh3IS1YMvUFSwjosffvWLQ==","crc32c":"hWd0Rw==","etag":"COaz4K/R7pMDEAE=","timeCreated":"2026-04-15T00:49:18.620Z","updated":"2026-04-15T00:49:18.620Z","timeStorageClassUpdated":"2026-04-15T00:49:18.620Z","timeFinalized":"2026-04-15T00:49:18.620Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1776731684057929","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1776731684057929&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1776731684057929","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"568","md5Hash":"jr+xZimF399OukTsAs9S6g==","crc32c":"ZzMWRw==","etag":"CMnmjqfZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:44.066Z","updated":"2026-04-21T00:34:44.066Z","timeStorageClassUpdated":"2026-04-21T00:34:44.066Z","timeFinalized":"2026-04-21T00:34:44.066Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"results_202504300000_authorisations.psv.jsonl\", \"instance\": \"atn\",
         \"ts\": \"2025-06-01T00:00:00+00:00\"}"}}'
     headers:
@@ -598,18 +594,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2026 00:49:19 GMT
+      - Tue, 21 Apr 2026 00:34:44 GMT
       ETag:
-      - COaz4K/R7pMDEAE=
+      - CMnmjqfZ/ZMDEAE=
       Expires:
-      - Wed, 15 Apr 2026 00:49:19 GMT
+      - Tue, 21 Apr 2026 00:34:44 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1j5-SBJPZ7rJzbhhoFIY3eGSgCzs6BEmVT7dZ8YUk3vHMKOfy9u-jOGxsoml-iD42A
+      - AMNfjG19AWx76_zrnmYWEV-yiDJhIdKp5063vengklqd9pnOby02qNXfXoIEnPd9dJCe2FFBD7aNhvU
     status:
       code: 200
       message: OK

--- a/airflow/tests/operators/test_littlepay_s3_to_gcs_operator.py
+++ b/airflow/tests/operators/test_littlepay_s3_to_gcs_operator.py
@@ -208,7 +208,7 @@ class TestLittlepayS3ToGCSOperator:
             "s3object": {
                 "Key": "atn/v3/authorisations/202510241114_authorisations.psv",
                 "LastModified": parsed_metadata["s3object"]["LastModified"],
-                "ETag": s3_file["ETag"].replace('"', ""),
+                "ETag": s3_file["ETag"],
                 "Size": s3_file["ContentLength"],
                 "StorageClass": None,
             },
@@ -231,7 +231,7 @@ class TestLittlepayS3ToGCSOperator:
                 "instance": "atn",
                 "s3bucket": "mock-littlepay-bucket",
                 "s3object": {
-                    "ETag": "5d46e84b9c9fa3cc87e4916c452c4de8",
+                    "ETag": '"5d46e84b9c9fa3cc87e4916c452c4de8"',
                     "Key": "atn/v3/authorisations/202510241114_authorisations.psv",
                     "LastModified": parsed_report[0]["extract"]["s3object"][
                         "LastModified"
@@ -373,8 +373,8 @@ class TestLittlepayS3ToGCSOperator:
                             "s3bucket": "mock-littlepay-bucket",
                             "s3object": {
                                 "Key": file_exists_source_path,
-                                "LastModified": str(s3_file["LastModified"]),
-                                "ETag": s3_file["ETag"].replace('"', ""),
+                                "LastModified": s3_file["LastModified"].isoformat(),
+                                "ETag": s3_file["ETag"],
                                 "Size": s3_file["ContentLength"],
                                 "StorageClass": None,
                             },
@@ -510,10 +510,10 @@ class TestLittlepayS3ToGCSOperator:
                             "s3bucket": "mock-littlepay-bucket",
                             "s3object": {
                                 "Key": old_file_source_path,
-                                "LastModified": "2025-05-01 00:00:00+00:00",
-                                "ETag": s3_file["ETag"].replace('"', ""),
+                                "LastModified": "2025-05-01T00:00:00+00:00",
+                                "ETag": s3_file["ETag"],
                                 "Size": s3_file["ContentLength"],
-                                "StorageClass": None,
+                                "StorageClass": "STANDARD",
                             },
                         }
                     )
@@ -563,7 +563,7 @@ class TestLittlepayS3ToGCSOperator:
             "s3object": {
                 "Key": "atn/v3/authorisations/202504300000_authorisations.psv",
                 "LastModified": parsed_metadata["s3object"]["LastModified"],
-                "ETag": s3_file["ETag"].replace('"', ""),
+                "ETag": s3_file["ETag"],
                 "Size": s3_file["ContentLength"],
                 "StorageClass": None,
             },
@@ -582,9 +582,9 @@ class TestLittlepayS3ToGCSOperator:
             "prior": {
                 "Key": "atn/v3/authorisations/202504300000_authorisations.psv",
                 "LastModified": parsed_report[0]["prior"]["LastModified"],
-                "ETag": s3_file["ETag"].replace('"', ""),
+                "ETag": s3_file["ETag"],
                 "Size": s3_file["ContentLength"],
-                "StorageClass": None,
+                "StorageClass": "STANDARD",
             },
             "exception": None,
             "extract": {
@@ -596,7 +596,7 @@ class TestLittlepayS3ToGCSOperator:
                     "LastModified": parsed_report[0]["extract"]["s3object"][
                         "LastModified"
                     ],
-                    "ETag": s3_file["ETag"].replace('"', ""),
+                    "ETag": s3_file["ETag"],
                     "Size": s3_file["ContentLength"],
                     "StorageClass": None,
                 },


### PR DESCRIPTION
# Description

When I ran the `download_and_parse_littlepay` DAG on Prod Airflow, I noticed that all files were downloaded again. 
I stopped before it parses, so no duplicated data was added.

Comparing the Metadata from previous files I found the issue:
* S3Hook timestamp format is different: Fixed by formatting `LastModified` to `ISO 8601 standard` timestamp.
New files with wrong format: "LastModified": "2026-03-21 11:15:38+00:00"
Old files with correct format: "LastModified": "2026-03-21T11:15:38+00:00"

* ETag quotes: We were removing the extra quotes from the ETag, but the old files were not removing, so I fixed by keeping as the old files.
New files without extra quotes: "ETag": "49dbb0e789a44cab8b379ef6ec1c0375"
Old files with extra quotes: "ETag": "\"49dbb0e789a44cab8b379ef6ec1c0375\""

Notes: I adjusted `airflow-providers-amazon` version on requirements file but it will not change the version. The version was set to >= 8.15.0 and the lock files already installed 9.17.0.

Resolves #4383

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally with pytests.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Run DAG again.