### PR TITLE
Redirect HTTP to HTTPS on JupyterHub GKE Ingress

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/templates/gke-frontend-config.yaml
+++ b/kubernetes/apps/charts/jupyterhub/templates/gke-frontend-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: jupyterhub-frontend
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: MOVED_PERMANENTLY

--- a/kubernetes/apps/charts/jupyterhub/templates/gke-ingress.yaml
+++ b/kubernetes/apps/charts/jupyterhub/templates/gke-ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jupyterhub-gce
   annotations:
     networking.gke.io/managed-certificates: jupyterhub-managed-cert
+    networking.gke.io/v1beta1.FrontendConfig: jupyterhub-frontend
 spec:
   ingressClassName: gce
   rules:


### PR DESCRIPTION
## Summary

Plain HTTP to `jupyterhub.dds.dot.ca.gov` is currently served (200) instead of redirected. Adds a GKE `FrontendConfig` with `redirectToHttps.enabled: true` and references it from the Ingress, so GCLB issues a 301 from `http://` to `https://`.

`responseCodeName: MOVED_PERMANENTLY` (HTTP 301) — appropriate since we want browsers and bookmarks to remember the upgrade.

## Test plan

- [ ] CI passes
- [ ] After merge & deploy, `curl -I http://jupyterhub.dds.dot.ca.gov/` returns 301 with `Location: https://jupyterhub.dds.dot.ca.gov/`
- [ ] HTTPS continues to work normally