### PR TITLE
TF cleanup leftovers from cluster decommission stream

### DIFF
--- a/iac/cal-itp-data-infra/firewall/us/compute_firewall.tf
+++ b/iac/cal-itp-data-infra/firewall/us/compute_firewall.tf
@@ -194,23 +194,6 @@ resource "google_compute_firewall" "tfer--gke-us-west2-calitp-airflow2-pr-171e4e
   target_tags   = ["gke-us-west2-calitp-airflow2-pr-171e4e47-gke-0b2083d6-node"]
 }
 
-resource "google_compute_firewall" "tfer--k8s-ad40eb3afc69e4deeaf43a1ed1393eeb-http-hc" {
-  allow {
-    ports    = ["32549"]
-    protocol = "tcp"
-  }
-
-  description   = "{\"kubernetes.io/service-name\":\"ingress-nginx/ingress-nginx-controller\", \"kubernetes.io/service-ip\":\"34.127.51.123\"}"
-  direction     = "INGRESS"
-  disabled      = "false"
-  name          = "k8s-ad40eb3afc69e4deeaf43a1ed1393eeb-http-hc"
-  network       = data.terraform_remote_state.networks.outputs.google_compute_network_tfer--default_self_link
-  priority      = "1000"
-  project       = "cal-itp-data-infra"
-  source_ranges = ["130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"]
-  target_tags   = ["gke-data-infra-apps-0fe1e974-node"]
-}
-
 resource "google_compute_firewall" "tfer--k8s-e092126e72b02003-node-http-hc" {
   allow {
     ports    = ["10256"]
@@ -239,24 +222,6 @@ resource "google_compute_firewall" "tfer--k8s-fw-a0d3bb39e959b49a1b6015fd2193e30
   direction          = "INGRESS"
   disabled           = "false"
   name               = "k8s-fw-a0d3bb39e959b49a1b6015fd2193e30d"
-  network            = data.terraform_remote_state.networks.outputs.google_compute_network_tfer--default_self_link
-  priority           = "1000"
-  project            = "cal-itp-data-infra"
-  source_ranges      = ["0.0.0.0/0"]
-  target_tags        = ["gke-data-infra-apps-0fe1e974-node"]
-}
-
-resource "google_compute_firewall" "tfer--k8s-fw-ad40eb3afc69e4deeaf43a1ed1393eeb" {
-  allow {
-    ports    = ["443", "80"]
-    protocol = "tcp"
-  }
-
-  description        = "{\"kubernetes.io/service-name\":\"ingress-nginx/ingress-nginx-controller\", \"kubernetes.io/service-ip\":\"34.127.51.123\"}"
-  destination_ranges = ["34.127.51.123"]
-  direction          = "INGRESS"
-  disabled           = "false"
-  name               = "k8s-fw-ad40eb3afc69e4deeaf43a1ed1393eeb"
   network            = data.terraform_remote_state.networks.outputs.google_compute_network_tfer--default_self_link
   priority           = "1000"
   project            = "cal-itp-data-infra"

--- a/iac/cal-itp-data-infra/firewall/us/outputs.tf
+++ b/iac/cal-itp-data-infra/firewall/us/outputs.tf
@@ -38,18 +38,10 @@ output "google_compute_firewall_tfer--gke-us-west2-calitp-airflow2-pr-171e4e47-g
   value = google_compute_firewall.tfer--gke-us-west2-calitp-airflow2-pr-171e4e47-gke-0b2083d6-ssh.self_link
 }
 
-output "google_compute_firewall_tfer--k8s-ad40eb3afc69e4deeaf43a1ed1393eeb-http-hc_self_link" {
-  value = google_compute_firewall.tfer--k8s-ad40eb3afc69e4deeaf43a1ed1393eeb-http-hc.self_link
-}
-
 output "google_compute_firewall_tfer--k8s-e092126e72b02003-node-http-hc_self_link" {
   value = google_compute_firewall.tfer--k8s-e092126e72b02003-node-http-hc.self_link
 }
 
 output "google_compute_firewall_tfer--k8s-fw-a0d3bb39e959b49a1b6015fd2193e30d_self_link" {
   value = google_compute_firewall.tfer--k8s-fw-a0d3bb39e959b49a1b6015fd2193e30d.self_link
-}
-
-output "google_compute_firewall_tfer--k8s-fw-ad40eb3afc69e4deeaf43a1ed1393eeb_self_link" {
-  value = google_compute_firewall.tfer--k8s-fw-ad40eb3afc69e4deeaf43a1ed1393eeb.self_link
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -312,7 +312,7 @@ resource "google_storage_bucket_iam_binding" "tfer--gtfs-data-reports" {
 
 resource "google_storage_bucket_iam_binding" "tfer--gtfs-data-test" {
   bucket  = "b/gtfs-data-test"
-  members = ["serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com", "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"]
+  members = ["serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com", "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"]
   role    = "roles/storage.objectAdmin"
 }
 
@@ -420,7 +420,7 @@ resource "google_storage_bucket_iam_binding" "tfer--test-calitp-gtfs-rt-parsed" 
 
 resource "google_storage_bucket_iam_binding" "tfer--test-calitp-gtfs-rt-raw" {
   bucket  = "b/test-calitp-gtfs-rt-raw"
-  members = ["serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:gtfs-rt-archiver-v3@cal-itp-data-infra.iam.gserviceaccount.com"]
+  members = ["serviceAccount:gtfs-rt-archiver-v3@cal-itp-data-infra.iam.gserviceaccount.com"]
   role    = "roles/storage.objectAdmin"
 }
 

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -2014,7 +2014,6 @@ resource "google_storage_bucket_iam_policy" "tfer--gtfs-data-test" {
     {
       "members": [
         "serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com",
-        "serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com",
         "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com",
         "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"
       ],
@@ -2702,7 +2701,6 @@ resource "google_storage_bucket_iam_policy" "tfer--test-calitp-gtfs-rt-raw" {
     },
     {
       "members": [
-        "serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com",
         "serviceAccount:gtfs-rt-archiver-v3@cal-itp-data-infra.iam.gserviceaccount.com"
       ],
       "role": "roles/storage.objectAdmin"


### PR DESCRIPTION
> [!NOTE]
> **Drafted with a question for the client.** See "Bucket retention question" below — that decision shapes whether this PR's scope grows or whether a follow-up is needed.

This PR cleans up the *unambiguously* dead Terraform leftovers from the cluster decommission stream (#4922). The trickier "do we keep the historical backup buckets?" question is documented at the bottom for client decision; this PR can grow to include those changes once we have an answer.

## What's in this PR

### Firewall rules — `iac/cal-itp-data-infra/firewall/us/`

The ingress-nginx LoadBalancer Service spawned auto-managed firewall rules that GKE created when the LB came up. With ingress-nginx torn down in #5244, GCP auto-reaped the underlying load balancer and the rules. Removed two `google_compute_firewall` resources from `compute_firewall.tf` plus their entries in `outputs.tf`:

- `k8s-ad40eb3afc69e4deeaf43a1ed1393eeb-http-hc` — already gone in GCP (`gcloud compute firewall-rules describe` → not found)
- `k8s-fw-ad40eb3afc69e4deeaf43a1ed1393eeb` — already gone in GCP

Both confirmed gone; no follow-up `gcloud` deletes needed. Just resolves the TF state drift.

### GCS IAM bindings for the orphan `gtfs-rt-archiver-test@` SA

The test environment was decommissioned in #5243, but IAM bindings granting that SA bucket access were left behind in:

- `storage_bucket_iam_binding.tf`: removed the SA from `roles/storage.objectAdmin` member lists on buckets `gtfs-data-test` and `test-calitp-gtfs-rt-raw` (other members preserved)
- `storage_bucket_iam_policy.tf`: removed the SA from the matching policy blocks

The SA itself (`gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com`) is **not** declared in `iam/us/service_account.tf`, so this just cleans up dangling references.

## What's deferred (the client question)

Several Terraform resources still describe real GCS buckets that may hold historical backup data we want to keep:

| File | Resource | What it is |
|------|----------|------------|
| `iac/cal-itp-data-infra/iam/us/service_account.tf` | `backup-sentry` SA | service account that backed up self-hosted Sentry's metadata DB |
| `iac/cal-itp-data-infra/iam/us/service_account.tf` | `backup-grafana` SA | service account that backed up in-cluster Grafana's PG |
| `iac/cal-itp-data-infra/gcs/us/storage_bucket.tf` | `calitp-backups-sentry` | bucket holding Restic snapshots of self-hosted Sentry's metadata DB |
| `iac/cal-itp-data-infra/gcs/us/storage_bucket.tf` | `calitp-backups-grafana` | bucket holding Restic snapshots of in-cluster Grafana's PG |
| `iac/cal-itp-data-infra/gcs/us/storage_bucket.tf` | `calitp-sentry`, `test-calitp-sentry` | older Sentry-related buckets |
| `iac/cal-itp-data-infra-staging/gcs/us/variables.tf` | `calitp-staging-sentry` | staging-side Sentry bucket |
| Plus matching ACLs / IAM bindings / outputs across `gcs/us/*.tf` | (~30 lines combined) | |

**The question for the client**: do we want to retain any of this backup data, or is it all safe to delete?

Specifically:

1. **Sentry metadata DB backups** (`calitp-backups-sentry`): the self-hosted Sentry instance is gone. Sentry's metadata DB (Postgres) held org config, project tokens, integration settings, recent issues. The Cal-ITP Benefits team has migrated off, so historical issues are no longer referenced. We probably don't need this. Delete?

2. **Grafana DB backups** (`calitp-backups-grafana`): held Grafana dashboard / panel configurations. The dashboards themselves are reproducible from source if we ever need to rebuild equivalents in Cloud Monitoring. Delete?

3. **Older Sentry buckets** (`calitp-sentry`, `test-calitp-sentry`, `calitp-staging-sentry`): unclear what these contained — they may have been Sentry event archives from an earlier configuration. Worth a quick `gsutil ls -L` peek before deciding.

### How to extend this PR with the answer

If retention is **not needed** (likely):

1. `gsutil ls -L gs://<bucket>/` on each bucket to confirm contents look stale / expendable
2. `gsutil -m rm -r gs://<bucket>/` to empty
3. Add resource removals here: SAs, buckets, ACLs, IAM bindings, outputs, variables
4. After merge, delete the GCS buckets via terraform-apply (or manually via `gsutil rb` + state removal if the buckets are pre-emptied)

If retention **is needed** for some buckets:

1. Apply lifecycle rules (e.g. transition to Archive class, set deletion to N years out) to keep storage costs negligible
2. Optionally remove the backup SAs (no longer writing) but keep the buckets

## Test plan

- [ ] CI green
- [ ] After merge: terraform apply on the firewall + gcs modules shows the expected state cleanups (no surprises)
- [ ] Client decision noted on the bucket retention question; PR scope expanded or a follow-up filed

## References

- #4922 (cluster maintenance tracker — see [latest comment](https://github.com/cal-itp/data-infra/issues/4922#issuecomment-4389027663))
- #5244 (ingress-nginx + cert-manager — context for the firewall rule cleanup)
- #5243 (gtfs-rt-archiver-v3-test decommission — context for the IAM binding cleanup)
- #5245 (Sentry decommission — context for the deferred bucket question)
- #5279 (Sentry SDK removal — handles the dead `CALITP_BUCKET__SENTRY_EVENTS` env var passthroughs in Composer)