### PR TITLE
Add bucket and service account for production GTFS-RT archiver

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra/gcs/us/variables.tf
@@ -2,6 +2,7 @@ locals {
   environment_buckets = toset([
     "calitp-gtfs-schedule-manual",
     "calitp-kuba",
+    "calitp-gtfs-rt-archiver"
   ])
 }
 

--- a/iac/cal-itp-data-infra/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra/iam/us/outputs.tf
@@ -521,3 +521,7 @@ output "google_service_account_metabase-service-account_email" {
 output "google_service_account_metabase-service-account_name" {
   value = google_service_account.metabase-service-account.name
 }
+
+output "google_service_account_gtfs-rt-archiver_email" {
+  value = google_service_account.gtfs-rt-archiver.email
+}

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -628,3 +628,21 @@ resource "google_project_iam_member" "metabase-service-account" {
   member  = "serviceAccount:${google_service_account.metabase-service-account.email}"
   project = "cal-itp-data-infra"
 }
+
+resource "google_project_iam_member" "gtfs-rt-archiver" {
+  for_each = toset([
+    "roles/bigquery.dataViewer",
+    "roles/bigquery.jobUser",
+    "roles/iam.serviceAccountTokenCreator",
+    "roles/logging.logWriter",
+    "roles/pubsub.publisher",
+    "roles/pubsub.subscriber",
+    "roles/secretmanager.secretAccessor",
+    "roles/storage.objectUser",
+    "roles/workflows.invoker",
+    "roles/run.invoker"
+  ])
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.gtfs-rt-archiver.email}"
+  project = "cal-itp-data-infra-staging"
+}

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -272,6 +272,14 @@ resource "google_service_account" "metabase-service-account" {
   project      = "cal-itp-data-infra"
 }
 
+resource "google_service_account" "gtfs-rt-archiver" {
+  account_id   = "gtfs-rt-archiver"
+  description  = "Service account for the GTFS-RT archiver"
+  disabled     = "false"
+  display_name = "gtfs-rt-archiver"
+  project      = "cal-itp-data-infra"
+}
+
 resource "google_service_account" "vctc-payments-user" {
   account_id = "vctc-payments-user"
   disabled   = "false"


### PR DESCRIPTION
# Description

This PR adds the storage bucket and IAM service account for the production GTFS-RT archiver. This is a preliminary commit to support the GTFS-RT archiver production deployment.

Relates to #4488

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`