### PR TITLE
Add Enghouse agencies to Elavon transactions (#5200)

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -413,7 +413,11 @@ models:
         description: |
           The Littlepay-assigned `participant_id` value that corresponds to this customer name/merchant number.
           If null, this customer/merchant's activity is not associated with Littlepay (for example, office or
-          online sales not processed by Littlepay).
+          online sales not processed by Littlepay, or this agency uses another processor).
+      - name: enghouse_operator_id
+        description: |
+          Enghouse operator ID for agencies that use Enghouse as fare processor.
+          Null for agencies that use a different processor.
       - &payment_reference
         name: payment_reference
         description: |

--- a/warehouse/models/mart/payments/fct_elavon__transactions.sql
+++ b/warehouse/models/mart/payments/fct_elavon__transactions.sql
@@ -13,9 +13,26 @@ int_elavon__deposit_transactions AS (
 
 payments_entity_mapping AS (
     SELECT
-        * EXCEPT(elavon_customer_name),
-        elavon_customer_name AS customer_name
+        gtfs_dataset_source_record_id,
+        organization_source_record_id,
+        littlepay_participant_id,
+        null as enghouse_operator_id,
+        elavon_customer_name AS customer_name,
+        _in_use_from,
+        _in_use_until
     FROM {{ ref('payments_entity_mapping') }}
+
+    UNION ALL
+
+    SELECT
+        gtfs_dataset_source_record_id,
+        organization_source_record_id,
+        null as littlepay_participant_id,
+        enghouse_operator_id,
+        elavon_customer_name AS customer_name,
+        _in_use_from,
+        _in_use_until
+    FROM {{ ref('payments_entity_mapping_enghouse') }}
 ),
 
 orgs AS (
@@ -39,7 +56,8 @@ join_orgs AS (
         union_deposits_and_billing.*,
         orgs.name AS organization_name,
         orgs.source_record_id AS organization_source_record_id,
-        littlepay_participant_id
+        littlepay_participant_id,
+        enghouse_operator_id
     FROM union_deposits_and_billing
     LEFT JOIN payments_entity_mapping USING (customer_name)
     LEFT JOIN orgs
@@ -53,6 +71,7 @@ fct_elavon__transactions AS (
         organization_name,
         organization_source_record_id,
         littlepay_participant_id,
+        enghouse_operator_id,
         LAST_DAY(payment_date, MONTH) AS end_of_month_date,
         payment_reference,
         payment_date,


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #5200

Adds Enghouse mapping information to transactions model so that Elavon transactions are visible for agencies using Enghouse.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

```sql
select 
  customer_name,
  organization_name is null,
  extract(month from transaction_date),
  count(*)
from `cal-itp-data-infra-staging.laurie_mart_payments.fct_elavon__transactions`
where transaction_date >= '2026-02-01' 
group by 1,2,3
order by 1, 3 desc
```

Now shows that organization name is not null for RABA and Camarillo 

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
