### PR TITLE
Payments(Enghouse): filter duplicate header rows from Enghouse CSV parse

### DIFF
--- a/airflow/plugins/operators/enghouse_csv_to_jsonl_operator.py
+++ b/airflow/plugins/operators/enghouse_csv_to_jsonl_operator.py
@@ -36,13 +36,16 @@ def _parse_csv(content: bytes) -> list:
         restkey="calitp_unknown_fields",
         delimiter=";",
     )
+    fieldnames = [
+        k for k in (reader.fieldnames or []) if k and k != "calitp_unknown_fields"
+    ]
     return [
         {**row, "_line_number": line_number}
         for line_number, row in enumerate(reader, start=1)
-        if not all(
-            row.get(k) == k
-            for k in (reader.fieldnames or [])
-            if k != "calitp_unknown_fields"
+        if not (
+            fieldnames
+            and all(row.get(k) in (k, None, "") for k in fieldnames)
+            and any(row.get(k) == k for k in fieldnames)
         )
     ]
 

--- a/airflow/plugins/operators/enghouse_csv_to_jsonl_operator.py
+++ b/airflow/plugins/operators/enghouse_csv_to_jsonl_operator.py
@@ -39,6 +39,11 @@ def _parse_csv(content: bytes) -> list:
     return [
         {**row, "_line_number": line_number}
         for line_number, row in enumerate(reader, start=1)
+        if not all(
+            row.get(k) == k
+            for k in (reader.fieldnames or [])
+            if k != "calitp_unknown_fields"
+        )
     ]
 
 


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._
Enghouse has repeatedly delivered CSV files structured as two copies of the same file concatenated — header+data rows, then header+data rows again. csv.DictReader reads the second header as a data row, causing bad records to pass through to BigQuery.

This change filters out any row where all field values equal their column name, dropping these mid-file header rows before the JSONL is written.

File modified:
* `enghouse_csv_to_jsonl_operator.py` - Added a 4-line filter in `_parse_csv` to skip rows where every field value equals its column name.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
`parse_enghouse` dag
<img width="576" height="188" alt="Screenshot 2026-05-01 at 12 54 43" src="https://github.com/user-attachments/assets/bd4e4ef5-05a6-48bc-adf5-45d9861ccf1c" />

`create_external_tables` dag
<img width="593" height="105" alt="Screenshot 2026-05-01 at 12 56 18" src="https://github.com/user-attachments/assets/ef3c1a81-8876-4728-bfb4-d1989a452a43" />

`uv run dbt run -s +fct_payments_rides_enghouse`
<img width="801" height="199" alt="Screenshot 2026-05-01 at 13 00 02" src="https://github.com/user-attachments/assets/18ff4e32-1b55-4649-8822-ba1d640b9812" />

`SELECT DISTINCT operator_id FROM `cal-itp-data-infrastaging.charlie_staging.stg_enghouse__ticket_results`
(no header rows in the data)
<img width="961" height="355" alt="Screenshot 2026-05-01 at 16 03 27" src="https://github.com/user-attachments/assets/09230026-05c1-41d0-867a-3cdf299405fb" />

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Delete the parsed file with duplicates for Ventura ticket results for 2026-04-22 and re-trigger `parse_enghouse` to produce a clean file