### PR TITLE
feat(metabase): unify Dockerfile + add Cloud SQL backup-restore runbooks (with prod IAM grant)

### DIFF
--- a/.github/workflows/build-metabase.yml
+++ b/.github/workflows/build-metabase.yml
@@ -21,42 +21,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  changes:
-    name: Detect changes
-
+  build:
+    name: Build image
     runs-on: ubuntu-latest
-
-    outputs:
-      staging: ${{ steps.staging-changes.outputs.all_changed_files }}
-      production: ${{ steps.production-changes.outputs.all_changed_files }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Staging Changes
-        uses: tj-actions/changed-files@v46
-        id: staging-changes
-        with:
-          matrix: true
-          dir_names: true
-          files: 'services/metabase/Dockerfile.staging'
-
-      - name: Production Changes
-        uses: tj-actions/changed-files@v46
-        id: production-changes
-        with:
-          matrix: true
-          dir_names: true
-          files: 'services/metabase/Dockerfile.production'
-
-  staging:
-    name: Build staging image
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: ${{ needs.changes.outputs.staging != '[]' || needs.changes.outputs.staging != '' }}
 
     permissions:
       contents: read
@@ -79,41 +46,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: services/metabase
-          file: services/metabase/Dockerfile.staging
+          file: services/metabase/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}/metabase:staging
+          tags: |
+            ghcr.io/${{ github.repository }}/metabase:staging
+            ghcr.io/${{ github.repository }}/metabase:production
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/metabase:staging
-          cache-to: type=inline
-
-  production:
-    name: Build production image
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: ${{ needs.changes.outputs.production != '[]' || needs.changes.outputs.production != '' }}
-
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Login to GitHub Repository
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push
-        uses: docker/build-push-action@v6
-        with:
-          context: services/metabase
-          file: services/metabase/Dockerfile.production
-          push: true
-          tags: ghcr.io/${{ github.repository }}/metabase:production
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/metabase:production
           cache-to: type=inline

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -289,6 +289,10 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-backups-grafana" {
 POLICY
 }
 
+data "google_sql_database_instance" "metabase" {
+  name = "metabase"
+}
+
 resource "google_storage_bucket_iam_policy" "tfer--calitp-backups-metabase" {
   bucket = "b/calitp-backups-metabase"
 
@@ -323,7 +327,8 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-backups-metabase" {
     },
     {
       "members": [
-        "serviceAccount:backup-metabase@cal-itp-data-infra.iam.gserviceaccount.com"
+        "serviceAccount:backup-metabase@cal-itp-data-infra.iam.gserviceaccount.com",
+        "serviceAccount:${data.google_sql_database_instance.metabase.service_account_email_address}"
       ],
       "role": "roles/storage.objectAdmin"
     }

--- a/runbooks/workflow/metabase-restore.md
+++ b/runbooks/workflow/metabase-restore.md
@@ -145,15 +145,15 @@ curl -s https://metabase.dds.dot.ca.gov/api/health
 
 Measured against `metabase-restore-test` (db-g1-small, ~800 MB application DB seeded from a prod export, same Metabase version on each side of the restore). Wall-clock figures from the validation run on 2026-05-07 — actual times scale with database size.
 
-| Phase | Measured duration |
-|---|---|
-| List backups (step 1) | seconds |
-| On-demand pre-restore backup (step 2) | ~60–80 s |
-| Park Metabase — Cloud Run revision deploy (step 3) | ~10 s |
-| Restore from backup (step 4) | **~4 minutes** |
-| Bring Metabase back — Cloud Run revision deploy (step 5) | ~45 s |
-| Metabase startup health check returns `"ok"` (step 5–6) | ~5–10 minutes typical against prod's normal driver reachability |
-| **Total user-visible downtime** | **~10–15 minutes** typical |
+| Phase                                                    | Measured duration                                               |
+| -------------------------------------------------------- | --------------------------------------------------------------- |
+| List backups (step 1)                                    | seconds                                                         |
+| On-demand pre-restore backup (step 2)                    | ~60–80 s                                                        |
+| Park Metabase — Cloud Run revision deploy (step 3)       | ~10 s                                                           |
+| Restore from backup (step 4)                             | **~4 minutes**                                                  |
+| Bring Metabase back — Cloud Run revision deploy (step 5) | ~45 s                                                           |
+| Metabase startup health check returns `"ok"` (step 5–6)  | ~5–10 minutes typical against prod's normal driver reachability |
+| **Total user-visible downtime**                          | **~10–15 minutes** typical                                      |
 
 Notes on the dominant phases:
 

--- a/runbooks/workflow/metabase-restore.md
+++ b/runbooks/workflow/metabase-restore.md
@@ -1,45 +1,69 @@
-# Restoring Metabase to Cloud Run + Cloud SQL
+# Restoring Metabase from a Cloud SQL backup
 
