### PR TITLE
Add errors to littlepay sync results

### DIFF
--- a/airflow/plugins/operators/littlepay_s3_to_gcs_operator.py
+++ b/airflow/plugins/operators/littlepay_s3_to_gcs_operator.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Self, Sequence
 
-from airflow.exceptions import AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models import BaseOperator
 from airflow.models.taskinstance import Context
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -112,6 +112,7 @@ class LittlepayS3ToGCSOperator(BaseOperator):
         self.report_path: str = report_path
         self.aws_conn_id: str = aws_conn_id
         self.gcp_conn_id: str = gcp_conn_id
+        self.exception: Exception = None
         self._source_object = None
         self._prior_artifact: PriorArtifact = None
 
@@ -131,13 +132,38 @@ class LittlepayS3ToGCSOperator(BaseOperator):
         return os.path.basename(self.source_path)
 
     def source_object(self) -> any:
-        if self._source_object is None:
-            self._source_object = (
-                self.s3_hook()
-                .get_key(bucket_name=self.source_bucket_name(), key=self.source_path)
-                .get()
-            )
+        if self.exception is None and self._source_object is None:
+            try:
+                self._source_object = (
+                    self.s3_hook()
+                    .get_key(
+                        bucket_name=self.source_bucket_name(), key=self.source_path
+                    )
+                    .get()
+                )
+            except Exception as e:
+                self.exception = e
+                logging.error(e)
+
         return self._source_object
+
+    def s3object_metadata(self) -> dict:
+        if self.source_object() is None:
+            return {
+                "Key": self.source_path,
+                "LastModified": None,
+                "ETag": None,
+                "Size": None,
+                "StorageClass": None,
+            }
+
+        return {
+            "Key": self.source_path,
+            "LastModified": self.source_object()["LastModified"].isoformat(),
+            "ETag": self.source_object()["ETag"].replace('"', '"'),
+            "Size": self.source_object()["ContentLength"],
+            "StorageClass": self.source_object().get("StorageClass"),
+        }
 
     def metadata(self) -> dict:
         return {
@@ -145,13 +171,7 @@ class LittlepayS3ToGCSOperator(BaseOperator):
             "instance": self.provider,
             "ts": self.ts,
             "s3bucket": self.source_bucket_name(),
-            "s3object": {
-                "Key": self.source_path,
-                "LastModified": self.source_object()["LastModified"].isoformat(),
-                "ETag": self.source_object()["ETag"].replace('"', '"'),
-                "Size": self.source_object()["ContentLength"],
-                "StorageClass": self.source_object().get("StorageClass"),
-            },
+            "s3object": self.s3object_metadata(),
         }
 
     def prior_artifact(self) -> PriorArtifact:
@@ -166,7 +186,8 @@ class LittlepayS3ToGCSOperator(BaseOperator):
 
     def exists(self) -> bool:
         return (
-            self.prior_artifact().s3object_metadata() is not None
+            self.source_object() is not None
+            and self.prior_artifact().s3object_metadata() is not None
             and self.source_object()["LastModified"].isoformat()
             == self.prior_artifact().s3object_metadata().get("LastModified")
             and self.source_object()["ETag"]
@@ -174,36 +195,38 @@ class LittlepayS3ToGCSOperator(BaseOperator):
         )
 
     def execute(self, context: Context) -> dict:
-        if self.entity not in LITTLEPAY_ENTITIES:
-            logging.warning("Entity is not in the list.")
-            raise AirflowSkipException
+        if self.entity.lower() not in LITTLEPAY_ENTITIES:
+            self.exception = f"File '{self.entity}' is not on the list."
+            logging.error(self.exception)
         elif not self.filename().endswith(".psv"):
-            logging.warning("File is not a psv type.")
-            raise AirflowSkipException
-        elif self.exists():
-            logging.info("File already downloaded.")
-            raise AirflowSkipException
+            self.exception = f"File '{self.filename()}' is not a psv type."
+            logging.error(self.exception)
+        else:
+            if self.exists():
+                logging.info("File already downloaded.")
+                raise AirflowSkipException
 
-        self.gcs_hook().upload(
-            bucket_name=self.destination_bucket_name(),
-            object_name=self.destination_path,
-            data=self.source_object()["Body"].read(),
-            mime_type=self.source_object()["ContentType"],
-            gzip=False,
-            metadata={
-                "PARTITIONED_ARTIFACT_METADATA": json.dumps(
-                    self.metadata(), default=str
+            if self.source_object() is not None:
+                self.gcs_hook().upload(
+                    bucket_name=self.destination_bucket_name(),
+                    object_name=self.destination_path,
+                    data=self.source_object()["Body"].read(),
+                    mime_type=self.source_object()["ContentType"],
+                    gzip=False,
+                    metadata={
+                        "PARTITIONED_ARTIFACT_METADATA": json.dumps(
+                            self.metadata(), default=str
+                        )
+                    },
                 )
-            },
-        )
 
         self.gcs_hook().upload(
             bucket_name=self.destination_bucket_name(),
             object_name=self.report_path,
             data=json.dumps(
                 {
-                    "success": True,
-                    "exception": None,
+                    "success": (self.exception is None),
+                    "exception": self.exception,
                     "prior": self.prior_artifact().s3object_metadata(),
                     "extract": self.metadata(),
                 },
@@ -222,6 +245,9 @@ class LittlepayS3ToGCSOperator(BaseOperator):
                 )
             },
         )
+
+        if self.exception is not None:
+            raise AirflowException(str(self.exception))
 
         return {
             "provider": self.provider,

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute.yaml
@@ -13,17 +13,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/4224e17b-fe4c-4f83-9844-cb9435c7940e
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/8917aa4a-5739-456b-a13b-526b3fb346c0
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202510241114_authorisations.psv&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202510241114_authorisations.psv&prettyPrint=false
   response:
     body:
-      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776730490741333","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776730490741333&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776730490741333","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNXEjO7U/ZMDEAE=","timeCreated":"2026-04-21T00:14:50.745Z","updated":"2026-04-21T00:14:50.745Z","timeStorageClassUpdated":"2026-04-21T00:14:50.745Z","timeFinalized":"2026-04-21T00:14:50.745Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1777332462145462","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1777332462145462&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332462145462","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLaft7CXj5QDEAE=","timeCreated":"2026-04-27T23:27:42.149Z","updated":"2026-04-27T23:27:42.149Z","timeStorageClassUpdated":"2026-04-27T23:27:42.149Z","timeFinalized":"2026-04-27T23:27:42.149Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202510241114_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202510241114_authorisations.psv\",
-        \"LastModified\": \"2026-04-21T00:14:48+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"LastModified\": \"2026-04-27T23:27:39+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}]}'
     headers:
       Alt-Svc:
@@ -35,16 +35,16 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:03 GMT
+      - Mon, 27 Apr 2026 23:29:43 GMT
       Expires:
-      - Tue, 21 Apr 2026 00:29:03 GMT
+      - Mon, 27 Apr 2026 23:29:43 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2dj7AaouyWlDCLUS1CS-VY3P86XuQmNFD9dzDX_YIlpfdufIX3WsXYfJqHgQ599dfT2H2O4II
+      - AAVLpEhnVNbzadEWp0_TRNzTOHp86aoSfm3AlSvsldxIFlKDWlW7o_cQuznOmqPFY6fIJQw1A2DqvQ
     status:
       code: 200
       message: OK
@@ -64,7 +64,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/fbfbce84-8921-4830-aa5b-788c0f419e8d
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/c8fcbe41-6986-4c15-ae97-400b30b124df
       x-goog-user-project:
       - cal-itp-data-infra
     method: DELETE
@@ -82,7 +82,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Apr 2026 00:29:03 GMT
+      - Mon, 27 Apr 2026 23:29:43 GMT
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -93,7 +93,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1aJan2CEsU4isteNJLv92w2-OzvooqlYmL4mcc9ACvHv839lQiEEstvxv5oB_ZWhrszJC8jKA
+      - AAVLpEikmI-KJBKKw-1AP6yYbN6aIgBC8VcjNuhJPIMRt05WERmhwKkW6Q5aEzGBVqdrV-zEZkUpDQ
     status:
       code: 204
       message: No Content
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/23c3e21a-d4e1-42e6-9033-185d735cde11
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/dd5afbef-f489-4331-afda-c55b904b5a6b
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
@@ -129,29 +129,29 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:05 GMT
+      - Mon, 27 Apr 2026 23:29:45 GMT
       Expires:
-      - Tue, 21 Apr 2026 00:29:05 GMT
+      - Mon, 27 Apr 2026 23:29:45 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2_n1de0z0yzdGhFY9_wmXlezzqAqbACDC1Erf2Nej5OmuEEJ6NzY-vVGUtgSBz53Fh
+      - AAVLpEidhCGcagOP76zTUIG-81JLMzwyQx5Qlbf9EaXK7OfAoqpCc7mC44ojrJeqXBc7GhPI
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============4497047128848704485==\r\ncontent-type: application/json;
+    body: "--===============2189229449712142998==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202510241114_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\",
       \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
       \\\"atn/v3/authorisations/202510241114_authorisations.psv\\\", \\\"LastModified\\\":
-      \\\"2026-04-21T00:29:04+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
-      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============4497047128848704485==\r\ncontent-type:
-      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============4497047128848704485==--"
+      \\\"2026-04-27T23:29:44+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============2189229449712142998==\r\ncontent-type:
+      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============2189229449712142998==--"
     headers:
       Accept:
       - application/json
@@ -166,11 +166,11 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/162ff9e5-6ceb-42d6-a885-21a831abb38b
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/603edf94-a3fe-4191-abe9-c6a9a18381ab
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT00NDk3MDQ3MTI4ODQ4
-        NzA0NDg1PT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0yMTg5MjI5NDQ5NzEy
+        MTQyOTk4PT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -179,21 +179,21 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776731346327385\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1777332586772630\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776731346327385&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1777332586772630&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731346327385\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332586772630\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CNmuiYbY/ZMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-21T00:29:06.331Z\",\n  \"updated\": \"2026-04-21T00:29:06.331Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-21T00:29:06.331Z\",\n  \"timeFinalized\":
-        \"2026-04-21T00:29:06.331Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CJbx7euXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:29:46.775Z\",\n  \"updated\": \"2026-04-27T23:29:46.775Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:29:46.775Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:29:46.775Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202510241114_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202510241114_authorisations.psv\\\",
-        \\\"LastModified\\\": \\\"2026-04-21T00:29:04+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+        \\\"LastModified\\\": \\\"2026-04-27T23:29:44+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
         \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"\n  }\n}\n"
     headers:
       Alt-Svc:
@@ -205,9 +205,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:06 GMT
+      - Mon, 27 Apr 2026 23:29:46 GMT
       ETag:
-      - CNmuiYbY/ZMDEAE=
+      - CJbx7euXj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -218,17 +218,17 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1kN0jgWvdasi7M_N4Kx4_7UYvuwlWJI1_A_o9zLkKygEydb1pkNhMrfYE_IYGqH5AH_SfrDA
+      - AAVLpEhcQgo_J_6RHGl9H_RCtvTUt_U818Qsa9Kj9E3ZwjAslChXR6R8K854V8PL3_94YzVV
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============4885457531354250110==\r\ncontent-type: application/json;
+    body: "--===============2155259284947858141==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"results_202510241114_authorisations.psv.jsonl\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"},
-      \"crc32c\": \"zCxLLg==\"}\r\n--===============4885457531354250110==\r\ncontent-type:
-      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{},\"extract\":{\"filename\":\"202510241114_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202510241114_authorisations.psv\",\"LastModified\":\"2026-04-21T00:29:04+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============4885457531354250110==--"
+      \"crc32c\": \"NmTbjg==\"}\r\n--===============2155259284947858141==\r\ncontent-type:
+      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{},\"extract\":{\"filename\":\"202510241114_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202510241114_authorisations.psv\",\"LastModified\":\"2026-04-27T23:29:44+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============2155259284947858141==--"
     headers:
       Accept:
       - application/json
@@ -243,11 +243,11 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/38e877ac-c8b2-4f3b-b587-1629becd45b4
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/84fe2713-a497-4b13-b34f-a0e2646bc31e
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT00ODg1NDU3NTMxMzU0
-        MjUwMTEwPT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0yMTU1MjU5Mjg0OTQ3
+        ODU4MTQxPT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -256,17 +256,17 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1776731347422100\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1777332587961212\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1776731347422100&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1777332587961212&alt=media\",\n
         \ \"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731347422100\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332587961212\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
-        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"381\",\n  \"md5Hash\": \"RFR3tUEOSuiOzb6SZHRuEA==\",\n
-        \ \"crc32c\": \"zCxLLg==\",\n  \"etag\": \"CJSXzIbY/ZMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-21T00:29:07.435Z\",\n  \"updated\": \"2026-04-21T00:29:07.435Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-21T00:29:07.435Z\",\n  \"timeFinalized\":
-        \"2026-04-21T00:29:07.435Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"381\",\n  \"md5Hash\": \"RHwfZQLBdpupYIV6Dg4LBw==\",\n
+        \ \"crc32c\": \"NmTbjg==\",\n  \"etag\": \"CPy2tuyXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:29:47.970Z\",\n  \"updated\": \"2026-04-27T23:29:47.970Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:29:47.970Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:29:47.970Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"results_202510241114_authorisations.psv.jsonl\\\",
         \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"\n
         \ }\n}\n"
