### PR TITLE
Refactor TIDES models for SCD Type 2 historical correctness + persistent source_record_id seed

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -26,6 +26,7 @@ vars:
   GTFS_SCHEDULE_START: "{{ '2021-04-16' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   GTFS_RT_START: "{{ '2022-09-15' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   KUBA_DEVICE_START: '2025-08-11'
+  TIDES_PRODUCT_START: "{{ '2025-12-16' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   INCREMENTAL_MAX_DT: ''
   DBT_ALL_INCREMENTAL_LOOKBACK_DAYS: 5
   DBT_DAILY_INCREMENTAL_LOOKBACK_DAYS: 1

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -19,7 +19,7 @@ WITH observed AS (
     -- Drop TU-only trips (no VP) so every row has a derivable vehicle_id.
     WHERE appeared_in_vp = TRUE
       AND service_date
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("TIDES_PRODUCT_START")) }}
             AND {{ ranged_incremental_max_date() }}
 ),
 
@@ -36,7 +36,7 @@ scheduled AS (
         trip_last_arrival_ts
     FROM {{ ref('fct_scheduled_trips') }}
     WHERE service_date
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("TIDES_PRODUCT_START")) }}
             AND {{ ranged_incremental_max_date() }}
 ),
 
@@ -50,25 +50,34 @@ vehicle_per_trip AS (
     -- this is ok for the min date because t-X days for service date will be fully covered by t-X days for dt
     -- add one to the incremental max date because we need to get one extra UTC dt to ensure overlap with service date
     WHERE dt
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_RT_START")) }}
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("TIDES_PRODUCT_START")) }}
             AND {{ ranged_incremental_max_date() }} + 1
       AND vehicle_id IS NOT NULL
     GROUP BY 1, 2
 ),
 
