### PR TITLE
Payments(enghouse): Add fct_payments_aggregations_enghouse mart model

### DIFF
--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -916,7 +916,6 @@ models:
       - name: elavon_purch_id
         description: |
           Elavon purchase ID matched to this pay window via payment_reference. NULL if no Elavon match found.
-          Approximately 87% of closed pay windows are expected to match.
       - name: elavon_settlement_date
         description: Settlement date from Elavon deposit data for this pay window.
       - name: elavon_payment_date

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -853,6 +853,92 @@ models:
       - name: agency_id
       - name: agency_name
 
+  - name: fct_payments_aggregations_enghouse
+    description: |
+      Each row in this table is a pay window.
+      A pay window is a group of taps processed together against a single payment token — the Enghouse equivalent of a Littlepay aggregation.
+      This table summarizes pay window activity and can be used to reconcile Enghouse payments information with Elavon deposit data.
+    columns:
+      - name: operator_id
+        description: Enghouse operator ID identifying the transit agency.
+      - *organization_name
+      - *organization_source_record_id
+      - name: end_of_month_date_pacific
+        description: |
+          The last day of the month of the pay window open_date in Pacific Time.
+          Primarily for use in BI tooling to support consistent date grouping across activity types.
+      - name: end_of_month_date_utc
+        description: The last day of the month of the pay window open_date in UTC.
+      - name: pay_window_id
+        description: Unique identifier for the pay window (Enghouse `id` from the pay_windows table).
+      - name: payment_reference
+        description: |
+          Payment reference associated with the pay window. This is the join key to Elavon deposit data (`purch_id`).
+      - name: token
+        description: Tokenized card identifier associated with the pay window.
+      - name: stage
+        description: |
+          Current stage of the pay window lifecycle. Known values: Open, Closed, Debt, DebtFinal, NoAuthDone.
+      - name: terminal_id
+        description: Terminal ID where the pay window was initiated.
+      - name: open_date
+        description: Timestamp when the pay window was opened (first tap).
+      - name: close_date
+        description: Timestamp when the pay window was closed and settled.
+      - name: agency
+        description: Agency identifier from the source file partition.
+      - name: amount_to_settle
+        description: Total fare amount that should be charged for this pay window.
+      - name: amount_settled
+        description: Amount actually settled for this pay window.
+      - name: debt_settled
+        description: Amount recovered through debt recovery for this pay window.
+      - name: num_taps
+        description: Number of distinct taps associated with this pay window's payment_reference.
+      - name: num_ticket_results
+        description: Number of ticket results associated with the taps in this pay window.
+      - name: total_fare_amount
+        description: Sum of fare amounts across all ticket results for this pay window.
+      - name: num_transactions
+        description: Total number of transaction records (all operation types) for this payment_reference.
+      - name: net_transaction_amount
+        description: Net amount across all transactions (charges minus refunds).
+      - name: latest_transaction_timestamp
+        description: Timestamp of the most recent transaction for this payment_reference.
+      - name: num_charges
+        description: Number of transactions with a positive amount (charges).
+      - name: num_refunds
+        description: Number of transactions with a negative amount (refunds).
+      - name: gross_charges
+        description: Sum of all positive transaction amounts for this pay window.
+      - name: gross_refunds
+        description: Sum of absolute values of all negative transaction amounts for this pay window.
+      - name: elavon_purch_id
+        description: |
+          Elavon purchase ID matched to this pay window via payment_reference. NULL if no Elavon match found.
+          Approximately 87% of closed pay windows are expected to match.
+      - name: elavon_settlement_date
+        description: Settlement date from Elavon deposit data for this pay window.
+      - name: elavon_payment_date
+        description: Payment date from Elavon deposit data for this pay window.
+      - name: elavon_net_amount
+        description: Net amount from Elavon deposit data (sum of all Elavon transactions for this purch_id).
+      - name: elavon_sales
+        description: Total sales amount from Elavon deposit data for this pay window.
+      - name: elavon_refunds
+        description: Total refund amount from Elavon deposit data for this pay window.
+      - name: reconciliation_category
+        description: |
+          High-level reconciliation status derived from pay window stage and Elavon match.
+          Values:
+          - "Settled (with Elavon match)": stage=Closed and matched to an Elavon deposit record
+          - "Settled (no Elavon match)": stage=Closed but no corresponding Elavon deposit record found
+          - "Debt (recovery ongoing)": stage=Debt — cardholder was charged separately via debt recovery
+          - "Debt (unrecovered)": stage=DebtFinal — debt recovery was finalized with no full recovery
+          - "Open": stage=Open or NoAuthDone — pay window not yet settled
+          - "Authorization Declined": stage=AuthDeclined — authorization attempt was declined; terminal state, no money moved
+          - "Unknown": stage value not recognized
+
   - name: fct_payments_settlements_enghouse
     description: Enghouse settlements (completed transactions.)
     columns:

