### PR TITLE
Enable kafka startupProbe to tolerate slow log recovery

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -122,6 +122,17 @@ sentry:
       repository: bitnamilegacy/kafka
     logRetentionHours: 72 # 3 days, the default is 7
     numPartitions: 12
+    # Tolerate long log recovery after unclean shutdowns. Without this,
+    # the liveness probe (~40s budget) kills kafka mid-recovery, producing
+    # more unflushed segments and a death spiral. The startupProbe runs
+    # only during startup; once it succeeds, liveness takes over with
+    # normal timing. Gives ~20min startup window before liveness kicks in.
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 120
     kraft:
       enabled: false
     zookeeper:


### PR DESCRIPTION
## Summary

When a Sentry kafka broker shuts down uncleanly, it has to replay unflushed log segments before opening port 9092. With only a liveness probe configured (`delay=10s`, `period=10s`, `failureThreshold=3` → ~40s budget), kubelet was killing the broker mid-recovery, leaving more unflushed segments for the next restart — a death spiral.

Happened again today on `sentry-kafka-2`, blocking the `sentry-db-check` post-upgrade hook and failing the last two `deploy-kubernetes` runs. We've unstuck it manually before by bumping `livenessProbe.initialDelaySeconds`, but that gets reverted on every helm redeploy.

## Fix

A `startupProbe` is the idiomatic fix: it runs only while the container is starting and, once it succeeds, is disabled permanently (for the life of that pod) so the steady-state `livenessProbe` takes over with its original tight timing.

- `failureThreshold: 120` × `periodSeconds: 10` + `initialDelaySeconds: 30` ≈ **20 min startup window**
- `timeoutSeconds: 5` (bitnami default of 1s is tight for a TCP dial on a loaded node)
- Healthy kafka starts in well under a minute — this just adds headroom for recovery scenarios, not a behavior change in the happy path.

## Test plan

- [ ] CI passes
- [ ] Next `deploy-kubernetes` run successfully rolls `sentry-kafka` with the new probe config
- [ ] `kubectl get statefulset sentry-kafka -n sentry -o jsonpath='{.spec.template.spec.containers[0].startupProbe}'` shows the new probe settings after deploy
- [ ] Next unclean kafka shutdown recovers on its own instead of crash-looping

## Notes

- Related: #4922 (cluster maintenance), #3463 (sentry upgrade) — self-hosted sentry stack is fragile in general; this is a targeted hardening, not a rethink.
- No change to the chart vendored under `charts/sentry-20.0.0.tgz`; just passing a value through to the bitnami kafka subchart, which has supported `startupProbe` since before our version.