--- Same feed-key filter as fct_tides_vehicle_locations.
-public_subfeed_keys AS (
-    SELECT DISTINCT vehicle_positions_gtfs_dataset_key AS gtfs_dataset_key
-    FROM {{ ref('dim_provider_gtfs_data') }}
-    WHERE _is_current = TRUE
-      AND public_customer_facing_or_regional_subfeed_fixed_route = TRUE
-      AND vehicle_positions_gtfs_dataset_key IS NOT NULL
+-- Persistent source-record IDs in the publication set. Stable across
+-- upstream gtfs_dataset_key rotations.
+publication_source_record_ids AS (
+    SELECT vehicle_positions_source_record_id
+    FROM {{ ref('tides_publication_keys') }}
 ),
 
--- Same publication-key narrowing as fct_tides_vehicle_locations.
-publication_keys AS (
-    SELECT gtfs_dataset_key
-    FROM {{ ref('tides_publication_keys') }}
+-- SCD Type 2 join to dim_provider_gtfs_data: resolve the dim record valid
+-- at vp_min_ts (the earliest VP timestamp for the trip), not the current
+-- state. Filter to the publication-list source_record_ids and to the
+-- public-customer-facing or regional-subfeed fixed-route flag as it stood
+-- when the trip was observed.
+filtered_observed AS (
+    SELECT o.*
+    FROM observed AS o
+    INNER JOIN {{ ref('dim_provider_gtfs_data') }} AS d
+        ON d.vehicle_positions_gtfs_dataset_key = o.vp_gtfs_dataset_key
+        AND o.vp_min_ts BETWEEN d._valid_from AND d._valid_to
+    WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
+      AND d.vehicle_positions_source_record_id IN (
+          SELECT vehicle_positions_source_record_id FROM publication_source_record_ids
+      )
 ),
 
 tides_trips_performed AS (
@@ -114,11 +123,7 @@ tides_trips_performed AS (
         -- dropped at export.
         o.vp_base64_url AS base64_url,
         o.vp_gtfs_dataset_key AS gtfs_dataset_key
-    FROM observed o
-    INNER JOIN public_subfeed_keys
-        ON o.vp_gtfs_dataset_key = public_subfeed_keys.gtfs_dataset_key
-    INNER JOIN publication_keys
-        ON o.vp_gtfs_dataset_key = publication_keys.gtfs_dataset_key
+    FROM filtered_observed o
     LEFT JOIN scheduled s
         ON s.trip_instance_key = o.trip_instance_key
     LEFT JOIN vehicle_per_trip v

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -62,7 +62,7 @@ vehicle_per_trip AS (
 publication_dim_records AS (
     SELECT d.*
     FROM {{ ref('dim_provider_gtfs_data') }} AS d
-    INNER JOIN {{ ref('tides_publication_keys') }} AS p
+    INNER JOIN {{ ref('tides_publication_keys') }}
         USING (vehicle_positions_source_record_id)
     WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
 ),

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -56,28 +56,25 @@ vehicle_per_trip AS (
     GROUP BY 1, 2
 ),
 
--- Persistent source-record IDs in the publication set. Stable across
--- upstream gtfs_dataset_key rotations.
-publication_source_record_ids AS (
-    SELECT vehicle_positions_source_record_id
-    FROM {{ ref('tides_publication_keys') }}
+-- Pre-filter dim_provider_gtfs_data to the publication-set source_record_ids
+-- (persistent Airtable IDs, stable across upstream gtfs_dataset_key rotations)
+-- with the public-customer-facing or regional-subfeed fixed-route flag.
+publication_dim_records AS (
+    SELECT d.*
+    FROM {{ ref('dim_provider_gtfs_data') }} AS d
+    INNER JOIN {{ ref('tides_publication_keys') }} AS p
+        USING (vehicle_positions_source_record_id)
+    WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
 ),
 
--- SCD Type 2 join to dim_provider_gtfs_data: resolve the dim record valid
--- at vp_min_ts (the earliest VP timestamp for the trip), not the current
--- state. Filter to the publication-list source_record_ids and to the
--- public-customer-facing or regional-subfeed fixed-route flag as it stood
--- when the trip was observed.
+-- SCD Type 2 join: resolve the dim record valid at vp_min_ts (the earliest
+-- VP timestamp for the trip), not the current state.
 filtered_observed AS (
     SELECT o.*
     FROM observed AS o
-    INNER JOIN {{ ref('dim_provider_gtfs_data') }} AS d
+    INNER JOIN publication_dim_records AS d
         ON d.vehicle_positions_gtfs_dataset_key = o.vp_gtfs_dataset_key
         AND o.vp_min_ts BETWEEN d._valid_from AND d._valid_to
-    WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
-      AND d.vehicle_positions_source_record_id IN (
-          SELECT vehicle_positions_source_record_id FROM publication_source_record_ids
-      )
 ),
 
 tides_trips_performed AS (

--- a/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
+++ b/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
@@ -41,7 +41,7 @@ WITH source_vehicle_locations AS (
 publication_dim_records AS (
     SELECT d.*
     FROM {{ ref('dim_provider_gtfs_data') }} AS d
-    INNER JOIN {{ ref('tides_publication_keys') }} AS p
+    INNER JOIN {{ ref('tides_publication_keys') }}
         USING (vehicle_positions_source_record_id)
     WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
 ),

--- a/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
+++ b/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
@@ -4,7 +4,7 @@
         incremental_strategy='microbatch',
         event_time = 'dt',
         batch_size = 'day',
-        begin=var('GTFS_RT_START'),
+        begin=var('TIDES_PRODUCT_START'),
         lookback=var('DBT_ALL_INCREMENTAL_LOOKBACK_DAYS'),
         partition_by={
             'field': 'dt',
@@ -33,22 +33,29 @@ WITH source_vehicle_locations AS (
     ) = 1
 ),
 
--- Filter to feeds tagged public-customer-facing or regional-subfeed
--- fixed-route. Org info isn't part of the TIDES spec and isn't carried
--- through; org metadata for the publish flow lives separately.
-public_subfeed_keys AS (
-    SELECT DISTINCT vehicle_positions_gtfs_dataset_key AS gtfs_dataset_key
-    FROM {{ ref('dim_provider_gtfs_data') }}
-    WHERE _is_current = TRUE
-      AND public_customer_facing_or_regional_subfeed_fixed_route = TRUE
-      AND vehicle_positions_gtfs_dataset_key IS NOT NULL
+-- Persistent source-record IDs in the publication set. Stable across
+-- upstream gtfs_dataset_key rotations.
+publication_source_record_ids AS (
+    SELECT vehicle_positions_source_record_id
+    FROM {{ ref('tides_publication_keys') }}
 ),
 
--- Narrows the public-subfeed set to the MVP publication list (Hermosa Beach
--- traversing operators). Additive on top of the public-subfeed filter above.
-publication_keys AS (
-    SELECT gtfs_dataset_key
-    FROM {{ ref('tides_publication_keys') }}
+-- SCD Type 2 join to dim_provider_gtfs_data: resolve the dim record valid
+-- at each VP row's _extract_ts (not the current state). Filter to the
+-- publication-list source_record_ids and to the public-customer-facing
+-- or regional-subfeed fixed-route flag as it stood at the time the data
+-- was scraped. Org info isn't part of the TIDES spec and isn't carried
+-- through; org metadata for the publish flow lives separately.
+filtered_vehicle_locations AS (
+    SELECT vp.*
+    FROM source_vehicle_locations AS vp
+    INNER JOIN {{ ref('dim_provider_gtfs_data') }} AS d
+        ON d.vehicle_positions_gtfs_dataset_key = vp.gtfs_dataset_key
+        AND vp._extract_ts BETWEEN d._valid_from AND d._valid_to
+    WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
+      AND d.vehicle_positions_source_record_id IN (
+          SELECT vehicle_positions_source_record_id FROM publication_source_record_ids
+      )
 ),
 
 tides_vehicle_locations AS (
@@ -119,9 +126,7 @@ tides_vehicle_locations AS (
         vp.dt,
         vp.base64_url,
         vp.gtfs_dataset_key
-    FROM source_vehicle_locations AS vp
-    INNER JOIN public_subfeed_keys USING (gtfs_dataset_key)
-    INNER JOIN publication_keys USING (gtfs_dataset_key)
+    FROM filtered_vehicle_locations AS vp
 )
 
 SELECT * FROM tides_vehicle_locations

--- a/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
+++ b/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
@@ -33,29 +33,27 @@ WITH source_vehicle_locations AS (
     ) = 1
 ),
 
--- Persistent source-record IDs in the publication set. Stable across
--- upstream gtfs_dataset_key rotations.
-publication_source_record_ids AS (
-    SELECT vehicle_positions_source_record_id
-    FROM {{ ref('tides_publication_keys') }}
+-- Pre-filter dim_provider_gtfs_data to the publication-set source_record_ids
+-- (persistent Airtable IDs, stable across upstream gtfs_dataset_key rotations)
+-- with the public-customer-facing or regional-subfeed fixed-route flag. Org
+-- info isn't part of the TIDES spec and isn't carried through; org metadata
+-- for the publish flow lives separately.
+publication_dim_records AS (
+    SELECT d.*
+    FROM {{ ref('dim_provider_gtfs_data') }} AS d
+    INNER JOIN {{ ref('tides_publication_keys') }} AS p
+        USING (vehicle_positions_source_record_id)
+    WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
 ),
 
--- SCD Type 2 join to dim_provider_gtfs_data: resolve the dim record valid
--- at each VP row's _extract_ts (not the current state). Filter to the
--- publication-list source_record_ids and to the public-customer-facing
--- or regional-subfeed fixed-route flag as it stood at the time the data
--- was scraped. Org info isn't part of the TIDES spec and isn't carried
--- through; org metadata for the publish flow lives separately.
+-- SCD Type 2 join: resolve the dim record valid at each VP row's
+-- _extract_ts (not the current state).
 filtered_vehicle_locations AS (
     SELECT vp.*
     FROM source_vehicle_locations AS vp
-    INNER JOIN {{ ref('dim_provider_gtfs_data') }} AS d
+    INNER JOIN publication_dim_records AS d
         ON d.vehicle_positions_gtfs_dataset_key = vp.gtfs_dataset_key
         AND vp._extract_ts BETWEEN d._valid_from AND d._valid_to
-    WHERE d.public_customer_facing_or_regional_subfeed_fixed_route = TRUE
-      AND d.vehicle_positions_source_record_id IN (
-          SELECT vehicle_positions_source_record_id FROM publication_source_record_ids
-      )
 ),
 
 tides_vehicle_locations AS (

--- a/warehouse/seeds/_seeds.yml
+++ b/warehouse/seeds/_seeds.yml
@@ -398,8 +398,8 @@ seeds:
 
   - name: tides_publication_keys
     description: |
-      Feed keys included in the TIDES public publication. Acts as a narrowing
-      layer over `dim_provider_gtfs_data.public_customer_facing_or_regional_subfeed_fixed_route`
+      Source-record IDs included in the TIDES public publication. Acts as a
+      narrowing layer over `dim_provider_gtfs_data.public_customer_facing_or_regional_subfeed_fixed_route`
       while the publish flow is in MVP. Initial set covers agencies whose
       vehicles traverse Hermosa Beach (SCAG technical-assistance pilot):
       Beach Cities Transit, LA Metro Bus, Torrance Transit.
@@ -408,8 +408,11 @@ seeds:
         domain: seeds
         dataset: tides
     columns:
-      - name: gtfs_dataset_key
-        description: Stable key from `dim_provider_gtfs_data.vehicle_positions_gtfs_dataset_key`.
+      - name: vehicle_positions_source_record_id
+        description: |
+          Persistent identifier from `dim_provider_gtfs_data.vehicle_positions_source_record_id`
+          (the upstream Airtable record). Stable across GTFS feed-key
+          rotations, so the publication set survives upstream re-versioning.
         data_tests:
           - not_null
           - unique

--- a/warehouse/seeds/tides_publication_keys.csv
+++ b/warehouse/seeds/tides_publication_keys.csv
@@ -1,4 +1,4 @@
-gtfs_dataset_key,agency_name,notes
-9edf45e373638700ca420b1e588efdaf,Beach Cities Transit,Hermosa Beach local operator (BCT JPA)
-1745f7d9b9fa48cdbc8ea282e60602bd,LA Metro Bus,South Bay routes traverse Hermosa Beach
-46b00e5c738a0ebf93522371d9899627,Torrance Transit,Adjacent operator (Swiftly feed)
+vehicle_positions_source_record_id,agency_name,notes
+recUKDWE8Vq7rRAPM,Beach Cities Transit,Hermosa Beach local operator (BCT JPA)
+rectUboB2NipaQROx,LA Metro Bus,South Bay routes traverse Hermosa Beach
+rece8srb8wQEhqzh9,Torrance Transit,Adjacent operator (Swiftly feed)


### PR DESCRIPTION
# Description

Follow-up to #5216 and #5220 addressing two compounding SCD-related correctness issues that surfaced during their production deploys, plus a bounded microbatch backfill window.

## What was wrong

1. **Versioned-key seed.** `tides_publication_keys.csv` keyed on `vehicle_positions_gtfs_dataset_key` (the versioned MD5 hash). When operators rotate GTFS feed URLs, the hash changes, so historical `fct_vehicle_locations` rows tagged with old hashes silently fall out of the publication set.

2. **`_is_current = TRUE` on `dim_provider_gtfs_data`.** The prior `public_subfeed_keys` CTE filtered to the CURRENT public-customer-facing flag bound to the CURRENT key. Historical RT rows tagged with old keys couldn't match.

3. **`begin=var('GTFS_RT_START')`** on `fct_tides_vehicle_locations`. On `target.name == 'prod'` that resolves to `'2022-09-15'`, generating 1332 daily microbatches from scratch on first deploy. Most scan upstream daily partitions and filter to 0 rows due to issues 1 + 2 above.

The 1+2 combination was flagged in @lauriemerrell's inline review on #5216 ([discussion_r3204968948](https://github.com/cal-itp/data-infra/pull/5216#discussion_r3204968948), [discussion_r3204978905](https://github.com/cal-itp/data-infra/pull/5216#discussion_r3204978905)). Issue 3 manifested when the post-merge prod deploys were observed running ~90 min on empty batches before being cancelled.

## What this PR does

- Replaces the `_is_current = TRUE` + versioned-key filter with a single **SCD Type 2 join** to `dim_provider_gtfs_data` using `_valid_from` / `_valid_to`. Each VP row's join uses the dim record valid at that row's `_extract_ts` (or `vp_min_ts` for the trips_performed equivalent). Recovers historical correctness for both the public-fixed-route flag and the operator identity.
- Swaps the seed from `gtfs_dataset_key` to `vehicle_positions_source_record_id` (persistent Airtable record IDs from `dim_provider_gtfs_data`). Stable across upstream feed-key rotations.
- Adds a new `TIDES_PRODUCT_START` dbt var (mirrors `KUBA_DEVICE_START` shape) bounding the prod backfill to `'2025-12-16'`, aligning with when current dim records for our 3 publication operators became valid. Both fct models now use this var instead of `GTFS_RT_START`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested locally (target=dev, 7-day window):

```bash
uv run dbt seed --select tides_publication_keys --target dev
uv run dbt run --select fct_tides_vehicle_locations --target dev
uv run dbt run --select fct_tides_trips_performed --target dev
```

`fct_tides_vehicle_locations` produced **264,250 rows for 2026-05-01 across all 3 Hermosa feeds (1,562 distinct vehicles)**. SCD Type 2 join correctly resolves the dim record valid at each row's `_extract_ts`. Other batches in the local sandbox produced 0 rows because `christopher_mart_gtfs.fct_vehicle_locations` only has May 1 data — the model logic itself is verified.

`fct_tides_trips_performed` compiled and ran cleanly with the symmetric SCD Type 2 join on `vp_min_ts`.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

The cancelled prior deploys of #5216 and #5220 left empty partitions in `cal-itp-data-infra.mart_tides.fct_tides_vehicle_locations` (and an empty `fct_tides_trips_performed` if 5220's deploy ran far enough). To get a clean post-merge state, recommend dropping both prod tables before this PR's merge triggers the new deploy:

```sql
DROP TABLE IF EXISTS `cal-itp-data-infra.mart_tides.fct_tides_vehicle_locations`;
DROP TABLE IF EXISTS `cal-itp-data-infra.mart_tides.fct_tides_trips_performed`;
```

If the drop doesn't happen, the deploy will still succeed — just with empty pre-2025-12-16 partitions persisting (cosmetic-only, no impact on query correctness for `dt >= '2025-12-16'`).

cc @vevetron @lauriemerrell
