### PR TITLE
Add agency URL to HubSpot ticket email body

### DIFF
--- a/airflow/plugins/operators/airtable_issues_create_operator.py
+++ b/airflow/plugins/operators/airtable_issues_create_operator.py
@@ -83,6 +83,7 @@ class AirtableIssuesCreateOperator(BaseOperator):
                     "expiration_status": source_row["expiration_status"],
                     "max_end_date": str(source_row["max_end_date"]),
                     "organization_name": source_row["organization_name"],
+                    "schedule_feed": source_row["uri"],
                 }
             )
 

--- a/airflow/plugins/operators/airtable_issues_email_operator.py
+++ b/airflow/plugins/operators/airtable_issues_email_operator.py
@@ -100,6 +100,7 @@ class AirtableIssuesEmailOperator(BaseOperator):
         expiration_status = row.get("expiration_status", "")
         max_end_date = row.get("max_end_date", "")
         organization_name = row.get("organization_name", "")
+        schedule_feed = row.get("schedule_feed", "")
 
         ticket_description = self.build_ticket_description(
             expiration_status=expiration_status,
@@ -109,13 +110,12 @@ class AirtableIssuesEmailOperator(BaseOperator):
         is_mtc_511 = self.is_mtc_511_agency(gtfs_dataset_name)
 
         return f"""
-        <table>
-            <tr><td><b>Ticket description:</b></td><td>{ticket_description}</td></tr>
-            <tr><td><b>Issue Type:</b></td><td>{issue_type}</td></tr>
-            <tr><td><b>Is this an MTC 511 agency?</b></td><td>{is_mtc_511}</td></tr>
-            <tr><td><b>Companies Associated records:</b></td><td>{organization_name}</td></tr>
-            <tr><td><b>Internal Support Ticket Subject:</b></td><td>GTFS Data Quality</td></tr>
-        </table>
+        <b>Ticket description:</b> {ticket_description}.<br>
+        <b>Issue Type:</b> {issue_type}.<br>
+        <b>Is this an MTC 511 agency?</b> {is_mtc_511}.<br>
+        <b>Companies Associated records:</b> {organization_name}.<br>
+        <b>Internal Support Ticket Subject:</b> GTFS Data Quality.<br>
+        <b>Schedule Feed:</b> {schedule_feed}.
         """
 
     def send_individual_create_emails(

--- a/airflow/tests/operators/test_airtable_issues_create_operator.py
+++ b/airflow/tests/operators/test_airtable_issues_create_operator.py
@@ -52,6 +52,7 @@ class TestAirtableIssuesCreateOperator:
                 "max_end_date": date(2026, 1, 15),
                 "expiration_status": "Expired",
                 "organization_name": "Organization A",
+                "uri": "https://uriA.com",
             },
             {
                 "gtfs_dataset_name": "Dataset B",
@@ -61,6 +62,7 @@ class TestAirtableIssuesCreateOperator:
                 "max_end_date": date(2026, 1, 30),
                 "expiration_status": "Expiring in Less Than 30 Days",
                 "organization_name": "Organization B",
+                "uri": "https://uriB.com",
             },
         ]
 
@@ -168,6 +170,7 @@ class TestAirtableIssuesCreateOperator:
                 "expiration_status": "Expired",
                 "max_end_date": "2026-01-15",
                 "organization_name": "Organization A",
+                "schedule_feed": "https://uriA.com",
             },
             {
                 "issue_number": 102,
@@ -176,5 +179,6 @@ class TestAirtableIssuesCreateOperator:
                 "expiration_status": "Expiring in Less Than 30 Days",
                 "max_end_date": "2026-01-30",
                 "organization_name": "Organization B",
+                "schedule_feed": "https://uriB.com",
             },
         ]

--- a/airflow/tests/operators/test_airtable_issues_email_operator.py
+++ b/airflow/tests/operators/test_airtable_issues_email_operator.py
@@ -63,6 +63,7 @@ class TestAirtableIssuesEmailOperator:
                     "expiration_status": "Expired",
                     "max_end_date": "2026-03-25",
                     "organization_name": "Organization C",
+                    "schedule_feed": "https://uriC.com",
                 },
                 {
                     "issue_number": "ISSUE-4",
@@ -71,6 +72,7 @@ class TestAirtableIssuesEmailOperator:
                     "expiration_status": "Expiring",
                     "max_end_date": "2026-03-30",
                     "organization_name": "Organization D",
+                    "schedule_feed": "https://uriD.com",
                 },
             ],
             "failed_batches": [{"batch_num": 1, "error": "Create failure"}],


### PR DESCRIPTION
# Description

Add the agency schedule feed URL to the HubSpot ticket email body generated by the `airtable_issue_management` DAG.

This change propagates the `uri` field from the upstream dbt model through the Airtable issue creation workflow and includes the schedule feed URL in the HubSpot ticket details sent to Customer Success.

Resolves https://github.com/cal-itp/data-infra/issues/5272

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Successfully ran operator unit tests with cassette rewrite enabled:

```bash
uv run pytest tests/operators/test_airtable_issues_create_operator.py --record-mode=rewrite -vv
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.11.10, pytest-9.0.2, pluggy-1.6.0 -- /home/jovyan/data-infra/airflow/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/jovyan/data-infra/airflow
configfile: pyproject.toml
plugins: anyio-4.12.0, dotenv-0.5.2, recording-0.13.4, freezegun-0.4.2
collected 1 item                                                                                                                                                                                    

tests/operators/test_airtable_issues_create_operator.py::TestAirtableIssuesCreateOperator::test_execute PASSED                                                                                [100%]

uv run pytest tests/operators/test_airtable_issues_email_operator.py --record-mode=rewrite -vv
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.11.10, pytest-9.0.2, pluggy-1.6.0 -- /home/jovyan/data-infra/airflow/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/jovyan/data-infra/airflow
configfile: pyproject.toml
plugins: anyio-4.12.0, dotenv-0.5.2, recording-0.13.4, freezegun-0.4.2
collected 4 items                                                                                                                                                                                   

tests/operators/test_airtable_issues_email_operator.py::TestAirtableIssuesEmailOperator::test_build_failed_html_with_batches PASSED                                                           [ 25%]
tests/operators/test_airtable_issues_email_operator.py::TestAirtableIssuesEmailOperator::test_build_email_body PASSED                                                                         [ 50%]
tests/operators/test_airtable_issues_email_operator.py::TestAirtableIssuesEmailOperator::test_execute_no_created_updated_or_failed_batches PASSED                                             [ 75%]
tests/operators/test_airtable_issues_email_operator.py::TestAirtableIssuesEmailOperator::test_execute_sends_email PASSED                                                                      [100%]

========================================================================================= warnings summary ==========================================================================================
plugins/calitp_data_infra/storage.py:7
  /home/jovyan/data-infra/airflow/tests/../plugins/calitp_data_infra/storage.py:7: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
.venv/lib/python3.11/site-packages/pytest_freezegun.py:17
  /home/jovyan/data-infra/airflow/.venv/lib/python3.11/site-packages/pytest_freezegun.py:17: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 4 passed, 9 warnings in 17.09s ===================================================================================
```
Also verified the generated HubSpot ticket body now includes the Schedule Feed field.

## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)
