### PR TITLE
Add configuration for sftp-endpoints cluster

### DIFF
--- a/iac/cal-itp-data-infra/gke/us/container_cluster.tf
+++ b/iac/cal-itp-data-infra/gke/us/container_cluster.tf
@@ -116,13 +116,12 @@ resource "google_container_cluster" "airflow-jobs" {
 }
 
 resource "google_container_cluster" "sftp-endpoints" {
-
   name     = "sftp-endpoints"
   location = "us-west2"
   project  = "cal-itp-data-infra"
 
   enable_autopilot    = true
-  deletion_protection = false
+  deletion_protection = true
   network             = data.terraform_remote_state.networks.outputs.google_compute_network_tfer--default_self_link
 
   secret_manager_config {
@@ -136,6 +135,14 @@ resource "google_container_cluster" "sftp-endpoints" {
   node_config {
     workload_metadata_config {
       mode = "GKE_METADATA"
+    }
+
+    reservation_affinity {
+      consume_reservation_type = "NO_RESERVATION"
+    }
+
+    gvnic {
+      enabled = true
     }
   }
 


### PR DESCRIPTION
# Description

This PR adds missing configuration for sftp-endpoints cluster to avoid recreation on pull request merges.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
