### PR TITLE
Fix: Incremental logic for VP trip/stop/day grouping

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -26,6 +26,7 @@ vars:
   GTFS_SCHEDULE_START: "{{ '2021-04-16' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   GTFS_RT_START: "{{ '2022-09-15' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   KUBA_DEVICE_START: '2025-08-11'
+  GTFS_RT_STOP_ANALYSIS_START: "{{ '2025-12-31' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   INCREMENTAL_MAX_DT: ''
   DBT_ALL_INCREMENTAL_LOOKBACK_DAYS: 5
   DBT_DAILY_INCREMENTAL_LOOKBACK_DAYS: 1

--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -27,6 +27,7 @@ vars:
   GTFS_RT_START: "{{ '2022-09-15' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   KUBA_DEVICE_START: '2025-08-11'
   TIDES_PRODUCT_START: "{{ '2025-12-01' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
+  GTFS_RT_STOP_ANALYSIS_START: "{{ '2025-12-31' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   INCREMENTAL_MAX_DT: ''
   DBT_ALL_INCREMENTAL_LOOKBACK_DAYS: 5
   DBT_DAILY_INCREMENTAL_LOOKBACK_DAYS: 1

--- a/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
+++ b/warehouse/models/intermediate/gtfs/_int_gtfs.yaml
@@ -720,10 +720,6 @@ models:
             # this will fail if run on all historical data, specifically for days where a given feed's time zone changed;
             # even then the number of failures is very small
             where: '__rt_sampled__'
-  - name: int_gtfs_rt__vehicle_positions_trip_stop_day_map_grouping
+  - name: int_gtfs_rt__vehicle_positions_stops_by_service_date
     description: |
-      This table groups vehicle positions messages by `dt` (UTC) and `service_date` (usually Pacific)
-      to enable:
-        1. Incremental materialization based on `dt` (to make efficient use of upstream partitions)
-        2. Downstream grouping by `service_date` alone (since that is the appropriate final grain for trip-based analysis)
-      See downstream `fct_vehicle_positions_stop_metrics` table for further documentation.
+      Vehicle position proximity to stops by service date.

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
@@ -13,7 +13,7 @@
 -- depends_on: {{ ref('dim_schedule_feeds') }}
 -- add dependency hint to let dbt know about the dependency inside the call statement block
 
--- fetch a list of feed keys
+-- fetch a list of _feed_valid_from dates that are implicated in these updates
 -- **the where clause here needs to align exactly with the where clause used on fct_scheduled_trips below**
 -- this allows us to filter stop times grouped for significant efficiency gains
 {% call statement('get_dates', fetch_result=True) %}

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
@@ -3,13 +3,16 @@
         materialized='incremental',
         incremental_strategy = 'insert_overwrite',
         partition_by={
-            'field': 'dt',
+            'field': 'service_date',
             'data_type': 'date',
             'granularity': 'day'
-        }, cluster_by=['dt', 'vp_base64_url', 'feed_key']
+        }, cluster_by=['service_date', 'vp_base64_url', 'feed_key']
     )
 }}
 
+-- fetch a list of feed keys
+-- the where clause here needs to align exactly with the where clause used on fct_scheduled_trips below
+-- this allows us to filter stop times grouped for significant efficiency gains
 {%- call statement('get_keys', fetch_result=True) -%}
     SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT '"' || feed_key || '"' ), ',')
     FROM {{ ref('fct_scheduled_trips') }}
@@ -45,6 +48,8 @@ stop_times_grouped AS (
         stop_id_array,
 
     FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
+    -- use the list of feed keys fetched above
+    -- note that you can't use a subquery here because BQ doesn't do partition elimination on subqueries
     WHERE feed_key in ({{ key_list }})
 ),
 

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
@@ -11,7 +11,7 @@
 }}
 
 {%- call statement('get_keys', fetch_result=True) -%}
-    SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT feed_key), ',')
+    SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT '"' || feed_key || '"' ), ',')
     FROM {{ ref('fct_scheduled_trips') }}
     WHERE service_date
         -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