-Restore a Metabase database backup from the Kubernetes restic repository into the Cloud SQL instance backing the Cloud Run deployment.
+Restore the prod Metabase database from a managed Cloud SQL backup, in place.
+
+This is the disaster-recovery path: bring the live deployment at `https://metabase.dds.dot.ca.gov/` back to a known-good state by overwriting the prod Cloud SQL instance with one of its own backups.
+
+For the upgrade-testing / "spin up a copy of prod to experiment with" workflow, see [`metabase-test-instance-from-prod.md`](metabase-test-instance-from-prod.md) instead.
+
+## When to use this runbook
+
+- Production Metabase data was lost or corrupted (accidental deletion, bad migration, etc.).
+- The application database needs to be rolled back to a specific point.
+
+This runbook is **destructive** for the live instance — the in-place restore overwrites the current Cloud SQL data. Anything created since the chosen backup is lost.
 
 ## Prerequisites
 
-- `gcloud` CLI authenticated with `cal-itp-data-infra` project access
-- `gsutil`
-- `psql` (`brew install libpq && brew link --force libpq`)
-- Restic credentials (see `.scratch/restic-envs/metabase/`)
+- `gcloud` CLI authenticated with `cal-itp-data-infra` project access. None of these steps require a database password.
+- Authority to take prod Metabase offline for ~10–15 minutes.
 
-## 1. Download the latest backup
+## Backup retention
 
-```bash
-# load restic credentials
-export GOOGLE_PROJECT_ID="1005246706141"
-export GOOGLE_APPLICATION_CREDENTIALS="/path/to/gcs-upload-svcacct.json"
-export RESTIC_REPOSITORY="gs:calitp-backups-metabase:/"
-export RESTIC_PASSWORD="..."
+The `metabase` Cloud SQL instance is configured for **7 daily automated backups**, retained on a rolling basis. See [`iac/cal-itp-data-infra/metabase/us/sql.tf`](../../iac/cal-itp-data-infra/metabase/us/sql.tf). Older history is not retained — if you need point-in-time recovery beyond 7 days, you must restore from a SQL export captured separately.
 
-# list available snapshots
-restic snapshots --latest=5
+## 1. Identify the backup to restore from
 
-# dump the latest snapshot
-restic dump latest /pg_dump.sql.gz > pg_dump.sql.gz
-gunzip pg_dump.sql.gz
-```
-
-## 2. Get the Cloud SQL password
+### gcloud
 
 ```bash
-cd iac/cal-itp-data-infra/metabase/us
-tofu init # if needed
-export PGPASSWORD=$(
-  tofu state pull \
-  | jq -r '.resources[] | select(.type=="random_password" and .name=="metabase-database") | .instances[0].attributes.result'
-)
+gcloud sql backups list \
+  --instance=metabase \
+  --project=cal-itp-data-infra
 ```
 
-## 3. Deploy a no-op image
+Note the `ID` of the chosen backup (e.g. `1778166920912`).
 
-Swap the Cloud Run service to a no-op image so Metabase releases all database connections:
+### Console
+
+1. Open <https://console.cloud.google.com/sql/instances/metabase/backups?project=cal-itp-data-infra>.
+2. Review the list and identify the backup to restore from. Note its window-start timestamp.
+
+## 2. Take an on-demand backup of the current state (recommended)
+
+Captures a recovery point you can fall back to if the restore goes wrong.
+
+### gcloud
+
+```bash
+gcloud sql backups create \
+  --instance=metabase \
+  --project=cal-itp-data-infra \
+  --description="pre-restore snapshot $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+### Console
+
+1. From the **Backups** tab, click **Create backup**.
+2. Add a description like `pre-restore snapshot <ISO timestamp>` and confirm.
+
+Wait for the operation to complete (~1 minute) before proceeding.
+
+## 3. Park Metabase
+
+Cloud Run instances hold pooled connections to Cloud SQL even when scaled to zero. Swap the service to a no-op image so all connections release before the restore.
+
+### gcloud
 
 ```bash
 gcloud run services update metabase \
@@ -49,37 +73,42 @@ gcloud run services update metabase \
   --project=cal-itp-data-infra
 ```
 
-## 4. Drop and recreate the database
+### Console
+
+1. Open <https://console.cloud.google.com/run/detail/us-west2/metabase/revisions?project=cal-itp-data-infra>.
+2. Click **Edit & Deploy New Revision**.
+3. Under **Container image URL**, replace the image with `gcr.io/cloudrun/hello`.
+4. Under **Autoscaling**, set **Minimum number of instances** to `0`.
+5. Click **Deploy** and wait for the new revision to roll out.
+
+`metabase.dds.dot.ca.gov` will return the Cloud Run "Hello World" page during this window.
+
+## 4. Restore the backup
+
+This is the destructive step. The chosen backup is written over the entire Cloud SQL instance.
+
+### gcloud
 
 ```bash
-gcloud sql databases delete metabase \
-  --instance=metabase \
-  --project=cal-itp-data-infra \
-  --quiet
-
-gcloud sql databases create metabase \
-  --instance=metabase \
-  --project=cal-itp-data-infra \
-  --charset=UTF8 \
-  --collation=en_US.UTF8
+gcloud sql backups restore <BACKUP_ID> \
+  --restore-instance=metabase \
+  --project=cal-itp-data-infra
 ```
 
-## 5. Import the backup
+The command waits for the restore operation to finish.
 
-Upload to GCS and run a server-side import (more reliable than piping through psql for large dumps):
+### Console
 
-```bash
-gsutil cp pg_dump.sql gs://calitp-backups-metabase/pg_dump.sql
+1. From the **Backups** tab, locate the chosen backup.
+2. Click the three-dot menu next to it and choose **Restore**.
+3. Confirm the target instance is `metabase` (in-place restore) and click **Restore**.
+4. Wait for the operation to complete.
 
