### PR TITLE
Add GKE Ingress alongside nginx for JupyterHub (test hostname)

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/templates/gke-backend-config.yaml
+++ b/kubernetes/apps/charts/jupyterhub/templates/gke-backend-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: jupyterhub-backend
+spec:
+  # Long notebook cells + WebSocket kernel sessions. Default 30s kills
+  # anything that takes longer than a trivial HTTP request.
+  timeoutSec: 86400
+  connectionDraining:
+    drainingTimeoutSec: 60
+  healthCheck:
+    requestPath: /hub/health
+    type: HTTP

--- a/kubernetes/apps/charts/jupyterhub/templates/gke-ingress.yaml
+++ b/kubernetes/apps/charts/jupyterhub/templates/gke-ingress.yaml
@@ -1,0 +1,24 @@
+# Second Ingress serving JupyterHub via GKE's built-in gce controller
+# (in parallel with the upstream chart's nginx-backed Ingress). Scoped
+# to the test hostname only during the staged migration off ingress-nginx
+# — prod notebooks.calitp.org continues flowing through nginx until
+# we're satisfied with the GKE Ingress behavior.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jupyterhub-gce
+  annotations:
+    networking.gke.io/managed-certificates: jupyterhub-managed-cert
+spec:
+  ingressClassName: gce
+  rules:
+    - host: hubtest.k8s.calitp.jarv.us
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: proxy-public
+                port:
+                  name: http

--- a/kubernetes/apps/charts/jupyterhub/templates/gke-ingress.yaml
+++ b/kubernetes/apps/charts/jupyterhub/templates/gke-ingress.yaml
@@ -1,8 +1,3 @@
-# Second Ingress serving JupyterHub via GKE's built-in gce controller
-# (in parallel with the upstream chart's nginx-backed Ingress). Scoped
-# to the test hostname only during the staged migration off ingress-nginx
-# — prod notebooks.calitp.org continues flowing through nginx until
-# we're satisfied with the GKE Ingress behavior.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -12,7 +7,7 @@ metadata:
 spec:
   ingressClassName: gce
   rules:
-    - host: hubtest.k8s.calitp.jarv.us
+    - host: jupyterhub.dds.dot.ca.gov
       http:
         paths:
           - path: /

--- a/kubernetes/apps/charts/jupyterhub/templates/gke-managed-certificate.yaml
+++ b/kubernetes/apps/charts/jupyterhub/templates/gke-managed-certificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: jupyterhub-managed-cert
+spec:
+  domains:
+    - hubtest.k8s.calitp.jarv.us

--- a/kubernetes/apps/charts/jupyterhub/templates/gke-managed-certificate.yaml
+++ b/kubernetes/apps/charts/jupyterhub/templates/gke-managed-certificate.yaml
@@ -4,4 +4,4 @@ metadata:
   name: jupyterhub-managed-cert
 spec:
   domains:
-    - hubtest.k8s.calitp.jarv.us
+    - jupyterhub.dds.dot.ca.gov

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -118,5 +118,12 @@ jupyterhub:
   proxy:
     service:
       type: ClusterIP
+      annotations:
+        # Enable container-native load balancing so the GKE Ingress
+        # routes directly to pods via NEG instead of through kube-proxy.
+        cloud.google.com/neg: '{"ingress": true}'
+        # Attach our BackendConfig so the GCLB uses our long timeout
+        # and the JupyterHub-specific health check path.
+        cloud.google.com/backend-config: '{"default": "jupyterhub-backend"}'
 debug:
   enabled: true


### PR DESCRIPTION
## Summary

Phase 1 of migrating JupyterHub off `ingress-nginx` (which is EOL as of March 2026) onto GKE's built-in `gce` Ingress controller. This PR stands up the new path in parallel with the existing one — prod `notebooks.calitp.org` stays flowing through nginx, unchanged. The new Ingress is scoped to the test hostname `hubtest.k8s.calitp.jarv.us` for validation.

## Changes

New templates in the wrapper chart's `templates/` dir:

- **ManagedCertificate** — Google-managed TLS cert for `hubtest.k8s.calitp.jarv.us`. Starts provisioning automatically once the hostname resolves to the new GCLB IP (~15-30 min).
- **BackendConfig** — `timeoutSec: 86400` (default 30s kills long-running cells and WebSocket kernels) + health check at `/hub/health`.
- **Ingress** — `ingressClassName: gce`, attaches the ManagedCertificate, routes to `proxy-public`. Scoped to the test hostname during staging.

Plus a `jupyterhub.proxy.service.annotations` update in `values.yaml` to:
- Enable container-native load balancing (NEG) so the GCLB routes directly to pods rather than through kube-proxy
- Attach the BackendConfig

## Why test hostname first

The Managed Certificate won't issue until the hostname resolves to the GCLB IP. Staging on the test hostname `hubtest.k8s.calitp.jarv.us` lets us:
1. Let the cert provision in a zero-risk window
2. Validate JupyterHub behavior end-to-end on GCLB (WebSockets, long cells, auth)
3. Flip prod DNS in a separate, deliberate step after soak

## Already applied

All four resources are already applied to the cluster (service annotation, ManagedCertificate, BackendConfig, test Ingress). `helm template` confirms next helm deploy is idempotent with this PR's contents.

## What's NOT in this PR

- `notebooks.calitp.org` DNS change (later phase, coordinates with team)
- Removal of the nginx Ingress (later phase, after prod validation)
- ingress-nginx + cert-manager removal (later, after grafana + sentry ingresses also go away)

## Test plan

- [x] CI passes (lint, kubernetes preview)
- [x] `kubectl get managedcertificate jupyterhub-managed-cert -n jupyterhub` → status transitions from Provisioning → Active once DNS points at the GCLB
- [x] `kubectl get ingress jupyterhub-gce -n jupyterhub` gets a GCLB external IP within ~10 min of apply
- [x] Update `hubtest.k8s.calitp.jarv.us` DNS A record to point at the new GCLB IP
- [ ] JupyterHub login flow works end-to-end on the test hostname
- [ ] Spawn a notebook; run a long-running cell; verify kernel survives
- [ ] Page refresh during long kernel operation does not disconnect (WebSocket health)
- [ ] Helm upgrade is a no-op against the cluster post-merge

## References

- #4922 (cluster maintenance tracker)