### PR TITLE
Recreate TIDES Buckets using variables in Terraform

### DIFF
--- a/airflow/.development.env
+++ b/airflow/.development.env
@@ -39,6 +39,7 @@ CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED_HOURLY=gs://calitp-staging-gtfs-schedule-u
 CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION=gs://calitp-staging-gtfs-schedule-validation
 CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY=gs://calitp-staging-gtfs-schedule-validation-hourly
 CALITP_BUCKET__KUBA=gs://calitp-staging-kuba
+CALITP_BUCKET__TIDES=gs://calitp-staging-tides
 CALITP_BUCKET__LITTLEPAY_PARSED=gs://calitp-staging-payments-littlepay-parsed
 CALITP_BUCKET__LITTLEPAY_PARSED_V3=gs://calitp-staging-payments-littlepay-parsed-v3
 CALITP_BUCKET__LITTLEPAY_RAW=gs://calitp-staging-payments-littlepay-raw

--- a/airflow/.test.env
+++ b/airflow/.test.env
@@ -26,6 +26,7 @@ CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED_HOURLY=gs://calitp-staging-pytest
 CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION=gs://calitp-staging-pytest
 CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY=gs://calitp-staging-pytest
 CALITP_BUCKET__KUBA=gs://calitp-staging-pytest
+CALITP_BUCKET__TIDES=gs://calitp-staging-pytest
 CALITP_BUCKET__LITTLEPAY_PARSED=gs://calitp-staging-pytest
 CALITP_BUCKET__LITTLEPAY_PARSED_V3=gs://calitp-staging-pytest
 CALITP_BUCKET__LITTLEPAY_RAW=gs://calitp-staging-pytest

--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -218,6 +218,10 @@ output "google_storage_bucket_calitp-staging-kuba_name" {
   value = google_storage_bucket.calitp-staging["calitp-staging-kuba"].name
 }
 
+output "google_storage_bucket_calitp-staging-tides_name" {
+  value = google_storage_bucket.calitp-staging["calitp-staging-tides"].name
+}
+
 output "google_storage_bucket_calitp-staging-payments-littlepay-parsed_name" {
   value = google_storage_bucket.calitp-staging["calitp-staging-payments-littlepay-parsed"].name
 }
@@ -280,8 +284,4 @@ output "google_storage_bucket_calitp-reports-staging_name" {
 
 output "google_storage_bucket_calitp-analysis-staging_name" {
   value = google_storage_bucket.calitp-analysis-staging.name
-}
-
-output "google_storage_bucket_calitp-staging-tides_name" {
-  value = google_storage_bucket.calitp-staging-tides.name
 }

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -272,15 +272,3 @@ resource "google_storage_bucket" "calitp-analysis-staging" {
     main_page_suffix = "index.html"
   }
 }
-
-resource "google_storage_bucket" "calitp-staging-tides" {
-  default_event_based_hold    = "false"
-  force_destroy               = "true"
-  location                    = "US-WEST2"
-  name                        = "calitp-staging-tides"
-  project                     = "cal-itp-data-infra-staging"
-  public_access_prevention    = "inherited"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "true"
-}

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
@@ -88,9 +88,3 @@ resource "google_storage_bucket_iam_member" "calitp-analysis-staging" {
   role   = "roles/storage.objectViewer"
   member = "allUsers"
 }
-
-resource "google_storage_bucket_iam_member" "calitp-staging-tides" {
-  bucket = google_storage_bucket.calitp-staging-tides.name
-  role   = "roles/storage.objectViewer"
-  member = "allUsers"
-}

--- a/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
@@ -21,6 +21,7 @@ locals {
     "calitp-staging-gtfs-schedule-validation",
     "calitp-staging-gtfs-schedule-validation-hourly",
     "calitp-staging-kuba",
+    "calitp-staging-tides",
     "calitp-staging-ntd-api-products",
     "calitp-staging-ntd-report-validation",
     "calitp-staging-ntd-xlsx-products-clean",

--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -1982,6 +1982,10 @@ output "google_storage_bucket_calitp-kuba_name" {
   value = google_storage_bucket.calitp["calitp-kuba"].name
 }
 
+output "google_storage_bucket_calitp-tides_name" {
+  value = google_storage_bucket.calitp["calitp-tides"].name
+}
+
 output "google_storage_bucket_calitp-gtfs-schedule-manual_name" {
   value = google_storage_bucket.calitp["calitp-gtfs-schedule-manual"].name
 }
@@ -2008,8 +2012,4 @@ output "google_storage_bucket_calitp-enghouse-parsed_name" {
 
 output "google_storage_bucket_calitp-elavon-raw-v2_name" {
   value = google_storage_bucket.calitp-elavon-raw-v2.name
-}
-
-output "google_storage_bucket_calitp-tides_name" {
-  value = google_storage_bucket.calitp-tides.name
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -1262,15 +1262,3 @@ resource "google_storage_bucket" "calitp" {
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
 }
-
-resource "google_storage_bucket" "calitp-tides" {
-  default_event_based_hold    = "false"
-  force_destroy               = "false"
-  location                    = "US-WEST2"
-  name                        = "calitp-tides"
-  project                     = "cal-itp-data-infra"
-  public_access_prevention    = "inherited"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "true"
-}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -435,9 +435,3 @@ resource "google_storage_bucket_iam_member" "elavon-raw-v2-sftp-service-account"
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${data.terraform_remote_state.iam.outputs.google_service_account_elavon-sftp-service-account_email}"
 }
-
-resource "google_storage_bucket_iam_member" "calitp-tides" {
-  bucket = google_storage_bucket.calitp-tides.name
-  role   = "roles/storage.objectViewer"
-  member = "allUsers"
-}

--- a/iac/cal-itp-data-infra/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra/gcs/us/variables.tf
@@ -2,6 +2,7 @@ locals {
   environment_buckets = toset([
     "calitp-gtfs-schedule-manual",
     "calitp-kuba",
+    "calitp-tides",
     "calitp-gtfs-rt-archiver"
   ])
 }


### PR DESCRIPTION
# Description

When I tried to reference the new TIDES Buckets on composer env variables, Terraform complained about not finding the bucket. There were some missing permission or config. I followed the same KUBA bucket set up to recreate TIDES buckets and it fixed the issue.

The TIDES DAG PR https://github.com/cal-itp/data-infra/pull/5307 will be able to create the composer variables once this PR is merged.

Relates to https://github.com/cal-itp/data-infra/issues/4838

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running Terraform locally.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
