### PR TITLE
GTFS-RT archiver saves correct metadata

### DIFF
--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/archiver.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/archiver.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from google.cloud.storage import Bucket, Client
 from gtfs_rt_archiver.configuration import Configuration
@@ -19,7 +20,11 @@ class Archiver:
         return self.client().bucket(bucket_name=self.destination_bucket())
 
     def save(self, result: Result) -> None:
-        blob = self.bucket().blob(blob_name=self.configuration.destination_path())
+        blob = self.bucket().blob(
+            blob_name=os.path.join(
+                self.configuration.destination_prefix(), result.filename()
+            )
+        )
         blob.metadata = {
             "PARTITIONED_ARTIFACT_METADATA": json.dumps(
                 result.metadata(), separators=(",", ":")

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
@@ -59,6 +59,7 @@ class Configuration:
         name: str,
         schedule_url_for_validation: str,
         url: str,
+        computed: bool,
         secret_resolver: Type = Secret,
         **extras,
     ) -> None:
@@ -72,6 +73,7 @@ class Configuration:
         self.name: str = name
         self.schedule_url_for_validation: str = schedule_url_for_validation
         self.url: str = url
+        self.computed: bool = computed
         self.secret_resolver: Type = secret_resolver
         if extras:
             logging.warning(f"Unsupported keys {list(extras.keys())}")
@@ -129,6 +131,7 @@ class Configuration:
             "schedule_url_for_validation": self.schedule_url_for_validation,
             "auth_query_params": self.auth_query_params,
             "auth_headers": self.auth_headers,
+            "computed": self.computed,
         }
 
     @staticmethod

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
@@ -95,14 +95,13 @@ class Configuration:
     def base64_url(self) -> str:
         return urlsafe_b64encode(self.url.encode()).decode()
 
-    def destination_path(self) -> str:
+    def destination_prefix(self) -> str:
         return os.path.join(
             self.feed_type,
             f"dt={self.dt()}",
             f"hour={self.hour()}",
             f"ts={self.ts()}",
             f"base64_url={self.base64_url()}",
-            "feed",
         )
 
     def headers(self) -> dict:

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/downloader.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/downloader.py
@@ -1,5 +1,6 @@
 import os
 import ssl
+from email.message import Message
 from urllib.parse import urlparse
 
 from gtfs_rt_archiver.configuration import Configuration
@@ -36,24 +37,33 @@ class Result:
         self.response: Response = response
 
     def code(self) -> int | None:
-        if self.response is not None:
-            return self.response.status_code
+        return self.response.status_code
 
     def headers(self) -> dict:
-        if self.response is not None:
-            return dict(self.response.headers)
+        return dict(self.response.headers)
 
     def content(self) -> str:
-        if self.response is not None:
-            return self.response.content
+        return self.response.content
 
     def mime_type(self) -> str:
