### PR TITLE
Add Terraform Plan to `gtfs_rt_archiver` workflow

### DIFF
--- a/.github/workflows/gtfs-rt-archiver.yml
+++ b/.github/workflows/gtfs-rt-archiver.yml
@@ -85,11 +85,46 @@ jobs:
           dir_names: true
           files: 'iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/*.tf'
 
-  staging:
-    name: Staging
-    needs: [targets]
-    if: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/staging')) && (needs.targets.outputs.staging == '[]' || needs.targets.outputs.staging == '') }}
+  staging-plan:
+    name: Staging plan
     runs-on: ubuntu-latest
+    needs: [targets]
+
+    # If there are changes to composer iac files `terraform-plan` workflow will take care
+    if: ${{ github.ref != 'refs/heads/main' && (needs.targets.outputs.staging == '[]' || needs.targets.outputs.staging == '') }}
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate Google Service Account
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.PROJECT_ID }}
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Terraform Plan
+        uses: dflook/terraform-plan@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          add_github_comment: changes-only
+          path: iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us
+
+  staging-apply:
+    name: Staging Apply
+    needs: [targets]
+    runs-on: ubuntu-latest
+
+    # If there are changes to composer iac files `terraform-apply` workflow will take care
+    if: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/staging')) && (needs.targets.outputs.staging == '[]' || needs.targets.outputs.staging == '') }}
 
     permissions:
       contents: read
@@ -114,8 +149,6 @@ jobs:
         uses: dflook/terraform-apply@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TERRAFORM_PRE_RUN: |
-            git config --global --add safe.directory $GITHUB_WORKSPACE
         with:
           path: iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us
           auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}


### PR DESCRIPTION
# Description

Include job to Generate Terraform Plan in `gtfs_rt_archiver` workflow when a PR is created and is not a `staging\` branch. It needs a Plan for these conditions otherwise Terraform Apply cannot execute the changes.

Resolves #\[issue\]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Testing on this PR.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor workflows.