### PR TITLE
Unpause production GTFS-RT archiver clock

### DIFF
--- a/iac/cal-itp-data-infra/gtfs-rt-archiver/us/workflow.tf
+++ b/iac/cal-itp-data-infra/gtfs-rt-archiver/us/workflow.tf
@@ -48,7 +48,7 @@ resource "google_workflows_workflow" "gtfs-rt-archiver-clock" {
 }
 
 resource "google_cloud_scheduler_job" "gtfs-rt-archiver-clock" {
-  paused      = true
+  paused      = false
   name        = "gtfs-rt-archiver-clock"
   description = "GTFS-RT Archiver Heartbeat"
   region      = "us-west2"

--- a/services/gtfs-rt-archiver/README.md
+++ b/services/gtfs-rt-archiver/README.md
@@ -13,6 +13,12 @@ The GTFS-RT Archiver consists of three parts running inside Google Cloud Provide
 
 The Clock and Heartbeat communicate via Google Pub/Sub.
 
+Google Cloud Provider APIs required:
+
+* Workflows
+* Cloud Run
+* Eventarc
+
 
 ## Deployment
 


### PR DESCRIPTION
# Description

This PR starts the clock GTFS-RT archiver clock in production

Relates to #4488

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`