### PR TITLE
feat(metabase-staging): protect with Cloud Armor security policy

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -1,0 +1,150 @@
+resource "google_compute_security_policy" "metabase-staging" {
+  name        = "metabase-staging-armor"
+  description = "Cloud Armor policy protecting Metabase Cloud Run (staging)"
+
+  rule {
+    priority    = 1000
+    action      = "deny(403)"
+    description = "OWASP SQLi"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('sqli-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1100
+    action      = "deny(403)"
+    description = "OWASP XSS"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1200
+    action      = "deny(403)"
+    description = "OWASP RCE"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1300
+    action      = "deny(403)"
+    description = "OWASP local file inclusion"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('lfi-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1400
+    action      = "deny(403)"
+    description = "OWASP remote file inclusion"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('rfi-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1500
+    action      = "deny(403)"
+    description = "Scanner / bot signatures"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1600
+    action      = "deny(403)"
+    description = "HTTP protocol attacks"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1700
+    action      = "deny(403)"
+    description = "Session fixation"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 9000
+    action      = "rate_based_ban"
+    description = "Per-IP login rate limit (10/min then 10-min ban)"
+    match {
+      expr {
+        expression = "request.path.startsWith('/api/session')"
+      }
+    }
+    rate_limit_options {
+      conform_action   = "allow"
+      exceed_action    = "deny(429)"
+      enforce_on_key   = "IP"
+      ban_duration_sec = 600
+      rate_limit_threshold {
+        count        = 10
+        interval_sec = 60
+      }
+      ban_threshold {
+        count        = 10
+        interval_sec = 60
+      }
+    }
+  }
+
+  rule {
+    priority    = 9100
+    action      = "throttle"
+    description = "Per-IP global throttle (600/min)"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    rate_limit_options {
+      conform_action = "allow"
+      exceed_action  = "deny(429)"
+      enforce_on_key = "IP"
+      rate_limit_threshold {
+        count        = 600
+        interval_sec = 60
+      }
+    }
+  }
+
+  rule {
+    priority    = 2147483647
+    action      = "allow"
+    description = "Default allow"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+  }
+}

--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -96,7 +96,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "Per-IP login rate limit (10/min then 10-min ban)"
     match {
       expr {
-        expression = "request.path.startsWith('/api/session')"
+        expression = "request.path.startsWith('/api/session') && request.method == 'POST' && !inIpRange(origin.ip, '149.136.0.0/16')"
       }
     }
     rate_limit_options {
@@ -120,9 +120,8 @@ resource "google_compute_security_policy" "metabase-staging" {
     action      = "throttle"
     description = "Per-IP global throttle (600/min)"
     match {
-      versioned_expr = "SRC_IPS_V1"
-      config {
-        src_ip_ranges = ["*"]
+      expr {
+        expression = "!inIpRange(origin.ip, '149.136.0.0/16')"
       }
     }
     rate_limit_options {

--- a/iac/cal-itp-data-infra-staging/metabase/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/service.tf
@@ -157,7 +157,7 @@ module "lb-http" {
 
       log_config = {
         enable      = true
-        sample_rate = 0.1
+        sample_rate = 1.0
       }
 
       security_policy = google_compute_security_policy.metabase-staging.self_link

--- a/iac/cal-itp-data-infra-staging/metabase/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/service.tf
@@ -156,8 +156,11 @@ module "lb-http" {
       }
 
       log_config = {
-        enable = false
+        enable      = true
+        sample_rate = 0.1
       }
+
+      security_policy = google_compute_security_policy.metabase-staging.self_link
     }
   }
 }


### PR DESCRIPTION
First step of #5255 — stand up the Cloud Armor policy on **staging** (`metabase-staging.dds.dot.ca.gov`) so we can validate rule shape against active probing + routine usage before applying to prod. Full plan / rationale in [this comment](https://github.com/cal-itp/data-infra/issues/5255#issuecomment-4394058378).

## Changes

### New: `iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf`

`google_compute_security_policy.metabase-staging` with the following rules (all enforcing — see "Why no preview" below):

| Priority | Rule | Action |
|---:|---|---|
| 1000 | OWASP SQLi (`sqli-v33-stable`) | `deny(403)` |
| 1100 | OWASP XSS (`xss-v33-stable`) | `deny(403)` |
| 1200 | OWASP RCE (`rce-v33-stable`) | `deny(403)` |
| 1300 | OWASP LFI (`lfi-v33-stable`) | `deny(403)` |
| 1400 | OWASP RFI (`rfi-v33-stable`) | `deny(403)` |
| 1500 | Scanner / bot signatures (`scannerdetection-v33-stable`) | `deny(403)` |
| 1600 | HTTP protocol attacks (`protocolattack-v33-stable`) | `deny(403)` |
| 1700 | Session fixation (`sessionfixation-v33-stable`) | `deny(403)` |
| 9000 | Per-IP login rate-based ban — 10 req/min on `/api/session` → 10-min ban | `rate_based_ban` (`deny(429)`) |
| 9100 | Per-IP global throttle — 600 req/min | `throttle` (`deny(429)`) |
| 2147483647 | Default | `allow` |

### Modified: `iac/cal-itp-data-infra-staging/metabase/us/service.tf`

Two-part wiring on the existing `module.lb-http` backend:

- `security_policy = google_compute_security_policy.metabase-staging.self_link` — attaches the policy
- `log_config.enable: false → true`, `sample_rate = 0.1` — flips on HTTPS LB logging at 10 % sampling so Cloud Armor decisions show up in Cloud Logging via the `enforcedSecurityPolicy` field. We need this on for the validation period; can revisit sampling later.

## Why no `preview = true` here

Staging exists to discover surprises before prod. Running rules in preview here just delays observation without buying anything. If a rule produces a false positive against routine analyst use of `metabase-staging.dds.dot.ca.gov`, we want it to actually fail so we notice and tune. The prod follow-up PR will start everything in `preview = true` and soak for ~7 days before a final flip.

## Validation plan post-merge

1. Confirm policy attached: `gcloud compute security-policies describe metabase-staging-armor --project=cal-itp-data-infra-staging` and `gcloud compute backend-services describe metabase-staging-backend-default --global --project=cal-itp-data-infra-staging --format='value(securityPolicy)'`.
2. **Manual probes (should be blocked)**:
   - SQLi: `curl -i 'https://metabase-staging.dds.dot.ca.gov/?id=1%27%20OR%201%3D1'` → expect 403
   - XSS: `curl -i 'https://metabase-staging.dds.dot.ca.gov/?q=<script>alert(1)</script>'` → expect 403
   - Login flood: `for i in {1..15}; do curl -s -o /dev/null -w "%{http_code}\n" -X POST 'https://metabase-staging.dds.dot.ca.gov/api/session' -d '{}'; done` → expect 429s after 10
3. **Routine usage check**: have an analyst spend a few minutes in normal Metabase staging workflows (open dashboards, run queries, edit a question). Confirm no rule fires by inspecting Cloud Logging:
   ```
   resource.type="http_load_balancer"
   resource.labels.url_map_name="metabase-staging-url-map"
   jsonPayload.enforcedSecurityPolicy.outcome="DENY"
   ```

## Rollout

- **This PR** → land + validate on staging.
- **Follow-up PR 1** → mirror policy onto prod (`iac/cal-itp-data-infra/metabase/us/`) with all rules in `preview = true`, ~7-day soak.
- **Follow-up PR 2** → tiny, flips prod previews off after the soak.

## Cost impact

Cloud Armor Standard: $1/policy/month + $0.75 per million evaluated requests. Staging traffic is in the noise so this is effectively a few dollars/month total across staging + prod once both land.

## References

- #5255 (the issue)
- [Plan comment](https://github.com/cal-itp/data-infra/issues/5255#issuecomment-4394058378)