@@ -280,9 +280,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:07 GMT
+      - Mon, 27 Apr 2026 23:29:47 GMT
       ETag:
-      - CJSXzIbY/ZMDEAE=
+      - CPy2tuyXj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -293,7 +293,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2BotN2uU_gcxEMrj2C7pu-hEtEUDgrvQ4wtZ3lt-0pNioYRDKCzrgqLEkvTrsrTjRp
+      - AAVLpEhm0eo2LlXOXx87vi37jKkCxKB845MYf7b6WtBhPuqcevkfug3h9KebsIKiwZwknUpBpIgzSg
     status:
       code: 200
       message: OK
@@ -309,7 +309,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/e30c4f67-5ff9-4702-a218-5ee50698f986
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/09b2893f-9f47-45ab-a06a-a54e2f9f0072
       accept-encoding:
       - gzip
       content-type:
@@ -339,13 +339,13 @@ interactions:
       Content-Type:
       - binary/octet-stream
       Date:
-      - Tue, 21 Apr 2026 00:29:07 GMT
+      - Mon, 27 Apr 2026 23:29:48 GMT
       ETag:
-      - CNmuiYbY/ZMDEAE=
+      - CJbx7euXj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Last-Modified:
-      - Tue, 21 Apr 2026 00:29:06 GMT
+      - Mon, 27 Apr 2026 23:29:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -354,9 +354,9 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG0e78Lyccu-bZKFCs9O3Q0bKTci0k_-8CybiUMdP2XfxPdhx-r6Rr0pkihKb_IkzvJb9K5FtFI
+      - AAVLpEileIIj8Adx6F-XmpbKQWd4VlnCmWkmnZfMUHHR8Vn82Q_Bt1Jw4pNnT1Gj_TayDjJwR6CKPw
       X-Goog-Generation:
-      - '1776731346327385'
+      - '1777332586772630'
       X-Goog-Hash:
       - crc32c=hQqhOQ==,md5=XUboS5yfo8yH5JFsRSxN6A==
       X-Goog-Metageneration:
@@ -384,17 +384,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/2dcf0ef4-1e26-46a0-8652-c3308e6abb87
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/cdacc058-125e-41aa-9658-3c9018da373a
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202510241114_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202510241114_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1776731346327385","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1776731346327385&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731346327385","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNmuiYbY/ZMDEAE=","timeCreated":"2026-04-21T00:29:06.331Z","updated":"2026-04-21T00:29:06.331Z","timeStorageClassUpdated":"2026-04-21T00:29:06.331Z","timeFinalized":"2026-04-21T00:29:06.331Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv/1777332586772630","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202510241114_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.psv?generation=1777332586772630&alt=media","name":"authorisations/instance=atn/filename=202510241114_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332586772630","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJbx7euXj5QDEAE=","timeCreated":"2026-04-27T23:29:46.775Z","updated":"2026-04-27T23:29:46.775Z","timeStorageClassUpdated":"2026-04-27T23:29:46.775Z","timeFinalized":"2026-04-27T23:29:46.775Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202510241114_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202510241114_authorisations.psv\",
-        \"LastModified\": \"2026-04-21T00:29:04+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"LastModified\": \"2026-04-27T23:29:44+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -406,18 +406,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:07 GMT
+      - Mon, 27 Apr 2026 23:29:48 GMT
       ETag:
-      - CNmuiYbY/ZMDEAE=
+      - CJbx7euXj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:29:07 GMT
+      - Mon, 27 Apr 2026 23:29:48 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG2nO-LDIR02HtAqipPQMIutBJA8qH-79kM37Tb5UpMNjmYyiAYaES9916zU0bplImMKTVg2xS0
+      - AAVLpEj1YYfsrjwYtlzxKHzmJtZPB-PhkttM0wmZjky2AsUcMkdweDiTVfBzPHShxMZnmtz53uqmpgJg2dSp
     status:
       code: 200
       message: OK
@@ -433,7 +433,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/4508268e-9b61-49b5-a659-6d6709382fb0
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/d01b4a1a-9723-40a8-badf-e1eb517a0c94
       accept-encoding:
       - gzip
       content-type:
@@ -446,7 +446,7 @@ interactions:
     uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202510241114_authorisations.jsonl?alt=media
   response:
     body:
-      string: '{"success":true,"exception":null,"prior":{},"extract":{"filename":"202510241114_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202510241114_authorisations.psv","LastModified":"2026-04-21T00:29:04+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":null}}}'
+      string: '{"success":true,"exception":null,"prior":{},"extract":{"filename":"202510241114_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202510241114_authorisations.psv","LastModified":"2026-04-27T23:29:44+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":null}}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -459,13 +459,13 @@ interactions:
       Content-Type:
       - application/jsonl
       Date:
-      - Tue, 21 Apr 2026 00:29:07 GMT
+      - Mon, 27 Apr 2026 23:29:48 GMT
       ETag:
-      - CJSXzIbY/ZMDEAE=
+      - CPy2tuyXj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Last-Modified:
-      - Tue, 21 Apr 2026 00:29:07 GMT
+      - Mon, 27 Apr 2026 23:29:47 GMT
       Pragma:
       - no-cache
       Server:
@@ -474,11 +474,11 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1VtT9uyQZYiB7XQNMuPssdS3XrQnHvS_u9G6GbFXf7If9NNW2pCqB-l6cuDOMw0mx0409kMLg
+      - AAVLpEh_i5Zqq6PMAchU9EGAmLyjmNiIcS2jNMNMFCltx3NhMtEDvUDdNsw1niE5bULR5P1B3naEmoht4pA0
       X-Goog-Generation:
-      - '1776731347422100'
+      - '1777332587961212'
       X-Goog-Hash:
-      - crc32c=zCxLLg==,md5=RFR3tUEOSuiOzb6SZHRuEA==
+      - crc32c=NmTbjg==,md5=RHwfZQLBdpupYIV6Dg4LBw==
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
@@ -504,14 +504,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/aaa165d1-d92c-43f2-b33e-bd9dda97847b
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/14595c08-a374-401f-957c-e3e010d1a60e
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202510241114_authorisations.jsonl?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1776731347422100","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1776731347422100&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1776731347422100","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"381","md5Hash":"RFR3tUEOSuiOzb6SZHRuEA==","crc32c":"zCxLLg==","etag":"CJSXzIbY/ZMDEAE=","timeCreated":"2026-04-21T00:29:07.435Z","updated":"2026-04-21T00:29:07.435Z","timeStorageClassUpdated":"2026-04-21T00:29:07.435Z","timeFinalized":"2026-04-21T00:29:07.435Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl/1777332587961212","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202510241114_authorisations.jsonl?generation=1777332587961212&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202510241114_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1777332587961212","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"381","md5Hash":"RHwfZQLBdpupYIV6Dg4LBw==","crc32c":"NmTbjg==","etag":"CPy2tuyXj5QDEAE=","timeCreated":"2026-04-27T23:29:47.970Z","updated":"2026-04-27T23:29:47.970Z","timeStorageClassUpdated":"2026-04-27T23:29:47.970Z","timeFinalized":"2026-04-27T23:29:47.970Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"results_202510241114_authorisations.psv.jsonl\", \"instance\": \"atn\",
         \"ts\": \"2025-06-01T00:00:00+00:00\"}"}}'
     headers:
@@ -524,18 +524,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:08 GMT
+      - Mon, 27 Apr 2026 23:29:48 GMT
       ETag:
-      - CJSXzIbY/ZMDEAE=
+      - CPy2tuyXj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:29:08 GMT
+      - Mon, 27 Apr 2026 23:29:48 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3VVIu-c2-gGQ6lbw4hnMAXGyf-v0tU9INkll4q-0pZ0yKawlbki-rSA4VEAl0zT3OjdP6YYBw
+      - AAVLpEhDe5Yz1pZTeHSCaJjNrVclk-tsgNX9nHeOgHyFdC9sHUvSxjaMI9dDDbjaeowbTZ7qY-1b0GEXdPaJ
     status:
       code: 200
       message: OK

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_file_exists.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_file_exists.yaml
@@ -1,14 +1,14 @@
 interactions:
 - request:
-    body: "--===============6863018647767187687==\r\ncontent-type: application/json;
+    body: "--===============7513779322318168087==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202504291120_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\",
       \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
       \\\"atn/v3/authorisations/202504291120_authorisations.psv\\\", \\\"LastModified\\\":
       \\\"2026-03-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
-      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============6863018647767187687==\r\ncontent-type:
-      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============6863018647767187687==--"
+      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============7513779322318168087==\r\ncontent-type:
+      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============7513779322318168087==--"
     headers:
       Accept:
       - application/json