-gcloud sql import sql metabase \
-  gs://calitp-backups-metabase/pg_dump.sql \
-  --database=metabase \
-  --user=metabase \
-  --project=cal-itp-data-infra \
-  --quiet
-```
+## 5. Bring Metabase back
 
-## 6. Restore the Metabase service
+### gcloud
+
+Use the prod image tag and minimum-instances setting that match the deployed terraform state.
 
 ```bash
 gcloud run services update metabase \
@@ -89,32 +118,52 @@ gcloud run services update metabase \
   --project=cal-itp-data-infra
 ```
 
-## 7. Verify
+### Console
+
+1. From the Cloud Run service page, click **Edit & Deploy New Revision**.
+2. Restore the image URL to `us-west2-docker.pkg.dev/cal-itp-data-infra/ghcr/cal-itp/data-infra/metabase:production`.
+3. Restore **Minimum number of instances** to `1`.
+4. Click **Deploy**.
+
+The first request after the new revision goes live triggers Metabase's startup. If the restored backup was taken on a previous Metabase version, the application schema migration runs at this point. The service returns 503 with `{"status":"initializing"}` from `/api/health` until it's complete.
+
+## 6. Verify
+
+### gcloud
 
 ```bash
-# get the instance IP
-export PGHOST=$(gcloud sql instances describe metabase \
-  --project=cal-itp-data-infra \
-  --format='value(ipAddresses[0].ipAddress)')
-
-# allowlist your IP (the psql connection will fail without a password, but the allowlisting takes effect)
-gcloud sql connect metabase --database=postgres --user=metabase --project=cal-itp-data-infra || true
-
-# then connect directly with psql
-psql -h "$PGHOST" -U metabase -d metabase \
-  -c "SELECT count(*) FROM core_user; SELECT count(*) FROM report_dashboard; SELECT count(*) FROM report_card;"
-
-# check health
 curl -s https://metabase.dds.dot.ca.gov/api/health
