### PR TITLE
Set up GCP-native monitoring for the GTFS-RT archiver

### DIFF
--- a/iac/cal-itp-data-infra/gke/us/container_cluster.tf
+++ b/iac/cal-itp-data-infra/gke/us/container_cluster.tf
@@ -55,6 +55,10 @@ resource "google_container_cluster" "tfer--data-infra-apps" {
 
   monitoring_config {
     enable_components = ["SYSTEM_COMPONENTS"]
+
+    managed_prometheus {
+      enabled = "true"
+    }
   }
 
   monitoring_service = "monitoring.googleapis.com/kubernetes"

--- a/iac/cal-itp-data-infra/monitoring/us/.terraform.lock.hcl
+++ b/iac/cal-itp-data-infra/monitoring/us/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.29.0"
+  hashes = [
+    "h1:TSCd6uQ5dz2vOpg9+DPn2czwC/KX0peRgeUJRYNYAJs=",
+    "zh:028196004cece6d376ef7e45936470657e154ca7fd2899abf85d9d4ffbe6e77b",
+    "zh:03f853dffd03bf80b3d3f9c2efbf3eee4d88136487c61be853f9063dfddad6eb",
+    "zh:0adc8e5065b46371cfdc96f906ba053d05c4cd184edc55ea5868dd130effe168",
+    "zh:258c6ecead44360a79b152fe04176643b3ea2ff31896fe815c4ffdca8424be66",
+    "zh:2ff21e5b28670a3309b7a7bea4a433ddb514f61e02db1d3e9f49ac36711f3017",
+    "zh:64cc8f690b12be5bd75da5b30d5de910789a7de29487e909149c91bdad08126e",
+    "zh:720f3f93cb82a2260abe05b24bc44fafa1b4f59c6462d23ff0ffad0bc124415c",
+    "zh:75ebfcf1131b88551666f98faa24ffc08b0f70ced0405faa4dac73946a6dc660",
+    "zh:819883473134b3e035a0b6312b943a583112fd49d48e237947a4d3e37d391bca",
+    "zh:8a1cf0ba3ccbcffc19f86adefbe879f210703723950a61f9b329d454d6b72549",
+    "zh:c8d70ff89ccbe7ab2a214ba0c57db8c4e9c48a82eb7bc1e18225c7076c55b298",
+    "zh:c94d070449c4c32960087b2a1b8806e67854451d2ea1f5676da962baa8b8587e",
+    "zh:e8ceac9091530203295dbc952d1831ad7986b8f004d3deef2b0e95d3cd8cd23a",
+    "zh:f481f2c4017fe4914bbbd769f69f3d13a1dd019257da1112b7ec674f71095b21",
+    "zh:f54f34576966895fbf99fe0c180d086f799e937bbacb259e3a1a5a57e7cd0f9e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.23.0"
+  constraints = "~> 7.23.0"
+  hashes = [
+    "h1:8NwMbqR/drRxeWfc1IG6yfvQeXesX8cFSpA0Pnpe+fk=",
+    "zh:23b834f436dec7132cc42fdbe6ab7d74fc574b7a86ec7a56f7be9d42911a3afc",
+    "zh:2f1e2db52a79ee913fef18f0a0445d8c1cbda4c253d7ffb2a7c1f2b87e84980c",
+    "zh:4903221645602f42c6b642275a748b85b9621f6a24a2417cc6424d68a46ca88c",
+    "zh:4cae4ab9dc9e6779437395a353e173b4eb697a06e29fbc1aefa0cf2f5b5e31cc",
+    "zh:50e6bf71226e688519f4fff24a925ff396495afbdbddadb9c960a291c351fe84",
+    "zh:67fe1762aff9d270624c8d5a002c527d37a0e0ccc3c5eea712dfed7d0ecc46ab",
+    "zh:7ae8fb0cc76fbca06cd4f32bacd69984152b8d4b34268546e295f1e28892af13",
+    "zh:b8ec2d6626bb0795aea3fc6db052e7d472777ce9838e92f4396826bcdbfc1880",
+    "zh:d5642b8d0e2dda6316379a7e128d724f604b0f8625f9ecc706c662d9f302c32b",
+    "zh:dfc8f2d943aeed758b89166a1c20d6af67ae692b9cae832a9048e0cfb1e01ff5",
+    "zh:e768422d524b19d7a327de97f9621c1abd5958d3787efa02c0c61bb164d3e925",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/iac/cal-itp-data-infra/monitoring/us/alerts.tf
+++ b/iac/cal-itp-data-infra/monitoring/us/alerts.tf
@@ -1,0 +1,89 @@
+# Alert policies for the GTFS-RT archiver, matching the pair of alerts
+# that previously existed in our in-cluster Grafana / Prometheus stack.
+#
+# Both queries use the `rate([2m]) * 20` idiom that converts per-second
+# rate back to "events per 20-second tick" — which equals the number of
+# feeds when the scheduler is healthy, since the ticker fires at :00,
+# :20, and :40 every minute (services/gtfs-rt-archiver-v3/ticker.py).
+
+data "google_monitoring_notification_channel" "gtfs_rt_archiver_email" {
+  display_name = "GTFS-RT Archivers Email Alert Channel - DDS App Notify"
+}
+
+resource "google_monitoring_alert_policy" "gtfs_rt_archiver_huey_tasks_expiring" {
+  display_name = "GTFS-RT archiver: Huey tasks expiring"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "Huey task expirations > 0"
+
+    condition_prometheus_query_language {
+      # Any tasks expiring at all is abnormal — it means the consumer
+      # queue is backed up past the task TTL.
+      query               = "sum(rate(huey_task_signals_total{namespace=\"gtfs-rt-v3\", signal=\"expired\"}[2m])) * 20 > 0"
+      duration            = "300s"
+      evaluation_interval = "60s"
+      alert_rule          = "HueyTasksExpiring"
+    }
+  }
+
+  notification_channels = [data.google_monitoring_notification_channel.gtfs_rt_archiver_email.name]
+
+  documentation {
+    mime_type = "text/markdown"
+    content   = <<-EOT
+      One or more Huey tasks are expiring before the consumer can run
+      them. This usually means the consumer worker pool is too small
+      for the incoming tick rate, the Redis broker is having issues,
+      or a downstream step (e.g. uploads) is slow enough to back up
+      the queue.
+
+      Check:
+      - Pod health: `kubectl get pods -n gtfs-rt-v3`
+      - Redis: `kubectl logs -n gtfs-rt-v3 deploy/redis`
+      - Throughput and p99 latency on the GTFS RT Archiver dashboard
+    EOT
+  }
+}
+
+resource "google_monitoring_alert_policy" "gtfs_rt_archiver_huey_too_few_successes" {
+  display_name = "GTFS-RT archiver: Huey task completions too low"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "Huey task completions < 265 per tick"
+
+    condition_prometheus_query_language {
+      # When all feeds are healthy we expect ~the full feed count to
+      # complete each 20s tick. 265 is the empirical floor below which
+      # something is visibly wrong.
+      query               = "sum(rate(huey_task_signals_total{namespace=\"gtfs-rt-v3\", signal=\"complete\"}[2m])) * 20 < 265"
+      duration            = "300s"
+      evaluation_interval = "60s"
+      alert_rule          = "HueyTooFewSuccesses"
+    }
+  }
+
+  notification_channels = [data.google_monitoring_notification_channel.gtfs_rt_archiver_email.name]
+
+  documentation {
+    mime_type = "text/markdown"
+    content   = <<-EOT
+      Huey task completions per tick have dropped below 265. In a
+      healthy state this should roughly equal the count of configured
+      feeds, since the ticker fires every 20 seconds and each feed
+      produces one task per tick.
+
+      A drop indicates feeds are timing out, the consumer is
+      under-provisioned, or feeds are being dropped upstream.
+
+      Check:
+      - HTTP Errors / Non-HTTP Request Errors / Non-Fetch Errors
+        panels on the GTFS RT Archiver dashboard
+      - Airtable Configuration Age (is feed config stale?)
+      - Consumer pod count and resource saturation
+    EOT
+  }
+}

--- a/iac/cal-itp-data-infra/monitoring/us/dashboards.tf
+++ b/iac/cal-itp-data-infra/monitoring/us/dashboards.tf
@@ -1,0 +1,3 @@
+resource "google_monitoring_dashboard" "gtfs_rt_archiver" {
+  dashboard_json = file("${path.module}/dashboards/gtfs-rt-archiver.json")
+}

--- a/iac/cal-itp-data-infra/monitoring/us/dashboards/gtfs-rt-archiver.json
+++ b/iac/cal-itp-data-infra/monitoring/us/dashboards/gtfs-rt-archiver.json
@@ -126,14 +126,14 @@
               {
                 "breakdowns": [],
                 "dimensions": [],
-                "legendTemplate": "delay",
+                "legendTemplate": "upload",
                 "measures": [],
                 "plotType": "STACKED_AREA",
                 "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "histogram_quantile(0.9, sum(rate(fetch_processing_delay_seconds_bucket[2m])) by (le))",
+                  "prometheusQuery": "histogram_quantile(0.9, sum(rate(fetch_uploading_time_seconds_bucket[2m])) by (le))",
                   "unitOverride": ""
                 }
               },
