### PR TITLE
Run dbt models job only if there are model changes

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -215,6 +215,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compile, dbt-run]
 
+    if: ${{ !failure() && !cancelled() }}
+
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -177,6 +177,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, dbt-changed]
 
+    if: ${{ needs.dbt-changed.outputs.has-changed == 'true' }}
+
     permissions:
       contents: read
       id-token: write
@@ -191,25 +193,27 @@ jobs:
       - *install-project
       - *dbt-deps
 
+      - name: List changed and downstream models
+        working-directory: warehouse
+        run: uv run dbt list --select "${{ needs.dbt-changed.outputs.changed-downstream }}" --target ${{ env.DBT_TARGET }} --resource-type=model
+
       - name: Run seeds
         if: ${{ needs.dbt-changed.outputs.has-changed-seeds == 'true' }}
         working-directory: warehouse
         run: uv run dbt seed --select "${{ needs.dbt-changed.outputs.changed-seeds }}" --target ${{ env.DBT_TARGET }}
 
       - name: Full-Refresh changed models
-        if: ${{ needs.dbt-changed.outputs.has-changed == 'true' }}
         working-directory: warehouse
         run: uv run dbt run --select "${{ needs.dbt-changed.outputs.changed-models }}" --target ${{ env.DBT_TARGET }} --full-refresh
 
       - name: Run downstream models
-        if: ${{ needs.dbt-changed.outputs.has-changed == 'true' }}
         working-directory: warehouse
         run: uv run dbt run --select "${{ needs.dbt-changed.outputs.changed-downstream }}" --target ${{ env.DBT_TARGET }} --exclude "${{ needs.dbt-changed.outputs.changed-models }}"
 
   metabase:
     name: Sync Metabase
     runs-on: ubuntu-latest
-    needs: [setup, dbt-changed, compile, dbt-run]
+    needs: [compile, dbt-run]
 
     permissions:
       contents: read


### PR DESCRIPTION
# Description

This PR adds back the condition to only run models if there were changes to the job instead of in the command lines.
It reduces the extra workflow running time when there are no dbt model changes.

I also simplifying the Metabase to `needs: [compile, dbt-run]` since now it also needs `dbt-run` that already requires `[setup, dbt-changed]` so we don’t need to repeat it.

@jamalk23 needs `Sync Metabase` to run even without dbt models changes, for example there were a macro, or a documentation change. So I added the check `if: ${{ !failure() && !cancelled() }}` to run for those cases, but not when it fails or was cancelled.

Related to [#5161 and #4929] 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running workflow through this PR, it shows skipping the `dbt-run` job but still runs `Sync Metabase`:
<img width="930" height="293" alt="image" src="https://github.com/user-attachments/assets/2a3caa74-f2e2-4865-8cd3-c3cbfc4d804b" />

Before it was running but skipping steps:
<img width="625" height="317" alt="image" src="https://github.com/user-attachments/assets/9dc64abd-e10f-41df-b88a-4ff0d4be1e78" />
<img width="418" height="778" alt="image" src="https://github.com/user-attachments/assets/525c585f-6d95-4cf9-891f-7fda8a20b9b2" />


## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
