### PR TITLE
5240: Unpin uv version to align with jupyterlab image in warehouse uv.lock

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -40,6 +40,10 @@ jobs:
         name: Checkout
         uses: actions/checkout@v6
 
+      - &setup-graphviz
+        name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+
       - &install-uv
         name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -93,10 +97,7 @@ jobs:
         name: Setup GCloud utilities
         uses: google-github-actions/setup-gcloud@v2
 
-      - &setup-graphviz
-        name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
-
+      - *setup-graphviz
       - *install-uv
       - *cache-dbt-setup
       - *install-project

--- a/warehouse/pyproject.toml
+++ b/warehouse/pyproject.toml
@@ -59,7 +59,6 @@ dev = [
 [tool.uv]
 package = false
 default-groups = "all"
-required-version = ">=0.10.9"
 
 [build-system]
 requires = ["uv_build>=0.9.21,<0.10.0"]


### PR DESCRIPTION
# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #5240 - the container jupyter lab installs a specific uv version that is older than the minimum version specified in warehouse/uv.lock. From discussion noted on the ticket the preference is to remove the version check in warehouse/uv.lock rather than installing a newer uv version. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

I used compose to exec into a locally running jupyter lab container (added `.warehouse/` as a volume mount). I was able to:
- run `uv sync` within `.warehouse/`
- run `uv run dbt init` with `.warehouse/`

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
