### PR TITLE
Add Setup Graphviz step to build-model-report.yml compile job

### DIFF
--- a/.github/workflows/build-model-report.yml
+++ b/.github/workflows/build-model-report.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Setup GCloud utilities
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Adds the missing `Setup Graphviz` step to the `compile` job in `build-model-report.yml`. The job's `Install the project` (`uv sync`) was failing on PRs that touch `warehouse/**` because `pygraphviz` (a transitive `calitp-warehouse` dep) needs the system graphviz headers (`graphviz/cgraph.h`) to build its C extension.

The companion workflow `deploy-dbt.yml` already has this step in its `compile` job (added in #5162). This PR mirrors it into `build-model-report.yml`'s `compile` job so both workflows install graphviz before `uv sync`. Same `ts-graphviz/setup-graphviz@v2` action used by the existing `visualize` job in this same file, so no new tooling.

Symptom on affected PRs:

```
pygraphviz/graphviz_wrap.c:3023:10: fatal error: graphviz/cgraph.h: No such file or directory
 3023 | #include "graphviz/cgraph.h"
       |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
error: command '/usr/bin/cc' failed with exit code 1
```

Affects #5216, #5220, #5229, #5230 currently; will affect any future dbt PR until merged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

This PR's own CI run will exercise the `compile` job; if it passes here it'll pass on the affected dbt PRs once they rebase onto this fix.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