@@ -23,11 +23,11 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/c4acc78f-ef00-4849-8187-d5d591b76b3f
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/4faa8565-328a-479d-9505-ba478b697369
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT02ODYzMDE4NjQ3NzY3
-        MTg3Njg3PT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT03NTEzNzc5MzIyMzE4
+        MTY4MDg3PT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -36,17 +36,17 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1777332590488595\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332590488595&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731349823421\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332590488595\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CL3f3ofY/ZMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-21T00:29:09.835Z\",\n  \"updated\": \"2026-04-21T00:29:09.835Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-21T00:29:09.835Z\",\n  \"timeFinalized\":
-        \"2026-04-21T00:29:09.835Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CJPY0O2Xj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:29:50.498Z\",\n  \"updated\": \"2026-04-27T23:29:50.498Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:29:50.498Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:29:50.498Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202504291120_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202504291120_authorisations.psv\\\",
@@ -62,9 +62,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:09 GMT
+      - Mon, 27 Apr 2026 23:29:50 GMT
       ETag:
-      - CL3f3ofY/ZMDEAE=
+      - CJPY0O2Xj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -75,7 +75,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1in2oi8KVNJFIWIhZl5w_2FKWQwqWQeqLHOqtw5dNCc_NTW7rDVPwiMcD0VeYm4WQJqZW91yc
+      - AAVLpEhUjlOePpeFSg0skqpqyXn6AYeGQaWrTcVbGQt3Aw5NEJo5kbUSG8nYey_6H6NuDKq-ySeMC3e2IUuO
     status:
       code: 200
       message: OK
@@ -93,14 +93,18 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/dd9a0e6d-6a62-488a-ba4a-a8b6bd016dfe
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/39750321-d67c-4c0e-a8fb-34e3eb7f82aa
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202504291120_authorisations.psv&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv&prettyPrint=false
   response:
     body:
