### PR TITLE
Deduplicate Enghouse ticket_results

### DIFF
--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -769,3 +769,32 @@ models:
         description: '{{ doc("customer_funding_source_principal_customer_id") }}'
       - *bin
       - *card_scheme
+
+  - name: int_payments__enghouse_ticket_results_deduped
+    description: |
+      Deduplicates stg_enghouse__ticket_results on `_content_hash`. Among rows sharing the
+      same content hash, keeps the row with the most fields populated (non-null
+      `start_dttm`, then `end_dttm`, then `created_dttm`).
+      Columns have the same meanings as in the upstream staging model.
+    columns:
+      - name: operator_id
+      - name: id
+      - name: ticket_id
+      - name: station_name
+      - name: amount
+      - name: clearing_id
+      - name: reason
+      - name: tap_id
+      - name: ticket_type
+      - name: created_dttm
+      - name: line
+      - name: start_station
+      - name: end_station
+      - name: start_dttm
+      - name: end_dttm
+      - name: ticket_code
+      - name: additional_infos
+      - name: _content_hash
+        data_tests:
+          - unique
+          - not_null

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -772,10 +772,11 @@ models:
 
   - name: int_payments__enghouse_ticket_results_deduped
     description: |
-      Deduplicates stg_enghouse__ticket_results on `_content_hash`. Among rows sharing the
-      same content hash, keeps the row with the most fields populated (non-null
-      `start_dttm`, then `end_dttm`, then `created_dttm`).
-      Columns have the same meanings as in the upstream staging model.
+      Deduplicates stg_enghouse__ticket_results on `_content_hash` by taking the
+      `MIN` of `created_dttm`, `start_dttm`, `end_dttm`, and `clearing_id` across
+      rows sharing a hash, so these columns may be a combination of values from
+      multiple input rows. All other columns are part of the hash and identical
+      across the group. Columns have the same meanings as in the upstream staging model.
     columns:
       - name: operator_id
       - name: id

--- a/warehouse/models/intermediate/payments/int_payments__enghouse_ticket_results_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__enghouse_ticket_results_deduped.sql
@@ -4,22 +4,6 @@ WITH ticket_results AS (
     SELECT * FROM {{ ref('stg_enghouse__ticket_results') }}
 ),
 
-deduplicated AS (
-    SELECT * FROM (
-        SELECT
-            *,
-            ROW_NUMBER() OVER (
-                PARTITION BY _content_hash
-                ORDER BY
-                    CASE WHEN start_dttm IS NOT NULL THEN 0 ELSE 1 END ASC,
-                    CASE WHEN end_dttm IS NOT NULL THEN 0 ELSE 1 END ASC,
-                    CASE WHEN created_dttm IS NOT NULL THEN 0 ELSE 1 END ASC
-            ) AS row_num
-        FROM ticket_results
-    )
-    WHERE row_num = 1
-),
-
 int_payments__enghouse_ticket_results_deduped AS (
     SELECT
         operator_id,
@@ -27,20 +11,21 @@ int_payments__enghouse_ticket_results_deduped AS (
         ticket_id,
         station_name,
         amount,
-        clearing_id,
         reason,
         tap_id,
         ticket_type,
-        created_dttm,
         line,
         start_station,
         end_station,
-        start_dttm,
-        end_dttm,
         ticket_code,
         additional_infos,
-        _content_hash
-    FROM deduplicated
+        _content_hash,
+        MIN(clearing_id) AS clearing_id,
+        MIN(created_dttm) AS created_dttm,
+        MIN(start_dttm) AS start_dttm,
+        MIN(end_dttm) AS end_dttm
+    FROM ticket_results
+    {{ dbt_utils.group_by(n=14) }}
 )
 
 SELECT * FROM int_payments__enghouse_ticket_results_deduped

--- a/warehouse/models/intermediate/payments/int_payments__enghouse_ticket_results_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__enghouse_ticket_results_deduped.sql
@@ -1,0 +1,46 @@
+{{ config(materialized = 'table') }}
+
+WITH ticket_results AS (
+    SELECT * FROM {{ ref('stg_enghouse__ticket_results') }}
+),
+
+deduplicated AS (
+    SELECT * FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (
+                PARTITION BY _content_hash
+                ORDER BY
+                    CASE WHEN start_dttm IS NOT NULL THEN 0 ELSE 1 END ASC,
+                    CASE WHEN end_dttm IS NOT NULL THEN 0 ELSE 1 END ASC,
+                    CASE WHEN created_dttm IS NOT NULL THEN 0 ELSE 1 END ASC
+            ) AS row_num
+        FROM ticket_results
+    )
+    WHERE row_num = 1
+),
+
+int_payments__enghouse_ticket_results_deduped AS (
+    SELECT
+        operator_id,
+        id,
+        ticket_id,
+        station_name,
+        amount,
+        clearing_id,
+        reason,
+        tap_id,
+        ticket_type,
+        created_dttm,
+        line,
+        start_station,
+        end_station,
+        start_dttm,
+        end_dttm,
+        ticket_code,
+        additional_infos,
+        _content_hash
+    FROM deduplicated
+)
+
+SELECT * FROM int_payments__enghouse_ticket_results_deduped

