### PR TITLE
Fix production GTFS-RT archiver permissions

### DIFF
--- a/iac/cal-itp-data-infra/gtfs-rt-archiver/us/workflow.tf
+++ b/iac/cal-itp-data-infra/gtfs-rt-archiver/us/workflow.tf
@@ -48,7 +48,6 @@ resource "google_workflows_workflow" "gtfs-rt-archiver-clock" {
 }
 
 resource "google_cloud_scheduler_job" "gtfs-rt-archiver-clock" {
-  paused      = false
   name        = "gtfs-rt-archiver-clock"
   description = "GTFS-RT Archiver Heartbeat"
   region      = "us-west2"

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -644,5 +644,5 @@ resource "google_project_iam_member" "gtfs-rt-archiver" {
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.gtfs-rt-archiver.email}"
-  project = "cal-itp-data-infra-staging"
+  project = "cal-itp-data-infra"
 }


### PR DESCRIPTION
# Description

This PR fixes the IAM permissions for the gtfs-rt-archiver service account.

Relates to #4488

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`