-      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731349823421","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CL3f3ofY/ZMDEAE=","timeCreated":"2026-04-21T00:29:09.835Z","updated":"2026-04-21T00:29:09.835Z","timeStorageClassUpdated":"2026-04-21T00:29:09.835Z","timeFinalized":"2026-04-21T00:29:09.835Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1777332590488595","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332590488595&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332590488595","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJPY0O2Xj5QDEAE=","timeCreated":"2026-04-27T23:29:50.498Z","updated":"2026-04-27T23:29:50.498Z","timeStorageClassUpdated":"2026-04-27T23:29:50.498Z","timeFinalized":"2026-04-27T23:29:50.498Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
+        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": null}}"}},{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv/1777332484269346","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332484269346&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332484269346","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CKLK/bqXj5QDEAE=","timeCreated":"2026-04-27T23:28:04.278Z","updated":"2026-04-27T23:28:04.278Z","timeStorageClassUpdated":"2026-04-27T23:28:04.278Z","timeFinalized":"2026-04-27T23:28:04.278Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
         \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
@@ -111,20 +115,20 @@ interactions:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1711'
+      - '3386'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:11 GMT
+      - Mon, 27 Apr 2026 23:29:51 GMT
       Expires:
-      - Tue, 21 Apr 2026 00:29:11 GMT
+      - Mon, 27 Apr 2026 23:29:51 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG0h_XniABDbpe0DtgywMdAfQSaio8EQyUBr4OXZ20Pzy050pH6cRt1vD6mU_A6BrqexURDlM_o
+      - AAVLpEhIulUOIrx1iWxvjnDKPF5HJXlfotP-CTsP8z2J_ZggOEh5wTTWPJnzXcUOmeZhISIH1j6p_cYy3gzf
     status:
       code: 200
       message: OK
@@ -142,14 +146,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/297a7cc8-891b-48ed-9eba-6595e41c63a1
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/73333382-fa8e-47bc-9769-e63ac372677b
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731349823421","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CL3f3ofY/ZMDEAE=","timeCreated":"2026-04-21T00:29:09.835Z","updated":"2026-04-21T00:29:09.835Z","timeStorageClassUpdated":"2026-04-21T00:29:09.835Z","timeFinalized":"2026-04-21T00:29:09.835Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1777332590488595","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332590488595&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332590488595","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJPY0O2Xj5QDEAE=","timeCreated":"2026-04-27T23:29:50.498Z","updated":"2026-04-27T23:29:50.498Z","timeStorageClassUpdated":"2026-04-27T23:29:50.498Z","timeFinalized":"2026-04-27T23:29:50.498Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
         \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
@@ -164,18 +168,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:11 GMT
+      - Mon, 27 Apr 2026 23:29:51 GMT
       ETag:
-      - CL3f3ofY/ZMDEAE=
+      - CJPY0O2Xj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:29:11 GMT
+      - Mon, 27 Apr 2026 23:29:51 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG10jfD0C5shKlut_GeDk9alh9JzVJO6mN5BTN0V_O1utglPVpjboqkB_UKGT88rzi43j77LIRQ
+      - AAVLpEiaFLKBtwRuUE3_56ckcxN0P-KV8VSii4Qk11X7uQlVC_DnUhWzA0WFWsDMzJtIpg57g3fUKQ
     status:
       code: 200
       message: OK
@@ -193,14 +197,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/efc343d4-9e86-441b-b961-b5260a5b23a3
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/cde41f23-606d-4e38-a935-8395747f7a1e
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
-    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1776731349823421","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1776731349823421&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731349823421","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CL3f3ofY/ZMDEAE=","timeCreated":"2026-04-21T00:29:09.835Z","updated":"2026-04-21T00:29:09.835Z","timeStorageClassUpdated":"2026-04-21T00:29:09.835Z","timeFinalized":"2026-04-21T00:29:09.835Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv/1777332484269346","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332484269346&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332484269346","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CKLK/bqXj5QDEAE=","timeCreated":"2026-04-27T23:28:04.278Z","updated":"2026-04-27T23:28:04.278Z","timeStorageClassUpdated":"2026-04-27T23:28:04.278Z","timeFinalized":"2026-04-27T23:28:04.278Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
         \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
@@ -215,18 +219,69 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:29:11 GMT
+      - Mon, 27 Apr 2026 23:29:52 GMT
       ETag:
-      - CL3f3ofY/ZMDEAE=
+      - CKLK/bqXj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:29:11 GMT
+      - Mon, 27 Apr 2026 23:29:52 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3izm2i7DdWObfdUu8JgZbsoqmgFP-VkJwqSLCn9RMgVPK_D5HmpBcDKIK8THhIVe4A67bIYpo
+      - AAVLpEhWqRZFaqj5iu4lesfT1UifmZoqaMql6dh7Bn1ls8t4pHb6pNq9seaMaTwwniqeScLydSnJElcf6E74
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/41a5363d-4531-4789-947f-cab31da139c9
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
+  response:
+    body:
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1777332590488595","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332590488595&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332590488595","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJPY0O2Xj5QDEAE=","timeCreated":"2026-04-27T23:29:50.498Z","updated":"2026-04-27T23:29:50.498Z","timeStorageClassUpdated":"2026-04-27T23:29:50.498Z","timeFinalized":"2026-04-27T23:29:50.498Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
+        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": null}}"}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '1674'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:29:52 GMT
+      ETag:
+      - CJPY0O2Xj5QDEAE=
+      Expires:
+      - Mon, 27 Apr 2026 23:29:52 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEjOdhiww_GafG1M7SIscOiZAIIOLscEsdEcGK30sXRtDonVvsuiLvE9IsdUy8nPJcxa-s0Ekqz0LQ7A
     status:
       code: 200
       message: OK

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_invalid_entity.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_invalid_entity.yaml
@@ -1,0 +1,239 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/acaba86b-40a3-443e-983b-47ef8584e024
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202504291120_something.psv&prefix=something%2Finstance%3Datn%2Ffilename%3D202504291120_something.psv&prettyPrint=false
+  response:
+    body:
+      string: '{"kind":"storage#objects"}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '26'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:00 GMT
+      Expires:
+      - Mon, 27 Apr 2026 23:30:00 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEjCUNugql4vMf5zAv6CmqjtE4k_xfJcIEOyASxc26588KlHGf4dFhmAP3W3uo9Fz6ouJZd7fQ
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "--===============1907315588180774151==\r\ncontent-type: application/json;
+      charset=UTF-8\r\n\r\n{\"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_something.jsonl\",
+      \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"results_202504291120_something.psv.jsonl\\\",
+      \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"},
+      \"crc32c\": \"sn/3eA==\"}\r\n--===============1907315588180774151==\r\ncontent-type:
+      application/jsonl\r\n\r\n{\"success\":false,\"exception\":\"File 'something'
+      is not on the list.\",\"prior\":{},\"extract\":{\"filename\":\"202504291120_something.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/something/202504291120_something.psv\",\"LastModified\":null,\"ETag\":null,\"Size\":null,\"StorageClass\":null}}}\r\n--===============1907315588180774151==--"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '860'
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/e80feff9-ee09-47e6-a111-078cbc21220b
+      content-type:
+      - !!binary |
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0xOTA3MzE1NTg4MTgw
+        Nzc0MTUxPT0i
+      x-goog-user-project:
+      - cal-itp-data-infra
+      x-upload-content-type:
+      - application/jsonl
+    method: POST
+    uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_something.jsonl/1777332601230469\",\n
+        \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_something.jsonl\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_something.jsonl?generation=1777332601230469&alt=media\",\n
+        \ \"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_something.jsonl\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332601230469\",\n
+        \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"345\",\n  \"md5Hash\": \"NbEfR5sG4WphQObDi8IogQ==\",\n
+        \ \"crc32c\": \"sn/3eA==\",\n  \"etag\": \"CIWp4PKXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:30:01.240Z\",\n  \"updated\": \"2026-04-27T23:30:01.240Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:30:01.240Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:30:01.240Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \"{\\\"filename\\\": \\\"results_202504291120_something.psv.jsonl\\\", \\\"instance\\\":
+        \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"\n  }\n}\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '1379'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:01 GMT
+      ETag:
+      - CIWp4PKXj5QDEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEhPgucQ0rnYV7UBDjN42GxAty8QfmcI16c6YgDNYnE8__updWs1LQ8SgMkkA1vrxqFHqa29hw
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/8f9a315f-d567-44f2-b7ea-7462335252c4
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/something%2Finstance%3Datn%2Ffilename%3D202504291120_something.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_something.psv?fields=name&prettyPrint=false
+  response:
+    body:
+      string: '{"error":{"code":404,"message":"No such object: calitp-staging-pytest/something/instance=atn/filename=202504291120_something.psv/ts=2025-06-01T00:00:00+00:00/202504291120_something.psv","errors":[{"message":"No
+        such object: calitp-staging-pytest/something/instance=atn/filename=202504291120_something.psv/ts=2025-06-01T00:00:00+00:00/202504291120_something.psv","domain":"global","reason":"notFound"}]}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '403'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:02 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEhHLSpcuUjmuOI4uYkrfhuJc1t5Gq9p1avxT0fSh2M7OlTGuh0STxia6wkBcfm8rfe0AHn5_IowKk_O
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/28da5333-b6da-4fec-aed6-d215fe07e0ec
+      accept-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=UTF-8
+      x-goog-user-project:
+      - cal-itp-data-infra
+      x-upload-content-type:
+      - application/json; charset=UTF-8
+    method: GET
+    uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_something.jsonl?alt=media
+  response:
+    body:
+      string: '{"success":false,"exception":"File ''something'' is not on the list.","prior":{},"extract":{"filename":"202504291120_something.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/something/202504291120_something.psv","LastModified":null,"ETag":null,"Size":null,"StorageClass":null}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '345'
+      Content-Type:
+      - application/jsonl
+      Date:
+      - Mon, 27 Apr 2026 23:30:02 GMT
+      ETag:
+      - CIWp4PKXj5QDEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Last-Modified:
+      - Mon, 27 Apr 2026 23:30:01 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEhWoGRTA0Xc4YYPmo0ShQxfw4270YtKEntuA0yS-7K9vqZsZNnjE7JstKHwKc7ZMGdBqHpEX1Mqcyg1
+      X-Goog-Generation:
+      - '1777332601230469'
+      X-Goog-Hash:
+      - crc32c=sn/3eA==,md5=NbEfR5sG4WphQObDi8IogQ==
+      X-Goog-Metageneration:
+      - '1'
+      X-Goog-Storage-Class:
+      - STANDARD
+      X-Goog-Stored-Content-Encoding:
+      - identity
+      X-Goog-Stored-Content-Length:
+      - '345'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_invalid_file_type.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_invalid_file_type.yaml
@@ -1,0 +1,241 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/75d1b5a2-0585-4eb1-8962-ad8409d6a244
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202504291120_authorisations.txt&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.txt&prettyPrint=false
+  response:
+    body:
+      string: '{"kind":"storage#objects"}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '26'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:03 GMT
+      Expires:
+      - Mon, 27 Apr 2026 23:30:03 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEheyfUxNb8XuMPZT8ecPwUHlm-HMqihXMVWypCTCgE3DMZHhrRRsTKWugF5XJZNfXQwG4Wb64JLJuZl
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "--===============2511719572486947131==\r\ncontent-type: application/json;
+      charset=UTF-8\r\n\r\n{\"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.jsonl\",
+      \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"results_202504291120_authorisations.txt.jsonl\\\",
+      \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"},
+      \"crc32c\": \"wA9TPw==\"}\r\n--===============2511719572486947131==\r\ncontent-type:
+      application/jsonl\r\n\r\n{\"success\":false,\"exception\":\"File '202504291120_authorisations.txt'
+      is not a psv type.\",\"prior\":{},\"extract\":{\"filename\":\"202504291120_authorisations.txt\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202504291120_authorisations.txt\",\"LastModified\":null,\"ETag\":null,\"Size\":null,\"StorageClass\":null}}}\r\n--===============2511719572486947131==--"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '906'
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/c7c61e5f-2893-4a88-9feb-9bfd1f21cafc
+      content-type:
+      - !!binary |
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0yNTExNzE5NTcyNDg2
+        OTQ3MTMxPT0i
+      x-goog-user-project:
+      - cal-itp-data-infra
+      x-upload-content-type:
+      - application/jsonl
+    method: POST
+    uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.jsonl/1777332605141275\",\n
+        \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.jsonl\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.jsonl?generation=1777332605141275&alt=media\",\n
+        \ \"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.jsonl\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332605141275\",\n
+        \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"381\",\n  \"md5Hash\": \"oRYy8/5zb297Uv5809Ckow==\",\n
+        \ \"crc32c\": \"wA9TPw==\",\n  \"etag\": \"CJuCz/SXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:30:05.149Z\",\n  \"updated\": \"2026-04-27T23:30:05.149Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:30:05.149Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:30:05.149Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \"{\\\"filename\\\": \\\"results_202504291120_authorisations.txt.jsonl\\\",
+        \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"\n
+        \ }\n}\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '1404'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:05 GMT
+      ETag:
+      - CJuCz/SXj5QDEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEipg3ohddJO5pQz74Yydu0T3aaTFHQntJissSBbjr1OgAfcTHOJjSADovi8RM_jzj62fDkLsdisdy7o
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/7ec2f1f5-75e2-4256-9596-c92f1e27709a
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.txt%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.txt?fields=name&prettyPrint=false
+  response:
+    body:
+      string: '{"error":{"code":404,"message":"No such object: calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.txt/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.txt","errors":[{"message":"No
+        such object: calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.txt/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.txt","domain":"global","reason":"notFound"}]}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '433'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:06 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEjBDrvr9RTrYqxRSLy4kdrcA-DmwtCX37D7JYrNThHU9OhpGgXTUn0ih4W59qEhmQQaIO2eTM9QvWmu
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/35ab0c5a-abbe-4eea-9a8d-09b42aeb689a
+      accept-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=UTF-8
+      x-goog-user-project:
+      - cal-itp-data-infra
+      x-upload-content-type:
+      - application/json; charset=UTF-8
+    method: GET
+    uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.jsonl?alt=media
+  response:
+    body:
+      string: '{"success":false,"exception":"File ''202504291120_authorisations.txt''
+        is not a psv type.","prior":{},"extract":{"filename":"202504291120_authorisations.txt","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202504291120_authorisations.txt","LastModified":null,"ETag":null,"Size":null,"StorageClass":null}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '381'
+      Content-Type:
+      - application/jsonl
+      Date:
+      - Mon, 27 Apr 2026 23:30:06 GMT
+      ETag:
+      - CJuCz/SXj5QDEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Last-Modified:
+      - Mon, 27 Apr 2026 23:30:05 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEjO0VjBeG9bIYtt4KW70oVu43_nPhCvrHXwQfG7RP7IaEAenPTiYDupCGKNdOxj59FfBUG0ug
+      X-Goog-Generation:
+      - '1777332605141275'
+      X-Goog-Hash:
+      - crc32c=wA9TPw==,md5=oRYy8/5zb297Uv5809Ckow==
+      X-Goog-Metageneration:
+      - '1'
+      X-Goog-Storage-Class:
+      - STANDARD
+      X-Goog-Stored-Content-Encoding:
+      - identity
+      X-Goog-Stored-Content-Length:
+      - '381'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_not_found.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_not_found.yaml
@@ -1,0 +1,434 @@
+interactions:
+- request:
+    body: "--===============8234282983823893756==\r\ncontent-type: application/json;
+      charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv\",
+      \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202504291120_authorisations.psv\\\",
+      \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\",
+      \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
+      \\\"atn/v3/authorisations/202504291120_authorisations.psv\\\", \\\"LastModified\\\":
+      \\\"2026-03-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============8234282983823893756==\r\ncontent-type:
+      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============8234282983823893756==--"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1235'
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/bd835ecd-3257-4339-ae1f-2118fac64848
+      content-type:
+      - !!binary |
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT04MjM0MjgyOTgzODIz
+        ODkzNzU2PT0i
+      x-goog-user-project:
+      - cal-itp-data-infra
+      x-upload-content-type:
+      - binary/octet-stream
+    method: POST
+    uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv/1777332607813656\",\n
+        \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332607813656&alt=media\",\n
+        \ \"name\": \"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332607813656\",\n
+        \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CJiQ8vWXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:30:07.823Z\",\n  \"updated\": \"2026-04-27T23:30:07.823Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:30:07.823Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:30:07.823Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \"{\\\"filename\\\": \\\"202504291120_authorisations.psv\\\", \\\"instance\\\":
+        \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
+        \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202504291120_authorisations.psv\\\",
+        \\\"LastModified\\\": \\\"2026-03-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+        \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"\n  }\n}\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '1761'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:07 GMT
+      ETag:
+      - CJiQ8vWXj5QDEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEhtBCt0k-hMW2Qf8LIXIUFO2xWuIXnC50w4ou8fX2nePAuzVW0-CuMm-dexRsIHasFQqfAaug
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/cfe36842-cbdb-41b8-aabf-3bac17674036
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202504291120_authorisations.psv&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv&prettyPrint=false
+  response:
+    body:
+      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1777332590488595","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332590488595&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332590488595","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJPY0O2Xj5QDEAE=","timeCreated":"2026-04-27T23:29:50.498Z","updated":"2026-04-27T23:29:50.498Z","timeStorageClassUpdated":"2026-04-27T23:29:50.498Z","timeFinalized":"2026-04-27T23:29:50.498Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
+        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": null}}"}},{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv/1777332607813656","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332607813656&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332607813656","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJiQ8vWXj5QDEAE=","timeCreated":"2026-04-27T23:30:07.823Z","updated":"2026-04-27T23:30:07.823Z","timeStorageClassUpdated":"2026-04-27T23:30:07.823Z","timeFinalized":"2026-04-27T23:30:07.823Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
+        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": null}}"}}]}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '3386'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      Expires:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEgM5A5JhI3FE_4gmK2yxYJ69BnRBDEQ4NYJjdfdxwifM7pqPkw2TRzsPtaoCXn5b3ilB7dtVw
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/0fb31c17-dfa5-4f65-a536-e542ffe19611
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
+  response:
+    body:
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv/1777332590488595","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332590488595&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332590488595","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJPY0O2Xj5QDEAE=","timeCreated":"2026-04-27T23:29:50.498Z","updated":"2026-04-27T23:29:50.498Z","timeStorageClassUpdated":"2026-04-27T23:29:50.498Z","timeFinalized":"2026-04-27T23:29:50.498Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
+        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": null}}"}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '1674'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      ETag:
+      - CJPY0O2Xj5QDEAE=
+      Expires:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEg-qA_aLmpMJjfjfYRfXX_mKcqbTnG_7NoN486Z0_LjaMiVxqx1nsIZeQyIxav7zAQ51YY6TcBs-Rd6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/07c68306-9b0a-4000-8284-998c28afec76
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
+  response:
+    body:
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv/1777332607813656","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332607813656&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332607813656","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJiQ8vWXj5QDEAE=","timeCreated":"2026-04-27T23:30:07.823Z","updated":"2026-04-27T23:30:07.823Z","timeStorageClassUpdated":"2026-04-27T23:30:07.823Z","timeFinalized":"2026-04-27T23:30:07.823Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
+        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": null}}"}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '1674'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      ETag:
+      - CJiQ8vWXj5QDEAE=
+      Expires:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEjzUhqsIExyZn4aYBCnJ8UIrGPgczJ1pphklH78ey4aBinJ4Betr5GY7vxZNLVs_XzgXomd-A
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/c8b3fd31-6b8c-44da-93e2-73e8dd0c5bbd
+      x-goog-user-project:
+      - cal-itp-data-infra
+    method: GET
+    uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504291120_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.psv?prettyPrint=false&projection=noAcl
+  response:
+    body:
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv/1777332607813656","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504291120_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.psv?generation=1777332607813656&alt=media","name":"authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332607813656","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CJiQ8vWXj5QDEAE=","timeCreated":"2026-04-27T23:30:07.823Z","updated":"2026-04-27T23:30:07.823Z","timeStorageClassUpdated":"2026-04-27T23:30:07.823Z","timeFinalized":"2026-04-27T23:30:07.823Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"202504291120_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
+        \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504291120_authorisations.psv\",
+        \"LastModified\": \"2026-03-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"Size\": 429, \"StorageClass\": null}}"}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '1674'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      ETag:
+      - CJiQ8vWXj5QDEAE=
+      Expires:
+      - Mon, 27 Apr 2026 23:30:09 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEgT2v97gElAoqlPnD_fWrsdUyTkDOa9-xUXZAqqaH3HUP0NF5VJED6KIraqTgIinqyK77U-dR92twUT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "--===============4499621233754999367==\r\ncontent-type: application/json;
+      charset=UTF-8\r\n\r\n{\"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.jsonl\",
+      \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"results_202504291120_authorisations.psv.jsonl\\\",
+      \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"},
+      \"crc32c\": \"pR4PZQ==\"}\r\n--===============4499621233754999367==\r\ncontent-type:
+      application/jsonl\r\n\r\n{\"success\":false,\"exception\":\"An error occurred
+      (404) when calling the HeadObject operation: Not Found\",\"prior\":{\"Key\":\"atn/v3/authorisations/202504291120_authorisations.psv\",\"LastModified\":\"2026-03-01T00:00:00+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":null},\"extract\":{\"filename\":\"202504291120_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202504291120_authorisations.psv\",\"LastModified\":null,\"ETag\":null,\"Size\":null,\"StorageClass\":null}}}\r\n--===============4499621233754999367==--"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1102'
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/648b8a6a-2e74-4884-b8cf-a6671e856af4
+      content-type:
+      - !!binary |
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT00NDk5NjIxMjMzNzU0
+        OTk5MzY3PT0i
+      x-goog-user-project:
+      - cal-itp-data-infra
+      x-upload-content-type:
+      - application/jsonl
+    method: POST
+    uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.jsonl/1777332610869569\",\n
+        \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.jsonl\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504291120_authorisations.jsonl?generation=1777332610869569&alt=media\",\n
+        \ \"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.jsonl\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332610869569\",\n
+        \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"577\",\n  \"md5Hash\": \"kei1xxIQKE9tpp9DRHi7Gg==\",\n
+        \ \"crc32c\": \"pR4PZQ==\",\n  \"etag\": \"CMHSrPeXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:30:10.878Z\",\n  \"updated\": \"2026-04-27T23:30:10.878Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:30:10.878Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:30:10.878Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \"{\\\"filename\\\": \\\"results_202504291120_authorisations.psv.jsonl\\\",
+        \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"\n
+        \ }\n}\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '1404'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 27 Apr 2026 23:30:10 GMT
+      ETag:
+      - CMHSrPeXj5QDEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEh-pgbb1Lf5eHBG-oNwhnL4a5DF4JzJRHm0bVTeqNJ-J2ZUD8X6z86_Pw_RtWlBndECTd6nxieByovX
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - FILTERED
+      Connection:
+      - keep-alive
+      User-Agent:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
+      X-Goog-API-Client:
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/4ea7a69c-5ec7-45c3-ae29-379ecfd4f007
+      accept-encoding:
+      - gzip
+      content-type:
+      - application/json; charset=UTF-8
+      x-goog-user-project:
+      - cal-itp-data-infra
+      x-upload-content-type:
+      - application/json; charset=UTF-8
+    method: GET
+    uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504291120_authorisations.jsonl?alt=media
+  response:
+    body:
+      string: '{"success":false,"exception":"An error occurred (404) when calling
+        the HeadObject operation: Not Found","prior":{"Key":"atn/v3/authorisations/202504291120_authorisations.psv","LastModified":"2026-03-01T00:00:00+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":null},"extract":{"filename":"202504291120_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202504291120_authorisations.psv","LastModified":null,"ETag":null,"Size":null,"StorageClass":null}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '577'
+      Content-Type:
+      - application/jsonl
+      Date:
+      - Mon, 27 Apr 2026 23:30:11 GMT
+      ETag:
+      - CMHSrPeXj5QDEAE=
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Last-Modified:
+      - Mon, 27 Apr 2026 23:30:10 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+      X-GUploader-UploadID:
+      - AAVLpEh5sLXICTFHpS1skQhvYrd7zvcOrvLZPKGcGwmKOQBU1wcEr6iyaytFMpwdASH9Vb5sXRvqzQ
+      X-Goog-Generation:
+      - '1777332610869569'
+      X-Goog-Hash:
+      - crc32c=pR4PZQ==,md5=kei1xxIQKE9tpp9DRHi7Gg==
+      X-Goog-Metageneration:
+      - '1'
+      X-Goog-Storage-Class:
+      - STANDARD
+      X-Goog-Stored-Content-Encoding:
+      - identity
+      X-Goog-Stored-Content-Length:
+      - '577'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_old_file.yaml
+++ b/airflow/tests/operators/cassettes/test_littlepay_s3_to_gcs_operator/TestLittlepayS3ToGCSOperator.test_execute_old_file.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: "--===============1744729538959686207==\r\ncontent-type: application/json;
+    body: "--===============5731798804678641315==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\",
@@ -8,7 +8,7 @@ interactions:
       \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\", \\\"LastModified\\\":
       \\\"2025-05-01T00:00:00+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
       \\\"Size\\\": 429, \\\"StorageClass\\\": \\\"STANDARD\\\"}}\"}, \"crc32c\":
