### PR TITLE
Add mart_transit_database and mart_transit_database_latest to staging Metabase BQ connection

### DIFF
--- a/iac/cal-itp-data-infra-staging/dashboards/us/database.tf
+++ b/iac/cal-itp-data-infra-staging/dashboards/us/database.tf
@@ -9,6 +9,6 @@ resource "metabase_database" "bigquery" {
     service_account_key      = base64decode(google_service_account_key.metabase-staging-key.private_key)
     project_id               = "cal-itp-data-infra-staging"
     dataset_filters_type     = "inclusion"
-    dataset_filters_patterns = "mart_gtfs,mart_gtfs_audit,mart_payments_audit"
+    dataset_filters_patterns = "mart_gtfs,mart_gtfs_audit,mart_payments_audit,mart_transit_database,mart_transit_database_latest"
   }
 }


### PR DESCRIPTION
# Description

Add `mart_transit_database` and `mart_transit_database_latest` to staging Metabase BQ connection in the `iac/` code. Enables transferring the GTFS-RT monitoring dashboards as used in production Metabase.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

There are two new dashboards in staging metabase:

- **Feed Level V2** -- https://metabase-staging.dds.dot.ca.gov/dashboard/11-feed-level-v2
- **(v2 Pipeline) GTFS RT Files: Hourly View by Day** -- https://metabase-staging.dds.dot.ca.gov/dashboard/12-v2-pipeline-gtfs-rt-files-hourly-view-by-day

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