@@ -22,8 +22,7 @@
     LEFT JOIN {{ ref('dim_schedule_feeds') }} AS feeds
     ON trips.feed_key = feeds.key
     WHERE service_date
-        -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }} - 1
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
             AND {{ ranged_incremental_max_date() }}
 {% endcall %}
 
@@ -38,8 +37,7 @@ WITH trips AS (
         trip_first_departure_sec,
     FROM {{ ref('fct_scheduled_trips') }}
     WHERE service_date
-        -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }} - 1
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
             AND {{ ranged_incremental_max_date() }}
 ),
 
@@ -76,8 +74,9 @@ daily_rt_feeds AS (
         base64_url AS vp_base64_url,
     FROM {{ ref('fct_daily_rt_feed_files') }}
     WHERE `date`
+        -- add one to the incremental max date because we need to get one extra UTC dt to ensure overlap with service date
         BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
-            AND {{ ranged_incremental_max_date() }}
+            AND {{ ranged_incremental_max_date() }} + 1
         AND feed_type = 'vehicle_positions'
 ),
 
@@ -90,10 +89,11 @@ vehicle_locations AS (
         location
     FROM {{ ref('fct_vehicle_locations') }}
     -- we load this by dt rather than service date
-    -- this is ok because t-X days for service date will be fully covered by t-X days for dt
+    -- this is ok for the min date because t-X days for service date will be fully covered by t-X days for dt
+    -- add one to the incremental max date because we need to get one extra UTC dt to ensure overlap with service date
     WHERE dt
         BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
-            AND {{ ranged_incremental_max_date() }}
+            AND {{ ranged_incremental_max_date() }} + 1
 ),
 
 schedule_joins AS (
@@ -116,6 +116,7 @@ schedule_joins AS (
         ON trips.feed_key = stops.feed_key
         AND trips.service_date = stops.service_date
         AND stop_id = stops.stop_id
+    -- TODO: add a where filter if needed to filter out rows missing any critical info
 ),
 
 -- we only want scheduled trips that have a VP url associated
@@ -154,6 +155,7 @@ vp_near_stops AS (
 
     FROM scheduled_with_vp_url
     -- we only want trips with data so inner join is ok
+    -- TODO, though, for testing: try a left join and confirm that trips only get dropped because they don't have locations data and not because of date mismatches
     INNER JOIN vehicle_locations
         ON scheduled_with_vp_url.vp_base64_url = vehicle_locations.base64_url
         AND scheduled_with_vp_url.service_date = vehicle_locations.service_date

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
@@ -11,14 +11,14 @@
 }}
 
 -- fetch a list of feed keys
--- the where clause here needs to align exactly with the where clause used on fct_scheduled_trips below
+-- **the where clause here needs to align exactly with the where clause used on fct_scheduled_trips below**
 -- this allows us to filter stop times grouped for significant efficiency gains
 {%- call statement('get_keys', fetch_result=True) -%}
     SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT '"' || feed_key || '"' ), ',')
     FROM {{ ref('fct_scheduled_trips') }}
     WHERE service_date
         -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }} - 1
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }} - 1
             AND {{ ranged_incremental_max_date() }}
 {%- endcall -%}
 
@@ -35,7 +35,7 @@ WITH trips AS (
     FROM {{ ref('fct_scheduled_trips') }}
     WHERE service_date
         -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }} - 1
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }} - 1
             AND {{ ranged_incremental_max_date() }}
 ),
 
@@ -62,8 +62,7 @@ stops AS (
 
     FROM {{ ref('fct_daily_scheduled_stops') }}
     WHERE service_date
-        -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }} - 1
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
             AND {{ ranged_incremental_max_date() }}
 ),
 
@@ -73,115 +72,94 @@ daily_rt_feeds AS (
         base64_url AS vp_base64_url,
     FROM {{ ref('fct_daily_rt_feed_files') }}
     WHERE `date`
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
             AND {{ ranged_incremental_max_date() }}
         AND feed_type = 'vehicle_positions'
 ),
 