-        if self.response is not None:
-            return self.response.headers.get("Content-Type", "application/octet-stream")
+        return self.response.headers.get("Content-Type", "application/octet-stream")
+
+    def attachment_filename(self) -> str:
+        msg = Message()
+        msg["content-disposition"] = self.headers().get(
+            "Content-Disposition", "attachment"
+        )
+        return msg.get_filename()
+
+    def filename(self) -> str:
+        filename = self.attachment_filename()
+        if not filename:
+            filename = "feed"
+        return filename
 
     def metadata(self) -> dict:
         return {
-            "filename": "feed",
+            "filename": self.filename(),
             "ts": self.configuration.ts(),
             "config": self.configuration.json(),
             "response_code": self.code(),

--- a/services/gtfs-rt-archiver/tests/cassettes/test_downloader/TestDownloader.test_downloader_calculates_filename.yaml
+++ b/services/gtfs-rt-archiver/tests/cassettes/test_downloader/TestDownloader.test_downloader_calculates_filename.yaml
@@ -1,0 +1,151 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en-US,en;q=0.9
+      Cache-Control:
+      - max-age=0
+      Connection:
+      - keep-alive
+      Sec-Ch-Ua:
+      - '"Not:A-Brand";v="99", "Google Chrome";v="145", "Chromium";v="145'
+      Sec-Fetch-Dest:
+      - document
+      Sec-Fetch-Mode:
+      - navigate
+      Sec-Fetch-Site:
+      - cross-site
+      Sec-Fetch-User:
+      - ?1
+      Upgrade-Insecure-Requests:
+      - '1'
+      User-Agent:
+      - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+        like Gecko) Chrome/145.0.0.0 Safari/537.36
+    method: GET
+    uri: http://avl.yctd.org/RealTime/GTFS_ServiceAlerts.pb
+  response:
+    body:
+      string: '<head><title>Document Moved</title></head>
+
+        <body><h1>Object Moved</h1>This document may be found <a HREF="https://avl.yctd.org/RealTime/GTFS_ServiceAlerts.pb">here</a></body>'
+    headers:
+      Content-Length:
+      - '174'
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Wed, 22 Apr 2026 16:46:27 GMT
+      Location:
+      - https://avl.yctd.org/RealTime/GTFS_ServiceAlerts.pb
+      Server:
+      - Microsoft-IIS/10.0
+      X-Powered-By:
+      - ASP.NET
+    status:
+      code: 303
+      message: See Other
+- request:
+    body: null
+    headers:
+      Accept:
+      - text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en-US,en;q=0.9
+      Cache-Control:
+      - max-age=0
+      Connection:
+      - keep-alive
+      Sec-Ch-Ua:
+      - '"Not:A-Brand";v="99", "Google Chrome";v="145", "Chromium";v="145'
+      Sec-Fetch-Dest:
+      - document
+      Sec-Fetch-Mode:
+      - navigate
+      Sec-Fetch-Site:
+      - cross-site
+      Sec-Fetch-User:
+      - ?1
+      Upgrade-Insecure-Requests:
+      - '1'
+      User-Agent:
+      - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML,
+        like Gecko) Chrome/145.0.0.0 Safari/537.36
+    method: GET
+    uri: https://avl.yctd.org/RealTime/GTFS_ServiceAlerts.pb
+  response:
+    body:
+      string: !!binary |
+        CgsKAzIuMBjX9qPPBhL/AwoDMTYzKvcDCgwI+LztzwYQ0NfuzwYqDRICNDAqBTIzNTYzMAAqDRIC
+        NDAqBTIzNjAwMAAqDRICNDEqBTIzMzkxMAAqDRICNDEqBTIzNjAwMAAqDhIDMjQwKgUyMzU2MzAA
+        Kg4SAzI0MCoFMjMzOTEwACoOEgMyNDAqBTIzNjAwMAAqDRICNDAqBTIzMzkxMAAqDRICNDEqBTIz
+        NTYzMAAwATgEQggKBgoAEgJlblIjCiEKG0NhcGl0b2wgTWFsbCBGYXJtZXJzIE1hcmtldBICZW5a
+        MAouCihFdmVyeSBXZWRuZXNkYXkgZnJvbSBBcHJpbCAyOS1PY3RvYmVyIDI5EgJlbmIICgYKABIC
+        ZW5q6wEK6AEK4QFGcm9tIFdlZG5lc2RheSwgQXByaWwgMjksIDIwMjYsIHVudGlsIFdlZG5lc2Rh
+        eSwgT2N0b2JlciAyOCwgMjAyNiwgWW9sb2J1cyBSb3V0ZXMgNDAsIDQxLCBhbmQgMjQwIGdvaW5n
+        IHRocm91Z2ggQ2FwaXRvbCBNYWxsIHdpbGwgYmUgcmVyb3V0ZWQgZXZlcnkgV2VkbmVzZGF5IGZy
+        b20gODozMCBBTSB1bnRpbCAwMjowMCBQTS4gVGhpcyBkZXRvdXIgaGFzIG5vIGJ1cyBzdG9wIGNs
+        b3N1cmVzLiASAmVucAMShAQKAzE2MSr8AwoMCPjHyM8GENDiyc8GKg0SAjQwKgUyMzU2MzAAKg0S
+        AjQwKgUyMzM5MTAAKg0SAjQwKgUyMzYwMDAAKg0SAjQxKgUyMzU2MzAAKg0SAjQxKgUyMzM5MTAA
+        Kg0SAjQxKgUyMzYwMDAAKg4SAzI0MCoFMjM1NjMwACoOEgMyNDAqBTIzMzkxMAAqDhIDMjQwKgUy
+        MzYwMDAAMAE4BEIICgYKABICZW5SIwohChtDYXBpdG9sIE1hbGwgRmFybWVycyBNYXJrZXQSAmVu
+        WjAKLgooRXZlcnkgV2VkbmVzZGF5IGZyb20gQXByaWwgMjktT2N0b2JlciAyORICZW5iCAoGCgAS
+        AmVuavABCu0BCuYBQmVnaW5uaW5nIFdlZG5lc2RheSwgQXByaWwgMjksIDIwMjYsIHVudGlsIFdl
+        ZG5lc2RheSwgT2N0b2JlciAyOCwgMjAyNiwgWW9sb2J1cyBSb3V0ZXMgNDAsIDQxLCBhbmQgMjQw
+        IGdvaW5nIHRocm91Z2ggQ2FwaXRvbCBNYWxsIHdpbGwgYmUgcmVyb3V0ZWQgZXZlcnkgV2VkbmVz
+        ZGF5IGZyb20gODozMCBBTSB1bnRpbCAwMjowMCBQTS4gVGhpcyBkZXRvdXIgaGFzIG5vIGJ1cyBz
+        dG9wIGNsb3N1cmVzLiASAmVucAMS8AYKAzE2NCroBgoMCJCBq88GELSprM8GKg0SAjM3KgUyMzM4
+        NjAAKg0SAjM3KgUyMzUzNTAAKg0SAjM3KgUyMzM4OTAAKg0SAjM3KgUyMzUzMTAAKg0SAjM3KgUy
+        MzM4ODAAKg0SAjM3KgUyMzM4NzAAKg0SAjM3KgUyMzM5NzAAKg0SAjM3KgUyMzM5ODAAKg0SAjM3
+        KgUyMzM4NTAAKg0SAjM3KgUyMzQwMDAAKg0SAjQwKgUyMzU2MzAAKg0SAjQwKgUyMzM5MTAAKg0S
+        AjQwKgUyMzYwMDAAKg0SAjQwKgUyMzM4ODAAKg0SAjQwKgUyMzM4OTAAKg0SAjQxKgUyMzU2MzAA
+        Kg0SAjQxKgUyMzM5MTAAKg0SAjQxKgUyMzYwMDAAKg0SAjQxKgUyMzM4ODAAKg0SAjQxKgUyMzM4
+        OTAAKg4SAzQyQSoFMjMzOTcwACoOEgM0MkEqBTIzMzk4MAAqDhIDNDJBKgUyMzM4NTAAKg4SAzQy
+        QSoFMjM0MDAwACoOEgM0MkEqBTIzNDExMAAqDhIDNDJCKgUyMzQxMjAAKg4SAzQyQioFMjMzODcw
+        ACoOEgM0MkIqBTIzMzk3MAAqDhIDNDJCKgUyMzM5ODAAKg4SAzQyQioFMjMzODUwACoOEgM0MkIq
+        BTIzNDAwMAAqDhIDNDJCKgUyMzM5NjAAKg4SAzI0MCoFMjM1NjMwACoOEgMyNDAqBTIzMzkxMAAq
+        DhIDMjQwKgUyMzYwMDAAKg4SAzI0MCoFMjMzODgwACoOEgMyNDAqBTIzMzg5MAAwATgEQggKBgoA
+        EgJlblIWChQKDjQvMjMvMjYgRGV0b3VyEgJlblojCiEKG0dvbGRlbiAxIENlbnRlciBFdmVudCAr
+        IFNIUBICZW5iCAoGCgASAmVuasQBCsEBCroBT24gVGh1cnNkYXksIEFwcmlsIDIzLCAyMDI2LCBZ
+        b2xvYnVzIFJvdXRlcyA0MkEvQiwgMzcsIDQwLCA0MSwgYW5kIDI0MCBvcGVyYXRpbmcgaW4gRG93
+        bnRvd24gU2FjcmFtZW50byB3aWxsIGJlIHJlcm91dGVkIGR1ZSB0byBhIGNvbmNlcnQgYXQgdGhl
+        IEdvbGRlbiAxIENlbnRlciBmcm9tIDY6MDAgUE0gdG8gMTE6NTkgUE0uEgJlbnADEtYECgMxNjUq
+        zgQKDAiQ6rrPBhC0krzPBioNEgI0MCoFMjM1NjMwACoNEgI0MCoFMjMzOTEwACoNEgI0MCoFMjM2
+        MDAwACoNEgI0MCoFMjMzODgwACoOEgM0MkEqBTIzMzk3MAAqDhIDNDJBKgUyMzM5ODAAKg4SAzQy
+        QSoFMjMzODUwACoOEgM0MkEqBTIzNDAwMAAqDhIDNDJBKgUyMzQxMTAAKg4SAzQyQioFMjM0MTIw
+        ACoOEgM0MkIqBTIzMzg3MAAqDhIDNDJCKgUyMzM5NzAAKg4SAzQyQioFMjMzOTgwACoOEgM0MkIq
+        BTIzMzg1MAAqDhIDNDJCKgUyMzQwMDAAKg4SAzI0MCoFMjM1NjMwACoOEgMyNDAqBTIzMzkxMAAq
+        DhIDMjQwKgUyMzYwMDAAKg4SAzI0MCoFMjMzODgwADABOARCCAoGCgASAmVuUhYKFAoONC8yNi8y
+        NiBEZXRvdXISAmVuWiMKIQobR29sZGVuIDEgQ2VudGVyIEV2ZW50ICsgU0hQEgJlbmIICgYKABIC
+        ZW5qugEKtwEKsAFPbiBTdW5kYXksIEFwcmlsIDI2LCAyMDI2LCBZb2xvYnVzIFJvdXRlcyA0MkEv
+        QiwgNDAsIGFuZCAyNDAgb3BlcmF0aW5nIGluIERvd250b3duIFNhY3JhbWVudG8gd2lsbCBiZSBy
+        ZXJvdXRlZCBkdWUgdG8gYSBjb25jZXJ0IGF0IHRoZSBHb2xkZW4gMSBDZW50ZXIgZnJvbSA2OjAw
+        IFBNIHRvIDExOjU5IFBNLhICZW5wAw==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '2530'
+      Content-Type:
+      - application/x-protobuf
+      Date:
+      - Wed, 22 Apr 2026 16:46:27 GMT
+      ETag:
+      - W/"b953f68877d2dc1:0"
+      Last-Modified:
+      - Wed, 22 Apr 2026 16:46:15 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Powered-By:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/services/gtfs-rt-archiver/tests/test_archiver.py
+++ b/services/gtfs-rt-archiver/tests/test_archiver.py
@@ -29,6 +29,7 @@ class TestArchiver:
             "name": "Example",
             "schedule_url_for_validation": "http://www.yolobus.com/GTFS/google_transit.zip",
             "url": url,
