### PR TITLE
Staging  -  airflow sends email via acs

### DIFF
--- a/airflow/plugins/src/acs_email_backend.py
+++ b/airflow/plugins/src/acs_email_backend.py
@@ -1,0 +1,37 @@
+from airflow.configuration import conf
+from airflow.hooks.base import BaseHook
+from azure.communication.email import EmailClient
+
+def send_email(
+    to,
+    subject,
+    html_content,
+    files=None,
+    cc=None,
+    bcc=None,
+    mime_subtype="mixed",
+    mime_charset="utf-8",
+    **kwargs,
+):
+    conn = BaseHook.get_connection("azure_acs_default")
+    connection_string = conn.password
+    client = EmailClient.from_connection_string(connection_string)
+
+    if isinstance(to, str):
+        to = [to]
+
+    recipients = {"to": [{"address": addr} for addr in to]}
+    sender_address = conf.get("email", "from_email")
+
+    message = {
+        "senderAddress": sender_address,
+        "recipients": recipients,
+        "content": {
+            "subject": subject,
+            "html": html_content,
+        },
+    }
+
+    poller = client.begin_send(message)
+    result = poller.result()
+    return result.message_id

--- a/airflow/plugins/src/acs_email_backend.py
+++ b/airflow/plugins/src/acs_email_backend.py
@@ -33,5 +33,4 @@ def send_email(
     }
 
     poller = client.begin_send(message)
-    result = poller.result()
-    return result.message_id
+    poller.result()

--- a/airflow/plugins/src/acs_email_backend.py
+++ b/airflow/plugins/src/acs_email_backend.py
@@ -1,6 +1,8 @@
+from azure.communication.email import EmailClient
+
 from airflow.configuration import conf
 from airflow.hooks.base import BaseHook
-from azure.communication.email import EmailClient
+
 
 def send_email(
     to,

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "apache-airflow-providers-cncf-kubernetes==10.1.0",
     "apache-airflow-providers-google==15.1.0",
     "astronomer-cosmos==1.9.0",
+    "azure-communication-email>=1.0.0",
     "beautifulsoup4==4.12.3",
     "boto3==1.41.2",
     "ckanapi>=4.8",

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,5 +1,6 @@
 apache-airflow-providers-amazon>=9.17.0
 astronomer-cosmos
+azure-communication-email>=1.0.0
 beautifulsoup4==4.12.3
 boto3==1.41.2
 ckanapi==4.8

--- a/airflow/uv.lock
+++ b/airflow/uv.lock
@@ -643,6 +643,33 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-communication-email"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/de/f71191ead5e778a7d8939744977a049f796f6fb6549847c667fad373605e/azure_communication_email-1.1.0.tar.gz", hash = "sha256:6a4af8281024327c3ab18a4996919069a99a69aad3a19c40f7852a6682493327", size = 55546, upload-time = "2025-10-17T20:30:23.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/fe/9bd1028853c4b351c756ba4acc39ef5b5914a3452ebe2df0b8ddd6051114/azure_communication_email-1.1.0-py3-none-any.whl", hash = "sha256:9212153f21cf7e68734c32ebfe8702b43398bd01df2dddb0ca52cd5a8bbd5024", size = 64170, upload-time = "2025-10-17T20:30:24.829Z" },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/d9/6f5972b44761277394527a3a76af5ae2ef82fc5f20ce351abf0c826eca67/azure_core-1.40.0.tar.gz", hash = "sha256:ecf5b6ddf2564471fae9d576147b7e77a4da285958b2d9f4fd6c3af104f3e9d7", size = 380057, upload-time = "2026-05-01T00:59:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/c9/25edc67692fb17523c7d29c73898be649b4d3c7ae13cc0f74f5c91938022/azure_core-1.40.0-py3-none-any.whl", hash = "sha256:7f3ea02579b1bb1d34e45043423b650621d11d7c2ea3b05e5554010080b78dfd", size = 220450, upload-time = "2026-05-01T00:59:47.17Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1106,6 +1133,7 @@ dependencies = [
     { name = "apache-airflow-providers-cncf-kubernetes" },
     { name = "apache-airflow-providers-google" },
     { name = "astronomer-cosmos" },
+    { name = "azure-communication-email" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "ckanapi" },
@@ -1138,6 +1166,7 @@ requires-dist = [
     { name = "apache-airflow-providers-cncf-kubernetes", specifier = "==10.1.0" },
     { name = "apache-airflow-providers-google", specifier = "==15.1.0" },
     { name = "astronomer-cosmos", specifier = "==1.9.0" },
+    { name = "azure-communication-email", specifier = ">=1.0.0" },
     { name = "beautifulsoup4", specifier = "==4.12.3" },
     { name = "boto3", specifier = "==1.41.2" },
     { name = "ckanapi", specifier = ">=4.8" },
@@ -3174,6 +3203,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -48,7 +48,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         core-max_templated_field_length            = 25000
         cosmos-use_dataset_airflow3_uri_standard   = true
         email-email_backend                        = "src.acs_email_backend.send_email"
-        email-from_email                           = "DoNotReply@dds.dot.ca.gov"
+        email-from_email                           = "DoNotReply@49b9b73f-ee9a-41ec-bd74-88138a3637ed.azurecomm.net"
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -47,9 +47,8 @@ resource "google_composer_environment" "calitp-staging-composer" {
         core-max_active_tasks_per_dag              = 128
         core-max_templated_field_length            = 25000
         cosmos-use_dataset_airflow3_uri_standard   = true
-        email-email_backend                        = "airflow.utils.email.send_email_smtp"
-        email-email_conn_id                        = "smtp_postmark"
-        email-from_email                           = "bot+airflow@calitp.org"
+        email-email_backend                        = "src.acs_email_backend.send_email"
+        email-from_email                           = "DoNotReply@dds.dot.ca.gov"
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -48,7 +48,7 @@ resource "google_composer_environment" "calitp-staging-composer" {
         core-max_templated_field_length            = 25000
         cosmos-use_dataset_airflow3_uri_standard   = true
         email-email_backend                        = "src.acs_email_backend.send_email"
-        email-from_email                           = "DoNotReply@49b9b73f-ee9a-41ec-bd74-88138a3637ed.azurecomm.net"
+        email-from_email                           = "DoNotReply@notifications.dot.ca.gov"
         scheduler-min_file_process_interval        = 120
         scheduler-scheduler_health_check_threshold = 120
         secrets-backend                            = "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"


### PR DESCRIPTION
# Description

Sets airflow to use an ACS connection string to send emails 

Staging only - when production ready instance is available these can be updated and production can have the same changes applied.

ref: #4786 
