### PR TITLE
Fix archiver spin-down patch targets: scope to kind: Deployment

### DIFF
--- a/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/gtfs-rt-archiver-v3-prod/kustomization.yaml
@@ -10,12 +10,15 @@ resources:
 patches:
 - path: consumer.patch.yaml
   target:
+    kind: Deployment
     name: gtfs-rt-archiver-consumer
 - path: ticker.patch.yaml
   target:
+    kind: Deployment
     name: gtfs-rt-archiver-ticker
 - path: redis.patch.yaml
   target:
+    kind: Deployment
     name: redis
 
 images:


### PR DESCRIPTION
## Summary

Hotfix for #5194 — kubernetes deploys are currently failing with:

> The request is invalid: patch: ... unknown field \"spec.replicas\"

The redis patch I added in #5194 targeted only by \`name: redis\`, but the prod overlay renders both a Deployment and a Service with that name. Kustomize was therefore applying the strategic merge patch (which contains \`spec.replicas: 0\`) to the Service too, and kubectl correctly rejects \`spec.replicas\` on a Service.

Failure: https://github.com/cal-itp/data-infra/actions/runs/25221841913

## Fix

Add \`kind: Deployment\` to each patch target. Consumer and ticker don't have a name-collision today, but adding kind to those patches as well matches the consistent pattern and protects against future additions.

## Test plan

- [ ] CI passes (preview)
- [ ] After merge, deploy-kubernetes for this commit succeeds
- [ ] `kubectl get deploy -n gtfs-rt-v3` shows all three at 0/0
- [ ] `kubectl get svc redis -n gtfs-rt-v3` is unaffected (still ClusterIP, no spec.replicas)