-int_vp_trips AS (
-    SELECT DISTINCT
-        dt,
-        service_date,
-        base64_url,
-        trip_id,
-    FROM {{ ref('int_gtfs_rt__vehicle_positions_trip_day_map_grouping') }}
-    WHERE dt
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
-            AND {{ ranged_incremental_max_date() }}
-),
-
-vp_trips AS (
-    SELECT DISTINCT
-        service_date,
-        base64_url,
-        trip_id,
-        trip_instance_key,
-    FROM {{ ref('fct_vehicle_positions_trip_summaries') }}
-),
-
-
 vehicle_locations AS (
     SELECT
         key,
-        dt,
         service_date,
         base64_url,
         trip_instance_key,
         location
-
     FROM {{ ref('fct_vehicle_locations') }}
     WHERE dt
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_SCHEDULE_START")) }}
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
             AND {{ ranged_incremental_max_date() }}
 ),
 
 schedule_joins AS (
     SELECT
-        int_vp_trips.dt,
         trips.feed_key,
         trips.service_date,
         trips.trip_instance_key,
         stop_times_grouped.key AS st_trip_key,
         stop_id,
         stops.pt_geom,
-        daily_rt_feeds.vp_base64_url,
-
-
+    -- what we want is the batch of all scheduled trips from the last X service dates
     FROM trips
-    INNER JOIN stop_times_grouped
+    LEFT JOIN stop_times_grouped
         ON trips.feed_key = stop_times_grouped.feed_key
         AND trips.trip_id = stop_times_grouped.trip_id
         AND trips.trip_first_departure_sec = stop_times_grouped.trip_first_departure_sec
     -- use trip_first_departure_sec instead of iteration_num because scheduled_trips does more coalescing on iteration_num, so we might not match it
     LEFT JOIN UNNEST(stop_times_grouped.stop_id_array) AS stop_id
-    INNER JOIN stops
+    LEFT JOIN stops
         ON trips.feed_key = stops.feed_key
         AND trips.service_date = stops.service_date
         AND stop_id = stops.stop_id
+),
+
+-- we only want scheduled trips that have a VP url associated
+-- this could potentially be split out into a dedicated upstream model
+-- so that the filtering on grouped stop times could be even tighter
+scheduled_with_vp_url AS (
+    SELECT
+        schedule_joins.feed_key,
+        schedule_joins.service_date,
+        schedule_joins.trip_instance_key,
+        schedule_joins.st_trip_key,
+        schedule_joins.stop_id,
+        schedule_joins.pt_geom,
+        daily_rt_feeds.vp_base64_url
+    FROM schedule_joins
     INNER JOIN daily_rt_feeds
         ON trips.feed_key = daily_rt_feeds.schedule_feed_key
-    INNER JOIN vp_trips
-        ON trips.service_date = vp_trips.service_date
-        AND daily_rt_feeds.vp_base64_url = vp_trips.base64_url
-        AND trips.trip_id = vp_trips.trip_id
-        AND trips.trip_instance_key = vp_trips.trip_instance_key
-    INNER JOIN int_vp_trips
-        ON trips.service_date = int_vp_trips.service_date
-        AND vp_trips.base64_url = int_vp_trips.base64_url
-        AND vp_trips.trip_id = int_vp_trips.trip_id
 ),