-      \"hQqhOQ==\"}\r\n--===============1744729538959686207==\r\ncontent-type: binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============1744729538959686207==--"
+      \"hQqhOQ==\"}\r\n--===============5731798804678641315==\r\ncontent-type: binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============5731798804678641315==--"
     headers:
       Accept:
       - application/json
@@ -23,11 +23,11 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/ad2ba3a4-6f05-40c1-b3af-241c9b7a22a0
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/37dc6096-960b-47f5-b3e3-98a223e5c952
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT0xNzQ0NzI5NTM4OTU5
-        Njg2MjA3PT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT01NzMxNzk4ODA0Njc4
+        NjQxMzE1PT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -36,17 +36,17 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1777332593631290\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332593631290&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731680545492\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332593631290\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CNS1uKXZ/ZMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-21T00:34:40.556Z\",\n  \"updated\": \"2026-04-21T00:34:40.556Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-21T00:34:40.556Z\",\n  \"timeFinalized\":
-        \"2026-04-21T00:34:40.556Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CLrAkO+Xj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:29:53.641Z\",\n  \"updated\": \"2026-04-27T23:29:53.641Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:29:53.641Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:29:53.641Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-05-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\",
@@ -62,9 +62,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:40 GMT
+      - Mon, 27 Apr 2026 23:29:53 GMT
       ETag:
-      - CNS1uKXZ/ZMDEAE=
+      - CLrAkO+Xj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -75,7 +75,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3D7jpnP9OTBG5xQrohIuPO5z4PdfpUmm9C2g7T9eFBHbk6S6irHfglq7YtpSH0Oel-6JJOQFM
+      - AAVLpEg-7qZ6bXnD10TDgHVH9u-IDqIzD-ZDJecJIr6h6DM3TMhsi3T6vXMViuRrhOdkrs1n8mnmgg
     status:
       code: 200
       message: OK
@@ -93,21 +93,21 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/6686fc87-03e2-42ab-b084-4071afdf21b7
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/bdf155bd-fe33-4a10-81f1-9458237dbfb8
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o?matchGlob=%2A%2A%2F202504300000_authorisations.psv&prefix=authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv&prettyPrint=false
   response:
     body:
-      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731680545492","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNS1uKXZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:40.556Z","updated":"2026-04-21T00:34:40.556Z","timeStorageClassUpdated":"2026-04-21T00:34:40.556Z","timeFinalized":"2026-04-21T00:34:40.556Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#objects","items":[{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1777332593631290","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332593631290&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332593631290","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLrAkO+Xj5QDEAE=","timeCreated":"2026-04-27T23:29:53.641Z","updated":"2026-04-27T23:29:53.641Z","timeStorageClassUpdated":"2026-04-27T23:29:53.641Z","timeFinalized":"2026-04-27T23:29:53.641Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
         \"LastModified\": \"2025-05-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
