### PR TITLE
GTFS-RT archiver invocation is done by the service account

### DIFF
--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
@@ -59,6 +59,8 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver-heartbeat" {
     runtime     = "python311"
     entry_point = "process_clock_event"
 
+    automatic_update_policy {}
+
     source {
       storage_source {
         bucket = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-rt-archiver_name
@@ -68,10 +70,11 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver-heartbeat" {
   }
 
   event_trigger {
-    trigger_region = "us-west2"
-    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
-    pubsub_topic   = google_pubsub_topic.gtfs-rt-archiver-staging-heartbeat.id
-    retry_policy   = "RETRY_POLICY_RETRY"
+    trigger_region        = "us-west2"
+    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic          = google_pubsub_topic.gtfs-rt-archiver-staging-heartbeat.id
+    retry_policy          = "RETRY_POLICY_RETRY"
+    service_account_email = data.terraform_remote_state.iam.outputs.google_service_account_gtfs-rt-archiver_email
   }
 }
 
@@ -82,15 +85,19 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
   depends_on = [google_storage_bucket_object.gtfs-rt-archiver]
 
   service_config {
+    available_cpu    = "167m"
     available_memory = "256M"
     ingress_settings = "ALLOW_INTERNAL_ONLY"
+
+    max_instance_count               = 160
+    max_instance_request_concurrency = 1
 
     all_traffic_on_latest_revision = true
     service_account_email          = data.terraform_remote_state.iam.outputs.google_service_account_gtfs-rt-archiver_email
 
     environment_variables = {
       CALITP_BUCKET__GTFS_RT_RAW = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-rt-raw-v2_name}"
-      REQUEST_CONNECT_TIMEOUT    = 5
+      REQUEST_CONNECT_TIMEOUT    = 1
       REQUEST_READ_TIMEOUT       = 5
     }
   }
@@ -98,6 +105,8 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
   build_config {
     runtime     = "python311"
     entry_point = "process_heartbeat_event"
+
+    automatic_update_policy {}
 
     source {
       storage_source {
@@ -108,9 +117,10 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
   }
 
   event_trigger {
-    trigger_region = "us-west2"
-    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
-    pubsub_topic   = google_pubsub_topic.gtfs-rt-archiver-staging.id
-    retry_policy   = "RETRY_POLICY_RETRY"
+    trigger_region        = "us-west2"
+    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic          = google_pubsub_topic.gtfs-rt-archiver-staging.id
+    retry_policy          = "RETRY_POLICY_RETRY"
+    service_account_email = data.terraform_remote_state.iam.outputs.google_service_account_gtfs-rt-archiver_email
   }
 }

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -276,7 +276,8 @@ resource "google_project_iam_member" "gtfs-rt-archiver" {
     "roles/pubsub.subscriber",
     "roles/secretmanager.secretAccessor",
     "roles/storage.objectUser",
-    "roles/workflows.invoker"
+    "roles/workflows.invoker",
+    "roles/run.invoker"
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.gtfs-rt-archiver.email}"

--- a/services/gtfs-rt-archiver/README.md
+++ b/services/gtfs-rt-archiver/README.md
@@ -40,6 +40,8 @@ You can tell this is happening when this error appears in the logs:
 SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1016)'))
 ```
 
+The impact is that feeds served by this host are not able to be downloaded.
+
 The solution is certificate pinning, which will periodically fail due to certificate expiration.
 To capture the custom certificate chain for this domain, use the following script and change `example.com` to the domain in question:
 
@@ -50,3 +52,30 @@ $ echo | openssl s_client -showcerts -connect example.com:443 2>/dev/null | open
 Once you check this certificate in, the next request should succeed.
 
 > Security Note: when a custom certificate is provided, hostname verification is disabled.
+
+
+## Runbook: Hitting an Autoscaling Limit
+
+From time to time, the GTFS-RT archiver Cloud Run service runs out of capacity.
+You can tell this is happening when this warning appears in the logs:
+
+```
+HTTP Status 429: The request was aborted because there was no available instance. Additional troubleshooting documentation can be found at: https://cloud.google.com/run/docs/troubleshooting#abort-request
+```
+
+The impact is that some feeds downloads may be scheduled after a delay, potentially changing the results of the GTFS-RT archiving process.
+
+The solution is to increase the maximum instances for the `gtfs-rt-archiver` service, usually by a small number:
+
+```diff
++++ b/iac/cal-itp-data-infra/gtfs-rt-archiver/us/service.tf
+@@ -87,7 +87,7 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
+     available_memory = "256M"
+     ingress_settings = "ALLOW_INTERNAL_ONLY"
+
+-    max_instance_count               = 160
++    max_instance_count               = 170
+     max_instance_request_concurrency = 1
+
+     all_traffic_on_latest_revision = true
+```

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/downloader.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/downloader.py
@@ -19,7 +19,6 @@ class HostnameIgnoringHTTPSAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs) -> None:
-        print(f"cafile={self.cafile} {os.path.isfile(self.cafile)}")
         if os.path.isfile(self.cafile):
             context = ssl.create_default_context(cafile=self.cafile)
             kwargs["assert_hostname"] = False

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/service.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/service.py
@@ -59,10 +59,9 @@ class Service:
                 json.dumps(
                     {
                         "severity": "Error",
-                        "message": f"Failed {self.configuration().url} - {e}",
+                        "message": f"Failed {self.configuration().url} - {e}\n{traceback.format_exc()}",
                         "url": self.configuration().url,
                         "message_id": self.message_id,
-                        "traceback": traceback.format_exc(),
                         "publish_time": self.publish_time.isoformat(),
                     }
                 )


### PR DESCRIPTION
# Description

This PR uses the service account for gtfs-rt-archiver to enqueue clock, hearbeat, and service calls.

Related to #4488

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

Monitor `terraform apply`

- [x] No action required
- [ ] Actions required (specified below)
