### PR TITLE
GTFS-RT archiver explicitly requests Protocol Buffers files

### DIFF
--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
@@ -89,7 +89,7 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
     available_memory = "256M"
     ingress_settings = "ALLOW_INTERNAL_ONLY"
 
-    max_instance_count               = 160
+    max_instance_count               = 300
     max_instance_request_concurrency = 1
 
     all_traffic_on_latest_revision = true
@@ -98,7 +98,7 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
     environment_variables = {
       CALITP_BUCKET__GTFS_RT_RAW = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-rt-raw-v2_name}"
       REQUEST_CONNECT_TIMEOUT    = 1
-      REQUEST_READ_TIMEOUT       = 5
+      REQUEST_READ_TIMEOUT       = 30
     }
   }
 

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
@@ -10,7 +10,7 @@ from google.cloud.secretmanager import SecretManagerServiceClient
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Accept": "application/x-protobuf,text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
     "Accept-Language": "en-US,en;q=0.9",
     "Connection": "keep-alive",
     "Upgrade-Insecure-Requests": "1",


### PR DESCRIPTION
# Description

This PR updates the configuration for the GTFS-RT archiver to add `application/x-protobuf` to the `Accept` header when making a request. Metrolink returns a Base64-encoded protocol buffer file if this mimetype is not present before `text/html`

Relates to #4488

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`curl` with the appropriate header set

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor files saved in staging buckets