### PR TITLE
Expose the GTFS-RT archiver source bucket name

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2866,6 +2866,10 @@ output "google_storage_bucket_calitp-gtfs-schedule-manual_name" {
   value = google_storage_bucket.calitp["calitp-gtfs-schedule-manual"].name
 }
 
+output "google_storage_bucket_calitp-gtfs-rt-archiver_name" {
+  value = google_storage_bucket.calitp["calitp-gtfs-rt-archiver"].name
+}
+
 output "google_storage_bucket_cal-itp-data-infra-cf-source_name" {
   value = google_storage_bucket.cal-itp-data-infra-cf-source-tf.name
 }


### PR DESCRIPTION
# Description

This PR exposes the `google_storage_bucket`.`calitp-gtfs-rt-archiver`.`name` attribute for reuse in other resources.

Relates to #4488

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`