@@ -154,14 +154,14 @@
               {
                 "breakdowns": [],
                 "dimensions": [],
-                "legendTemplate": "upload",
+                "legendTemplate": "delay",
                 "measures": [],
                 "plotType": "STACKED_AREA",
                 "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "histogram_quantile(0.9, sum(rate(fetch_uploading_time_seconds_bucket[2m])) by (le))",
+                  "prometheusQuery": "histogram_quantile(0.9, sum(rate(fetch_processing_delay_seconds_bucket[2m])) by (le))",
                   "unitOverride": ""
                 }
               }
@@ -183,14 +183,14 @@
               {
                 "breakdowns": [],
                 "dimensions": [],
-                "legendTemplate": "delay",
+                "legendTemplate": "upload",
                 "measures": [],
                 "plotType": "STACKED_AREA",
                 "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "histogram_quantile(0.99, sum(rate(fetch_processing_delay_seconds_bucket[2m])) by (le))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum(rate(fetch_uploading_time_seconds_bucket[2m])) by (le))",
                   "unitOverride": ""
                 }
               },
@@ -211,14 +211,14 @@
               {
                 "breakdowns": [],
                 "dimensions": [],
-                "legendTemplate": "upload",
+                "legendTemplate": "delay",
                 "measures": [],
                 "plotType": "STACKED_AREA",
                 "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "histogram_quantile(0.99, sum(rate(fetch_uploading_time_seconds_bucket[2m])) by (le))",
+                  "prometheusQuery": "histogram_quantile(0.99, sum(rate(fetch_processing_delay_seconds_bucket[2m])) by (le))",
                   "unitOverride": ""
                 }
               }

