### PR TITLE
Send an alert when the GTFS-RT archiver latency spikes

### DIFF
--- a/iac/cal-itp-data-infra-staging/alerting/us/.terraform.lock.hcl
+++ b/iac/cal-itp-data-infra-staging/alerting/us/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.10.0"
+  constraints = "~> 7.10.0"
+  hashes = [
+    "h1:itPAvjmGmV6R8KpBsDGnONKfi9AXPt0LCFThnDF/3+g=",
+    "zh:40b90c1e6cc95cccfc935d4af4478590410bf2ce24d2cd7f6b583e7791b9b5b3",
+    "zh:56f25840e253ea527ab196ffb5cc3f896ef129c6d0dbe795eb9dd305d84354cd",
+    "zh:5bb291ae271b3363052ea4b01073c91ce9a5fcf58bf8c1d01a919099e1b4e946",
+    "zh:671daceb89669b51586a1a32861ea77d30233d6c2adb1ec2d3ada48d3f485634",
+    "zh:965834aeda62b59b8140b8db9d378658d5e3bb56a828a5158d2625237ae925b5",
+    "zh:9a83c890f65bcd3777eb42a9a7de622c6f9ceb3fe3ceedfe532c1cb4de24ddb2",
+    "zh:a2a995d03f8a669a753e99e12e6826c0b7081ac573a66c9c90db2d70f00b8ed4",
+    "zh:a4473ea1f59b6a5837f5e27ac4383a566dc8bdf60e0e63b5fddc5a2523fdaeb5",
+    "zh:a568e0b3c475629de3d00f60693270d7ae2d8cda7a9b8b28613baec9fb09b37c",
+    "zh:c53002313ea07dba92503eec6c0876b13b5217a703313c3ac74b31fefa52afbb",
+    "zh:dbd8c9e2099ca321ebab124b9c9a3421469714ac2d329d0047d0981c8c64ab21",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/iac/cal-itp-data-infra-staging/alerting/us/alert.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/alert.tf
@@ -1,7 +1,7 @@
 resource "google_monitoring_alert_policy" "alert_policy" {
   display_name          = "Burn rate on 99% 10s Latency for GTFS-RT Archiver"
   combiner              = "OR"
-  notification_channels = [google_monitoring_notification_channel.calitp-meta.id, google_monitoring_notification_channel.gcp-monitoring.id]
+  notification_channels = [google_monitoring_notification_channel.calitp-slack-gcp-monitoring.id]
 
   conditions {
     display_name = "Burn rate on 99% 10s Latency for GTFS-RT Archiver"

--- a/iac/cal-itp-data-infra-staging/alerting/us/alert.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/alert.tf
@@ -1,7 +1,7 @@
 resource "google_monitoring_alert_policy" "alert_policy" {
   display_name          = "Burn rate on 99% 10s Latency for GTFS-RT Archiver"
   combiner              = "OR"
-  notification_channels = [google_monitoring_notification_channel.calitp-meta.id]
+  notification_channels = [google_monitoring_notification_channel.calitp-meta.id, google_monitoring_notification_channel.gcp-monitoring.id]
 
   conditions {
     display_name = "Burn rate on 99% 10s Latency for GTFS-RT Archiver"

--- a/iac/cal-itp-data-infra-staging/alerting/us/alert.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/alert.tf
@@ -1,0 +1,18 @@
+resource "google_monitoring_alert_policy" "alert_policy" {
+  display_name          = "Burn rate on 99% 10s Latency for GTFS-RT Archiver"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.calitp-meta.id]
+
+  conditions {
+    display_name = "Burn rate on 99% 10s Latency for GTFS-RT Archiver"
+    condition_threshold {
+      filter          = "select_slo_burn_rate(\"${google_monitoring_slo.gtfs-rt-archiver-latency.id}\", \"3600s\")"
+      duration        = "0s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 10
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/iac/cal-itp-data-infra-staging/alerting/us/channel.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/channel.tf
@@ -6,3 +6,12 @@ resource "google_monitoring_notification_channel" "calitp-meta" {
     team         = "minifast"
   }
 }
+
+resource "google_monitoring_notification_channel" "gcp-monitoring" {
+  display_name = "gcp-monitoring"
+  type         = "slack"
+  labels = {
+    channel_name = "#gcp-monitoring"
+    team         = "cal-itp"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/alerting/us/channel.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/channel.tf
@@ -1,13 +1,4 @@
-resource "google_monitoring_notification_channel" "calitp-meta" {
-  display_name = "calitp-meta"
-  type         = "slack"
-  labels = {
-    channel_name = "#calitp-meta"
-    team         = "minifast"
-  }
-}
-
-resource "google_monitoring_notification_channel" "gcp-monitoring" {
+resource "google_monitoring_notification_channel" "calitp-slack-gcp-monitoring" {
   display_name = "gcp-monitoring"
   type         = "slack"
   labels = {

--- a/iac/cal-itp-data-infra-staging/alerting/us/channel.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/channel.tf
@@ -1,0 +1,8 @@
+resource "google_monitoring_notification_channel" "calitp-meta" {
+  display_name = "calitp-meta"
+  type         = "slack"
+  labels = {
+    channel_name = "#calitp-meta"
+    team         = "minifast"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/alerting/us/provider.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/provider.tf
@@ -1,0 +1,16 @@
+provider "google" {
+  project = "cal-itp-data-infra-staging"
+}
+
+terraform {
+  required_providers {
+    google = {
+      version = "~> 7.10.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "calitp-staging-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra-staging/alerting"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/alerting/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/service.tf
@@ -1,0 +1,12 @@
+resource "google_monitoring_service" "gtfs-rt-archiver" {
+  service_id   = "gtfs-rt-archiver"
+  display_name = "GTFS-RT Archiver"
+
+  basic_service {
+    service_type = "CLOUD_RUN"
+    service_labels = {
+      location     = "us-west2"
+      service_name = "gtfs-rt-archiver"
+    }
+  }
+}

--- a/iac/cal-itp-data-infra-staging/alerting/us/slo.tf
+++ b/iac/cal-itp-data-infra-staging/alerting/us/slo.tf
@@ -1,0 +1,15 @@
+resource "google_monitoring_slo" "gtfs-rt-archiver-latency" {
+  service = google_monitoring_service.gtfs-rt-archiver.service_id
+
+  slo_id       = "gtfs-rt-archiver-latency"
+  display_name = "99% 10s Latency for GTFS-RT Archiver"
+
+  goal            = 0.99
+  calendar_period = "DAY"
+
+  basic_sli {
+    latency {
+      threshold = "10s"
+    }
+  }
+}


### PR DESCRIPTION
# Description

This PR contains channel, service, SLO, and alert configuration for GTFS-RT archiver monitoring.

Relates to #4488

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan` and staging

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply` and tune alert