### PR TITLE
Remove pre-v3 gtfs-rt-archiver service account

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra/iam/us/outputs.tf
@@ -410,10 +410,6 @@ output "google_service_account_tfer--111041565629350650664_id" {
   value = google_service_account.tfer--111041565629350650664.id
 }
 
-output "google_service_account_tfer--111080371999374643299_id" {
-  value = google_service_account.tfer--111080371999374643299.id
-}
-
 output "google_service_account_tfer--111148370496926482871_id" {
   value = google_service_account.tfer--111148370496926482871.id
 }
@@ -464,10 +460,6 @@ output "google_service_account_tfer--117250920371991618056_id" {
 
 output "google_service_account_tfer--117710413824821071161_id" {
   value = google_service_account.tfer--117710413824821071161.id
-}
-
-output "google_service_account_tfer--117956330948086473326_id" {
-  value = google_service_account.tfer--117956330948086473326.id
 }
 
 output "google_service_account_tfer--118350215382382143206_id" {

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -128,14 +128,6 @@ resource "google_service_account" "tfer--111041565629350650664" {
   project    = "cal-itp-data-infra"
 }
 
-resource "google_service_account" "tfer--111080371999374643299" {
-  account_id   = "gtfs-rt-archiver-test"
-  description  = "Access to the gtfs-data-test bucket"
-  disabled     = "false"
-  display_name = "gtfs-rt-archiver-test"
-  project      = "cal-itp-data-infra"
-}
-
 resource "google_service_account" "tfer--111148370496926482871" {
   account_id = "jyoung-cal-itp"
   disabled   = "false"
@@ -221,14 +213,6 @@ resource "google_service_account" "tfer--117710413824821071161" {
   account_id   = "amplitude-export"
   disabled     = "false"
   display_name = "amplitude-export"
-  project      = "cal-itp-data-infra"
-}
-
-resource "google_service_account" "tfer--117956330948086473326" {
-  account_id   = "gtfs-rt-archiver"
-  description  = "Service to upload GTFS-RT feeds to storage bucket"
-  disabled     = "false"
-  display_name = "gtfs-rt-archiver"
   project      = "cal-itp-data-infra"
 }
 


### PR DESCRIPTION
# Description

This PR removes the pre-v3 gtfs-rt-archiver service accounts.

Relates to #4488

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