+
 
 vp_near_stops AS (
    SELECT
-        schedule_joins.dt,
-        schedule_joins.service_date,
-        schedule_joins.vp_base64_url,
+        scheduled_with_vp_url.dt,
+        scheduled_with_vp_url.service_date,
+        scheduled_with_vp_url.vp_base64_url,
         vehicle_locations.key AS vp_key,
         --vehicle_locations.location,
 
-        schedule_joins.feed_key,
-        schedule_joins.trip_instance_key,
-        schedule_joins.stop_id,
-        schedule_joins.st_trip_key, -- use to key back into schedule trip info found in stop times (int_gtfs_schedule__stop_times_grouped)
+        scheduled_with_vp_url.feed_key,
+        scheduled_with_vp_url.trip_instance_key,
+        scheduled_with_vp_url.stop_id,
+        scheduled_with_vp_url.st_trip_key, -- use to key back into schedule trip info found in stop times (int_gtfs_schedule__stop_times_grouped)
         --schedule_joins.pt_geom,
 
-        MIN(ROUND(ST_DISTANCE(vehicle_locations.location, schedule_joins.pt_geom), 2)) AS distance_meters,
+        MIN(ROUND(ST_DISTANCE(vehicle_locations.location, scheduled_with_vp_url.pt_geom), 2)) AS distance_meters,
         --ST_CLOSESTPOINT(vehicle_locations.location, schedule_joins.pt_geom) is returning a point useful? It'll be difficult to match against, use vp_keys instead and distances
 
-    FROM schedule_joins
+    FROM scheduled_with_vp_url
     INNER JOIN vehicle_locations
-        ON schedule_joins.vp_base64_url = vehicle_locations.base64_url
-        AND schedule_joins.service_date = vehicle_locations.service_date
-        AND schedule_joins.trip_instance_key = vehicle_locations.trip_instance_key
-        AND ST_DWITHIN(vehicle_locations.location, schedule_joins.pt_geom, 100)
+        ON scheduled_with_vp_url.vp_base64_url = vehicle_locations.base64_url
+        AND scheduled_with_vp_url.service_date = vehicle_locations.service_date
+        AND scheduled_with_vp_url.trip_instance_key = vehicle_locations.trip_instance_key
+        AND ST_DWITHIN(vehicle_locations.location, scheduled_with_vp_url.pt_geom, 100)
         -- 100 meters ~ 0.1 miles, 328 ft
-    GROUP BY dt, service_date, vp_base64_url, feed_key, trip_instance_key, stop_id, st_trip_key, vp_key
+    GROUP BY service_date, vp_base64_url, feed_key, trip_instance_key, stop_id, st_trip_key, vp_key
 ),
 
 
-vp_counts_near_stops AS (
+int_gtfs_rt__vehicle_positions_stops_by_service_date AS (
     SELECT
-        dt,
         service_date,
         vp_base64_url,
         feed_key,
@@ -197,7 +175,7 @@ vp_counts_near_stops AS (
         ARRAY_AGG(vp_key ORDER BY distance_meters, vp_key) AS vp_key_array,
 
     FROM vp_near_stops
-    GROUP BY dt, service_date, vp_base64_url, feed_key, trip_instance_key, stop_id, st_trip_key
+    GROUP BY service_date, vp_base64_url, feed_key, trip_instance_key, stop_id, st_trip_key
 )
 
-SELECT * FROM vp_counts_near_stops
+SELECT * FROM int_gtfs_rt__vehicle_positions_stops_by_service_date

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
@@ -10,20 +10,24 @@
     )
 }}
 
+-- depends_on: {{ ref('dim_schedule_feeds') }}
+-- add dependency hint to let dbt know about the dependency inside the call statement block
+
 -- fetch a list of feed keys
 -- **the where clause here needs to align exactly with the where clause used on fct_scheduled_trips below**
 -- this allows us to filter stop times grouped for significant efficiency gains
-{%- call statement('get_keys', fetch_result=True) -%}
-    SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT '"' || feed_key || '"' ), ',')
-    FROM {{ ref('fct_scheduled_trips') }}
+{% call statement('get_dates', fetch_result=True) %}
+    SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT '"' || feeds._valid_from || '"' ), ',')
+    FROM {{ ref('fct_scheduled_trips') }} AS trips
+    LEFT JOIN {{ ref('dim_schedule_feeds') }} AS feeds
+    ON trips.feed_key = feeds.key
     WHERE service_date
         -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
         BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }} - 1
             AND {{ ranged_incremental_max_date() }}
-{%- endcall -%}
+{% endcall %}
 
