### PR TITLE
Remove schedule from deprecated Littlepay DAGs

### DIFF
--- a/airflow/dags/README.md
+++ b/airflow/dags/README.md
@@ -12,8 +12,6 @@
 | 11:00 AM    | 3:00 AM              | 4:00 AM              | [create_external_tables](./create_external_tables)                                                                               | Every Day  |
 | 12:00 PM    | 4:00 AM              | 5:00 AM              | [download_and_parse_littlepay](#download_and_parse_littlepay)                                                                    | Every Day  |
 |  1:00 PM    | 5:00 AM              | 6:00 AM              | [parse_enghouse](./parse_enghouse)                                                                                               | Every Day  |
-|             | Every Hour           |                      | [sync_littlepay_v3](./sync_littlepay_v3)                                                                                         | Every Day  |
-|             | Every<br>Hour:30 min                       || [parse_littlepay_v3](./parse_littlepay_v3)                                                                                       | Every Day  |
 |             | Every<br>Hour:15 min                       || [parse_and_validate_rt](#parse_and_validate_rt)                                                                                  | Every Day  |
 |  2:00 PM    | 6:00 AM              | 7:00 AM              | [dbt_all](#dbt_all)                                                                                                              | Monday and Thursday |
 |  2:00 PM    | 6:00 AM              | 7:00 AM              | [dbt_daily](#dbt_daily)                                                                                                          | Sunday, Tuesday, Wednesday, Friday, and Saturday |

--- a/airflow/dags/parse_littlepay_v3/METADATA.yml
+++ b/airflow/dags/parse_littlepay_v3/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Parse feed v3 Littlepay files into JSONL"
-schedule_interval: "30 * * * *"
+schedule_interval: null
 tags:
   - littlepay
   - payments

--- a/airflow/dags/parse_littlepay_v3/README.md
+++ b/airflow/dags/parse_littlepay_v3/README.md
@@ -1,4 +1,4 @@
-# `parse_littlepay_v3`
+# DEPRECATED - `parse_littlepay_v3`
 
 Type: [Data interval processing  / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
 

--- a/airflow/dags/sync_littlepay_v3/METADATA.yml
+++ b/airflow/dags/sync_littlepay_v3/METADATA.yml
@@ -1,5 +1,5 @@
 description: "Syncs feed V3 Littlepay data from S3 bucket to our buckets"
-schedule_interval: "0 * * * *"
+schedule_interval: null
 tags:
   - littlepay
   - payments

--- a/airflow/dags/sync_littlepay_v3/README.md
+++ b/airflow/dags/sync_littlepay_v3/README.md
@@ -1,4 +1,4 @@
-# `sync_littlepay_v3`
+# DEPRECATED - `sync_littlepay_v3`
 
 Type: [Now / Scheduled](https://docs.calitp.org/data-infra/airflow/dags-maintenance.html)
 


### PR DESCRIPTION
# Description

This PR removed the schedule from deprecated Littlepay DAGs `sync_littlepay_v3` and `parse_littlepay_v3`.
Those DAGs still available to run manually if needed.
A follow up PR will be needed to remove them.

Update Readme files informing the deprecation.
[#5091]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

Tested running airflow locally.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
