### PR TITLE
Downgrade permissions on specific unused iam members

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -139,13 +139,13 @@ resource "google_project_iam_member" "tfer--roles-002F-editorserviceAccount-003A
 resource "google_project_iam_member" "tfer--roles-002F-ownerserviceAccount-003A-amplitude-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:amplitude@cal-itp-data-infra-staging.iam.gserviceaccount.com"
   project = "cal-itp-data-infra-staging"
-  role    = "roles/owner"
+  role    = "roles/viewer"
 }
 
 resource "google_project_iam_member" "tfer--roles-002F-ownerserviceAccount-003A-local-airflow-dev-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com"
   project = "cal-itp-data-infra-staging"
-  role    = "roles/owner"
+  role    = "roles/viewer"
 }
 
 resource "google_project_iam_member" "tfer--roles-002F-pubsub-002E-serviceAgentserviceAccount-003A-service-473674835135-0040-gcp-sa-pubsub-002E-iam-002E-gserviceaccount-002E-com" {

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -397,7 +397,7 @@ resource "google_project_iam_member" "tfer--roles-002F-firestore-002E-serviceAge
 resource "google_project_iam_member" "tfer--roles-002F-ownerserviceAccount-003A-cc-jarvus-airflow-0040-cal-itp-data-infra-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:cc-jarvus-airflow@cal-itp-data-infra.iam.gserviceaccount.com"
   project = "cal-itp-data-infra"
-  role    = "roles/owner"
+  role    = "roles/viewer"
 }
 
 resource "google_project_iam_member" "tfer--roles-002F-run-002E-serviceAgentserviceAccount-003A-service-1005246706141-0040-serverless-robot-prod-002E-iam-002E-gserviceaccount-002E-com" {


### PR DESCRIPTION
# Description

Downgrade three unused service accounts from `roles/owner` to `roles/viewer` as a first step toward removal (see #4960). If we need to revert this would make things easier.  Work towards #4960 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
Audited logs of local-airflow-dev,  amplitude, and cc-jarvus-airflow.  Keys have been rotated recently but Audit activity shows nothing for 90 days.
```
gcloud logging read \
    'protoPayload.authenticationInfo.principalEmail="amplitude@cal-itp-data-infra-staging.iam.gserviceaccount.com"' \
    --project=cal-itp-data-infra-staging \
    --freshness=90d \
    --limit=5
```
## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)
In 2 weeks if nothing breaks remove those accounts.