### PR TITLE
Disable Google Managed Service for Prometheus on data-infra-apps

### DIFF
--- a/iac/cal-itp-data-infra/gke/us/container_cluster.tf
+++ b/iac/cal-itp-data-infra/gke/us/container_cluster.tf
@@ -57,7 +57,7 @@ resource "google_container_cluster" "tfer--data-infra-apps" {
     enable_components = ["SYSTEM_COMPONENTS"]
 
     managed_prometheus {
-      enabled = "true"
+      enabled = "false"
     }
   }
 


### PR DESCRIPTION
## Summary

Flips `managed_prometheus.enabled` to `false` on the `data-infra-apps` cluster. Cleanly reverses the GMP enablement from #5156 now that the in-cluster GTFS-RT archiver dashboard (#5247) is gone and no other workload in the cluster references GMP.

## Context

GMP was enabled in #5156 specifically to back the archiver's Cloud Monitoring dashboard via a `PodMonitoring` resource scraping the archiver's `/metrics` endpoint. That dashboard, the alert policies, the log-based metrics, and the `PodMonitoring` itself were all torn down with #5247 / its post-merge cleanup.

Right now the cluster has:

- 15 collector pods (one per node) running idle — nothing to scrape
- The `gmp-operator` Deployment in `gmp-system`
- 7 GMP CRDs (`PodMonitoring`, `ClusterPodMonitoring`, `ClusterNodeMonitoring`, `ClusterRules`, `GlobalRules`, `OperatorConfig`, `Rules`)
- 0 `PodMonitoring` / `ClusterPodMonitoring` / `ClusterNodeMonitoring` resources defined

Verified via the Cloud Monitoring `monitoring.googleapis.com/collection/attribution/write_sample_count` metric that 0 samples are attributed to `data-infra-apps`. (Project-level samples come from the unrelated `sftp-endpoints` and Composer clusters.)

## Cost impact

- **GCP billing**: $0 change. GMP pricing is per-sample-ingested with no per-cluster fee, and we're already at zero samples from this cluster.
- **Cluster overhead**: small reclaim — the collector DaemonSet reserves ~4m CPU + ~36 MiB memory per node (~60m + 540 MiB across 15 nodes).

## Re-enable path

If a future workload wants GMP-style scraping, this is a one-line revert (`enabled = "true"`), followed by deploying a `PodMonitoring` resource pointing at the workload's metrics endpoint. No state to migrate.

## Test plan

- [ ] CI terraform plan shows only the `managed_prometheus.enabled` flip (1 resource modified)
- [ ] After merge, terraform-apply succeeds
- [ ] After GKE reconciles: `kubectl get ns gmp-system` returns NotFound (or has no pods); `kubectl get crd | grep monitoring.googleapis` returns no rows

## References

- #5156 (the original enablement)
- #5247 (the dependent dashboard / monitoring module decommission, now landed)
- #4922 (cluster maintenance tracker)