--- a/iac/cal-itp-data-infra/monitoring/us/dashboards/gtfs-rt-archiver.json
+++ b/iac/cal-itp-data-infra/monitoring/us/dashboards/gtfs-rt-archiver.json
@@ -51,8 +51,8 @@
             "thresholds": [],
             "timeSeriesQuery": {
               "outputFullDuration": false,
-              "prometheusQuery": "airtable_configuration_age != 0",
-              "unitOverride": ""
+              "prometheusQuery": "airtable_configuration_age / 3600 != 0",
+              "unitOverride": "h"
             }
           }
         }

--- a/iac/cal-itp-data-infra/monitoring/us/dashboards/gtfs-rt-archiver.json
+++ b/iac/cal-itp-data-infra/monitoring/us/dashboards/gtfs-rt-archiver.json
@@ -1,0 +1,271 @@
+{
+  "displayName": "GTFS RT Archiver",
+  "dashboardFilters": [
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "namespace",
+      "stringValue": "gtfs-rt-v3",
+      "templateVariable": "namespace"
+    }
+  ],
+  "description": "GTFS-RT archiver performance metrics. Backed by Google Managed Service for Prometheus; scraped via PodMonitoring in kubernetes/apps/manifests/gtfs-rt-archiver-v3/podmonitoring.yaml. Managed by terraform at iac/cal-itp-data-infra/monitoring/us/.",
+  "mosaicLayout": {
+    "columns": 24,
+    "tiles": [
+      {
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "Huey Task Successes",
+          "id": "",
+          "scorecard": {
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
+            "sparkChartView": {
+              "sparkChartType": "SPARK_LINE"
+            },
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "prometheusQuery": "sum(rate(huey_task_signals_total{signal=\"complete\"}[2m])) * 20",
+              "unitOverride": ""
+            }
+          }
+        }
+      },
+      {
+        "xPos": 8,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "Airtable Configuration Age",
+          "id": "",
+          "scorecard": {
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
+            "sparkChartView": {
+              "sparkChartType": "SPARK_LINE"
+            },
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "prometheusQuery": "airtable_configuration_age != 0",
+              "unitOverride": ""
+            }
+          }
+        }
+      },
+      {
+        "xPos": 16,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "Huey Task Signals",
+          "id": "",
+          "xyChart": {
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "${labels.signal} ${labels.exc_type}",
+                "measures": [],
+                "plotType": "LINE",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (signal, exc_type) (rate(huey_task_signals_total{signal!=\"executing\"}[2m])) * 20 != 0",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": []
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "Throughput",
+          "id": "",
+          "xyChart": {
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "${labels.record_feed_type}",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by(record_feed_type) (rate(fetch_processed_bytes_total[2m]))",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": []
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 8,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "p90s",
+          "id": "",
+          "xyChart": {
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "delay",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "histogram_quantile(0.9, sum(rate(fetch_processing_delay_seconds_bucket[2m])) by (le))",
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "download",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "histogram_quantile(0.9, sum(rate(fetch_downloading_time_seconds_bucket[2m])) by (le))",
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "upload",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "histogram_quantile(0.9, sum(rate(fetch_uploading_time_seconds_bucket[2m])) by (le))",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": []
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 16,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "p99s",
+          "id": "",
+          "xyChart": {
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "delay",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "histogram_quantile(0.99, sum(rate(fetch_processing_delay_seconds_bucket[2m])) by (le))",
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "download",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "histogram_quantile(0.99, sum(rate(fetch_downloading_time_seconds_bucket[2m])) by (le))",
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "upload",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "histogram_quantile(0.99, sum(rate(fetch_uploading_time_seconds_bucket[2m])) by (le))",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": []
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 0,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "HTTP Errors",
+          "logsPanel": {
+            "filter": "resource.type=\"k8s_container\"\nresource.labels.cluster_name=\"data-infra-apps\"\njsonPayload.event=\"unexpected HTTP response code from feed request\"",
+            "resourceNames": []
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 8,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "Non-HTTP Request Errors",
+          "logsPanel": {
+            "filter": "resource.type=\"k8s_container\"\nresource.labels.cluster_name=\"data-infra-apps\"\njsonPayload.event=\"request exception occurred from feed request\"",
+            "resourceNames": []
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 16,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "Non-Fetch Errors",
+          "logsPanel": {
+            "filter": "resource.type=\"k8s_container\"\nresource.labels.cluster_name=\"data-infra-apps\"\njsonPayload.event=\"other non-request exception occurred during download_feed\"",
+            "resourceNames": []
+          }
+        }
+      }
+    ]
+  }
+}

--- a/iac/cal-itp-data-infra/monitoring/us/log_metrics.tf
+++ b/iac/cal-itp-data-infra/monitoring/us/log_metrics.tf
@@ -1,0 +1,146 @@
+# Log-based metrics derived from the GTFS-RT archiver's structured logs.
+# Each counts occurrences of a specific error event emitted by
+# services/gtfs-rt-archiver-v3/gtfs_rt_archiver_v3/tasks.py, labeled by
+# the fields logged alongside — making them alertable and chartable via
+# Cloud Monitoring and Managed Service for Prometheus.
+
+resource "google_logging_metric" "gtfs_rt_archiver_http_errors" {
+  name        = "gtfs_rt_archiver_http_errors"
+  description = "Count of unexpected HTTP response codes from GTFS-RT feed requests, labeled by response code and source feed."
+
+  filter = <<-EOT
+    resource.type="k8s_container"
+    resource.labels.cluster_name="data-infra-apps"
+    jsonPayload.event="unexpected HTTP response code from feed request"
+  EOT
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "namespace"
+      value_type  = "STRING"
+      description = "Kubernetes namespace the archiver pod is in."
+    }
+    labels {
+      key         = "exc_type"
+      value_type  = "STRING"
+      description = "Exception class name raised by the HTTP client."
+    }
+    labels {
+      key         = "code"
+      value_type  = "STRING"
+      description = "HTTP response status code."
+    }
+    labels {
+      key         = "record_name"
+      value_type  = "STRING"
+      description = "Feed name (usually agency + feed type)."
+    }
+    labels {
+      key         = "record_feed_type"
+      value_type  = "STRING"
+      description = "Feed type (e.g. vehicle_positions, trip_updates)."
+    }
+  }
+
+  label_extractors = {
+    "namespace"        = "EXTRACT(resource.labels.namespace_name)"
+    "exc_type"         = "EXTRACT(jsonPayload.exc_type)"
+    "code"             = "EXTRACT(jsonPayload.code)"
+    "record_name"      = "EXTRACT(jsonPayload.record_name)"
+    "record_feed_type" = "EXTRACT(jsonPayload.record_feed_type)"
+  }
+}
+
+resource "google_logging_metric" "gtfs_rt_archiver_request_errors" {
+  name        = "gtfs_rt_archiver_request_errors"
+  description = "Count of non-HTTP request exceptions raised by GTFS-RT feed downloads (e.g. connection errors, timeouts)."
+
+  filter = <<-EOT
+    resource.type="k8s_container"
+    resource.labels.cluster_name="data-infra-apps"
+    jsonPayload.event="request exception occurred from feed request"
+  EOT
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "namespace"
+      value_type  = "STRING"
+      description = "Kubernetes namespace the archiver pod is in."
+    }
+    labels {
+      key         = "exc_type"
+      value_type  = "STRING"
+      description = "Exception class name raised by the HTTP client."
+    }
+    labels {
+      key         = "record_name"
+      value_type  = "STRING"
+      description = "Feed name (usually agency + feed type)."
+    }
+    labels {
+      key         = "record_feed_type"
+      value_type  = "STRING"
+      description = "Feed type (e.g. vehicle_positions, trip_updates)."
+    }
+  }
+
+  label_extractors = {
+    "namespace"        = "EXTRACT(resource.labels.namespace_name)"
+    "exc_type"         = "EXTRACT(jsonPayload.exc_type)"
+    "record_name"      = "EXTRACT(jsonPayload.record_name)"
+    "record_feed_type" = "EXTRACT(jsonPayload.record_feed_type)"
+  }
+}
+
+resource "google_logging_metric" "gtfs_rt_archiver_non_fetch_errors" {
+  name        = "gtfs_rt_archiver_non_fetch_errors"
+  description = "Count of non-request exceptions raised during GTFS-RT feed download processing (outside the HTTP request itself)."
+
+  filter = <<-EOT
+    resource.type="k8s_container"
+    resource.labels.cluster_name="data-infra-apps"
+    jsonPayload.event="other non-request exception occurred during download_feed"
+  EOT
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "namespace"
+      value_type  = "STRING"
+      description = "Kubernetes namespace the archiver pod is in."
+    }
+    labels {
+      key         = "exc_type"
+      value_type  = "STRING"
+      description = "Exception class name raised."
+    }
+    labels {
+      key         = "record_name"
+      value_type  = "STRING"
+      description = "Feed name (usually agency + feed type)."
+    }
+    labels {
+      key         = "record_feed_type"
+      value_type  = "STRING"
+      description = "Feed type (e.g. vehicle_positions, trip_updates)."
+    }
+  }
+
+  label_extractors = {
+    "namespace"        = "EXTRACT(resource.labels.namespace_name)"
+    "exc_type"         = "EXTRACT(jsonPayload.exc_type)"
+    "record_name"      = "EXTRACT(jsonPayload.record_name)"
+    "record_feed_type" = "EXTRACT(jsonPayload.record_feed_type)"
+  }
+}

