### PR TITLE
Payments(onboarding): Add agency onboarding intake template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-payments-agency-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/new-payments-agency-onboarding.md
@@ -14,11 +14,11 @@ assignees: [mrtopsyt, csuyat-dot, amandaha8]
 
 **GTFS Feed Name / Identifier**:
 
-- \[add feed name as it appears in the transit database - find it in the "Name" column under "gtfs datasets" in Airtable\]
+- \[add feed name as it appears in the transit database - find it in the "Name" column under "[gtfs datasets](https://airtable.com/appPnJWrQ7ui4UmIl/tbl5V6Vjs4mNQgYbc/viwPOujIFNr6yn4ib?blocks=hide)" in Airtable\]
 
 **Organization Name** _(as it appears in the transit database)_:
 
-- \[add organization name - find it in the "Name" column under "organizations" in Airtable \]
+- \[add organization name - find it in the "Name" column under "[organizations](https://airtable.com/appPnJWrQ7ui4UmIl/tblFsd8D5oFRqep8Z/viwhhibWpFXRJ7nYc?blocks=hide)" in Airtable \]
 
 **Fare Processor Vendor**:
 
@@ -42,7 +42,7 @@ _Complete this section if the agency uses Littlepay. Leave blank otherwise._
 
 **AWS Credentials and S3 Bucket**:
 
-- Littlepay will provide the AWS access key and S3 bucket/prefix ahead of launch. Confirm this has been shared before closing this ticket.
+- Littlepay will provide the AWS access key and S3 bucket/prefix ahead of launch. **Do NOT share this information in a GitHub ticket.** An assignee should confirm this has been shared privately before closing this ticket.
 
 ______________________________________________________________________
 
@@ -52,7 +52,7 @@ _Complete this section if the agency uses Enghouse. Leave blank otherwise._
 
 **Operator ID** _(provided by Enghouse)_:
 
-- \[add\]
+- \[add Enghouse Operator ID\]
 
 ______________________________________________________________________
 
@@ -60,7 +60,7 @@ ______________________________________________________________________
 
 **Elavon Customer Name** _(as it appears in Elavon data)_:
 
-- \[add\]
+- \[add Elavon Customer Name\]
 
 ______________________________________________________________________
 

--- a/.github/ISSUE_TEMPLATE/new-payments-agency-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/new-payments-agency-onboarding.md
@@ -3,7 +3,7 @@ name: New Payments Agency Onboarding
 about: Use this template to kick off onboarding a new open-loop payments agency
 title: New Payments Agency Onboarding - [Agency Name]
 labels: project-payments
-assignees: [charlie-costanzo, mrtopsyt]
+assignees: [mrtopsyt, csuyat-dot, amandaha8]
 ---
 
 ## Agency Information
@@ -14,11 +14,11 @@ assignees: [charlie-costanzo, mrtopsyt]
 
 **GTFS Feed Name / Identifier**:
 
-- \[add feed name as it appears in the transit database\]
+- \[add feed name as it appears in the transit database - find it in the "Name" column under "gtfs datasets" in Airtable\]
 
 **Organization Name** _(as it appears in the transit database)_:
 
-- \[add organization name\]
+- \[add organization name - find it in the "Name" column under "organizations" in Airtable \]
 
 **Fare Processor Vendor**:
 
@@ -67,3 +67,11 @@ ______________________________________________________________________
 ### Notes
 
 _Any additional context or open questions?_
+
+______________________________________________________________________
+
+### Definition of Done
+
+- [ ] Entity mapping, service account, row access policy have been set up for the agency
+- [ ] A database has been created in Metabase and permissions have been assigned appropriatley
+- [ ] Analysts have been notified and an issue has been created in data-analyses to create dashboards

--- a/.github/ISSUE_TEMPLATE/new-payments-agency-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/new-payments-agency-onboarding.md
@@ -1,0 +1,69 @@
+---
+name: New Payments Agency Onboarding
+about: Use this template to kick off onboarding a new open-loop payments agency
+title: New Payments Agency Onboarding - [Agency Name]
+labels: project-payments
+assignees: [charlie-costanzo, mrtopsyt]
+---
+
+## Agency Information
+
+**Agency Name**:
+
+- \[add agency name\]
+
+**GTFS Feed Name / Identifier**:
+
+- \[add feed name as it appears in the transit database\]
+
+**Organization Name** _(as it appears in the transit database)_:
+
+- \[add organization name\]
+
+**Fare Processor Vendor**:
+
+- [ ] Littlepay
+- [ ] Enghouse
+
+**Contact for questions / when ticket is complete**:
+
+- \[add name\]
+- \[add email or other contact method\]
+
+______________________________________________________________________
+
+## Littlepay
+
+_Complete this section if the agency uses Littlepay. Leave blank otherwise._
+
+**Participant ID**:
+
+- \[e.g. `mst`, `clean-air-express`\]
+
+**AWS Credentials and S3 Bucket**:
+
+- Littlepay will provide the AWS access key and S3 bucket/prefix ahead of launch. Confirm this has been shared before closing this ticket.
+
+______________________________________________________________________
+
+## Enghouse
+
+_Complete this section if the agency uses Enghouse. Leave blank otherwise._
+
+**Operator ID** _(provided by Enghouse)_:
+
+- \[add\]
+
+______________________________________________________________________
+
+## Elavon
+
+**Elavon Customer Name** _(as it appears in Elavon data)_:
+
+- \[add\]
+
+______________________________________________________________________
+
+### Notes
+
+_Any additional context or open questions?_


### PR DESCRIPTION
# Description
Adds a GitHub issue template to standardize the intake process for onboarding new open-loop payments agencies.

The template captures the information needed to complete onboarding for both Littlepay and Enghouse agencies – including GTFS feed and organization identifiers, vendor-specific IDs, and Elavon customer name. Sensitive Littlepay credentials (AWS keys, S3 bucket/prefix) are shared as locations rather than collected in the issue body.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
n/a 

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Make sure if 