### PR TITLE
Remove mart payments schema from DBT Metabase exclusion (#5061)

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -218,9 +218,79 @@ jobs:
         working-directory: warehouse
         run: uv run dbt debug --target ${{ env.DBT_TARGET }}
 
+      - name: Discover Payments Metabase databases
+        id: payments-databases
+        run: |
+          set -euo pipefail
+
+          # Each agency has its own Metabase database connection named
+          # "Payments - <Agency Name>" (per the create-metabase-dashboards
+          # runbook). Column-level docs from dbt have to land on every one
+          # of those connections, not just the central warehouse connection,
+          # so this step enumerates them via the Metabase API.
+          PAYMENTS_DBS=$(curl -fsS \
+            -H "x-api-key: ${METABASE_API_KEY}" \
+            "${METABASE_URL}/api/database" \
+            | jq -r '.data[] | select(.name | startswith("Payments - ")) | .name')
+
+          if [ -z "${PAYMENTS_DBS}" ]; then
+            echo "No 'Payments - *' databases found. Will sync only the central database."
+          else
+            echo "Discovered Payments databases:"
+            printf '  - %s\n' ${PAYMENTS_DBS}
+          fi
+
+          {
+            echo "names<<EOF"
+            echo "${PAYMENTS_DBS}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Synchronize Metabase
         working-directory: warehouse
-        run: uv run dbt-metabase models -v --manifest-path=target/manifest.json --skip-sources --exclude-schemas=staging,payments --docs-url="${{ env.DBT_DOCS_URL }}" --metabase-url="${{ env.METABASE_URL }}" --metabase-database="${{ env.METABASE_DESTINATION_DATABASE }}" --metabase-api-key="${{ env.METABASE_API_KEY}}"
+        env:
+          PAYMENTS_DBS: ${{ steps.payments-databases.outputs.names }}
+        run: |
+          set -euo pipefail
+
+          sync_metabase_metadata() {
+            local db="$1"
+            echo "::group::dbt-metabase sync — ${db}"
+            uv run dbt-metabase models -v \
+              --manifest-path=target/manifest.json \
+              --skip-sources \
+              --exclude-schemas=staging,payments \
+              --docs-url="${DBT_DOCS_URL}" \
+              --metabase-url="${METABASE_URL}" \
+              --metabase-database="${db}" \
+              --metabase-api-key="${METABASE_API_KEY}"
+            echo "::endgroup::"
+          }
+
+          failed=0
+
+          # Central warehouse connection — preserves prior behavior.
+          if ! sync_metabase_metadata "${METABASE_DESTINATION_DATABASE}"; then
+            failed=1
+            echo "::warning::dbt-metabase sync failed for '${METABASE_DESTINATION_DATABASE}'"
+          fi
+
+          # Per-agency Payments connections — partial-tolerant so one agency
+          # outage doesn't block the rest.
+          if [ -n "${PAYMENTS_DBS}" ]; then
+            while IFS= read -r db; do
+              [ -z "${db}" ] && continue
+              if ! sync_metabase_metadata "${db}"; then
+                failed=1
+                echo "::warning::dbt-metabase sync failed for '${db}'"
+              fi
+            done <<< "${PAYMENTS_DBS}"
+          fi
+
+          if [ "${failed}" -ne 0 ]; then
+            echo "::error::One or more dbt-metabase syncs failed"
+            exit 1
+          fi
 
   upload_dbt_docs:
     name: Upload to dbt-docs site

--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -168,8 +168,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dbt-changed, compile]
 
-    if: ${{ needs.dbt-changed.outputs.has-changed == 'true' }}
-
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -26,7 +26,8 @@ env:
   CALITP_BUCKET__PUBLISH: ${{ github.ref == 'refs/heads/main' && 'calitp-publish' || 'calitp-staging-publish' }}
   GOOGLE_CLOUD_PROJECT: ${{ github.ref == 'refs/heads/main' && 'cal-itp-data-infra' || 'cal-itp-data-infra-staging' }}
   METABASE_DESTINATION_DATABASE: ${{ github.ref == 'refs/heads/main' && 'Data Marts (formerly Warehouse Views)' || '(Internal) Staging Warehouse Views' }}
-  METABASE_URL: 'https://metabase.dds.dot.ca.gov'
+  METABASE_URL: ${{ github.ref == 'refs/heads/main' && 'https://metabase.dds.dot.ca.gov' || 'https://metabase-staging.dds.dot.ca.gov' }}
+  METABASE_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.METABASE_API_KEY || secrets.METABASE_STAGING_API_KEY }}
   DBT_DOCS_URL: ${{ github.ref == 'refs/heads/main' && 'https://dbt-docs.dds.dot.ca.gov' || 'https://dbt-docs-staging.dds.dot.ca.gov' }}
 
 jobs:
