### PR TITLE
feat: add enghouse org names to fct payments * transactions models

### DIFF
--- a/warehouse/macros/annotate_payments_entities.sql
+++ b/warehouse/macros/annotate_payments_entities.sql
@@ -1,9 +1,26 @@
 {% macro label_elavon_entities(input_model, date_col = 'payment_date') %}
 WITH payments_entity_mapping AS (
     SELECT
-        * EXCEPT(elavon_customer_name),
-        elavon_customer_name AS customer_name
+        gtfs_dataset_source_record_id,
+        organization_source_record_id,
+        littlepay_participant_id,
+        null as enghouse_operator_id,
+        elavon_customer_name AS customer_name,
+        _in_use_from,
+        _in_use_until
     FROM {{ ref('payments_entity_mapping') }}
+
+    UNION ALL
+
+    SELECT
+        gtfs_dataset_source_record_id,
+        organization_source_record_id,
+        null as littlepay_participant_id,
+        enghouse_operator_id,
+        elavon_customer_name AS customer_name,
+        _in_use_from,
+        _in_use_until
+    FROM {{ ref('payments_entity_mapping_enghouse') }}
 ),
 
 orgs AS (
@@ -15,6 +32,7 @@ SELECT
     orgs.name AS organization_name,
     orgs.source_record_id AS organization_source_record_id,
     littlepay_participant_id,
+    enghouse_operator_id
 FROM {{ input_model }} AS input
 LEFT JOIN payments_entity_mapping USING (customer_name)
 LEFT JOIN orgs

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -414,7 +414,8 @@ models:
           The Littlepay-assigned `participant_id` value that corresponds to this customer name/merchant number.
           If null, this customer/merchant's activity is not associated with Littlepay (for example, office or
           online sales not processed by Littlepay, or this agency uses another processor).
-      - name: enghouse_operator_id
+      - &enghouse_operator_id
+        name: enghouse_operator_id
         description: |
           Enghouse operator ID for agencies that use Enghouse as fare processor.
           Null for agencies that use a different processor.
@@ -598,6 +599,7 @@ models:
       - *organization_name
       - *organization_source_record_id
       - *elavon_lp_participant_id
+      - *enghouse_operator_id
       - *fund_amt
       - *batch_reference
       - *batch_type
@@ -625,6 +627,7 @@ models:
       - *organization_name
       - *organization_source_record_id
       - *elavon_lp_participant_id
+      - *enghouse_operator_id
       - *payment_reference
       - *payment_date
       - *fund_amt
@@ -668,6 +671,7 @@ models:
       - *organization_name
       - *organization_source_record_id
       - *elavon_lp_participant_id
+      - *enghouse_operator_id
       - *payment_reference
       - *payment_date
       - *fund_amt
@@ -707,6 +711,7 @@ models:
       - *organization_name
       - *organization_source_record_id
       - *elavon_lp_participant_id
+      - *enghouse_operator_id
       - *payment_reference
       - *payment_date
       - *fund_amt


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #5211 

Adds organization name to a couple more Elavon tables so agencies can access in Metabase

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

```sql
select 
  customer_name,
  organization_name is null,
  extract(month from payment_date),
  count(*)
from `cal-itp-data-infra-staging.laurie_mart_payments.fct_payments_deposit_transactions`
where payment_date >= '2026-02-01' 
group by 1,2,3
order by 1, 3 desc
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
