### PR TITLE
Redirect notebooks.calitp.org → jupyterhub.dds.dot.ca.gov + repoint OAuth callback

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -77,7 +77,7 @@ jupyterhub:
       GitHubOAuthenticator:
         # client_id:     in existingSecret
         # client_secret: in existingSecret
-        oauth_callback_url: https://notebooks.calitp.org/hub/oauth_callback
+        oauth_callback_url: https://jupyterhub.dds.dot.ca.gov/hub/oauth_callback
         allowed_organizations:
           - cal-itp:warehouse-users
         scope:
@@ -107,14 +107,13 @@ jupyterhub:
       kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
+      nginx.ingress.kubernetes.io/permanent-redirect: https://jupyterhub.dds.dot.ca.gov$request_uri
     hosts:
       - notebooks.calitp.org
-      - hubtest.k8s.calitp.jarv.us
     tls:
       - secretName: jupyterhub-tls
         hosts:
           - notebooks.calitp.org
-          - hubtest.k8s.calitp.jarv.us
   proxy:
     service:
       type: ClusterIP


### PR DESCRIPTION
## Summary

Stages the cutover from `notebooks.calitp.org` to `jupyterhub.dds.dot.ca.gov`. **Do not merge until the Cal-ITP GitHub OAuth App allows the new callback URL** — see "Pre-merge step" below.

Two coordinated changes:

### 1. Repoint `oauth_callback_url` to the new hostname

```diff
-oauth_callback_url: https://notebooks.calitp.org/hub/oauth_callback
+oauth_callback_url: https://jupyterhub.dds.dot.ca.gov/hub/oauth_callback
```

Effect: every login flow — including ones initiated on the old domain — completes on the new domain. Nudges users toward `jupyterhub.dds.dot.ca.gov` even before they update their bookmarks.

### 2. 301 redirect from notebooks.calitp.org to the new URL

Adds `nginx.ingress.kubernetes.io/permanent-redirect: https://jupyterhub.dds.dot.ca.gov$request_uri` to the chart's nginx Ingress and removes the now-defunct `hubtest.k8s.calitp.jarv.us` hostname (replaced by the GKE Ingress in #5157).

The annotation applies to all hosts on the Ingress; after removing hubtest only `notebooks.calitp.org` remains, so the redirect's scope matches the intent.

`$request_uri` preserves the path/query — e.g. `notebooks.calitp.org/user/alice/lab/foo` → `https://jupyterhub.dds.dot.ca.gov/user/alice/lab/foo`.

## Pre-merge step (one-time external action)

Add `https://jupyterhub.dds.dot.ca.gov/hub/oauth_callback` to the **Cal-ITP GitHub OAuth App's** Authorization callback URL list. Keep the existing `https://notebooks.calitp.org/hub/oauth_callback` registered for now so the redirect path doesn't fail mid-flow.

OAuth App ownership / how to request changes: see #367.

## What this PR does NOT do

- Doesn't remove anything from the GitHub OAuth App's list of allowed callback URLs (the old URL stays registered until we're confident everyone's transitioned)
- Doesn't change any docs (\`docs/**\`, kubernetes README) — separate doc-cleanup PR can follow once the migration is settled
- Doesn't change DNS — `notebooks.calitp.org` keeps pointing at the nginx LB IP and serving traffic (now as a redirect)

## Test plan

- [ ] CI passes
- [x] **Before merge:** GitHub OAuth App has the new callback URL added
- [ ] After merge & deploy:
  - [ ] `curl -sI https://notebooks.calitp.org/` returns 301 with `Location: https://jupyterhub.dds.dot.ca.gov/`
  - [ ] Path preservation: `curl -sI https://notebooks.calitp.org/user/<name>/lab` redirects to `https://jupyterhub.dds.dot.ca.gov/user/<name>/lab`
  - [ ] Login flow on `https://jupyterhub.dds.dot.ca.gov/` works end-to-end (GitHub OAuth → notebook spawn)
  - [ ] Active sessions on `notebooks.calitp.org` get redirected without losing kernel state (kernel processes are namespaced per user, not per hostname, so they should persist; cookies on the old domain become inert but redirect → re-auth on new domain → spawn returns the same user pod)