### PR TITLE
Add fct_tides_trips_performed dbt model

### DIFF
--- a/warehouse/models/mart/tides/_mart_tides.yml
+++ b/warehouse/models/mart/tides/_mart_tides.yml
@@ -112,3 +112,126 @@ models:
         description: '{{ doc("column_base64_url") }}'
       - name: gtfs_dataset_key
         description: '{{ doc("gtfs_schedule_gtfs_dataset_key") }}'
+
+  - name: fct_tides_trips_performed
+    description: |
+      Trips performed reshaped to the TIDES (Transit Integrated Data Exchange
+      Specification) `trips_performed` schema (https://tides-transit.org/main/).
+      Sourced from `fct_observed_trips`, joined to `fct_scheduled_trips` for
+      route metadata and to `fct_tides_vehicle_locations` for canonical
+      vehicle_id per trip. Filtered upstream to `appeared_in_vp = TRUE` so
+      every row has a derivable vehicle_id.
+    columns:
+      - name: service_date
+        description: TIDES PK (with trip_id_performed). From `fct_observed_trips.service_date`.
+        data_tests:
+          - not_null:
+              arguments:
+                config:
+                  where: 'service_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)'
+      - name: trip_id_performed
+        description: TIDES PK (with service_date). From `fct_observed_trips.trip_id`.
+        data_tests:
+          - not_null:
+              arguments:
+                config:
+                  where: 'service_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)'
+      - name: vehicle_id
+        description: |
+          Most-frequent vehicle_id observed in `fct_tides_vehicle_locations`
+          for the same (service_date, trip_id_performed). TIDES required.
+        data_tests:
+          - not_null:
+              arguments:
+                config:
+                  where: 'service_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)'
+          - relationships:
+              arguments:
+                to: ref('fct_tides_vehicle_locations')
+                field: vehicle_id
+                config:
+                  where: 'service_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)'
+      - name: trip_id_scheduled
+        description: |
+          Coarse MVP: equals trip_id_performed when the trip appeared in VP
+          or TU. A stricter join to `fct_scheduled_trips` is a follow-up.
+      - name: route_id
+        description: From `fct_scheduled_trips` via trip_instance_key. NULL when no schedule.
+      - name: route_type
+        description: GTFS route_type. From `fct_scheduled_trips`.
+      - name: ntd_mode
+        description: NULL in MVP.
+      - name: route_type_agency
+        description: NULL in MVP.
+      - name: shape_id
+        description: From `fct_scheduled_trips`.
+      - name: pattern_id
+        description: NULL in MVP.
+      - name: direction_id
+        description: From `fct_scheduled_trips`.
+      - name: operator_id
+        description: NULL; not derivable from GTFS-RT.
+      - name: block_id
+        description: From `fct_scheduled_trips`.
+      - name: trip_start_stop_id
+        description: NULL in MVP; needs stop_times join on min stop_sequence.
+      - name: trip_end_stop_id
+        description: NULL in MVP; needs stop_times join on max stop_sequence.
+      - name: schedule_trip_start
+        description: |
+          DATETIME in agency tz from `fct_scheduled_trips.trip_first_departure_ts`.
+      - name: schedule_trip_end
+        description: |
+          DATETIME in agency tz from `fct_scheduled_trips.trip_last_arrival_ts`.
+      - name: actual_trip_start
+        description: DATETIME in agency tz from `fct_observed_trips.vp_min_ts`.
+      - name: actual_trip_end
+        description: DATETIME in agency tz from `fct_observed_trips.vp_max_ts`.
+      - name: trip_type
+        description: |
+          Constant 'In service' in MVP because the model filters to VP-observed
+          trips. Future expansion could distinguish deadhead / layover / pull-in
+          / pull-out given supplemental signals.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['In service', 'Deadhead', 'Layover', 'Pullout', 'Pullin', 'Extra Pullout', 'Extra Pullin', 'Deadhead To Layover', 'Deadhead From Layover', 'Other not in service']
+                config:
+                  where: 'service_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)'
+      - name: schedule_relationship
+        description: |
+          TIDES enum (Scheduled / Added / Unscheduled / Canceled / Duplicated)
+          mapped from `fct_observed_trips.tu_starting_schedule_relationship`.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ['Scheduled', 'Added', 'Unscheduled', 'Canceled', 'Duplicated']
+                config:
+                  where: 'service_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 2 DAY)'
+      - name: base64_url
+        description: '{{ doc("column_base64_url") }}'
+      - name: gtfs_dataset_key
+        description: '{{ doc("gtfs_schedule_gtfs_dataset_key") }}'
+
+exposures:
+  - name: california_tides
+    type: application
+    maturity: low
+    url: https://tides-transit.org/main/
+    description: >
+      Cal-ITP TIDES (Transit Integrated Data Exchange Specification) tables,
+      reshaped from GTFS-RT and joined to GTFS Schedule. Published as a
+      statewide TIDES product for analytics and TIDES-ecosystem tooling.
+
+    depends_on:
+      - ref("fct_tides_vehicle_locations")
+      - ref("fct_tides_trips_performed")
+
+    owner:
+      email: hello@calitp.org
+
+    meta:
+      methodology: |
+        Cal-ITP collects GTFS-RT vehicle position and trip update messages
+        statewide and reshapes them into the open TIDES specification for
+        analytics use. See https://tides-transit.org for the spec.

--- a/warehouse/models/mart/tides/_mart_tides.yml
+++ b/warehouse/models/mart/tides/_mart_tides.yml
@@ -218,10 +218,7 @@ exposures:
     type: application
     maturity: low
     url: https://tides-transit.org/main/
-    description: >
-      Cal-ITP TIDES (Transit Integrated Data Exchange Specification) tables,
-      reshaped from GTFS-RT and joined to GTFS Schedule. Published as a
-      statewide TIDES product for analytics and TIDES-ecosystem tooling.
+    description: California TIDES (Transit Integrated Data Exchange Specification) data published to a public GCS bucket.
 
     depends_on:
       - ref("fct_tides_vehicle_locations")
@@ -232,6 +229,5 @@ exposures:
 
     meta:
       methodology: |
-        Cal-ITP collects GTFS-RT vehicle position and trip update messages
-        statewide and reshapes them into the open TIDES specification for
-        analytics use. See https://tides-transit.org for the spec.
+        Cal-ITP reshapes GTFS-RT vehicle position and trip update messages into the
+        open TIDES specification for analytics use. See https://tides-transit.org for the spec.

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -40,6 +40,12 @@ public_subfeed_keys AS (
       AND vehicle_positions_gtfs_dataset_key IS NOT NULL
 ),
 
+-- Same publication-key narrowing as fct_tides_vehicle_locations.
+publication_keys AS (
+    SELECT gtfs_dataset_key
+    FROM {{ ref('tides_publication_keys') }}
+),
+
 tides_trips_performed AS (
     SELECT
         o.service_date,
@@ -86,6 +92,8 @@ tides_trips_performed AS (
     FROM observed o
     INNER JOIN public_subfeed_keys
         ON o.vp_gtfs_dataset_key = public_subfeed_keys.gtfs_dataset_key
+    INNER JOIN publication_keys
+        ON o.vp_gtfs_dataset_key = publication_keys.gtfs_dataset_key
     LEFT JOIN scheduled s
         ON s.trip_instance_key = o.trip_instance_key
     LEFT JOIN vehicle_per_trip v

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -1,10 +1,26 @@
-{{ config(materialized='view') }}
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partition_by={
+            'field': 'service_date',
+            'data_type': 'date',
+            'granularity': 'day',
+        },
+        cluster_by=['service_date', 'base64_url'],
+        on_schema_change='append_new_columns',
+        tags=['tides_product'],
+    )
+}}
 
 WITH observed AS (
     SELECT *
     FROM {{ ref('fct_observed_trips') }}
     -- Drop TU-only trips (no VP) so every row has a derivable vehicle_id.
     WHERE appeared_in_vp = TRUE
+    {% if is_incremental() %}
+      AND service_date >= DATE_SUB((SELECT MAX(service_date) FROM {{ this }}), INTERVAL 1 DAY)
+    {% endif %}
 ),
 
 scheduled AS (

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -1,0 +1,108 @@
+{{ config(materialized='view') }}
+
+WITH observed AS (
+    SELECT *
+    FROM {{ ref('fct_observed_trips') }}
+    -- Drop TU-only trips (no VP) so every row has a derivable vehicle_id.
+    WHERE appeared_in_vp = TRUE
+),
+
+scheduled AS (
+    SELECT
+        trip_instance_key,
+        route_id,
+        route_type,
+        direction_id,
+        shape_id,
+        block_id,
+        feed_timezone,
+        trip_first_departure_ts,
+        trip_last_arrival_ts
+    FROM {{ ref('fct_scheduled_trips') }}
+),
+
+vehicle_per_trip AS (
+    SELECT
+        service_date,
+        trip_id_performed,
+        APPROX_TOP_COUNT(vehicle_id, 1)[OFFSET(0)].value AS vehicle_id
+    FROM {{ ref('fct_tides_vehicle_locations') }}
+    WHERE vehicle_id IS NOT NULL
+    GROUP BY 1, 2
+),
+
+-- Same feed-key filter as fct_tides_vehicle_locations.
+public_subfeed_keys AS (
+    SELECT DISTINCT vehicle_positions_gtfs_dataset_key AS gtfs_dataset_key
+    FROM {{ ref('dim_provider_gtfs_data') }}
+    WHERE _is_current = TRUE
+      AND public_customer_facing_or_regional_subfeed_fixed_route = TRUE
+      AND vehicle_positions_gtfs_dataset_key IS NOT NULL
+),
+
+tides_trips_performed AS (
+    SELECT
+        o.service_date,
+        o.trip_id AS trip_id_performed,
+        v.vehicle_id,
+
+        -- trip_id_scheduled coarse: trip appeared in VP or TU implies a
+        -- scheduled trip. A stricter test would require fct_scheduled_trips
+        -- presence.
+        o.trip_id AS trip_id_scheduled,
+
+        s.route_id,
+        s.route_type,
+        CAST(NULL AS STRING) AS ntd_mode,
+        CAST(NULL AS STRING) AS route_type_agency,
+        s.shape_id,
+        CAST(NULL AS STRING) AS pattern_id,
+        s.direction_id,
+        CAST(NULL AS STRING) AS operator_id,
+        s.block_id,
+        CAST(NULL AS STRING) AS trip_start_stop_id,
+        CAST(NULL AS STRING) AS trip_end_stop_id,
+
+        DATETIME(s.trip_first_departure_ts, COALESCE(s.feed_timezone, 'America/Los_Angeles')) AS schedule_trip_start,
+        DATETIME(s.trip_last_arrival_ts, COALESCE(s.feed_timezone, 'America/Los_Angeles')) AS schedule_trip_end,
+        DATETIME(o.vp_min_ts, COALESCE(s.feed_timezone, 'America/Los_Angeles')) AS actual_trip_start,
+        DATETIME(o.vp_max_ts, COALESCE(s.feed_timezone, 'America/Los_Angeles')) AS actual_trip_end,
+
+        -- Constant 'In service' since the model filters to VP-observed trips.
+        'In service' AS trip_type,
+
+        CASE
+            WHEN o.tu_starting_schedule_relationship = 'SCHEDULED'   THEN 'Scheduled'
+            WHEN o.tu_starting_schedule_relationship = 'ADDED'       THEN 'Added'
+            WHEN o.tu_starting_schedule_relationship = 'CANCELED'    THEN 'Canceled'
+            WHEN o.tu_starting_schedule_relationship = 'UNSCHEDULED' THEN 'Unscheduled'
+            WHEN o.tu_starting_schedule_relationship = 'DUPLICATED'  THEN 'Duplicated'
+        END AS schedule_relationship,
+
+        -- Internal columns retained for partitioning and downstream joins;
+        -- dropped at export.
+        o.vp_base64_url AS base64_url,
+        o.vp_gtfs_dataset_key AS gtfs_dataset_key
+    FROM observed o
+    INNER JOIN public_subfeed_keys
+        ON o.vp_gtfs_dataset_key = public_subfeed_keys.gtfs_dataset_key
+    LEFT JOIN scheduled s
+        ON s.trip_instance_key = o.trip_instance_key
+    LEFT JOIN vehicle_per_trip v
+        ON v.service_date = o.service_date
+       AND v.trip_id_performed = o.trip_id
+),
+
+-- TIDES IDs are only unique within feed; partition the dedup by feed identity
+-- so trips that share trip_id_performed across different feeds both survive.
+deduped AS (
+    SELECT *
+    FROM tides_trips_performed
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY service_date, trip_id_performed, gtfs_dataset_key
+        ORDER BY actual_trip_end DESC NULLS LAST,
+                 actual_trip_start ASC NULLS LAST
+    ) = 1
+)
+
+SELECT * FROM deduped

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -18,9 +18,9 @@ WITH observed AS (
     FROM {{ ref('fct_observed_trips') }}
     -- Drop TU-only trips (no VP) so every row has a derivable vehicle_id.
     WHERE appeared_in_vp = TRUE
-    {% if is_incremental() %}
-      AND service_date >= DATE_SUB((SELECT MAX(service_date) FROM {{ this }}), INTERVAL 1 DAY)
-    {% endif %}
+      AND service_date
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
+            AND {{ ranged_incremental_max_date() }}
 ),
 
 scheduled AS (
@@ -35,6 +35,9 @@ scheduled AS (
         trip_first_departure_ts,
         trip_last_arrival_ts
     FROM {{ ref('fct_scheduled_trips') }}
+    WHERE service_date
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
+            AND {{ ranged_incremental_max_date() }}
 ),
 
 vehicle_per_trip AS (
@@ -43,7 +46,13 @@ vehicle_per_trip AS (
         trip_id_performed,
         APPROX_TOP_COUNT(vehicle_id, 1)[OFFSET(0)].value AS vehicle_id
     FROM {{ ref('fct_tides_vehicle_locations') }}
-    WHERE vehicle_id IS NOT NULL
+    -- we load this by dt rather than service date
+    -- this is ok for the min date because t-X days for service date will be fully covered by t-X days for dt
+    -- add one to the incremental max date because we need to get one extra UTC dt to ensure overlap with service date
+    WHERE dt
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
+            AND {{ ranged_incremental_max_date() }} + 1
+      AND vehicle_id IS NOT NULL
     GROUP BY 1, 2
 ),
 


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Adds `mart_tides.fct_tides_trips_performed`, sourced from `fct_observed_trips` and joined to `fct_scheduled_trips` for route metadata and to `fct_tides_vehicle_locations` for canonical vehicle_id per trip. Filtered to public, customer-facing or regional-subfeed fixed-route GTFS feeds via `dim_provider_gtfs_data`.

Stacked on `feat/tides-vehicle-locations`. Lives alongside `fct_tides_vehicle_locations` in the new `mart/tides/` folder. Includes a `relationships` test asserting that every `vehicle_id` here resolves to at least one row in `fct_tides_vehicle_locations`. Also adds the `california_tides` exposure on `_mart_tides.yml`.

A few design decisions worth flagging:

- Materialized as `incremental` with `incremental_strategy='insert_overwrite'`, `partition_by` on `service_date`, and `cluster_by=['service_date', 'base64_url']`, mirroring [fct_observed_trips](https://github.com/cal-itp/data-infra/blob/main/warehouse/models/mart/gtfs/fct_observed_trips.sql). Tagged `tides_product`. Per the team's [4/13 policy on dt-vs-service_date materialization](https://github.com/cal-itp/data-infra/issues/4865#issuecomment-4245166778) and PR #5092, the incremental window uses `ranged_incremental_min_date` / `ranged_incremental_max_date` macros on every upstream ref. When sourcing from `fct_tides_vehicle_locations` (microbatch on `dt` per #5216), the upper bound on `dt` is offset by `+1` day to ensure overlap with `service_date`, per the pattern in `int_gtfs_rt__vehicle_positions_stops_by_service_date` (PR #5237).
- Filtered to `appeared_in_vp = TRUE` upstream so every row has a derivable vehicle_id. Trips that only appeared in trip_updates (no VP) are excluded.
- Each trip is assigned its most-frequent vehicle_id during VP coverage (`APPROX_TOP_COUNT(vehicle_id, 1)`). Vehicles that change mid-trip get the dominant one.
- `schedule_trip_start` / `schedule_trip_end` cast to DATETIME using `feed_timezone` from `fct_scheduled_trips`. Falls back to `America/Los_Angeles` when the feed timezone is NULL, defensible default for California, flag if you'd rather a different fallback.
- Cross-feed dedup partition is `(service_date, trip_id_performed, gtfs_dataset_key)` so trips that share `trip_id_performed` across different feeds both survive.

Scope is narrowed to the Hermosa Beach traversing operator set (Beach Cities Transit, LA Metro Bus, Torrance Transit) via the `tides_publication_keys` seed inherited from #5216. Row count post-narrowing: ~100k rows over the 8-day window (down from ~590k unnarrowed).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

```bash
uv run dbt run -s +fct_tides_trips_performed --target staging --full-refresh
uv run dbt test -s fct_tides_trips_performed --target staging
```

Materialized in `cal-itp-data-infra-staging.christopher_mart_tides.fct_tides_trips_performed`. Row counts under the Hermosa-narrow seed match the prior view-materialized run (the materialization change reshapes storage, not the data):

- ~100k rows over the 8-day window across the three feeds in scope
- Zero PK duplicates on `(service_date, trip_id_performed, gtfs_dataset_key)`
- Zero NULL on `service_date`, `trip_id_performed`, `vehicle_id`
- `schedule_relationship` distribution matches the unnarrowed prototype (Scheduled / NULL / Canceled / Added / Duplicated)

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

- Initial deployment populates per the standard ranged-incremental lookback (`DBT_ALL_INCREMENTAL_LOOKBACK_DAYS`, default 5 days). To narrow or extend the initial load, coordinate with the team on adjusting `GTFS_RT_START` or running with explicit date filters.
- Update the Frictionless validation harness to include trips_performed schema validation.
- Open follow-up issue for `stop_visits` model and for `trip_start_stop_id` / `trip_end_stop_id` derivation (deferred past MVP, requires stop_times join).
