### PR TITLE
Allow Terraform to apply changes when the Plan changed

### DIFF
--- a/.github/workflows/gtfs-rt-archiver.yml
+++ b/.github/workflows/gtfs-rt-archiver.yml
@@ -82,9 +82,8 @@ jobs:
         uses: tj-actions/changed-files@v46
         id: staging-changes
         with:
-          matrix: true
           dir_names: true
-          files: 'iac/cal-itp-data-infra-staging/**/*.tf'
+          files: 'iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/*.tf'
 
   staging:
     name: Staging
@@ -95,11 +94,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        path: ${{ fromJson(needs.targets.outputs.staging) }}
 
     steps:
       - name: Checkout
@@ -123,5 +117,5 @@ jobs:
           TERRAFORM_PRE_RUN: |
             git config --global --add safe.directory $GITHUB_WORKSPACE
         with:
-          path: ${{ matrix.path }}
-          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}
+          path: iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us
+          auto_approve: true

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -96,7 +96,7 @@ jobs:
             git config --global --add safe.directory $GITHUB_WORKSPACE
         with:
           path: ${{ matrix.path }}
-          auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}
+          auto_approve: 'true'
 
   production:
     name: Production
@@ -136,3 +136,4 @@ jobs:
             git config --global --add safe.directory $GITHUB_WORKSPACE
         with:
           path: ${{ matrix.path }}
+          auto_approve: 'true'


### PR DESCRIPTION
# Description

As part of this PR we added a missing folder to the `gtfs-rt-archiver` workflow to check changes only on 'iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/*.tf' instead of the whole `iac/cal-itp-data-infra-staging\` folder.

Part of the review for #4970

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running workflows through this PR.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