+# expect: {"status":"ok"}
 ```
 
-## 8. Clean up
+### Console
 
-```bash
-gsutil rm gs://calitp-backups-metabase/pg_dump.sql
-```
+1. Open <https://metabase.dds.dot.ca.gov/>, sign in, and confirm dashboards and questions reflect the restored point in time.
+2. Spot-check a known-affected dashboard or question if you're restoring after a specific incident.
+
+## Expected timeline
+
+Measured against `metabase-restore-test` (db-g1-small, ~800 MB application DB seeded from a prod export, same Metabase version on each side of the restore). Wall-clock figures from the validation run on 2026-05-07 — actual times scale with database size.
+
+| Phase | Measured duration |
+|---|---|
+| List backups (step 1) | seconds |
+| On-demand pre-restore backup (step 2) | ~60–80 s |
+| Park Metabase — Cloud Run revision deploy (step 3) | ~10 s |
+| Restore from backup (step 4) | **~4 minutes** |
+| Bring Metabase back — Cloud Run revision deploy (step 5) | ~45 s |
+| Metabase startup health check returns `"ok"` (step 5–6) | ~5–10 minutes typical against prod's normal driver reachability |
+| **Total user-visible downtime** | **~10–15 minutes** typical |
+
+Notes on the dominant phases:
+
+- **Restore from backup (step 4)** scales with the size of the Cloud SQL instance's storage volume — at ~800 MB the operation took 4 minutes.
+- **Metabase startup** is dominated by Liquibase changelog reading + search index initialization + per-driver feature checks against every configured external database. In prod, the external databases (BigQuery, Payments DBs) are reachable, so the driver probes complete quickly. In an isolated test instance the same probes time out, dramatically extending boot time — see the comparable "Expected timeline" notes in [`metabase-test-instance-from-prod.md`](metabase-test-instance-from-prod.md).
+- If the restored backup was taken on a different Metabase version, expect Liquibase to take noticeably longer as it applies migrations on top of the restored schema.
 
 ## Notes
 
-- Metabase auto-migrates its schema on startup when the application version is newer than the database schema version. Check Cloud Run logs if startup is slow.
-- The backup chart (`kubernetes/apps/charts/postgresql-backup`) uses `pg_dump --no-owner --no-privileges`, so dumps are portable across different database users without any transformation.
+- All steps in this runbook are server-side gcloud API calls or Cloud Run revision deploys; **no database password is required**. Earlier restic-era runbooks needed `psql` and the Cloud SQL instance password to drop/recreate the database — that's no longer necessary because `gcloud sql backups restore` is fully managed.
+- `gcloud sql backups restore` operates only within the same project. To restore prod data into a different project (e.g. for upgrade testing), use the export/import workflow in [`metabase-test-instance-from-prod.md`](metabase-test-instance-from-prod.md).
+- If `/api/health` returns `{"status":"initializing","progress":...}` after step 5, it is running schema migrations — leave it alone. Watch the progress value in successive polls; it should advance.
+- Cloud Run logs for the running revision: <https://console.cloud.google.com/run/detail/us-west2/metabase/logs?project=cal-itp-data-infra>.

--- a/runbooks/workflow/metabase-test-instance-from-prod.md
+++ b/runbooks/workflow/metabase-test-instance-from-prod.md
@@ -198,18 +198,18 @@ gcloud run deploy "$INSTANCE" \
 
 ### Console
 
-1. Open <https://console.cloud.google.com/run/create?project=cal-itp-data-infra-staging>.
-2. **Service name**: `metabase-restore-test`.
-3. **Region**: `us-west2`.
-4. **Container image URL**: `us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/data-infra/metabase:staging`.
-5. **Authentication**: Require authentication.
-6. **CPU allocation**: CPU is only allocated during request processing.
-7. Under **Containers → Edit container**:
+01. Open <https://console.cloud.google.com/run/create?project=cal-itp-data-infra-staging>.
+02. **Service name**: `metabase-restore-test`.
+03. **Region**: `us-west2`.
+04. **Container image URL**: `us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/data-infra/metabase:staging`.
+05. **Authentication**: Require authentication.
+06. **CPU allocation**: CPU is only allocated during request processing.
+07. Under **Containers → Edit container**:
     - **Resources**: 1 CPU, 2 GiB memory.
     - **Container port**: `3000`.
     - **Environment variables**: set `MB_DB_TYPE=postgres`, `MB_DB_DBNAME=metabase`, `MB_DB_HOST=127.0.0.1`, `MB_DB_USER=postgres`, `MB_DB_PASS=<your password>`, `JAVA_OPTS=-Xmx2048m`, `CLOUD_SQL_INSTANCE_CONNECTION_NAME=cal-itp-data-infra-staging:us-west2:metabase-restore-test`.
-8. Under **Cloud SQL connections**, add the temp instance's connection name.
-9. Under **Networking** / Service account, choose `metabase-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com`.
+08. Under **Cloud SQL connections**, add the temp instance's connection name.
+09. Under **Networking** / Service account, choose `metabase-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com`.
 10. Under **Autoscaling**, set **Minimum number of instances** to `1`.
 11. Click **Create**.
 
@@ -277,16 +277,16 @@ rm "/tmp/${INSTANCE}-postgres-pass"
 
 Measured from the validation run on 2026-05-07 (prod metabase ~800 MB SQL export, db-g1-small temp Cloud SQL, db-g1-small Cloud Run with 1 vCPU / 2 GiB).
 
-| Phase | Measured duration |
-|---|---|
-| Export prod DB to GCS (step 1) | ~56 s |
-| Create Cloud SQL instance (step 2) | ~2:17 |
-| Set password + create database (steps 3–4) | seconds each |
-| IAM grant for cross-project read (step 5) | seconds |
-| Import (step 6) | ~56 s |
-| Cloud Run deploy (step 7) | ~45 s |
-| Metabase first-boot startup (step 8) | **~25–50 minutes** — see below |
-| **Total wall-clock to ready instance** | **~30–55 minutes** |
+| Phase                                      | Measured duration              |
+| ------------------------------------------ | ------------------------------ |
+| Export prod DB to GCS (step 1)             | ~56 s                          |
+| Create Cloud SQL instance (step 2)         | ~2:17                          |
+| Set password + create database (steps 3–4) | seconds each                   |
+| IAM grant for cross-project read (step 5)  | seconds                        |
+| Import (step 6)                            | ~56 s                          |
+| Cloud Run deploy (step 7)                  | ~45 s                          |
+| Metabase first-boot startup (step 8)       | **~25–50 minutes** — see below |
+| **Total wall-clock to ready instance**     | **~30–55 minutes**             |
 
 The "Metabase first-boot startup" range reflects three components, listed in their measured order of impact:
 

--- a/runbooks/workflow/metabase-test-instance-from-prod.md
+++ b/runbooks/workflow/metabase-test-instance-from-prod.md
@@ -1,0 +1,301 @@
+# Spinning up a Metabase test instance from a prod snapshot
+
+Provision a temporary, isolated Metabase deployment in `cal-itp-data-infra-staging` seeded with a recent snapshot of the prod application database. Useful for:
+
+- **Validating Metabase upgrades** before deploying to prod (the application's first-boot schema migration runs against real data, surfacing any incompatibilities).
+- **Validating the restore runbook** itself periodically (annual exercise — see [issue #4864](https://github.com/cal-itp/data-infra/issues/4864)).
+- **Investigating bugs or data anomalies** without touching production.
+
+For in-place disaster-recovery against the prod instance itself, see [`metabase-restore.md`](metabase-restore.md) instead.
+
+## When *not* to use this runbook
+
+- Don't use this for in-place rollback — `gcloud sql backups restore` against the prod instance is far simpler. See `metabase-restore.md`.
+- The existing `metabase-staging` deployment in `cal-itp-data-infra-staging` is **not** a prod snapshot — it's an empty staging environment used by the team for testing new dashboards. Don't destroy or re-seed it; spin up a separate temp instance per this runbook.
+
+## Prerequisites
+
+- `gcloud` CLI authenticated against both `cal-itp-data-infra` (prod, read-only for the export step) and `cal-itp-data-infra-staging` (write, for the temp resources).
+- The prod Metabase Cloud SQL service agent has `roles/storage.objectAdmin` on `gs://calitp-backups-metabase` (provisioned by [`iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf`](../../iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf)). Without this the export in step 1 fails.
+- The unified Metabase image is published at `ghcr.io/cal-itp/data-infra/metabase:staging` (built from [`services/metabase/Dockerfile`](../../services/metabase/Dockerfile)). It auto-creates the Cloud SQL Unix-socket symlink at runtime based on the `CLOUD_SQL_INSTANCE_CONNECTION_NAME` env var, so the same image works against any Cloud SQL instance.
+
+A throwaway temp instance like the one this runbook produces costs roughly **$2–5/day** (db-g1-small Cloud SQL + Cloud Run min=1) — tear it down promptly with the cleanup section.
+
+## Choose names and the connection name format
+
+Use a unique, descriptive name for each temp deployment so multiple validations can run in parallel without clashing. Throughout this runbook the placeholder is `metabase-restore-test`; replace with your own.
+
+```bash
+export PROJECT=cal-itp-data-infra-staging
+export INSTANCE=metabase-restore-test
+export REGION=us-west2
+export CONNECTION_NAME="${PROJECT}:${REGION}:${INSTANCE}"
+```
+
+## 1. Export prod database to GCS
+
+Server-side `pg_dump` from the prod Cloud SQL instance into the existing backups bucket. Off-peak hours (early morning Pacific) are best — the export reads the live database.
+
+### gcloud
+
+```bash
+gcloud sql export sql metabase \
+  "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql" \
+  --database=metabase \
+  --project=cal-itp-data-infra
+```
+
+### Console
+
+1. Open <https://console.cloud.google.com/sql/instances/metabase/overview?project=cal-itp-data-infra>.
+2. Click **Export** in the toolbar.
+3. **File format**: SQL.
+4. **Database for export**: `metabase`.
+5. **Storage path**: `calitp-backups-metabase/exports/metabase-<YYYY-MM-DD>.sql`.
+6. Click **Export** and wait for it to finish (status shows in the **Operations** tab).
+
+## 2. Create the temp Cloud SQL instance
+
+Match the prod tier and Postgres version so first-boot schema migration timing approximates what prod would experience. Backup config is enabled so you can also test the restore runbook against this instance later.
+
+### gcloud
+
+```bash
+gcloud sql instances create "$INSTANCE" \
+  --database-version=POSTGRES_18 \
+  --region="$REGION" \
+  --tier=db-g1-small \
+  --edition=ENTERPRISE \
+  --backup \
+  --backup-start-time=10:00 \
+  --retained-backups-count=7 \
+  --backup-location="$REGION" \
+  --project="$PROJECT"
+```
+
+### Console
+
+1. Open <https://console.cloud.google.com/sql/choose-instance-engine?project=cal-itp-data-infra-staging>, choose **PostgreSQL**.
+2. **Instance ID**: `metabase-restore-test`.
+3. **Database version**: `PostgreSQL 18`.
+4. **Edition**: Enterprise; **Preset**: Sandbox; **Machine type**: `db-g1-small`.
+5. **Region**: `us-west2`.
+6. Expand **Data Protection**, leave **Automated backups** enabled, set retention to 7.
+7. Click **Create instance** and wait until the state is **Runnable** (~2 minutes).
+
+## 3. Set the postgres user password
+
+Needed only for the import step's `--user=postgres` argument and for any direct `psql` introspection. Cloud Run won't use it (it talks to the instance via the mounted Unix socket and the unified image creates that automatically).
+
+### gcloud
+
+```bash
+POSTGRES_PASS=$(openssl rand -hex 24)
+echo "$POSTGRES_PASS" > "/tmp/${INSTANCE}-postgres-pass"
+chmod 600 "/tmp/${INSTANCE}-postgres-pass"
+
+gcloud sql users set-password postgres \
+  --instance="$INSTANCE" \
+  --password="$POSTGRES_PASS" \
+  --project="$PROJECT"
+```
+
+### Console
+
+1. From the temp instance page, open the **Users** tab.
+2. Find the `postgres` user, click the three-dot menu and choose **Change password**.
+3. Generate a password (or paste one), copy it somewhere local, and confirm.
+
+## 4. Create the metabase database
+
+### gcloud
+
+```bash
+gcloud sql databases create metabase \
+  --instance="$INSTANCE" \
+  --project="$PROJECT"
+```
+
+### Console
+
+1. From the temp instance page, open the **Databases** tab.
+2. Click **Create database**, name it `metabase`, click **Create**.
+
+## 5. Grant the temp instance read access to the prod export
+
+The temp Cloud SQL instance has its own per-instance service agent (a `p<staging-project-number>-…@gcp-sa-cloud-sql.iam.gserviceaccount.com` SA, distinct from the prod instance's). To import a SQL file from the prod project's GCS bucket, that staging-side service agent needs `roles/storage.objectViewer` on the bucket.
+
+This is intentionally a **manual, ephemeral** grant managed alongside the temp instance — the binding is removed in cleanup once the test instance is torn down. Persistent automation belongs in terraform if a use case justifies it.
+
+### gcloud
+
+```bash
+TEMP_SA=$(gcloud sql instances describe "$INSTANCE" \
+  --project="$PROJECT" \
+  --format='value(serviceAccountEmailAddress)')
+
+gcloud storage buckets add-iam-policy-binding gs://calitp-backups-metabase \
+  --member="serviceAccount:${TEMP_SA}" \
+  --role="roles/storage.objectViewer" \
+  --project=cal-itp-data-infra
+```
+
+### Console
+
+1. On the temp instance's **Overview** page, copy the **Service account** email under **Connect to this instance**.
+2. Open <https://console.cloud.google.com/storage/browser/calitp-backups-metabase;tab=permissions?project=cal-itp-data-infra>.
+3. Click **Grant access**.
+4. **New principals**: paste the service account email.
+5. **Role**: `Storage Object Viewer`.
+6. Click **Save**.
+
+## 6. Import the export
+
+### gcloud
+
+```bash
+gcloud sql import sql "$INSTANCE" \
+  "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql" \
+  --database=metabase \
+  --user=postgres \
+  --project="$PROJECT" \
+  --quiet
+```
+
+### Console
+
+1. From the temp instance page, click **Import** in the toolbar.
+2. **Source**: choose the SQL file in `gs://calitp-backups-metabase/exports/...`.
+3. **File format**: SQL.
+4. **Database**: `metabase`.
+5. **User**: `postgres`.
+6. Click **Import** and wait for the operation to finish.
+
+## 7. Deploy the Metabase Cloud Run service
+
+The unified image creates the Cloud SQL Unix-socket symlink at runtime from `CLOUD_SQL_INSTANCE_CONNECTION_NAME`. No per-instance image build is required.
+
+### gcloud
+
+```bash
+POSTGRES_PASS=$(cat "/tmp/${INSTANCE}-postgres-pass")
+
+gcloud run deploy "$INSTANCE" \
+  --image=us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/data-infra/metabase:staging \
+  --region="$REGION" \
+  --platform=managed \
+  --no-allow-unauthenticated \
+  --service-account=metabase-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com \
+  --add-cloudsql-instances="$CONNECTION_NAME" \
+  --set-env-vars="^@^MB_DB_TYPE=postgres@MB_DB_DBNAME=metabase@MB_DB_HOST=127.0.0.1@MB_DB_USER=postgres@MB_DB_PASS=${POSTGRES_PASS}@JAVA_OPTS=-Xmx2048m@CLOUD_SQL_INSTANCE_CONNECTION_NAME=${CONNECTION_NAME}" \
+  --min-instances=1 \
+  --memory=2Gi \
+  --cpu=1 \
+  --port=3000 \
+  --timeout=300 \
+  --project="$PROJECT"
+```
+
+### Console
+
+1. Open <https://console.cloud.google.com/run/create?project=cal-itp-data-infra-staging>.
+2. **Service name**: `metabase-restore-test`.
+3. **Region**: `us-west2`.
+4. **Container image URL**: `us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/data-infra/metabase:staging`.
+5. **Authentication**: Require authentication.
+6. **CPU allocation**: CPU is only allocated during request processing.
+7. Under **Containers → Edit container**:
+    - **Resources**: 1 CPU, 2 GiB memory.
+    - **Container port**: `3000`.
+    - **Environment variables**: set `MB_DB_TYPE=postgres`, `MB_DB_DBNAME=metabase`, `MB_DB_HOST=127.0.0.1`, `MB_DB_USER=postgres`, `MB_DB_PASS=<your password>`, `JAVA_OPTS=-Xmx2048m`, `CLOUD_SQL_INSTANCE_CONNECTION_NAME=cal-itp-data-infra-staging:us-west2:metabase-restore-test`.
+8. Under **Cloud SQL connections**, add the temp instance's connection name.
+9. Under **Networking** / Service account, choose `metabase-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com`.
+10. Under **Autoscaling**, set **Minimum number of instances** to `1`.
+11. Click **Create**.
+
+## 8. Wait for first-boot schema migration
+
+The first time Metabase connects to the imported database, it runs Liquibase migrations to bring the application schema in line with the running version. With prod-sized data this can take **5–10 minutes**.
+
+### gcloud
+
+```bash
+URL=$(gcloud run services describe "$INSTANCE" \
+  --region="$REGION" \
+  --project="$PROJECT" \
+  --format='value(status.url)')
+
+TOKEN=$(gcloud auth print-identity-token)
+until curl -s -H "Authorization: Bearer $TOKEN" "$URL/api/health" | grep -q '"ok"'; do
+  curl -s -H "Authorization: Bearer $TOKEN" "$URL/api/health"; echo
+  sleep 30
+done
+echo "Ready: $URL"
+```
+
+### Console
+
+1. From the Cloud Run service page, copy the service URL.
+2. With an authorized session (or a `gcloud auth print-identity-token` bearer header) hit `${URL}/api/health` and watch for `{"status":"ok"}`.
+3. Open the service URL in your browser to log into the temp instance once it's ready.
+
+## 9. Use it
+
+The temp instance has the same users, dashboards, and questions as prod at the moment of the export. You can log in with any prod user's credentials. Make whatever destructive changes you need — they are isolated to the temp instance.
+
+To exercise the **restore runbook** against this instance instead of prod, follow [`metabase-restore.md`](metabase-restore.md) substituting `metabase-restore-test` for the prod instance/service names.
+
+## 10. Tear down
+
+When the test is finished, remove all resources promptly to stop billing and avoid drift from the live IAM policy on `gs://calitp-backups-metabase`.
+
+### gcloud
+
+```bash
+gcloud run services delete "$INSTANCE" --region="$REGION" --project="$PROJECT" --quiet
+
+gcloud sql instances delete "$INSTANCE" --project="$PROJECT" --quiet
+
+gcloud storage buckets remove-iam-policy-binding gs://calitp-backups-metabase \
+  --member="serviceAccount:${TEMP_SA}" \
+  --role="roles/storage.objectViewer" \
+  --project=cal-itp-data-infra
+
+gsutil rm "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql"
+
+rm "/tmp/${INSTANCE}-postgres-pass"
+```
+
+### Console
+
+1. **Cloud Run** → `metabase-restore-test` → **Delete**.
+2. **Cloud SQL** → `metabase-restore-test` → **Delete**. (You may need to disable deletion protection first — see the **Edit** screen.)
+3. **GCS** → `calitp-backups-metabase` → **Permissions** tab → remove the temp instance's service account binding.
+4. **GCS** → `calitp-backups-metabase` → `exports/metabase-<date>.sql` → **Delete**.
+
+## Expected timeline
+
+Measured from the validation run on 2026-05-07 (prod metabase ~800 MB SQL export, db-g1-small temp Cloud SQL, db-g1-small Cloud Run with 1 vCPU / 2 GiB).
+
+| Phase | Measured duration |
+|---|---|
+| Export prod DB to GCS (step 1) | ~56 s |
+| Create Cloud SQL instance (step 2) | ~2:17 |
+| Set password + create database (steps 3–4) | seconds each |
+| IAM grant for cross-project read (step 5) | seconds |
+| Import (step 6) | ~56 s |
+| Cloud Run deploy (step 7) | ~45 s |
+| Metabase first-boot startup (step 8) | **~25–50 minutes** — see below |
+| **Total wall-clock to ready instance** | **~30–55 minutes** |
+
+The "Metabase first-boot startup" range reflects three components, listed in their measured order of impact:
+
+1. **Driver feature checks against external databases**. Metabase tries to verify each configured external database (BigQuery, Payments DBs, etc.) by calling `supports?` on its driver, with a 5-second timeout per database. In a test instance these connections typically fail because the temp Cloud Run service does not have the BigQuery / Payments credentials or network reach that prod has. With a few hundred external databases configured (as in prod), this serializes into a many-minute stall — the dominant component of slow boot in the validation run.
+2. **Liquibase changelog reading + search index initialization**. Metabase logged "Metabase Initialization COMPLETE in 26.4 mins" on the first boot of the validation run. Liquibase reports "no unrun migrations" quickly when the source and target Metabase versions match; the bulk is search-index bootstrap and reading hundreds of changelog files.
+3. **Cloud Run cold-start churn**. Cloud Run's default request-driven CPU allocation can starve the JVM between probe requests, multiplying boot time. The validation run saw an additional ~20 min between successful deploy and JVM successfully reaching steady boot.
+
+If first-boot is consistently slow, deploy the temp service with `--cpu-boost` and/or `--no-cpu-throttling` to keep CPU allocated during boot — that addresses (3). Components (1) and (2) scale with the size of the application database and the number of external databases configured.
+
+Subsequent boots on the same instance after the data-restore loop is exercised do not re-run all of the above; expect ~1–2 min once the JVM warms.
+
+If you only need to inspect the application database state (counts, individual rows, reasoning about a regression) and don't need the Metabase web UI, a much faster path is to allowlist your IP on the temp Cloud SQL instance and connect with `psql` directly using the postgres password from step 3.

--- a/services/metabase/Dockerfile
+++ b/services/metabase/Dockerfile
@@ -2,8 +2,6 @@ FROM metabase/metabase:v0.58.7
 
 RUN apk update && apk add --no-cache socat
 
-RUN ln -s /cloudsql/cal-itp-data-infra:us-west2:metabase/.s.PGSQL.5432 pg.sock
-
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/services/metabase/Dockerfile.staging
+++ b/services/metabase/Dockerfile.staging
@@ -1,9 +1,0 @@
-FROM metabase/metabase:v0.58.7
-
-RUN apk update && apk add --no-cache socat
-
-RUN ln -s /cloudsql/cal-itp-data-infra-staging:us-west2:metabase-staging/.s.PGSQL.5432 pg.sock
-
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-ENTRYPOINT ["/app/entrypoint.sh"]

--- a/services/metabase/entrypoint.sh
+++ b/services/metabase/entrypoint.sh
@@ -1,7 +1,18 @@
-#! /bin/bash
+#!/bin/bash
+set -euo pipefail
 
-# Forward TCP:5432 to Cloud SQL Unix socket
-nohup socat -d -d TCP4-LISTEN:5432,fork UNIX-CONNECT:pg.sock &
+if [[ -z "${CLOUD_SQL_INSTANCE_CONNECTION_NAME:-}" ]]; then
+  detected=$(ls /cloudsql 2>/dev/null | head -1 || true)
+  if [[ -n "$detected" ]]; then
+    CLOUD_SQL_INSTANCE_CONNECTION_NAME="$detected"
+  else
+    echo "ERROR: CLOUD_SQL_INSTANCE_CONNECTION_NAME must be set, or a single Cloud SQL instance must be mounted at /cloudsql/" >&2
+    exit 1
+  fi
+fi
 
-# Runs Metabase
-/app/run_metabase.sh
+ln -sf "/cloudsql/${CLOUD_SQL_INSTANCE_CONNECTION_NAME}/.s.PGSQL.5432" /app/pg.sock
+
+nohup socat -d -d TCP4-LISTEN:5432,fork UNIX-CONNECT:/app/pg.sock &
+
+exec /app/run_metabase.sh


### PR DESCRIPTION
# Description

Closes the Metabase backup-and-recovery exercise (#4864) and the runbook update it produced (#4980).

Three coordinated changes:

1. **`feat(iac)`** — grant the prod Metabase Cloud SQL service agent `roles/storage.objectAdmin` on `gs://calitp-backups-metabase`, enabling `gcloud sql export sql` from the live prod instance to that bucket. The grant is sourced dynamically via a `google_sql_database_instance` data source so it follows instance recreation.

2. **`refactor(metabase)`** — unify `services/metabase/Dockerfile.production` and `Dockerfile.staging` into a single `Dockerfile`. The Cloud SQL Unix-socket symlink is now created at runtime by `entrypoint.sh`. The connection name is auto-detected from `/cloudsql/` when only one Cloud SQL instance is mounted (the case for the existing prod and staging Metabase services), or it can be set explicitly via the `CLOUD_SQL_INSTANCE_CONNECTION_NAME` env var when an operator wants explicit control. The build workflow now produces one image and tags it as both `:staging` and `:production`. This is what makes the test-instance runbook reproducible — operators can deploy any instance from the same image.

3. **`docs(runbooks)`** — rewrite `metabase-restore.md` and add `metabase-test-instance-from-prod.md`. Drops the K8s/restic restore steps entirely (the K8s deployment was decommissioned in #5146). Documents both `gcloud` CLI and Console UI for every step. Includes measured timings from the validation run (see below).

Resolves #4980. Refs #4864.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

End-to-end validation run on 2026-05-07 in `cal-itp-data-infra-staging`:

1. Took an on-demand backup of prod Metabase: ~61 s.
2. Exported the prod database to GCS via `gcloud sql export sql` (~800 MB SQL): ~56 s.
3. Provisioned a `metabase-restore-test` Cloud SQL instance (db-g1-small, POSTGRES_18, daily backups enabled): ~2:17.
4. Imported the prod export into the temp instance via `gcloud sql import sql`: ~56 s.
5. Built the unified image via Cloud Build and deployed a `metabase-restore-test` Cloud Run service against the temp instance, with `CLOUD_SQL_INSTANCE_CONNECTION_NAME` set explicitly. The unified entrypoint correctly created the symlink and forwarded TCP 5432 → Unix socket via socat.
6. Waited for first-boot Liquibase + Quartz + search-index init: ~26 min internal Metabase initialization (per logs); Cloud Run cold-start churn added another ~20 min for total `~50 min` deploy → `/api/health="ok"`. Notable that **per-driver feature checks against the imported BigQuery / Payments DBs time out at 5 s each** in an isolated test instance — that's the dominant factor in slow test-instance boots and is documented in the runbook.
7. Took an on-demand backup of the temp instance: ~76 s.
8. Damaged data: deleted dashboards 348/349/350 + 50 most-recent cards via `psql`. Counts dropped 342→339 dashboards and 5334→5284 cards.
9. Parked Metabase via no-op image swap (`gcr.io/cloudrun/hello`): ~7 s.
10. Restored the temp instance from the on-demand backup: **~4 min — the key data point this PR captures for the in-place restore runbook.**
11. Verified counts back to baseline (342 dashboards, 5334 cards) and that the deleted dashboards 348/349/350 returned with their original names.
12. Brought Metabase back with the unified image; the unified entrypoint resumed correctly.
13. Tore down the temp Cloud Run service, Cloud SQL instance, and container image.

Timings are documented in the new runbooks' "Expected timeline" sections.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- The build-metabase workflow on this PR pushes new `:staging` and `:production` tags built from the unified Dockerfile. The auto-detect fallback in the unified entrypoint preserves behavior for the existing prod and staging Cloud Run revisions (which still pin to the digest captured at their last revision deploy). Nothing in this PR forces a redeploy; the unified image will be picked up the next time those services are intentionally redeployed (e.g., during the next image bump).
- Close #4864 and #4980 once merged. The validation also produced timing data Vee asked for; rough numbers are in the new runbook.
- During validation we observed Metabase first-boot taking ~25–50 minutes on db-g1-small + 1 vCPU Cloud Run when external databases are unreachable. Worth investigating whether `--cpu-boost` / `--no-cpu-throttling` should be set on the live prod and staging Metabase services to make restore-and-restart workflows faster — file as a follow-up after this lands.