-        \"Size\": 429, \"StorageClass\": \"STANDARD\"}}"}},{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731561315918","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731561315918&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731561315918","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CM6cy+zY/ZMDEAE=","timeCreated":"2026-04-21T00:32:41.325Z","updated":"2026-04-21T00:32:41.325Z","timeStorageClassUpdated":"2026-04-21T00:32:41.325Z","timeFinalized":"2026-04-21T00:32:41.325Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+        \"Size\": 429, \"StorageClass\": \"STANDARD\"}}"}},{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1777332473137069","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332473137069&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332473137069","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CK2P1rWXj5QDEAE=","timeCreated":"2026-04-27T23:27:53.145Z","updated":"2026-04-27T23:27:53.145Z","timeStorageClassUpdated":"2026-04-27T23:27:53.145Z","timeFinalized":"2026-04-27T23:27:53.145Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2026-04-21T00:32:37+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"LastModified\": \"2026-04-27T23:27:48+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}]}'
     headers:
       Alt-Svc:
@@ -119,16 +119,16 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:41 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       Expires:
-      - Tue, 21 Apr 2026 00:34:41 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3GPha0ASS4H542x8-ifx93eExgUDReqvLZw7lDzMWsufktDlV1wMKNJiQUd9ssMlZVD8TDaxqjx-mW
+      - AAVLpEgS_FU4dJsudK8EAsqsbF8hcWgcFxOBNiuh9heF1MbfMEsL-C8Kr1BXAMRxeEwr5YwnZ55WR3dHQcEz
     status:
       code: 200
       message: OK
@@ -146,14 +146,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/3c4b653b-d8ab-4323-a879-510b138fcbc2
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/fd55010a-e6d2-4c8f-91ac-33ba6661c4b5
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731680545492","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNS1uKXZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:40.556Z","updated":"2026-04-21T00:34:40.556Z","timeStorageClassUpdated":"2026-04-21T00:34:40.556Z","timeFinalized":"2026-04-21T00:34:40.556Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1777332593631290","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332593631290&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332593631290","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLrAkO+Xj5QDEAE=","timeCreated":"2026-04-27T23:29:53.641Z","updated":"2026-04-27T23:29:53.641Z","timeStorageClassUpdated":"2026-04-27T23:29:53.641Z","timeFinalized":"2026-04-27T23:29:53.641Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
         \"LastModified\": \"2025-05-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
@@ -168,18 +168,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:41 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       ETag:
-      - CNS1uKXZ/ZMDEAE=
+      - CLrAkO+Xj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:34:41 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG0PlPJr8Z_PXsMkejNsH707aqlVCRDlHsjRNHHMuqGRLKtZwVlYWO544giz7D4UQJ1a9kFc4kNjzRsh
+      - AAVLpEg0Z9vprk_eQqm7_1QHg9NcZSaRGSLioZGCdjDqhX4hQjwilgG8Eclg1JEusvY5sBJ5idZj3osBPJBM
     status:
       code: 200
       message: OK
@@ -197,17 +197,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/3b634cc6-cd4b-4703-adbb-a28769ccabcf
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/0518ce2a-e065-45f7-9e3f-9c30159337ad
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731561315918","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731561315918&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731561315918","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CM6cy+zY/ZMDEAE=","timeCreated":"2026-04-21T00:32:41.325Z","updated":"2026-04-21T00:32:41.325Z","timeStorageClassUpdated":"2026-04-21T00:32:41.325Z","timeFinalized":"2026-04-21T00:32:41.325Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1777332473137069","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332473137069&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332473137069","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CK2P1rWXj5QDEAE=","timeCreated":"2026-04-27T23:27:53.145Z","updated":"2026-04-27T23:27:53.145Z","timeStorageClassUpdated":"2026-04-27T23:27:53.145Z","timeFinalized":"2026-04-27T23:27:53.145Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2026-04-21T00:32:37+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"LastModified\": \"2026-04-27T23:27:48+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -219,18 +219,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:41 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       ETag:
-      - CM6cy+zY/ZMDEAE=
+      - CK2P1rWXj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:34:41 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3FXq1OoV7cTyU4nUBjv2vvlPXmSdVrlvJ0jqhXVYcEQgIeh4nwrK5ShjEcYFs_3Wsjm59UjuGguOoL
+      - AAVLpEggdIuGLJCHG89u_dR13rMz_JJhQVbn7XXR56ThO2pomPL4q5le75145xZIXRVxFBA87SYJTA
     status:
       code: 200
       message: OK
@@ -248,14 +248,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/5b7b8d5d-e661-498a-a3bb-9e67d1cccdbc
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/7ced0351-0a03-4a34-8473-b11743340694
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-05-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1776731680545492","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731680545492&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731680545492","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CNS1uKXZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:40.556Z","updated":"2026-04-21T00:34:40.556Z","timeStorageClassUpdated":"2026-04-21T00:34:40.556Z","timeFinalized":"2026-04-21T00:34:40.556Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv/1777332593631290","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-05-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332593631290&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332593631290","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLrAkO+Xj5QDEAE=","timeCreated":"2026-04-27T23:29:53.641Z","updated":"2026-04-27T23:29:53.641Z","timeStorageClassUpdated":"2026-04-27T23:29:53.641Z","timeFinalized":"2026-04-27T23:29:53.641Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-05-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
         \"LastModified\": \"2025-05-01T00:00:00+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
@@ -270,31 +270,31 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:42 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       ETag:
-      - CNS1uKXZ/ZMDEAE=
+      - CLrAkO+Xj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:34:42 GMT
+      - Mon, 27 Apr 2026 23:29:55 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1NoQPw0xQJrJrNb2UTdlCTSdWhj81nU4btKvjfi597NaRQX6NojWU-DLhU-mHXkBmVo2sUA5YLpKum
+      - AAVLpEidyBqWUpBKIbmEkz0anSIDQJ2nNtbXL1fAHNDubCeAtQ08plXspl_Q8BajmyxhnPhTOgQkXw
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============5233988074989703276==\r\ncontent-type: application/json;
+    body: "--===============9164134815841410773==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\",
       \\\"s3bucket\\\": \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\":
       \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\", \\\"LastModified\\\":
-      \\\"2026-04-21T00:34:39+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
-      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============5233988074989703276==\r\ncontent-type:
-      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============5233988074989703276==--"
+      \\\"2026-04-27T23:29:52+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+      \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"}, \"crc32c\": \"hQqhOQ==\"}\r\n--===============9164134815841410773==\r\ncontent-type:
+      binary/octet-stream\r\n\r\nparticipant_id|aggregation_id|acquirer_code|request_type|amount|currency_code|retrieval_reference_number|littlepay_reference_number|external_reference_number|response_code|status|authorisation_timestamp_utc|record_updated_timestamp_utc|request_created_timestamp_utc|channel\natn|abc123|CS|CARD_CHECK|0.00|840|1234567890123456789012|||100|VERIFIED|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|2025-10-24T00:00:00.000Z|TRANSIT\n\r\n--===============9164134815841410773==--"
     headers:
       Accept:
       - application/json
@@ -309,11 +309,11 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/2081e7ce-54e3-470a-9b27-79af624c679c
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/512893ed-e0ef-4783-a2b3-0b8577b2059a
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT01MjMzOTg4MDc0OTg5
-        NzAzMjc2PT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT05MTY0MTM0ODE1ODQx
+        NDEwNzczPT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -322,21 +322,21 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731683180353\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1777332596810427\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731683180353&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332596810427&alt=media\",\n
         \ \"name\": \"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731683180353\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332596810427\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"binary/octet-stream\",\n
         \ \"storageClass\": \"STANDARD\",\n  \"size\": \"429\",\n  \"md5Hash\": \"XUboS5yfo8yH5JFsRSxN6A==\",\n
-        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CMGe2abZ/ZMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-21T00:34:43.189Z\",\n  \"updated\": \"2026-04-21T00:34:43.189Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-21T00:34:43.189Z\",\n  \"timeFinalized\":
-        \"2026-04-21T00:34:43.189Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"crc32c\": \"hQqhOQ==\",\n  \"etag\": \"CLvF0vCXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:29:56.819Z\",\n  \"updated\": \"2026-04-27T23:29:56.819Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:29:56.819Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:29:56.819Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"202504300000_authorisations.psv\\\", \\\"instance\\\":
         \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\", \\\"s3bucket\\\":
         \\\"mock-littlepay-bucket\\\", \\\"s3object\\\": {\\\"Key\\\": \\\"atn/v3/authorisations/202504300000_authorisations.psv\\\",
-        \\\"LastModified\\\": \\\"2026-04-21T00:34:39+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
+        \\\"LastModified\\\": \\\"2026-04-27T23:29:52+00:00\\\", \\\"ETag\\\": \\\"\\\\\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\\\\\"\\\",
         \\\"Size\\\": 429, \\\"StorageClass\\\": null}}\"\n  }\n}\n"
     headers:
       Alt-Svc:
@@ -348,9 +348,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:43 GMT
+      - Mon, 27 Apr 2026 23:29:56 GMT
       ETag:
-      - CMGe2abZ/ZMDEAE=
+      - CLvF0vCXj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -361,17 +361,17 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG1tpxfQAf6QieWlnLzuIB9x4jchsQKepSxI6sAhb_Jio9LNDzAA8MmJOFfXZ81c6artiIG2gQ
+      - AAVLpEjf0U-cDapHlRB2hVEtVyGczbOhMurT9ne6YtOaZZBvhDCjdihSM-bJL4nG3QrUkf1xYqllyw
     status:
       code: 200
       message: OK
 - request:
-    body: "--===============8265524489122910330==\r\ncontent-type: application/json;
+    body: "--===============7256298317423607233==\r\ncontent-type: application/json;
       charset=UTF-8\r\n\r\n{\"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl\",
       \"metadata\": {\"PARTITIONED_ARTIFACT_METADATA\": \"{\\\"filename\\\": \\\"results_202504300000_authorisations.psv.jsonl\\\",
       \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"},
-      \"crc32c\": \"ZzMWRw==\"}\r\n--===============8265524489122910330==\r\ncontent-type:
-      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2025-05-01T00:00:00+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":\"STANDARD\"},\"extract\":{\"filename\":\"202504300000_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2026-04-21T00:34:39+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============8265524489122910330==--"
+      \"crc32c\": \"7CWcow==\"}\r\n--===============7256298317423607233==\r\ncontent-type:
+      application/jsonl\r\n\r\n{\"success\":true,\"exception\":null,\"prior\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2025-05-01T00:00:00+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":\"STANDARD\"},\"extract\":{\"filename\":\"202504300000_authorisations.psv\",\"instance\":\"atn\",\"ts\":\"2025-06-01T00:00:00+00:00\",\"s3bucket\":\"mock-littlepay-bucket\",\"s3object\":{\"Key\":\"atn/v3/authorisations/202504300000_authorisations.psv\",\"LastModified\":\"2026-04-27T23:29:52+00:00\",\"ETag\":\"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",\"Size\":429,\"StorageClass\":null}}}\r\n--===============7256298317423607233==--"
     headers:
       Accept:
       - application/json
@@ -386,11 +386,11 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/1af6f77d-974f-45ab-88a4-8c766ac8f2cc
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/215c02d8-8873-4286-a512-aa24cbd6cd2e
       content-type:
       - !!binary |
-        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT04MjY1NTI0NDg5MTIy
-        OTEwMzMwPT0i
+        bXVsdGlwYXJ0L3JlbGF0ZWQ7IGJvdW5kYXJ5PSI9PT09PT09PT09PT09PT03MjU2Mjk4MzE3NDIz
+        NjA3MjMzPT0i
       x-goog-user-project:
       - cal-itp-data-infra
       x-upload-content-type:
@@ -399,17 +399,17 @@ interactions:
     uri: https://storage.googleapis.com/upload/storage/v1/b/calitp-staging-pytest/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1776731684057929\",\n
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1777332597981753\",\n
         \ \"selfLink\": \"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl\",\n
-        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1776731684057929&alt=media\",\n
+        \ \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1777332597981753&alt=media\",\n
         \ \"name\": \"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl\",\n
-        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1776731684057929\",\n
+        \ \"bucket\": \"calitp-staging-pytest\",\n  \"generation\": \"1777332597981753\",\n
         \ \"metageneration\": \"1\",\n  \"contentType\": \"application/jsonl\",\n
-        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"568\",\n  \"md5Hash\": \"jr+xZimF399OukTsAs9S6g==\",\n
-        \ \"crc32c\": \"ZzMWRw==\",\n  \"etag\": \"CMnmjqfZ/ZMDEAE=\",\n  \"timeCreated\":
-        \"2026-04-21T00:34:44.066Z\",\n  \"updated\": \"2026-04-21T00:34:44.066Z\",\n
-        \ \"timeStorageClassUpdated\": \"2026-04-21T00:34:44.066Z\",\n  \"timeFinalized\":
-        \"2026-04-21T00:34:44.066Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
+        \ \"storageClass\": \"STANDARD\",\n  \"size\": \"568\",\n  \"md5Hash\": \"xEIQ+QItPpfifjj57Sa3Xg==\",\n
+        \ \"crc32c\": \"7CWcow==\",\n  \"etag\": \"CLmEmvGXj5QDEAE=\",\n  \"timeCreated\":
+        \"2026-04-27T23:29:57.990Z\",\n  \"updated\": \"2026-04-27T23:29:57.990Z\",\n
+        \ \"timeStorageClassUpdated\": \"2026-04-27T23:29:57.990Z\",\n  \"timeFinalized\":
+        \"2026-04-27T23:29:57.990Z\",\n  \"metadata\": {\n    \"PARTITIONED_ARTIFACT_METADATA\":
         \"{\\\"filename\\\": \\\"results_202504300000_authorisations.psv.jsonl\\\",
         \\\"instance\\\": \\\"atn\\\", \\\"ts\\\": \\\"2025-06-01T00:00:00+00:00\\\"}\"\n
         \ }\n}\n"