--- a/warehouse/models/mart/payments/fct_payments_aggregations_enghouse.sql
+++ b/warehouse/models/mart/payments/fct_payments_aggregations_enghouse.sql
@@ -1,0 +1,177 @@
+{{ config(materialized = 'table',
+    post_hook="{{ payments_enghouse_row_access_policy() }}") }}
+
+WITH pay_windows AS (
+    SELECT * FROM {{ ref('stg_enghouse__pay_windows') }}
+),
+
+taps AS (
+    SELECT * FROM {{ ref('stg_enghouse__taps') }}
+),
+
+ticket_results AS (
+    SELECT * FROM {{ ref('stg_enghouse__ticket_results') }}
+),
+
+transactions AS (
+    SELECT * FROM {{ ref('stg_enghouse__transactions') }}
+),
+
+payments_entity_mapping AS (
+    SELECT
+        * EXCEPT(enghouse_operator_id),
+        enghouse_operator_id AS operator_id
+    FROM {{ ref('payments_entity_mapping_enghouse') }}
+),
+
+dim_orgs AS (
+    SELECT * FROM {{ ref('dim_organizations') }}
+),
+
+ticket_results_by_payment_reference AS (
+    SELECT
+        taps.payment_reference,
+        taps.operator_id,
+        COUNT(DISTINCT taps.tap_id) AS num_taps,
+        COUNT(ticket_results.id) AS num_ticket_results,
+        SUM(ticket_results.amount) AS total_fare_amount
+    FROM taps
+    LEFT JOIN ticket_results
+        ON taps.tap_id = ticket_results.tap_id
+    WHERE taps.payment_reference IS NOT NULL
+    GROUP BY taps.payment_reference, taps.operator_id
+),
+
+transactions_by_payment_reference AS (
+    SELECT
+        payment_reference,
+        operator_id,
+        COUNT(*) AS num_transactions,
+        SUM(amount) AS net_transaction_amount,
+        MAX(timestamp) AS latest_transaction_timestamp,
+        COUNTIF(amount > 0) AS num_charges,
+        COUNTIF(amount < 0) AS num_refunds,
+        SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS gross_charges,
+        SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS gross_refunds
+    FROM transactions
+    WHERE payment_reference IS NOT NULL
+    GROUP BY payment_reference, operator_id
+),
+
+elavon_info AS (
+    SELECT
+        purch_id AS elavon_purch_id,
+        MAX(settlement_date) AS elavon_settlement_date,
+        MAX(payment_date) AS elavon_payment_date,
+        SUM(amount) AS elavon_net_amount,
+        SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS elavon_sales,
+        SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END) AS elavon_refunds
+    FROM {{ ref('fct_payments_deposit_transactions') }}
+    WHERE COALESCE(purch_id, '') != ''
+    GROUP BY purch_id
+),
+
+join_all AS (
+    SELECT
+        pay_windows.operator_id,
+        pay_windows.id AS pay_window_id,
+        pay_windows.payment_reference,
+        pay_windows.token,
+        pay_windows.stage,
+        pay_windows.terminal_id,
+        pay_windows.open_date,
+        pay_windows.close_date,
+        pay_windows.amount_to_settle,
+        pay_windows.amount_settled,
+        pay_windows.debt_settled,
+        pay_windows.agency,
+
+        ticket_results_by_payment_reference.num_taps,
+        ticket_results_by_payment_reference.num_ticket_results,
+        ticket_results_by_payment_reference.total_fare_amount,
+
+        transactions_by_payment_reference.num_transactions,
+        transactions_by_payment_reference.net_transaction_amount,
+        transactions_by_payment_reference.latest_transaction_timestamp,
+        transactions_by_payment_reference.num_charges,
+        transactions_by_payment_reference.num_refunds,
+        transactions_by_payment_reference.gross_charges,
+        transactions_by_payment_reference.gross_refunds,
+
+        elavon_info.elavon_purch_id,
+        elavon_info.elavon_settlement_date,
+        elavon_info.elavon_payment_date,
+        elavon_info.elavon_net_amount,
+        elavon_info.elavon_sales,
+        elavon_info.elavon_refunds,
+
+        dim_orgs.name AS organization_name,
+        entity_map.organization_source_record_id
+
+    FROM pay_windows
+    LEFT JOIN ticket_results_by_payment_reference
+        ON pay_windows.payment_reference = ticket_results_by_payment_reference.payment_reference
+            AND pay_windows.operator_id = ticket_results_by_payment_reference.operator_id
+    LEFT JOIN transactions_by_payment_reference
+        ON pay_windows.payment_reference = transactions_by_payment_reference.payment_reference
+            AND pay_windows.operator_id = transactions_by_payment_reference.operator_id
+    LEFT JOIN elavon_info
+        ON pay_windows.payment_reference = elavon_info.elavon_purch_id
+    LEFT JOIN payments_entity_mapping AS entity_map
+        ON pay_windows.operator_id = entity_map.operator_id
+            AND CAST(pay_windows.open_date AS TIMESTAMP)
+                BETWEEN CAST(entity_map._in_use_from AS TIMESTAMP)
+                AND CAST(entity_map._in_use_until AS TIMESTAMP)
+    LEFT JOIN dim_orgs
+        ON entity_map.organization_source_record_id = dim_orgs.source_record_id
+            AND CAST(pay_windows.open_date AS TIMESTAMP)
+                BETWEEN dim_orgs._valid_from AND dim_orgs._valid_to
+),
+
+fct_payments_aggregations_enghouse AS (
+    SELECT
+        operator_id,
+        organization_name,
+        organization_source_record_id,
+        LAST_DAY(EXTRACT(DATE FROM open_date AT TIME ZONE "America/Los_Angeles"), MONTH) AS end_of_month_date_pacific,
+        LAST_DAY(EXTRACT(DATE FROM open_date), MONTH) AS end_of_month_date_utc,
+        pay_window_id,
+        payment_reference,
+        token,
+        stage,
+        terminal_id,
+        open_date,
+        close_date,
+        agency,
+        amount_to_settle,
+        amount_settled,
+        debt_settled,
+        num_taps,
+        num_ticket_results,
+        total_fare_amount,
+        num_transactions,
+        net_transaction_amount,
+        latest_transaction_timestamp,
+        num_charges,
+        num_refunds,
+        gross_charges,
+        gross_refunds,
+        elavon_purch_id,
+        elavon_settlement_date,
+        elavon_payment_date,
+        elavon_net_amount,
+        elavon_sales,
+        elavon_refunds,
+        CASE
+            WHEN stage = 'Closed' AND elavon_purch_id IS NOT NULL THEN 'Settled (with Elavon match)'
+            WHEN stage = 'Closed' AND elavon_purch_id IS NULL THEN 'Settled (no Elavon match)'
+            WHEN stage = 'Debt' THEN 'Debt (recovery ongoing)'
+            WHEN stage = 'DebtFinal' THEN 'Debt (unrecovered)'
+            WHEN stage IN ('Open', 'NoAuthDone') THEN 'Open'
+            WHEN stage = 'AuthDeclined' THEN 'Authorization Declined'
+            ELSE 'Unknown'
+        END AS reconciliation_category
+    FROM join_all
+)
+
+SELECT * FROM fct_payments_aggregations_enghouse