-{%- set key_list = load_result('get_keys')['data'][0][0] -%}
-
+{% set date_list = load_result('get_dates')['data'][0][0] %}
 
 WITH trips AS (
     SELECT
@@ -50,7 +54,7 @@ stop_times_grouped AS (
     FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
     -- use the list of feed keys fetched above
     -- note that you can't use a subquery here because BQ doesn't do partition elimination on subqueries
-    WHERE feed_key in ({{ key_list }})
+    WHERE _feed_valid_from in ({{ date_list }})
 ),
 
 stops AS (
@@ -85,6 +89,8 @@ vehicle_locations AS (
         trip_instance_key,
         location
     FROM {{ ref('fct_vehicle_locations') }}
+    -- we load this by dt rather than service date
+    -- this is ok because t-X days for service date will be fully covered by t-X days for dt
     WHERE dt
         BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_STOP_ANALYSIS_START")) }}
             AND {{ ranged_incremental_max_date() }}
@@ -126,13 +132,12 @@ scheduled_with_vp_url AS (
         daily_rt_feeds.vp_base64_url
     FROM schedule_joins
     INNER JOIN daily_rt_feeds
-        ON trips.feed_key = daily_rt_feeds.schedule_feed_key
+        ON schedule_joins.feed_key = daily_rt_feeds.schedule_feed_key
 ),
 
 
 vp_near_stops AS (
    SELECT
-        scheduled_with_vp_url.dt,
         scheduled_with_vp_url.service_date,
         scheduled_with_vp_url.vp_base64_url,
         vehicle_locations.key AS vp_key,
@@ -148,6 +153,7 @@ vp_near_stops AS (
         --ST_CLOSESTPOINT(vehicle_locations.location, schedule_joins.pt_geom) is returning a point useful? It'll be difficult to match against, use vp_keys instead and distances
 
     FROM scheduled_with_vp_url
+    -- we only want trips with data so inner join is ok
     INNER JOIN vehicle_locations
         ON scheduled_with_vp_url.vp_base64_url = vehicle_locations.base64_url
         AND scheduled_with_vp_url.service_date = vehicle_locations.service_date
@@ -156,7 +162,6 @@ vp_near_stops AS (
         -- 100 meters ~ 0.1 miles, 328 ft
     GROUP BY service_date, vp_base64_url, feed_key, trip_instance_key, stop_id, st_trip_key, vp_key
 ),
-
 
 int_gtfs_rt__vehicle_positions_stops_by_service_date AS (
     SELECT

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_stops_by_service_date.sql
@@ -16,6 +16,7 @@
 -- fetch a list of _feed_valid_from dates that are implicated in these updates
 -- **the where clause here needs to align exactly with the where clause used on fct_scheduled_trips below**
 -- this allows us to filter stop times grouped for significant efficiency gains
+-- https://stackoverflow.com/questions/64007239/how-do-we-define-select-statement-as-a-variable-in-dbt
 {% call statement('get_dates', fetch_result=True) %}
     SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT '"' || feeds._valid_from || '"' ), ',')
     FROM {{ ref('fct_scheduled_trips') }} AS trips

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_trip_stop_day_map_grouping.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_trip_stop_day_map_grouping.sql
@@ -41,8 +41,8 @@ stops AS (
 
     FROM {{ ref('fct_daily_scheduled_stops') }}
     WHERE service_date
-        -- do microbatch lookback + 1 to account for 1-day offset between UTC and Pacific dates
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS")+1, data_earliest_start=var("GTFS_RT_START")) }}
+        -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }} - 1
             AND {{ ranged_incremental_max_date() }}
 ),
 

--- a/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_trip_stop_day_map_grouping.sql
+++ b/warehouse/models/intermediate/gtfs/int_gtfs_rt__vehicle_positions_trip_stop_day_map_grouping.sql
@@ -10,6 +10,17 @@
     )
 }}
 
