### PR TITLE
Set prometheus-server memory request and limit

### DIFF
--- a/kubernetes/apps/values/prometheus.yaml
+++ b/kubernetes/apps/values/prometheus.yaml
@@ -12,10 +12,19 @@ server:
   persistentVolume:
     size: 100Gi
 
+  # Steady-state memory usage is ~3-4Gi, but WAL replay after a restart
+  # can spike to 10Gi+ as Prometheus reconstructs its in-memory index
+  # from the write-ahead log. Without a memory limit, BestEffort scheduling
+  # and node memory pressure were OOM-killing the pod mid-replay, producing
+  # a crash loop: the pod would die part-way through replay, which made the
+  # next replay start from a larger WAL state, which needed more memory,
+  # which got OOM-killed sooner, etc.
   resources:
     requests:
       cpu: 500m
-      memory: 3Gi
+      memory: 8Gi
+    limits:
+      memory: 20Gi
 
 alertmanager:
   strategy:


### PR DESCRIPTION
## Summary

`prometheus-server` was running as BestEffort QoS with only a 3Gi memory request and no limit. That made it a first-eviction candidate under node memory pressure, and WAL replay on restart — which legitimately spikes memory to 10Gi+ — was triggering a textbook crash loop:

1. Pod restarts (any reason)
2. WAL replay begins, memory usage climbs past 3Gi
3. Node memory pressure → kubelet OOM-kills the pod mid-replay
4. Next pod sees a larger unflushed WAL, needs even more memory
5. Gets OOM-killed sooner, WAL grows further, goto 1

Same pattern as today's kafka-2 and redis-replica issues — the chart's defaults are too skimpy.

## Fix

- `requests.memory: 8Gi` — puts the pod in Burstable QoS and schedules it only on a node with real headroom
- `limits.memory: 20Gi` — WAL replay on our dataset peaked around 10-11Gi; 20Gi gives plenty of room

CPU stays as-is (request only, no limit — prometheus benefits from CPU bursting during replay).

User confirmed nodes have the headroom for the larger request.

## Context

The cluster-side deployment was already patched directly to unstick an active crash loop. This PR bakes the fix into the helm values so the next deploy (which replaces `spec.template.spec.containers[*].resources` with whatever the chart renders) doesn't revert the manual patch.

This is explicitly a stability fix, not a case for keeping Prometheus long-term — the in-cluster monitoring stack (Prometheus + Grafana + Loki + Promtail) is on track to be decommissioned once the GCP-native setup is verified against it for a period of parallel operation.

## Test plan

- [ ] CI passes
- [ ] Next `deploy-kubernetes` rolls `prometheus-server` with the new resources
- [ ] `kubectl get pod -n monitoring-prometheus -l app=prometheus,component=server -o jsonpath='{.items[0].status.qosClass}'` returns `Burstable`
- [ ] Pod completes WAL replay and reaches `2/2 Ready` without looping