@@ -423,9 +423,9 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:44 GMT
+      - Mon, 27 Apr 2026 23:29:57 GMT
       ETag:
-      - CMnmjqfZ/ZMDEAE=
+      - CLmEmvGXj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -436,7 +436,7 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG3vytuIa1FmJD97oCTY8sCQ3-SqvdVTAlSfxMM9zZp63TXip4W8AfYNzH10YMoUIYIL
+      - AAVLpEg80nXkYT33LP_nInwPF3NQFiPLM6j7XEEGQIuDfF5GQQZBv1JSOSUWk11k_2Ps1D4IixBCZA
     status:
       code: 200
       message: OK
@@ -454,17 +454,17 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/8f435d0a-b5ad-4270-a971-054e6a1097d6
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/5a7a01c1-0ab5-4fa0-8536-db1e0a0b1874
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance%3Datn%2Ffilename%3D202504300000_authorisations.psv%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.psv?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1776731683180353","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1776731683180353&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1776731683180353","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CMGe2abZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:43.189Z","updated":"2026-04-21T00:34:43.189Z","timeStorageClassUpdated":"2026-04-21T00:34:43.189Z","timeFinalized":"2026-04-21T00:34:43.189Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv/1777332596810427","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/authorisations%2Finstance=atn%2Ffilename=202504300000_authorisations.psv%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.psv?generation=1777332596810427&alt=media","name":"authorisations/instance=atn/filename=202504300000_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.psv","bucket":"calitp-staging-pytest","generation":"1777332596810427","metageneration":"1","contentType":"binary/octet-stream","storageClass":"STANDARD","size":"429","md5Hash":"XUboS5yfo8yH5JFsRSxN6A==","crc32c":"hQqhOQ==","etag":"CLvF0vCXj5QDEAE=","timeCreated":"2026-04-27T23:29:56.819Z","updated":"2026-04-27T23:29:56.819Z","timeStorageClassUpdated":"2026-04-27T23:29:56.819Z","timeFinalized":"2026-04-27T23:29:56.819Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"202504300000_authorisations.psv\", \"instance\": \"atn\", \"ts\": \"2025-06-01T00:00:00+00:00\",
         \"s3bucket\": \"mock-littlepay-bucket\", \"s3object\": {\"Key\": \"atn/v3/authorisations/202504300000_authorisations.psv\",
-        \"LastModified\": \"2026-04-21T00:34:39+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
+        \"LastModified\": \"2026-04-27T23:29:52+00:00\", \"ETag\": \"\\\"5d46e84b9c9fa3cc87e4916c452c4de8\\\"\",
         \"Size\": 429, \"StorageClass\": null}}"}}'
     headers:
       Alt-Svc:
@@ -476,18 +476,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:44 GMT
+      - Mon, 27 Apr 2026 23:29:58 GMT
       ETag:
-      - CMGe2abZ/ZMDEAE=
+      - CLvF0vCXj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:34:44 GMT
+      - Mon, 27 Apr 2026 23:29:58 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG32CLImRCaYqKIWMbGA0gXkAVjk_M55GiIghOoVuTXz8hhj3rOSH4bXhIvNvedCkMOD
+      - AAVLpEiR6kVHTO90oKAvJncPxBZs-58EbLpyJ-1KimE7_MLxwFNBa4TxG0HtIGpAqJe2xZGEjFzK9A
     status:
       code: 200
       message: OK
@@ -503,7 +503,7 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/54cf10f6-7e8f-403c-85b0-0611016b6ac4
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/a21bc602-1f72-4c5f-b2fd-2404f0c80624
       accept-encoding:
       - gzip
       content-type:
@@ -516,7 +516,7 @@ interactions:
     uri: https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.jsonl?alt=media
   response:
     body:
-      string: '{"success":true,"exception":null,"prior":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2025-05-01T00:00:00+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":"STANDARD"},"extract":{"filename":"202504300000_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2026-04-21T00:34:39+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":null}}}'
+      string: '{"success":true,"exception":null,"prior":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2025-05-01T00:00:00+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":"STANDARD"},"extract":{"filename":"202504300000_authorisations.psv","instance":"atn","ts":"2025-06-01T00:00:00+00:00","s3bucket":"mock-littlepay-bucket","s3object":{"Key":"atn/v3/authorisations/202504300000_authorisations.psv","LastModified":"2026-04-27T23:29:52+00:00","ETag":"\"5d46e84b9c9fa3cc87e4916c452c4de8\"","Size":429,"StorageClass":null}}}'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -529,13 +529,13 @@ interactions:
       Content-Type:
       - application/jsonl
       Date:
-      - Tue, 21 Apr 2026 00:34:44 GMT
+      - Mon, 27 Apr 2026 23:29:58 GMT
       ETag:
-      - CMnmjqfZ/ZMDEAE=
+      - CLmEmvGXj5QDEAE=
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Last-Modified:
-      - Tue, 21 Apr 2026 00:34:44 GMT
+      - Mon, 27 Apr 2026 23:29:57 GMT
       Pragma:
       - no-cache
       Server:
@@ -544,11 +544,11 @@ interactions:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG0GObiaNeFrEym9dIut55JM90Zcy0dytAphYIuCqaUZLUC-LXT2lKTAMVPh7mc9GMKq
+      - AAVLpEg_Jj20bdDq48AKSJ2jR2qu1rbvPFOIZsIC9GW3p4aEszK5OKTvsXQBfYfqYwYyJAtbEvtg_FwPlz5A
       X-Goog-Generation:
-      - '1776731684057929'
+      - '1777332597981753'
       X-Goog-Hash:
-      - crc32c=ZzMWRw==,md5=jr+xZimF399OukTsAs9S6g==
+      - crc32c=7CWcow==,md5=xEIQ+QItPpfifjj57Sa3Xg==
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
@@ -574,14 +574,14 @@ interactions:
       User-Agent:
       - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0
       X-Goog-API-Client:
-      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/32b01654-00b8-45d8-a591-7a950e903894
+      - gcloud-python/3.7.0  gl-python/3.11.13 grpc/1.76.0 gax/2.28.1 gccl/3.7.0 gccl-invocation-id/c024a89a-4985-4838-bc37-5071be5006b5
       x-goog-user-project:
       - cal-itp-data-infra
     method: GET
     uri: https://storage.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance%3Datn%2Fts%3D2025-06-01T00%3A00%3A00%2B00%3A00%2F202504300000_authorisations.jsonl?prettyPrint=false&projection=noAcl
   response:
     body:
-      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1776731684057929","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1776731684057929&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1776731684057929","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"568","md5Hash":"jr+xZimF399OukTsAs9S6g==","crc32c":"ZzMWRw==","etag":"CMnmjqfZ/ZMDEAE=","timeCreated":"2026-04-21T00:34:44.066Z","updated":"2026-04-21T00:34:44.066Z","timeStorageClassUpdated":"2026-04-21T00:34:44.066Z","timeFinalized":"2026-04-21T00:34:44.066Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
+      string: '{"kind":"storage#object","id":"calitp-staging-pytest/raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl/1777332597981753","selfLink":"https://www.googleapis.com/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl","mediaLink":"https://storage.googleapis.com/download/storage/v1/b/calitp-staging-pytest/o/raw_littlepay_sync_job_result%2Finstance=atn%2Fts=2025-06-01T00:00:00%2B00:00%2F202504300000_authorisations.jsonl?generation=1777332597981753&alt=media","name":"raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504300000_authorisations.jsonl","bucket":"calitp-staging-pytest","generation":"1777332597981753","metageneration":"1","contentType":"application/jsonl","storageClass":"STANDARD","size":"568","md5Hash":"xEIQ+QItPpfifjj57Sa3Xg==","crc32c":"7CWcow==","etag":"CLmEmvGXj5QDEAE=","timeCreated":"2026-04-27T23:29:57.990Z","updated":"2026-04-27T23:29:57.990Z","timeStorageClassUpdated":"2026-04-27T23:29:57.990Z","timeFinalized":"2026-04-27T23:29:57.990Z","metadata":{"PARTITIONED_ARTIFACT_METADATA":"{\"filename\":
         \"results_202504300000_authorisations.psv.jsonl\", \"instance\": \"atn\",
         \"ts\": \"2025-06-01T00:00:00+00:00\"}"}}'
     headers:
@@ -594,18 +594,18 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2026 00:34:44 GMT
+      - Mon, 27 Apr 2026 23:29:58 GMT
       ETag:
-      - CMnmjqfZ/ZMDEAE=
+      - CLmEmvGXj5QDEAE=
       Expires:
-      - Tue, 21 Apr 2026 00:34:44 GMT
+      - Mon, 27 Apr 2026 23:29:58 GMT
       Server:
       - UploadServer
       Vary:
       - Origin
       - X-Origin
       X-GUploader-UploadID:
-      - AMNfjG19AWx76_zrnmYWEV-yiDJhIdKp5063vengklqd9pnOby02qNXfXoIEnPd9dJCe2FFBD7aNhvU
+      - AAVLpEjdxSILjpkatfdYS-Z1Nf9o7mEKjA_CR0Qd4SE7SNI_sARUBOLJ22yAAFu2Pz_nEWzxC7hlDQ
     status:
       code: 200
       message: OK

--- a/airflow/tests/operators/test_littlepay_s3_to_gcs_operator.py
+++ b/airflow/tests/operators/test_littlepay_s3_to_gcs_operator.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 from moto import mock_aws
 from operators.littlepay_s3_to_gcs_operator import LittlepayS3ToGCSOperator
 
+from airflow.exceptions import AirflowException
 from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -625,9 +626,7 @@ class TestLittlepayS3ToGCSOperator:
 
     @pytest.fixture
     def invalid_entity_destination_path(self) -> str:
-        return (
-            "something/instance=atn/filename=202504291120_something.psv/ts=2025-06-01T00:00:00+00:00/202504291120_something.psv",
-        )
+        return "something/instance=atn/filename=202504291120_something.psv/ts=2025-06-01T00:00:00+00:00/202504291120_something.psv"
 
     @pytest.fixture
     def invalid_entity_path(self) -> str:
@@ -695,22 +694,56 @@ class TestLittlepayS3ToGCSOperator:
         gcs_hook: GCSHook,
         s3_hook: S3Hook,
         invalid_entity_source_path: str,
+        invalid_entity_destination_path: str,
+        invalid_entity_report_path: str,
         invalid_entity_path: str,
-        capsys,
     ):
-        invalid_entity_operator.run(
-            start_date=execution_date,
-            end_date=execution_date + timedelta(days=1),
-            ignore_first_depends_on_past=True,
-        )
+        with pytest.raises(AirflowException) as exception:
+            invalid_entity_operator.run(
+                start_date=execution_date,
+                end_date=execution_date + timedelta(days=1),
+                ignore_first_depends_on_past=True,
+            )
+        assert "File 'something' is not on the list." in str(exception.value)
 
         task = invalid_entity_dag.get_task("invalid_entity_littlepay_s3_to_gcs")
         task_instance = TaskInstance(task, execution_date=execution_date)
         xcom_value = task_instance.xcom_pull()
         assert xcom_value is None
 
