### PR TITLE
fix: add enghouse_operator_id to fct_payments_*_transactions SQL (#5211)

### DIFF
--- a/warehouse/models/mart/payments/fct_payments_adjustment_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_adjustment_transactions.sql
@@ -17,6 +17,7 @@ fct_payments_adjustment_transactions AS (
         organization_name,
         organization_source_record_id,
         littlepay_participant_id,
+        enghouse_operator_id,
         payment_reference,
         payment_date,
         fund_amt,

--- a/warehouse/models/mart/payments/fct_payments_billing_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_billing_transactions.sql
@@ -18,6 +18,7 @@ fct_payments_billing_transactions AS (
         organization_name,
         organization_source_record_id,
         littlepay_participant_id,
+        enghouse_operator_id,
         fund_amt,
         batch_reference,
         batch_type,

--- a/warehouse/models/mart/payments/fct_payments_chargeback_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_chargeback_transactions.sql
@@ -17,6 +17,7 @@ fct_payments_chargeback_transactions AS (
         organization_name,
         organization_source_record_id,
         littlepay_participant_id,
+        enghouse_operator_id,
         payment_reference,
         payment_date,
         fund_amt,

--- a/warehouse/models/mart/payments/fct_payments_deposit_transactions.sql
+++ b/warehouse/models/mart/payments/fct_payments_deposit_transactions.sql
@@ -16,6 +16,7 @@ fct_payments_deposit_transactions AS (
         organization_name,
         organization_source_record_id,
         littlepay_participant_id,
+        enghouse_operator_id,
         payment_reference,
         payment_date,
         fund_amt,


### PR DESCRIPTION
# Description

Resolves #5211. Follow-up fix to #5212.

#5212 added `enghouse_operator_id` to the YAML schema for four `fct_payments_*_transactions` models in `warehouse/models/mart/payments/_payments.yml` (anchor `&enghouse_operator_id` at L417/L418, referenced at L602, L630, L674, L714), but didn't update the corresponding `.sql` files to include the column in their final `SELECT`. Each model calls `label_elavon_entities` from `warehouse/macros/annotate_payments_entities.sql` (which adds the column in the intermediate `label` CTE), but the final CTE enumerates columns explicitly and drops `enghouse_operator_id` before materialization.

Net effect: the dbt manifest declares the column, BigQuery doesn't materialize it, Metabase doesn't see it. dbt-metabase warns `Field 'ENGHOUSE_OPERATOR_ID' not in table 'MART_PAYMENTS.FCT_PAYMENTS_*_TRANSACTIONS'` (× 4 tables) on each polling iteration, then errors after 30 s with `MetabaseStateError: Unable to sync models with Metabase`. This is currently breaking the staging Metabase sync and is structurally present in `main`, so the same failure mode will surface in production once the next dbt-touching PR merges and triggers `Sync Metabase`.

This PR adds `enghouse_operator_id` to the final SELECT in each of the four `.sql` files, next to `littlepay_participant_id` (the parallel column emitted by the same macro):

- `warehouse/models/mart/payments/fct_payments_billing_transactions.sql`
- `warehouse/models/mart/payments/fct_payments_deposit_transactions.sql`
- `warehouse/models/mart/payments/fct_payments_chargeback_transactions.sql`
- `warehouse/models/mart/payments/fct_payments_adjustment_transactions.sql`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Repro of the missing-column condition before the fix (run from repo root against `main`):

```bash
for m in fct_payments_{billing,deposit,chargeback,adjustment}_transactions; do
  grep -q enghouse_operator_id "warehouse/models/mart/payments/${m}.sql" \
    && echo "$m: ✓" || echo "$m: ✗ missing"
done
```

## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)
