### PR TITLE
Adding GTFS url to expiring issues model

### DIFF
--- a/warehouse/models/mart/transit_database/fct_create_expiring_gtfs_issues.sql
+++ b/warehouse/models/mart/transit_database/fct_create_expiring_gtfs_issues.sql
@@ -52,6 +52,7 @@ datasets_with_expiration AS (
     dg.name,
     dg.key AS gtfs_dataset_key,
     dg.source_record_id AS gtfs_dataset_source_record_id,
+    dg.uri,
     csf.max_end_date,
     CASE
       WHEN csf.max_end_date < CURRENT_DATE() THEN 'Expired'
@@ -71,6 +72,7 @@ expiring_datasets AS (
     dwe.gtfs_dataset_source_record_id,
     dwe.max_end_date,
     dwe.expiration_status,
+    dwe.uri,
     dp.service_name,
     dp.service_source_record_id,
     dp.organization_name
@@ -121,6 +123,7 @@ expiring_datasets_with_airtable_ids AS (
     ed.service_name,
     ed.service_source_record_id,
     ed.organization_name,
+    ed.uri,
     s.id AS service_record_id,
     d.id AS gtfs_dataset_record_id
   FROM expiring_datasets ed
@@ -153,7 +156,8 @@ fct_create_expiring_gtfs_issues AS (
     edwai.gtfs_dataset_record_id,
     edwai.service_name,
     edwai.service_record_id,
-    edwai.organization_name
+    edwai.organization_name,
+    edwai.uri
   FROM expiring_datasets_with_airtable_ids edwai
   LEFT JOIN expiring_open_issues i
     ON edwai.gtfs_dataset_source_record_id = i.gtfs_dataset_source_record_id


### PR DESCRIPTION

# Description

Add the `uri` field (GTFS URL) to the `fct_create_expiring_gtfs_issues` dbt model to support upcoming HubSpot ticket enhancements in the `airtable_issue_management` DAG.

This change allows Customer Success to access the agency website URL directly from the generated issue records and supports future inclusion of the URL in HubSpot auto-created tickets.

Ref #5272

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Successfully ran the updated dbt model locally using:

```
jovyan@jupyter-fsalemi:~/data-infra/warehouse$ uv run dbt run -s fct_create_expiring_gtfs_issues
21:59:56  Running with dbt=1.10.8
22:00:02  Registered adapter: bigquery=1.10.2
22:00:08  Found 633 models, 179 data tests, 17 seeds, 227 sources, 5 exposures, 1089 macros
22:00:08  
22:00:08  Concurrency: 8 threads (target='dev')
22:00:08  
22:00:14  1 of 1 START sql table model farhad_mart_transit_database.fct_create_expiring_gtfs_issues  [RUN]
22:00:18  1 of 1 OK created sql table model farhad_mart_transit_database.fct_create_expiring_gtfs_issues  [CREATE TABLE (1.0 rows, 1.2 GiB processed) in 3.69s]
22:00:18  
22:00:18  Finished running 1 table model in 0 hours 0 minutes and 10.08 seconds (10.08s).
22:00:19  
22:00:19  Completed successfully
22:00:19  
22:00:19  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
jovyan@jupyter-fsalemi:~/data-infra/warehouse$ 
```

Also Verified the `uri` field is included in the final model output.

## Post-merge follow-ups

- [ ] No action required
- [X] Actions required (specified below)

The ` airtable_issue_management` DAG should be modified to include this URL in the HobSpot ticket.