### PR TITLE
4691 Deduplicate dim_stops_latest from overlapping geometry

### DIFF
--- a/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
+++ b/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
@@ -13,10 +13,8 @@ stg_state_geoportal__state_highway_network_stops AS (
 
 
 buffer_geometry_table AS (
-    -- merge overlapping SHN segment buffers into a single multipolygon so that
-    -- stops sitting in overlap zones (interchanges, concurrencies) match once
-    -- instead of fanning out per overlapping segment. 30.48 = 100ft.
-    SELECT ST_UNION_AGG(ST_BUFFER(wkt_coordinates, 30.48)) AS buffer_geometry
+    -- 30.48 = 100ft
+    SELECT ST_BUFFER(wkt_coordinates, 30.48) AS buffer_geometry
     FROM stg_state_geoportal__state_highway_network_stops
 ),
 
@@ -27,11 +25,18 @@ current_stops AS (
     FROM dim_stops_latest
 ),
 
+-- semi-join: each stop is returned at most once regardless of how many SHN
+-- buffers overlap it (interchanges, concurrencies). Replaces the prior
+-- cross-join + DISTINCT hotfix and avoids ST_UNION_AGG on every build.
 stops_on_shn AS (
     SELECT current_stops._gtfs_key
-    FROM buffer_geometry_table, current_stops
-    WHERE ST_DWITHIN(
-            buffer_geometry_table.buffer_geometry, current_stops.pt_geom, 0)
+    FROM current_stops
+    WHERE EXISTS (
+        SELECT 1
+        FROM buffer_geometry_table
+        WHERE ST_DWITHIN(
+                buffer_geometry_table.buffer_geometry, current_stops.pt_geom, 0)
+    )
 ),
 
 dim_stops_latest_with_shn_boolean AS (

--- a/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
+++ b/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
@@ -13,10 +13,10 @@ stg_state_geoportal__state_highway_network_stops AS (
 
 
 buffer_geometry_table AS (
-    SELECT
-        -- equal to 100ft, as requested by Uriel
-        ST_BUFFER(wkt_coordinates,
-            30.48) AS buffer_geometry
+    -- merge overlapping SHN segment buffers into a single multipolygon so that
+    -- stops sitting in overlap zones (interchanges, concurrencies) match once
+    -- instead of fanning out per overlapping segment. 30.48 = 100ft.
+    SELECT ST_UNION_AGG(ST_BUFFER(wkt_coordinates, 30.48)) AS buffer_geometry
     FROM stg_state_geoportal__state_highway_network_stops
 ),
 
@@ -27,14 +27,11 @@ current_stops AS (
     FROM dim_stops_latest
 ),
 
-
 stops_on_shn AS (
-    SELECT distinct
-    current_stops._gtfs_key
-    -- current_stops.* old code, hotfix since we are getting duplicates here
+    SELECT current_stops._gtfs_key
     FROM buffer_geometry_table, current_stops
     WHERE ST_DWITHIN(
-            buffer_geometry_table.buffer_geometry,current_stops.pt_geom, 0)
+            buffer_geometry_table.buffer_geometry, current_stops.pt_geom, 0)
 ),
 
 dim_stops_latest_with_shn_boolean AS (

--- a/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
+++ b/warehouse/models/mart/gtfs_schedule_latest/dim_stops_latest.sql
@@ -25,9 +25,8 @@ current_stops AS (
     FROM dim_stops_latest
 ),
 
--- semi-join: each stop is returned at most once regardless of how many SHN
--- buffers overlap it (interchanges, concurrencies). Replaces the prior
--- cross-join + DISTINCT hotfix and avoids ST_UNION_AGG on every build.
+-- EXISTS yields each stop at most once even when overlapping SHN buffers match
+-- it multiple times (one stop can be in multiple buffers if line segments are small)
 stops_on_shn AS (
     SELECT current_stops._gtfs_key
     FROM current_stops
@@ -35,21 +34,18 @@ stops_on_shn AS (
         SELECT 1
         FROM buffer_geometry_table
         WHERE ST_DWITHIN(
-                buffer_geometry_table.buffer_geometry, current_stops.pt_geom, 0)
+            buffer_geometry_table.buffer_geometry, current_stops.pt_geom, 0
+        )
     )
 ),
 
 dim_stops_latest_with_shn_boolean AS (
-
-SELECT
-    dim_stops_latest.*,
-    IF(stops_on_shn._gtfs_key IS NOT NULL, TRUE, FALSE) AS on_state_highway_network
-FROM
-    dim_stops_latest
-LEFT JOIN
-    stops_on_shn
-ON
-    dim_stops_latest._gtfs_key = stops_on_shn._gtfs_key
+    SELECT
+        dim_stops_latest.*,
+        IF(stops_on_shn._gtfs_key IS NOT NULL, TRUE, FALSE) AS on_state_highway_network
+    FROM dim_stops_latest
+    LEFT JOIN stops_on_shn
+        ON dim_stops_latest._gtfs_key = stops_on_shn._gtfs_key
 )
 
 SELECT * FROM dim_stops_latest_with_shn_boolean


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #4691

Deduplicates duplicate stops appearing in dim_stops_latest from geospatial join -- my assumption is the line layer is buffering multiple small segments. Checking that the stop exists in the buffer seems to deduplicate. 

Testing against staging didn't turn up occurrences when I ran it, but prod had the issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Ran against bigquery and eliminated duplciates, put together a smaller query against some known problematic values in prod that seemed to pass.

<details><summary>query from dbt singular test</summary>

ran as a singular test but can be compiled to query in bigquery

```sql
WITH known_problem_keys AS (
    SELECT _gtfs_key FROM UNNEST([
        'b1b1d85645b299e1e1739244c25cf787',  -- prev count=6
        'f1d48435c307702ac7705945db8490a8',  -- prev count=4
        '7cf187a2140ec6400455549237de00e4',  -- prev count=4
        '11dc62711841b192e1c6ba47c4358d69',  -- prev count=4
        '86c943d394f8e846616bce7280d2fa40',  -- prev count=4
        '351b8e01a52a1ba51972fa0198b02725',  -- prev count=4
        '25e8a7f081c776d361ab8b1dab37cf4c',  -- prev count=4
        '1b108d5070f9b5630748455a2c22bea2'   -- prev count=4
    ]) AS _gtfs_key
),

dim_stops_latest AS (
    {{ get_latest_schedule_data(
        table_name = ref('dim_stops'),
        clean_table_name = 'dim_stops'
    ) }}
),

stg_state_geoportal__state_highway_network_stops AS (
    SELECT *
    FROM {{ ref('stg_state_geoportal__state_highway_network_stops') }}
),

buffer_geometry_table AS (
    SELECT ST_BUFFER(wkt_coordinates, 30.48) AS buffer_geometry
    FROM stg_state_geoportal__state_highway_network_stops
),

current_stops AS (
    SELECT
        pt_geom,
        _gtfs_key
    FROM dim_stops_latest
    WHERE _gtfs_key IN (SELECT _gtfs_key FROM known_problem_keys)
),

stops_on_shn AS (
    SELECT current_stops._gtfs_key
    FROM current_stops
    WHERE EXISTS (
        SELECT 1
        FROM buffer_geometry_table
        WHERE ST_INTERSECTS(
            buffer_geometry_table.buffer_geometry, current_stops.pt_geom
        )
    )
),

dim_stops_latest_with_shn_boolean AS (
    SELECT
        dim_stops_latest.*,
        IF(stops_on_shn._gtfs_key IS NOT NULL, TRUE, FALSE) AS on_state_highway_network
    FROM dim_stops_latest
    LEFT JOIN stops_on_shn
        ON dim_stops_latest._gtfs_key = stops_on_shn._gtfs_key
    WHERE dim_stops_latest._gtfs_key IN (SELECT _gtfs_key FROM known_problem_keys)
)

SELECT
    feed_key,
    stop_id,
    COUNT(*) AS n
FROM dim_stops_latest_with_shn_boolean
GROUP BY feed_key, stop_id
HAVING n > 1
```

</details>

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
