### PR TITLE
payments(enghouse): modify parse schedule to better align with warehouse runs

### DIFF
--- a/airflow/dags/README.md
+++ b/airflow/dags/README.md
@@ -11,7 +11,7 @@
 | 10:00 AM    | 2:00 AM              | 3:00 AM              | [ntd_report_from_blackcat](./ntd_report_from_blackcat)<br>[download_and_parse_ntd_xlsx](#download_and_parse_ntd_xlsx)            | Mondays    |
 | 11:00 AM    | 3:00 AM              | 4:00 AM              | [create_external_tables](./create_external_tables)                                                                               | Every Day  |
 | 12:00 PM    | 4:00 AM              | 5:00 AM              | [download_and_parse_littlepay](#download_and_parse_littlepay)                                                                    | Every Day  |
-|  2:00 PM    | 6:00 AM              | 7:00 AM              | [parse_enghouse](./parse_enghouse)                                                                                               | Every Day  |
+|  1:00 PM    | 5:00 AM              | 6:00 AM              | [parse_enghouse](./parse_enghouse)                                                                                               | Every Day  |
 |             | Every Hour           |                      | [sync_littlepay_v3](./sync_littlepay_v3)                                                                                         | Every Day  |
 |             | Every<br>Hour:30 min                       || [parse_littlepay_v3](./parse_littlepay_v3)                                                                                       | Every Day  |
 |             | Every<br>Hour:15 min                       || [parse_and_validate_rt](#parse_and_validate_rt)                                                                                  | Every Day  |

--- a/airflow/dags/parse_enghouse/METADATA.yml
+++ b/airflow/dags/parse_enghouse/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Parse Enghouse semicolon-delimited CSV files into JSONL"
-schedule_interval: "0 14 * * *"
+schedule_interval: "0 13 * * *"
 tags:
   - enghouse
   - payments


### PR DESCRIPTION
# Description
Follow-on to #5184. Adjusts parse_enghouse schedule from 14:00 UTC to 13:00 UTC to ensure the parse step completes before the dbt_all/dbt_daily runs at 14:00 UTC. Files are typically delivered by ~11:00 UTC, so 13:00 UTC provides a 2-hour delivery buffer and a 1-hour buffer before dbt.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
n/a

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