--- a/warehouse/models/mart/payments/fct_payments_rides_enghouse.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_enghouse.sql
@@ -2,7 +2,7 @@
     post_hook="{{ payments_enghouse_row_access_policy() }}") }}
 
 WITH ticket_results AS (
-    SELECT * FROM {{ ref('stg_enghouse__ticket_results') }}
+    SELECT * FROM {{ ref('int_payments__enghouse_ticket_results_deduped') }}
 ),
 
 taps AS (

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
@@ -24,8 +24,8 @@ clean_columns AS (
         agency,
         dt,
         {{ dbt_utils.generate_surrogate_key(['operator_id', 'id', 'ticket_id', 'station_name', 'amount', 'clearing_id',
-            'reason', 'tap_id', 'ticket_type', 'created_dttm', 'line', 'start_station', 'end_station', 'start_dttm',
-            'end_dttm', 'ticket_code', 'additional_infos']) }} AS _content_hash
+            'reason', 'tap_id', 'ticket_type', 'line', 'start_station', 'end_station',
+         'ticket_code', 'additional_infos']) }} AS _content_hash
     FROM source
 ),
 

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
@@ -29,16 +29,6 @@ clean_columns AS (
     FROM source
 ),
 
-deduplicated AS (
-    SELECT * FROM (
-        SELECT
-            *,
-            ROW_NUMBER() OVER (PARTITION BY _content_hash ORDER BY dt ASC) AS row_num
-        FROM clean_columns
-    )
-    WHERE row_num = 1
-),
-
 stg_enghouse__ticket_results AS (
     SELECT
         operator_id,

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
@@ -61,7 +61,7 @@ stg_enghouse__ticket_results AS (
         agency,
         dt,
         _content_hash
-    FROM deduplicated
+    FROM clean_columns
 )
 
 SELECT * FROM stg_enghouse__ticket_results


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #4964

Modifies the deduplication step to order by non-null datetime columns, and keep the first one. Observations on the ticket indicated that duplicate records had a mix of non-null and null date time records, while all other columns were equivalent.

This broadly fixes the duplicate data issue, though I did find two pairs of records that survive, as noted in the testing block. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

<details><summary>I had to run this test query against prod because I didn't have duplicate records available in staging</summary>

```sql
-- Sanity check: current row count vs. post-fix row count, and the delta (rows dropped by dedup).
WITH pre_fix AS (
  SELECT *
  FROM `cal-itp-data-infra-staging.staging.stg_enghouse__ticket_results`
),

ranked AS (
  SELECT
    *,
    ROW_NUMBER() OVER (
      PARTITION BY
        operator_id, id, ticket_id, station_name, amount, reason, tap_id,
        ticket_type, line, start_station, end_station, ticket_code, additional_infos
      ORDER BY
        CASE WHEN start_dttm   IS NOT NULL THEN 0 ELSE 1 END ASC,
        CASE WHEN end_dttm     IS NOT NULL THEN 0 ELSE 1 END ASC,
        CASE WHEN created_dttm IS NOT NULL THEN 0 ELSE 1 END ASC
    ) AS row_num
  FROM pre_fix
),

post_fix AS (
  SELECT * FROM ranked WHERE row_num = 1
)

SELECT
  (SELECT COUNT(*) FROM pre_fix)  AS pre_fix_rows,
  (SELECT COUNT(*) FROM post_fix) AS post_fix_rows,
  (SELECT COUNT(*) FROM pre_fix) - (SELECT COUNT(*) FROM post_fix) AS rows_dropped;
```

```text
Row	pre_fix_rows	post_fix_rows	rows_dropped
1	9016	8979	37
```

```sh
> uv run dbt run --select stg_enghouse__ticket_results
17:34:27  Found 628 models, 178 data tests, 16 seeds, 227 sources, 4 exposures, 1089 macros
17:34:27  
17:34:27  Concurrency: 8 threads (target='staging')
17:34:27  
17:34:35  1 of 1 START sql view model staging.stg_enghouse__ticket_results ............... [RUN]
17:34:38  1 of 1 OK created sql view model staging.stg_enghouse__ticket_results .......... [CREATE VIEW (0 processed) in 2.38s]
17:34:38  
17:34:38  Finished running 1 view model in 0 hours 0 minutes and 10.58 seconds (10.58s).
17:34:50  
17:34:50  Completed successfully
17:34:50  
17:34:50  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```
</details>

<details> <summary> Separately, I tested the deduplication itself and found that there are two sets of 2 records each that survive deduplication. Each pair has identical tap_ids, but very different other values. </summary>

```sql

WITH source AS (
    SELECT * FROM `cal-itp-data-infra-staging`.`external_enghouse`.`ticket_results`
),

clean_columns AS (
    SELECT
        

CASE
    WHEN TRIM(Operator_Id) = ""
        THEN NULL
    ELSE TRIM(Operator_Id)
END

 AS operator_id,
        

CASE
    WHEN TRIM(id) = ""
        THEN NULL
    ELSE TRIM(id)
END

 AS id,
        

CASE
    WHEN TRIM(ticket_id) = ""
        THEN NULL
    ELSE TRIM(ticket_id)
END

 AS ticket_id,
        

CASE
    WHEN TRIM(station_name) = ""
        THEN NULL
    ELSE TRIM(station_name)
END

 AS station_name,
        ROUND(SAFE_CAST(amount AS NUMERIC) / 100.0, 2) AS amount,
        

CASE
    WHEN TRIM(clearing_id) = ""
        THEN NULL
    ELSE TRIM(clearing_id)
END

 AS clearing_id,
        

CASE
    WHEN TRIM(reason) = ""
        THEN NULL
    ELSE TRIM(reason)
END

 AS reason,
        

CASE
    WHEN TRIM(tap_id) = ""
        THEN NULL
    ELSE TRIM(tap_id)
END

 AS tap_id,
        

CASE
    WHEN TRIM(ticket_type) = ""
        THEN NULL
    ELSE TRIM(ticket_type)
END

 AS ticket_type,
        SAFE_CAST(created_dttm AS TIMESTAMP) AS created_dttm,
        

CASE
    WHEN TRIM(line) = ""
        THEN NULL
    ELSE TRIM(line)
END

 AS line,
        

CASE
    WHEN TRIM(start_station) = ""
        THEN NULL
    ELSE TRIM(start_station)
END

 AS start_station,
        

CASE
    WHEN TRIM(end_station) = ""
        THEN NULL
    ELSE TRIM(end_station)
END

 AS end_station,
        SAFE_CAST(start_dttm AS TIMESTAMP) AS start_dttm,
        SAFE_CAST(end_dttm AS TIMESTAMP) AS end_dttm,
        

CASE
    WHEN TRIM(ticket_code) = ""
        THEN NULL
    ELSE TRIM(ticket_code)
END

 AS ticket_code,
        

CASE
    WHEN TRIM(additional_infos) = ""
        THEN NULL
    ELSE TRIM(additional_infos)
END

 AS additional_infos,
        to_hex(md5(cast(coalesce(cast(operator_id as string), '') || '-' || coalesce(cast(id as string), '') || '-' || coalesce(cast(ticket_id as string), '') || '-' || coalesce(cast(station_name as string), '') || '-' || coalesce(cast(amount as string), '') || '-' || coalesce(cast(reason as string), '') || '-' || coalesce(cast(tap_id as string), '') || '-' || coalesce(cast(ticket_type as string), '') || '-' || coalesce(cast(line as string), '') || '-' || coalesce(cast(start_station as string), '') || '-' || coalesce(cast(end_station as string), '') || '-' || coalesce(cast(ticket_code as string), '') || '-' || coalesce(cast(additional_infos as string), '') as string))) AS _content_hash
    FROM source
),

deduplicated AS (
    SELECT * FROM (
        SELECT
            *,
            ROW_NUMBER() OVER (
                PARTITION BY _content_hash
                ORDER BY
                    CASE WHEN start_dttm IS NOT NULL THEN 0 ELSE 1 END ASC,
                    CASE WHEN end_dttm IS NOT NULL THEN 0 ELSE 1 END ASC,
                    CASE WHEN created_dttm IS NOT NULL THEN 0 ELSE 1 END ASC
            ) AS row_num
        FROM clean_columns
    )
    WHERE row_num = 1
),

stg_enghouse__ticket_results AS (
    SELECT
        operator_id,
        id,
        ticket_id,
        station_name,
        amount,
        clearing_id,
        reason,
        tap_id,
        ticket_type,
        created_dttm,
        line,
        start_station,
        end_station,
        start_dttm,
        end_dttm,
        ticket_code,
        additional_infos,
        _content_hash
    FROM deduplicated
)

SELECT COUNT(*) FROM stg_enghouse__ticket_results
HAVING COUNT(*) > 1
```

</details>

<details> <summary>` uv run dbt test -s stg_enghouse__ticket_results+`</summary>

```sh
uv run dbt test -s stg_enghouse__ticket_results+
13:51:16  Running with dbt=1.10.8
13:51:19  Registered adapter: bigquery=1.10.2
13:51:23  Found 628 models, 178 data tests, 16 seeds, 227 sources, 4 exposures, 1091 macros
13:51:23  
13:51:23  Concurrency: 8 threads (target='staging')
13:51:23  
13:51:27  1 of 1 START test dbt_utils_expression_is_true_v2_payments_reliability_weekly_unlabeled_routes_enghouse_n_all_rides_total_unlabeled_rides  [RUN]
13:51:28  1 of 1 PASS dbt_utils_expression_is_true_v2_payments_reliability_weekly_unlabeled_routes_enghouse_n_all_rides_total_unlabeled_rides  [PASS in 1.47s]
13:51:28  
13:51:28  Finished running 1 test in 0 hours 0 minutes and 5.35 seconds (5.35s).
13:51:29  
13:51:29  Completed successfully
13:51:29  
13:51:29  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```


</details>

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