### PR DESCRIPTION
# Description
**IMPORTANT** Do not merge until reading the `Dependencies` and `Known limitations` sections below!!

- Adds `fct_payments_aggregations_enghouse`, a mart table that aggregates
  Enghouse pay window activity with tap/ticket, transaction, and Elavon
  deposit data for reconciliation reporting
- Each row is a pay window; includes org name, Pacific/UTC month-end dates,
  transaction aggregates (charges, refunds, gross/net), and Elavon deposit
  match columns
- Derives `reconciliation_category` from pay window stage and Elavon match
  status (Settled with/without Elavon match, Debt, Open, Authorization Declined)
- Adds full column-level documentation to `_payments.yml`

## Dependencies

Elavon matches for Ventura (operator 253) will be NULL until
`payments-seed-fixes` is merged — that PR corrects the `elavon_customer_name`
values in `payments_entity_mapping_enghouse.csv` from the full org name to
the actual Elavon-side customer names. RABA (278) matches correctly today.

## Known limitations (follow-on to Enghouse/Caltrans)

- ~130 Ventura pay_windows have NULL `open_date`, causing NULL
  `organization_name` for those rows — source data quality issue to report
  to Enghouse
- ~2% of transactions have NULL `timestamp` — same class of issue, to report
  to Enghouse

Resolves #5013

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

_Include commands/logs/screenshots as relevant._

_If making changes to dbt models, make sure they were created or update on Staging. Please run the command `uv run dbt run -s CHANGED_MODEL --target staging` and `uv run dbt test -s CHANGED_MODEL --target staging`, then include the output in this section of the PR._

`uv run dbt run -s fct_payments_aggregations_enghouse --vars 'GOOGLE_CLOUD_PROJECT: cal-itp-data-infra'`
<img width="776" height="163" alt="Screenshot 2026-05-08 at 09 32 17" src="https://github.com/user-attachments/assets/3e52002a-ae2c-4616-98b1-40737a9b38b6" />


- [x] Queried full table output; verified org names populated for
  all operators, Pacific/UTC timezone boundary handling, `reconciliation_category`
  mapping for all observed stages (Open, NoAuthDone, Debt, AuthDeclined, Closed)
- [x] Confirmed NULL org names are traceable to NULL `open_date` in source,
  not a join defect
- [x] Confirmed all Closed rows currently have `amount_settled = 0`
  (zero-value windows); Elavon match logic correct, no non-zero settled windows
  in current data

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)
Investigate and resolve (If possible) contents of `Known limitations` section above