### PR TITLE
Check only GTFS RT folder on gtfs_rt_archiver workflow

### DIFF
--- a/.github/workflows/gtfs-rt-archiver.yml
+++ b/.github/workflows/gtfs-rt-archiver.yml
@@ -82,24 +82,18 @@ jobs:
         uses: tj-actions/changed-files@v46
         id: staging-changes
         with:
-          matrix: true
           dir_names: true
-          files: 'iac/cal-itp-data-infra-staging/**/*.tf'
+          files: 'iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/*.tf'
 
   staging:
     name: Staging
     needs: [targets]
-    if: ${{ needs.targets.outputs.staging == '[]' || needs.targets.outputs.staging == '' }}
+    if: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/staging')) && (needs.targets.outputs.staging == '[]' || needs.targets.outputs.staging == '') }}
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
       id-token: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        path: ${{ fromJson(needs.targets.outputs.staging) }}
 
     steps:
       - name: Checkout
@@ -123,5 +117,5 @@ jobs:
           TERRAFORM_PRE_RUN: |
             git config --global --add safe.directory $GITHUB_WORKSPACE
         with:
-          path: ${{ matrix.path }}
+          path: iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us
           auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}


### PR DESCRIPTION
# Description

This PR adds a missing folder to the `gtfs-rt-archiver` workflow to check changes only on 'iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/*.tf' instead of the whole `iac/cal-itp-data-infra-staging\` folder.

The `gtfs-rt-archiver` workflow runs for `staging\` branches or when merged to main and it is only applying changes to Staging.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested on this PR.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