@@ -219,7 +220,7 @@ jobs:
 
       - name: Synchronize Metabase
         working-directory: warehouse
-        run: uv run dbt-metabase models -v --manifest-path=target/manifest.json --skip-sources --exclude-schemas=staging,payments,mart_payments --docs-url="${{ env.DBT_DOCS_URL }}" --metabase-url="${{ env.METABASE_URL }}" --metabase-database="${{ env.METABASE_DESTINATION_DATABASE }}" --metabase-api-key="${{ secrets.METABASE_API_KEY}}"
+        run: uv run dbt-metabase models -v --manifest-path=target/manifest.json --skip-sources --exclude-schemas=staging,payments --docs-url="${{ env.DBT_DOCS_URL }}" --metabase-url="${{ env.METABASE_URL }}" --metabase-database="${{ env.METABASE_DESTINATION_DATABASE }}" --metabase-api-key="${{ env.METABASE_API_KEY}}"
 
   upload_dbt_docs:
     name: Upload to dbt-docs site

--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -255,32 +255,37 @@ jobs:
 
           sync_metabase_metadata() {
             local db="$1"
+            shift
             echo "::group::dbt-metabase sync — ${db}"
             uv run dbt-metabase models -v \
               --manifest-path=target/manifest.json \
               --skip-sources \
-              --exclude-schemas=staging,payments \
               --docs-url="${DBT_DOCS_URL}" \
               --metabase-url="${METABASE_URL}" \
               --metabase-database="${db}" \
-              --metabase-api-key="${METABASE_API_KEY}"
+              --metabase-api-key="${METABASE_API_KEY}" \
+              "$@"
             echo "::endgroup::"
           }
 
           failed=0
 
-          # Central warehouse connection — preserves prior behavior.
-          if ! sync_metabase_metadata "${METABASE_DESTINATION_DATABASE}"; then
+          # Central warehouse connection — broad sync, exclude internal schemas.
+          if ! sync_metabase_metadata "${METABASE_DESTINATION_DATABASE}" \
+               --exclude-schemas=staging,payments; then
             failed=1
             echo "::warning::dbt-metabase sync failed for '${METABASE_DESTINATION_DATABASE}'"
           fi
 
-          # Per-agency Payments connections — partial-tolerant so one agency
-          # outage doesn't block the rest.
+          # Per-agency Payments connections — restrict to the schemas exposed
+          # via dataset_filters_patterns on those connections (mart_payments,
+          # mart_benefits per the create-metabase-dashboards runbook). Loop is
+          # partial-tolerant so one agency's outage doesn't block the rest.
           if [ -n "${PAYMENTS_DBS}" ]; then
             while IFS= read -r db; do
               [ -z "${db}" ] && continue
-              if ! sync_metabase_metadata "${db}"; then
+              if ! sync_metabase_metadata "${db}" \
+                   --include-schemas=mart_payments,mart_benefits; then
                 failed=1
                 echo "::warning::dbt-metabase sync failed for '${db}'"
               fi


### PR DESCRIPTION
# Description

Completed with @mjumbewu's direction and guidance in a KT session.

This PR removes the payments mart schemas from the dbt-metabase sync exclusion list in `deploy-dbt.yml`, so table and column level docs now sync to Metabase for all payments agency databases (not just CCJPA). It also routes the sync at the staging Metabase instance when the workflow runs from against staging, mirroring the branch-conditional pattern already used for `GOOGLE_CLOUD_PROJECT`, `METABASE_DESTINATION_DATABASE`, and `DBT_DOCS_URL` in the same env block.

A new GitHub secret `METABASE_STAGING_API_KEY` was created, holding a new API key generated in staging Metabase under the display name `GitHub Actions - dbt-metabase`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Opening this PR triggers the `Deploy dbt` workflow which will synchronize the payments mart schemas.

Update post workflow run: 

The `Deploy dbt` workflow ran on this PR, but the `Sync Metabase` job was skipped because it is gated behind a `dbt-changed` check that only flips to `true` when files under `warehouse/models/**/*.sql` or `warehouse/seeds/*.csv` change. This PR touches neither, so the new branch-conditional staging URL/key logic was not exercised on this PR's run.

The same gate applies to the on-merge `Deploy dbt` run on `main`, so `Sync Metabase` will likely also skip at merge time. The new logic will be first exercised on the next PR that modifies a dbt model or seed, against staging Metabase. I will need to further discuss this with @mjumbewu to understand how we can cause the sync to occur when the merge to `main` occurs.

## Post-merge follow-ups

- [] No action required
- [X] Actions required (specified below)

Must confirm that `Sync Metabase` is not skipped and causes the doc sync to occur successfully.
