### PR TITLE
Stabilize sentry redis (fix OOMs and replica thrash)

### DIFF
--- a/kubernetes/apps/charts/sentry/values.yaml
+++ b/kubernetes/apps/charts/sentry/values.yaml
@@ -8,15 +8,53 @@ sentry:
     enabled: true
     image:
       repository: bitnamilegacy/redis
-    replica:
-      replicaCount: 1
+    master:
+      # Master had no resource spec (BestEffort QoS), making it a first
+      # eviction candidate under node memory pressure. RDB snapshots are
+      # ~2.6Gi so the limit needs headroom above steady state.
       resources:
         requests:
-          cpu: 2
-          memory: 2Gi
+          cpu: 1
+          memory: 3Gi
         limits:
           cpu: 2
+          memory: 5Gi
+    replica:
+      replicaCount: 1
+      # Default probes ping BOTH local AND master via
+      # ping_liveness_local_and_master.sh, so the replica kills itself
+      # whenever master briefly blips. Each kill triggers a full RDB resync
+      # (~30s) during which sentry-relay can't read project state and
+      # returns 502s. Override to check local only.
+      customLivenessProbe:
+        exec:
+          command:
+            - sh
+            - -c
+            - /health/ping_liveness_local.sh 5
+        initialDelaySeconds: 20
+        periodSeconds: 5
+        timeoutSeconds: 6
+        failureThreshold: 5
+        successThreshold: 1
+      customReadinessProbe:
+        exec:
+          command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+        initialDelaySeconds: 20
+        periodSeconds: 5
+        timeoutSeconds: 2
+        failureThreshold: 5
+        successThreshold: 1
+      resources:
+        requests:
+          cpu: 1
           memory: 3Gi
+        limits:
+          cpu: 2
+          memory: 5Gi
 
   postgresql:
     enabled: true


### PR DESCRIPTION
## Summary

Two independent redis problems have been causing intermittent 502s from `sentry-relay`. These surface whenever upstream services talk to the Sentry API — most visibly, the `Notify Sentry of releases` workflow fails on every merge (e.g., [this run](https://github.com/cal-itp/data-infra/actions/runs/24866690932)).

### Problem 1: Master was BestEffort QoS

Redis master had **no resource requests or limits at all**, so it was BestEffort QoS — first in line for eviction when nodes hit memory pressure. Every few days master would get OOMKilled or evicted, causing a ~7min outage while it reloaded its 2.6Gi RDB.

### Problem 2: Replica liveness probe kills itself whenever master blips

The Bitnami chart's default replica probes use `ping_liveness_local_and_master.sh`, which checks **both** the local replica **and** master. So every time master has a brief hiccup — which happens regularly because of Problem 1 — the replica's liveness probe fails 5 times and kubelet kills it. Each kill triggers a full RDB resync (~30s), and while the replica is down, `sentry-relay` gets connection-refused errors reading project state and returns 502s.

Evidence: `sentry-sentry-redis-replicas-0` had **3,324 restarts over 25 days**. Events showed 1,376 liveness failures with `Could not connect to Redis at sentry-sentry-redis-master-0...: Connection refused` — i.e., the replica was killed because *master* was briefly unreachable, not because anything was wrong with the replica.

## Fix

- **Master**: set explicit requests (3Gi) and limits (5Gi) so it's Burstable QoS with headroom above the ~2.6Gi steady state
- **Replica**: override default probes via `customLivenessProbe` / `customReadinessProbe` to use `ping_liveness_local.sh` / `ping_readiness_local.sh` — matching what master uses for itself
- **Replica memory**: bumped to 5Gi to match master's ceiling

User confirmed nodes have headroom for the increased requests.

## Test plan

- [x] CI passes
- [x] Next deploy-kubernetes run rolls redis master and replica with the new spec
- [x] `kubectl get pod sentry-sentry-redis-master-0 -n sentry -o jsonpath='{.status.qosClass}'` returns `Burstable`
- [x] Replica liveness probe exec shows `ping_liveness_local.sh` (no `_and_master`)
- [x] Replica restart count stops climbing over next 24h (short-window: 0 restarts in first ~6min post-deploy; previously averaged ~1 restart every 11min)
- [x] Next merge triggers \`Notify Sentry of releases\` successfully without 502 (3 consecutive successful runs post-merge)

## Notes

- This is intended to buy time — the remaining Sentry users are migrating off next month, after which the self-hosted stack can be decommissioned rather than upgraded.
- The cluster has already been manually patched to break the immediate thrash cycle (replica livenessProbe overridden, but no values.yaml change until this PR); that direct patch will be overwritten on the next helm upgrade when this merges, applying the proper values-based fix.