--- a/iac/cal-itp-data-infra/monitoring/us/provider.tf
+++ b/iac/cal-itp-data-infra/monitoring/us/provider.tf
@@ -1,0 +1,16 @@
+provider "google" {
+  project = "cal-itp-data-infra"
+}
+
+terraform {
+  required_providers {
+    google = {
+      version = "~> 7.23.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "calitp-prod-gcp-components-tfstate"
+    prefix = "cal-itp-data-infra/monitoring"
+  }
+}

--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/kustomization.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/kustomization.yaml
@@ -2,4 +2,5 @@ resources:
 - archiver-app-vars.yaml
 - gtfs-rt-archiver-consumer.yaml
 - gtfs-rt-archiver-ticker.yaml
+- podmonitoring.yaml
 - redis.yaml

--- a/kubernetes/apps/manifests/gtfs-rt-archiver-v3/podmonitoring.yaml
+++ b/kubernetes/apps/manifests/gtfs-rt-archiver-v3/podmonitoring.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: gtfs-rt-archiver
+spec:
+  selector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - gtfs-rt-archiver-consumer
+          - gtfs-rt-archiver-ticker
+  endpoints:
+    - port: 9102
+      interval: 30s


### PR DESCRIPTION
## Screenshots

### Grafana Dashboard (before)

<img width="1593" height="1127" alt="Screenshot 2026-04-24 at 1 23 42 AM" src="https://github.com/user-attachments/assets/3a8f8cb6-141d-4eda-a6f1-6178240633c1" />

### GCP Monitoring Dashboard (after)

[Open Dashboard](https://console.cloud.google.com/monitoring/dashboards/builder/b5f8b250-768c-46ef-a2be-bcc356633749?project=cal-itp-data-infra)

<img width="1598" height="1105" alt="Screenshot 2026-04-24 at 1 23 47 AM" src="https://github.com/user-attachments/assets/df61a25f-ce0d-4e20-8756-fc6a2ee0d97a" />

## Summary

First step toward retiring the in-cluster Prometheus/Grafana/Loki/Promtail stack (see #4922): stand up GCP-native monitoring for the one workload we actually need observability for — the GTFS-RT archiver.

Three logical commits:

### 1. Enable Google Managed Service for Prometheus on the cluster

Adds `managed_prometheus { enabled = true }` to the cluster's `monitoring_config`. This installs the GMP collector DaemonSet and registers the cluster with Cloud Monitoring's Prometheus-compatible query API. Already applied to the cluster via `gcloud container clusters update --enable-managed-prometheus`, so the terraform plan is a no-op.

### 2. Scrape the archiver via a PodMonitoring CRD

Adds a `PodMonitoring` CRD to the archiver's base kustomize manifests pointing at port 9102 on the consumer and ticker pods. Because it's in the base, both `gtfs-rt-v3` and `gtfs-rt-v3-test` overlays deploy a copy into their respective namespaces.

The archiver already exposes metrics via the standard `prometheus.io/scrape` + `prometheus.io/port` annotations; this just gives GMP an explicit selector.

### 3. Add the `monitoring` terraform module (dashboard + log metrics)

New `iac/cal-itp-data-infra/monitoring/us/` module:

- **`google_monitoring_dashboard.gtfs_rt_archiver`** — a Cloud Monitoring dashboard backed by `dashboards/gtfs-rt-archiver.json`. The JSON was seeded from Cloud Monitoring's Grafana-import tool and then cleaned up:
  - Removed the Grafana-importer metadata labels
  - Dropped the 3 log-panel stubs the importer couldn't convert (LogQL ≠ PromQL)
  - Replaced them with proper `logsPanel` widgets querying Cloud Logging directly for the archiver's 3 structured error events
  - Added a namespace `dashboardFilter` (toggles between `gtfs-rt-v3` and `gtfs-rt-v3-test`)
  - Stripped inline `namespace=` label matchers — the `RESOURCE_LABEL` filter type auto-applies to every widget

- **Three `google_logging_metric` resources** — turn the archiver's structured error events (`unexpected HTTP response code from feed request`, `request exception occurred from feed request`, `other non-request exception occurred during download_feed`) into alertable Cloud Monitoring metrics, labeled by `namespace`, `exc_type`, `record_name`, `record_feed_type` (plus `code` on the HTTP one).

Both the dashboard and the log metrics have already been applied to GCP via `terraform apply`. The dashboard was imported into state (reusing the same ID the Grafana importer produced — URL is unchanged from what was first bookmarked). Merge-time CI `terraform apply` should be a no-op.

## What this replaces and what it doesn't

| Old (Grafana / Loki) | New (GCP) |
|---|---|
| Metric panels querying in-cluster Prometheus via Grafana | Same panels on Cloud Monitoring dashboard via GMP PromQL |
| Log panels in Grafana (Loki queries) | `logsPanel` widgets on the same dashboard (Cloud Logging filters) |
| No alertable error counts | 3 log-based metrics, ready for alerting policies |

The in-cluster stack stays up for now — letting both run in parallel so we can sanity-check the GCP-backed version before tearing Grafana/Prometheus/Loki/Promtail down.

## Test plan

- [ ] CI passes (terraform plan on `iac/cal-itp-data-infra/**`, kubernetes preview for archiver manifests)
- [ ] terraform apply on merge is a no-op (state already matches)
- [x] PodMonitoring resources land in both \`gtfs-rt-v3\` and \`gtfs-rt-v3-test\` namespaces after the kubernetes deploy
- [x] \`kubectl get podmonitoring -A\` shows \`ConfigurationCreateSuccess\` condition on both
- [x] Archiver metrics (\`fetch_processed_bytes_total\`, \`airtable_configuration_age\`, etc.) queryable via Cloud Monitoring Prometheus API
- [x] Dashboard tiles populate with data; namespace filter toggles the view
- [x] Log-based metrics visible under Cloud Monitoring → user metrics

## References

- Issue #4922 (cluster maintenance)
- Dashboard URL: https://console.cloud.google.com/monitoring/dashboards/builder/b5f8b250-768c-46ef-a2be-bcc356633749?project=cal-itp-data-infra