+{%- call statement('get_keys', fetch_result=True) -%}
+    SELECT ARRAY_TO_STRING(ARRAY_AGG(DISTINCT feed_key), ',')
+    FROM {{ ref('fct_scheduled_trips') }}
+    WHERE service_date
+        -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }} - 1
+            AND {{ ranged_incremental_max_date() }}
+{%- endcall -%}
+
+{%- set key_list = load_result('get_keys')['data'][0][0] -%}
+
 
 WITH trips AS (
     SELECT
@@ -19,6 +30,10 @@ WITH trips AS (
         trip_instance_key,
         trip_first_departure_sec,
     FROM {{ ref('fct_scheduled_trips') }}
+    WHERE service_date
+        -- subtract 1 at the end to account for 1-day offset between UTC and Pacific dates (always want one service day earlier than the UTC lookback day would be)
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }} - 1
+            AND {{ ranged_incremental_max_date() }}
 ),
 
 stop_times_grouped AS (
@@ -30,6 +45,7 @@ stop_times_grouped AS (
         stop_id_array,
 
     FROM {{ ref('int_gtfs_schedule__stop_times_grouped') }}
+    WHERE feed_key in ({{ key_list }})
 ),
 
 stops AS (
@@ -54,6 +70,7 @@ daily_rt_feeds AS (
     WHERE `date`
         BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
             AND {{ ranged_incremental_max_date() }}
+        AND feed_type = 'vehicle_positions'
 ),
 
 int_vp_trips AS (


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Additional follow up on #5137 post merge of #5092, which may not have fully fixed the issue -- see https://github.com/cal-itp/data-infra/issues/5137#issuecomment-4382256492

Leaving this for @tiffanychu90 to consult and ultimately take over the line. Recommended approach (partially implemented here, but not tested or fully validated):

* Rename this model -- it is not actually a `dt/service_date` mapping model, rename to model purpose
* As far as I can tell, the dependencies on the two VP trip models are not needed? It seems like we can join directly from schedule to vehicle locations using `trip_instance_key`?
* Related, it seems like the grain of this model is in fact just service_date, so it should be treated as such -- partition by service_date. I *think* that loading a couple models by `dt` should be ok in this fashion as noted in comments.
* This adds a new technique that we haven't used before but may be helpful in these large models going forward: pull a list of partition values using dbt's `call_statement` function and pass that to filter certain models (in this case stop times grouped, which is partitioned by `_feed_valid_from`, which we can't target effectively with a simple where statement/incremental logic.) We can't just do subqueries (`where (select thing from whatever)`) for these because BQ doesn't do partition elimination in those cases -- you need to pre-construct the list and pass it explicitly. 
* Adds a new start date variable in `dbt_project` just for these RT stop analysis models to limit how much history gets run for them while they're under construction. 

Remaining actions that would be needed to validate this approach:
* Compare results with what's in prod right now -- does this return equivalent information
* Run incrementally and confirm that we don't see variations at the date boundary between runs (i.e., should see pretty constant data volumes across all weekdays -- do some exploration to check the full universe of expected trips and make sure they are all present.) 
* If merged, delete the existing model.

In general, approach is: 
* Design the model you want (what columns), dependencies
* Then figure out how to make it incremental by constructing intentional batches to be inserted. You need to ensure that, when a date range is being processed, the affected date partitions will be covered in their entirety by the date ranges selected from the upstream parent models. So, if your batch has ANY data from a given service_date based on the selection criteria, you need to make sure that ALL data for that service_date will be present, because the partitions for all service date values will be dropped and overwritten based on what is present in the incoming batches. The one exception is the current_date() when the model is being run, which should be re-run in the subsequent dbt run and it's ok if it has one partial load as long as it gets a complete load on the next run. 
  * Note: As discussed offline, there is some challenge for `service_date` based models because there is sometimes late-arriving data for these (e.g., data for service_date 4/24 that arrives on 5/1, outside the lookback window). It could be possible to add a model that constructs dt/service_date combinations and then selects those (probably using the `call_statement` pattern) and passes those to filter the incoming models. However, the late-arriving data is not large in volume. Recommend that as a future initiative if needed but for now think that the number of affected trips is low enough to let it go.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

Has not yet been tested, needs testing & validation

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [ ] Actions required (specified below)
