### PR TITLE
Upgrade JupyterHub chart 3.3.7 → 3.3.8 (security patch)

### DIFF
--- a/kubernetes/apps/charts/jupyterhub/Chart.yaml
+++ b/kubernetes/apps/charts/jupyterhub/Chart.yaml
@@ -3,8 +3,8 @@ name: jupyterhub
 description: JupyterHub for Kubernetes
 type: application
 version: 0.1.0
-appVersion: "4.1.5"
+appVersion: "4.1.6"
 dependencies:
   - name: jupyterhub
-    version: 3.3.7
+    version: 3.3.8
     repository: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
## Summary

The 3.3.8 chart bumps the upstream JupyterHub app from 4.1.5 to 4.1.6, a security release fixing [**CVE-2024-41942**](https://github.com/jupyterhub/jupyterhub/security/advisories/GHSA-9cv4-fmm5-c8wx).

The CVE affects deployments where users hold the `admin:users` scope — which we do (the `admin_users` list in `values.yaml` includes vevetron, tiffanychu90, themightychris, evansiroky, charlie-costanzo, raebot).

## Why patch-only

This is the only release in the 3.x line above our 3.3.7. The chart's 4.x major has breaking changes (chart values restructuring, JupyterHub app 4.x → 5.x); that's a deliberate larger upgrade for another time. 3.3.8 is the safe, security-only step we can take today.

## Changes

```diff
-appVersion: "4.1.5"
+appVersion: "4.1.6"
 dependencies:
   - name: jupyterhub
-    version: 3.3.7
+    version: 3.3.8
```

CI runs `helm dependency update` during deploy, so `Chart.lock` and the bundled chart `.tgz` (both gitignored) refresh automatically.

## Test plan

- [ ] CI passes (kubernetes preview shows the chart dependency bump)
- [ ] Helm rev increments after deploy; hub pod restarts with the new image
- [ ] Login + notebook spawn still work end-to-end on `https://jupyterhub.dds.dot.ca.gov`
- [ ] Admins (anyone in `admin_users`) can still access the admin panel

## References

- [Chart 3.3.8 changelog](https://z2jh.jupyter.org/en/latest/changelog.html#3-3-8-2024-07-31)
- [CVE-2024-41942](https://github.com/jupyterhub/jupyterhub/security/advisories/GHSA-9cv4-fmm5-c8wx)
- #4922 (cluster maintenance tracker)