### PR TITLE
fix: add dbt-run dependency to metabase job (#4929)

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -40,6 +40,10 @@ jobs:
         name: Checkout
         uses: actions/checkout@v6
 
+      - &setup-graphviz
+        name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
+
       - &install-uv
         name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -93,9 +97,7 @@ jobs:
         name: Setup GCloud utilities
         uses: google-github-actions/setup-gcloud@v2
 
-      - &setup-graphviz
-        name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2
+      - *setup-graphviz
 
       - *install-uv
       - *cache-dbt-setup

--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -208,7 +208,7 @@ jobs:
   metabase:
     name: Sync Metabase
     runs-on: ubuntu-latest
-    needs: [setup, dbt-changed, compile]
+    needs: [setup, dbt-changed, compile, dbt-run]
 
     permissions:
       contents: read


### PR DESCRIPTION
# Description

Refs #4929. Small follow-up to #5162.

#5162 ("Split out dbt run and dbt compile in CI") moved `dbt run` out of the `compile` job into a new `dbt-run` job. The `metabase` job's `needs:` array wasn't updated to include the new job, so it can now run in parallel with `dbt-run` instead of strictly after it.

Symptom: when a dbt-changing PR merges, the `dbt-run` job rebuilds the affected tables in BigQuery, but the `metabase` job often starts (and sometimes finishes) before the BigQuery schema is updated. dbt-metabase reads the still-stale Metabase metadata, can't find newly-added columns, and fails with `MetabaseStateError: Unable to sync models with Metabase`. Repro from a recent prod run (2026-05-06 02:27 on the `7ef854e82` merge of #5241):

> WARNING — Field 'ENGHOUSE_OPERATOR_ID' not in table 'MART_PAYMENTS.FCT_PAYMENTS_BILLING_TRANSACTIONS'
> WARNING — Field 'ENGHOUSE_OPERATOR_ID' not in table 'MART_PAYMENTS.FCT_PAYMENTS_DEPOSIT_TRANSACTIONS'
> WARNING — Field 'ENGHOUSE_OPERATOR_ID' not in table 'MART_PAYMENTS.FCT_PAYMENTS_CHARGEBACK_TRANSACTIONS'
> WARNING — Field 'ENGHOUSE_OPERATOR_ID' not in table 'MART_PAYMENTS.FCT_PAYMENTS_ADJUSTMENT_TRANSACTIONS'
> ...
> MetabaseStateError: Unable to sync models with Metabase

The fix is one line in `.github/workflows/deploy-dbt.yml`: add `dbt-run` to `metabase`'s `needs:`.

**Skip behavior preserved.** When `dbt-changed.outputs.has-changed == 'false'`, the `dbt-run` job is skipped (the existing `if:` on each step gates on that output). GitHub Actions treats `skipped` as `success()` for downstream `needs:` resolution, so the `metabase` job still runs as before for non-dbt-touching PRs.

This is part of the broader work tracked in #4929 ("Clarify CICD GitHub Actions for dbt deployment -- possible race condition?"), but is scoped narrowly to closing this specific race so it can land fast and unblock the recurring metabase sync failures.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

The race is timing-dependent and not deterministically reproducible in a single test, but the fix is verifiable structurally:
- Inspect the workflow graph in the PR's Actions run: the `metabase` job should now appear with `dbt-run` listed under "Waiting for: ..." until `dbt-run` completes. Previously they ran in parallel.
- The `dbt-run` job's existing `if:` conditions (`needs.dbt-changed.outputs.has-changed == 'true'`) mean it skips on non-dbt PRs; verify the `metabase` job still runs in those cases (this PR itself is non-dbt-touching, so its own workflow run is a useful test of that property).
Empirical validation will come on the first dbt-changing PR after merge: that PR's workflow run should sync table+column docs to Metabase without `MetabaseStateError`. I'll monitor.

## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)