+            "computed": False,
         }
 
     @pytest.fixture

--- a/services/gtfs-rt-archiver/tests/test_configuration.py
+++ b/services/gtfs-rt-archiver/tests/test_configuration.py
@@ -116,14 +116,13 @@ class TestConfiguration:
     def test_base64_encodes_url(self, configuration: Configuration) -> None:
         assert configuration.base64_url() == "aHR0cDovL2V4YW1wbGUuY29t"
 
-    def test_builds_destination_path(self, configuration: Configuration) -> None:
-        assert configuration.destination_path() == os.path.join(
+    def test_builds_destination_prefix(self, configuration: Configuration) -> None:
+        assert configuration.destination_prefix() == os.path.join(
             "vehicle_positions",
             "dt=2026-04-01",
             "hour=2026-04-01T00:00:00+00:00",
             "ts=2026-04-01T00:01:20+00:00",
             "base64_url=aHR0cDovL2V4YW1wbGUuY29t",
-            "feed",
         )
 
     def test_empty_headers(self, configuration: Configuration) -> None:

--- a/services/gtfs-rt-archiver/tests/test_configuration.py
+++ b/services/gtfs-rt-archiver/tests/test_configuration.py
@@ -40,6 +40,7 @@ class TestConfiguration:
             "name": "Example",
             "schedule_url_for_validation": "http://example.com/gtfs.zip",
             "url": url,
+            "computed": False,
         }
 
     @pytest.fixture