-        captured = capsys.readouterr()
-        assert "WARNING - Entity is not in the list." in captured.out
+        destination_file = gcs_hook.exists(
+            bucket_name=os.environ.get("CALITP_BUCKET__LITTLEPAY_RAW_V3").replace(
+                "gs://", ""
+            ),
+            object_name=invalid_entity_destination_path,
+        )
+        assert not destination_file
+
+        report = gcs_hook.download(
+            bucket_name=os.environ.get("CALITP_BUCKET__LITTLEPAY_RAW_V3").replace(
+                "gs://", ""
+            ),
+            object_name=invalid_entity_report_path,
+        )
+        parsed_report = [json.loads(x) for x in report.splitlines()]
+        assert parsed_report[0] == {
+            "success": False,
+            "prior": {},
+            "exception": "File 'something' is not on the list.",
+            "extract": {
+                "filename": "202504291120_something.psv",
+                "instance": "atn",
+                "s3bucket": "mock-littlepay-bucket",
+                "s3object": {
+                    "Key": "atn/v3/something/202504291120_something.psv",
+                    "LastModified": None,
+                    "ETag": None,
+                    "Size": None,
+                    "StorageClass": None,
+                },
+                "ts": "2025-06-01T00:00:00+00:00",
+            },
+        }
 
     @pytest.fixture
     def invalid_file_type_source_path(self) -> str:
@@ -718,9 +751,7 @@ class TestLittlepayS3ToGCSOperator:
 
     @pytest.fixture
     def invalid_file_type_destination_path(self) -> str:
-        return (
-            "authorisations/instance=atn/filename=202504291120_authorisations.txt/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.txt",
-        )
+        return "authorisations/instance=atn/filename=202504291120_authorisations.txt/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.txt"
 
     @pytest.fixture
     def invalid_file_type_path(self) -> str:
@@ -788,13 +819,18 @@ class TestLittlepayS3ToGCSOperator:
         gcs_hook: GCSHook,
         s3_hook: S3Hook,
         invalid_file_type_source_path: str,
+        invalid_file_type_destination_path: str,
+        invalid_file_type_report_path: str,
         invalid_file_type_path: str,
-        capsys,
     ):
-        invalid_file_type_operator.run(
-            start_date=execution_date,
-            end_date=execution_date + timedelta(days=1),
-            ignore_first_depends_on_past=True,
+        with pytest.raises(AirflowException) as exception:
+            invalid_file_type_operator.run(
+                start_date=execution_date,
+                end_date=execution_date + timedelta(days=1),
+                ignore_first_depends_on_past=True,
+            )
+        assert "File '202504291120_authorisations.txt' is not a psv type." in str(
+            exception.value
         )
 
         task = invalid_file_type_dag.get_task("invalid_file_type_littlepay_s3_to_gcs")
@@ -802,5 +838,199 @@ class TestLittlepayS3ToGCSOperator:
         xcom_value = task_instance.xcom_pull()
         assert xcom_value is None
 
-        captured = capsys.readouterr()
-        assert "WARNING - File is not a psv type." in captured.out
+        destination_file = gcs_hook.exists(
+            bucket_name=os.environ.get("CALITP_BUCKET__LITTLEPAY_RAW_V3").replace(
+                "gs://", ""
+            ),
+            object_name=invalid_file_type_destination_path,
+        )
+        assert not destination_file
+
+        report = gcs_hook.download(
+            bucket_name=os.environ.get("CALITP_BUCKET__LITTLEPAY_RAW_V3").replace(
+                "gs://", ""
+            ),
+            object_name=invalid_file_type_report_path,
+        )
+        parsed_report = [json.loads(x) for x in report.splitlines()]
+        assert parsed_report[0] == {
+            "success": False,
+            "prior": {},
+            "exception": "File '202504291120_authorisations.txt' is not a psv type.",
+            "extract": {
+                "filename": "202504291120_authorisations.txt",
+                "instance": "atn",
+                "s3bucket": "mock-littlepay-bucket",
+                "s3object": {
+                    "Key": "atn/v3/authorisations/202504291120_authorisations.txt",
+                    "LastModified": None,
+                    "ETag": None,
+                    "Size": None,
+                    "StorageClass": None,
+                },
+                "ts": "2025-06-01T00:00:00+00:00",
+            },
+        }
+
+    @pytest.fixture
+    def not_found_source_path(self) -> str:
+        return "atn/v3/authorisations/202504291120_authorisations.psv"
+
+    @pytest.fixture
+    def not_found_destination_path(self) -> str:
+        return "authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.psv"
+
+    @pytest.fixture
+    def not_found_path(self) -> str:
+        return "authorisations/instance=atn/filename=202504291120_authorisations.psv/ts=2025-05-01T00:00:00+00:00/202504291120_authorisations.psv"
+
+    @pytest.fixture
+    def not_found_destination_search_prefix(self) -> str:
+        return "authorisations/instance=atn/filename=202504291120_authorisations.psv"
+
+    @pytest.fixture
+    def not_found_destination_search_glob(self) -> str:
+        return "**/202504291120_authorisations.psv"
+
+    @pytest.fixture
+    def not_found_report_path(self) -> str:
+        return "raw_littlepay_sync_job_result/instance=atn/ts=2025-06-01T00:00:00+00:00/202504291120_authorisations.jsonl"
+
+    @pytest.fixture
+    def not_found_dag(self, execution_date: datetime) -> DAG:
+        return DAG(
+            "test_not_found_dag",
+            default_args={
+                "owner": "airflow",
+                "start_date": execution_date,
+                "end_date": execution_date + relativedelta(months=+1),
+            },
+            schedule=relativedelta(months=+1),
+        )
+
+    @pytest.fixture
+    def not_found_operator(
+        self,
+        execution_date: datetime,
+        not_found_dag: DAG,
+        not_found_source_path: str,
+        not_found_destination_path: str,
+        not_found_destination_search_prefix: str,
+        not_found_destination_search_glob: str,
+        not_found_report_path: str,
+    ) -> LittlepayS3ToGCSOperator:
+        return LittlepayS3ToGCSOperator(
+            dag=not_found_dag,
+            task_id="not_found_littlepay_s3_to_gcs",
+            ts=execution_date.isoformat(),
+            provider="atn",
+            entity="authorisations",
+            aws_conn_id="aws_default",
+            gcp_conn_id="google_cloud_default",
+            source_bucket="mock-littlepay-bucket",
+            source_path=not_found_source_path,
+            destination_bucket=os.environ.get("CALITP_BUCKET__LITTLEPAY_RAW_V3"),
+            destination_path=not_found_destination_path,
+            destination_search_prefix=not_found_destination_search_prefix,
+            destination_search_glob=not_found_destination_search_glob,
+            report_path=not_found_report_path,
+        )
+
+    @mock_aws
+    @pytest.mark.vcr
+    def test_execute_not_found(
+        self,
+        not_found_dag: DAG,
+        not_found_operator: LittlepayS3ToGCSOperator,
+        execution_date: datetime,
+        gcs_hook: GCSHook,
+        s3_hook: S3Hook,
+        not_found_source_path: str,
+        not_found_destination_path: str,
+        not_found_report_path: str,
+        not_found_path: str,
+    ):
+        s3_hook.create_bucket("mock-littlepay-bucket")
+        fixture_path = os.path.normpath(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "../fixtures/littlepay-stub.psv",
+            )
+        )
+
+        with open(fixture_path, "r") as fixture_file:
+            gcs_hook.upload(
+                bucket_name=os.environ.get("CALITP_BUCKET__LITTLEPAY_RAW_V3").replace(
+                    "gs://", ""
+                ),
+                object_name=not_found_destination_path,
+                data=fixture_file.read(),
+                mime_type="binary/octet-stream",
+                gzip=False,
+                metadata={
+                    "PARTITIONED_ARTIFACT_METADATA": json.dumps(
+                        {
+                            "filename": "202504291120_authorisations.psv",
+                            "instance": "atn",
+                            "ts": "2025-05-01T00:00:00+00:00",
+                            "s3bucket": "mock-littlepay-bucket",
+                            "s3object": {
+                                "Key": "atn/v3/authorisations/202504291120_authorisations.psv",
+                                "LastModified": "2026-03-01T00:00:00+00:00",
+                                "ETag": '"5d46e84b9c9fa3cc87e4916c452c4de8"',
+                                "Size": 429,
+                                "StorageClass": None,
+                            },
+                        }
+                    )
+                },
+            )
+
+        with pytest.raises(AirflowException) as exception:
+            not_found_operator.run(
+                start_date=execution_date,
+                end_date=execution_date + timedelta(days=1),
+                ignore_first_depends_on_past=True,
+            )
+
+        assert (
+            "An error occurred (404) when calling the HeadObject operation: Not Found"
+            in str(exception.value)
+        )
+
+        task = not_found_dag.get_task("not_found_littlepay_s3_to_gcs")
+        task_instance = TaskInstance(task, execution_date=execution_date)
+        xcom_value = task_instance.xcom_pull()
+        assert xcom_value is None
+
+        report = gcs_hook.download(
+            bucket_name=os.environ.get("CALITP_BUCKET__LITTLEPAY_RAW_V3").replace(
+                "gs://", ""
+            ),
+            object_name=not_found_report_path,
+        )
+        parsed_report = [json.loads(x) for x in report.splitlines()]
+        assert parsed_report[0] == {
+            "success": False,
+            "prior": {
+                "Key": "atn/v3/authorisations/202504291120_authorisations.psv",
+                "LastModified": "2026-03-01T00:00:00+00:00",
+                "ETag": '"5d46e84b9c9fa3cc87e4916c452c4de8"',
+                "Size": 429,
+                "StorageClass": None,
+            },
+            "exception": "An error occurred (404) when calling the HeadObject operation: Not Found",
+            "extract": {
+                "filename": "202504291120_authorisations.psv",
+                "instance": "atn",
+                "s3bucket": "mock-littlepay-bucket",
+                "s3object": {
+                    "Key": "atn/v3/authorisations/202504291120_authorisations.psv",
+                    "LastModified": None,
+                    "ETag": None,
+                    "Size": None,
+                    "StorageClass": None,
+                },
+                "ts": "2025-06-01T00:00:00+00:00",
+            },
+        }


### PR DESCRIPTION
# Description

When running `download_and_parse_littlepay` DAG  and the `littlepay_copy` task fails, it generates the results file with the error to be visible on Metabase Littlepay Audit Dashboard.

Resolves #5171 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running Pytests and Airflow locally.
Even failing it uploaded the results file:
<img width="1578" height="828" alt="image" src="https://github.com/user-attachments/assets/22747f23-342b-476b-8ad1-8e09233fa0b9" />

Staging Dashboard:
<img width="1051" height="413" alt="image" src="https://github.com/user-attachments/assets/284bdd69-64f1-4554-949d-e6ce47aa3381" />


## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
