### PR TITLE
Spin down in-cluster gtfs-rt archiver (prod)

### DIFF
--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/consumer.patch.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/consumer.patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gtfs-rt-archiver-consumer
+spec:
+  replicas: 0

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -7,6 +7,17 @@ resources:
 - archiver-channel-vars.yaml
 - ../gtfs-rt-archiver-v3-release
 
+patches:
+- path: consumer.patch.yaml
+  target:
+    name: gtfs-rt-archiver-consumer
+- path: ticker.patch.yaml
+  target:
+    name: gtfs-rt-archiver-ticker
+- path: redis.patch.yaml
+  target:
+    name: redis
+
 images:
 - name: 'gtfs-rt-archiver'
   newName: 'ghcr.io/cal-itp/data-infra/gtfs-rt-archiver-v3'

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/redis.patch.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/redis.patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 0

--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/ticker.patch.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/ticker.patch.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gtfs-rt-archiver-ticker
+spec:
+  replicas: 0


### PR DESCRIPTION
## Summary

Sets prod replicas to 0 for all three deployments running the in-cluster gtfs-rt archiver, in preparation for switching prod traffic to a new version of the archiver running outside the cluster.

| Deployment | Replicas before | Replicas after |
|---|---|---|
| gtfs-rt-archiver-consumer | 6 | 0 |
| gtfs-rt-archiver-ticker | 1 | 0 |
| redis | 1 | 0 |

## Why patches in the prod overlay vs. editing the base manifests

The base manifests in `kubernetes/apps/manifests/gtfs-rt-archiver-v3/` are shared between the prod and test overlays. Editing the base would also affect test (which is intentionally being left running). Mirroring the existing test-overlay patch pattern is the cleaner, more isolated change.

## What this preserves

- All three Deployments still exist (just at 0 replicas)
- ConfigMaps (`archiver-app-vars`, `archiver-channel-vars`)
- Secrets (gtfs feed creds, etc.)
- `redis` ClusterIP service
- PodMonitoring resource

So we can revive prod by simply reverting this PR if needed — no chart re-bootstrapping, no secret reissuance.

## Operational note

Live spin-down via `kubectl scale` will be done out-of-band before this merges; this PR's job is to make that scale-to-0 stick across CI deploys.

## Test plan

- [ ] CI passes (kubernetes-preview)
- [ ] `kubectl kustomize kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod` shows replicas: 0 on all three deployments
- [ ] `kubectl kustomize kubernetes/apps/overlays/gtfs-rt-archiver-v3-test` is unchanged (still replicas: 1 for consumer, ticker, redis)
- [ ] After merge & deploy, `kubectl get deploy -n gtfs-rt-v3` shows all three at 0/0
- [ ] `kubectl get deploy -n gtfs-rt-v3-test` unaffected (consumer/ticker/redis still 1/1)