@@ -56,6 +57,7 @@ class TestConfiguration:
             "name": "Example",
             "schedule_url_for_validation": "http://example.com/gtfs.zip",
             "url": url,
+            "computed": False,
         }
 
     @pytest.fixture
@@ -72,6 +74,7 @@ class TestConfiguration:
             "name": "Example",
             "schedule_url_for_validation": "http://example.com/gtfs.zip",
             "url": url,
+            "computed": False,
         }
 
     @pytest.fixture
@@ -147,4 +150,5 @@ class TestConfiguration:
             "schedule_url_for_validation": "http://example.com/gtfs.zip",
             "auth_query_params": {},
             "auth_headers": {},
+            "computed": False,
         }

--- a/services/gtfs-rt-archiver/tests/test_downloader.py
+++ b/services/gtfs-rt-archiver/tests/test_downloader.py
@@ -25,7 +25,6 @@ class TestDownloader:
     def data(self, current_time: datetime, url: str) -> dict:
         return {
             "publish_time": "2026-04-01T00:01:23.45+00:00",
-            "current_time": current_time,
             "auth_headers": {},
             "auth_query_params": {},
             "extracted_at": "2026-04-01T00:00:00+00:00",
@@ -86,3 +85,7 @@ class TestDownloader:
         feed = gtfs_realtime_pb2.FeedMessage()
         feed.ParseFromString(downloader.get().content())
         assert len(feed.entity) > 0
+
+    @pytest.mark.vcr
+    def test_downloader_calculates_filename(self, downloader: Downloader) -> None:
+        assert downloader.get().filename() == "feed"

--- a/services/gtfs-rt-archiver/tests/test_downloader.py
+++ b/services/gtfs-rt-archiver/tests/test_downloader.py
@@ -32,6 +32,7 @@ class TestDownloader:
             "name": "Example",
             "schedule_url_for_validation": "http://www.yolobus.com/GTFS/google_transit.zip",
             "url": url,
+            "computed": False,
         }
 
     @pytest.fixture
@@ -46,6 +47,7 @@ class TestDownloader:
             "name": "Example",
             "schedule_url_for_validation": "https://example.com/google_transit.zip",
             "url": "https://uctransit.info/gtfs-rt/vehiclepositions",
+            "computed": False,
         }
 
     @pytest.fixture

--- a/services/gtfs-rt-archiver/tests/test_service.py
+++ b/services/gtfs-rt-archiver/tests/test_service.py
@@ -27,6 +27,7 @@ class TestService:
             "name": "Example",
             "schedule_url_for_validation": "http://www.yolobus.com/GTFS/google_transit.zip",
             "url": url,
+            "computed": False,
         }
 
     @pytest.fixture


### PR DESCRIPTION
# Description

This PR updates the GTFS-RT archiver filename to the attachment filename and includes the `computed` field in the file metadata.

Relates to #4488

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`pytest`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Compare metadata and filenames for one 20-second period of one feed type between staging and production