### PR TITLE
Scale back staging composer resources

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -17,7 +17,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         cpu        = 2
         memory_gb  = 2
         storage_gb = 1
-        count      = 2
+        count      = 1
       }
       web_server {
         cpu        = 2
@@ -26,7 +26,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
       }
       worker {
         cpu        = 4
-        memory_gb  = 8
+        memory_gb  = 13
         storage_gb = 1
         min_count  = 1
         max_count  = 8
@@ -39,13 +39,13 @@ resource "google_composer_environment" "calitp-staging-composer" {
       image_version = "composer-2.15.2-airflow-2.10.5"
 
       airflow_config_overrides = {
+        celery-worker_concurrency                  = 4
         core-dag_file_processor_timeout            = 1200
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true
         core-max_active_runs_per_dag               = 128
         core-max_active_tasks_per_dag              = 128
         core-max_templated_field_length            = 25000
-        core-parallelism                           = 0
         cosmos-use_dataset_airflow3_uri_standard   = true
         email-email_backend                        = "airflow.utils.email.send_email_smtp"
         email-email_conn_id                        = "smtp_postmark"

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -46,7 +46,6 @@ resource "google_composer_environment" "calitp-composer" {
         core-max_active_runs_per_dag               = 128
         core-max_active_tasks_per_dag              = 128
         core-max_templated_field_length            = 25000
-        core-parallelism                           = 0
         cosmos-use_dataset_airflow3_uri_standard   = true
         email-email_backend                        = "airflow.utils.email.send_email_smtp"
         email-email_conn_id                        = "smtp_postmark"


### PR DESCRIPTION
# Description

This PR scales back the Staging Composer resource usage, and removes `airflow-core-parallelism=0` as a setting from both environments.

Relates to #4488

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`