### PR TITLE
Shrink unused kubernetes node pools - scale jobs-v1 and gtfsrt-v4 node pool floors to 0

### DIFF
--- a/iac/cal-itp-data-infra/gke/us/container_node_pool.tf
+++ b/iac/cal-itp-data-infra/gke/us/container_node_pool.tf
@@ -65,7 +65,7 @@ resource "google_container_node_pool" "tfer--data-infra-apps_gtfsrt-v4" {
   autoscaling {
     location_policy      = "BALANCED"
     max_node_count       = "2"
-    min_node_count       = "1"
+    min_node_count       = "0"
     total_max_node_count = "0"
     total_min_node_count = "0"
   }
@@ -139,7 +139,7 @@ resource "google_container_node_pool" "tfer--data-infra-apps_jobs-v1" {
   autoscaling {
     location_policy      = "BALANCED"
     max_node_count       = "3"
-    min_node_count       = "1"
+    min_node_count       = "0"
     total_max_node_count = "0"
     total_min_node_count = "0"
   }


### PR DESCRIPTION
# Description

Drops `min_node_count` from `1` → `0` on the `jobs-v1` and `gtfsrt-v4` node pools in the `data-infra-apps` cluster (us-west1). Both pools are orphaned — Composer Airflow KPO jobs now target the `airflow-jobs` autopilot cluster in us-west2 (`POD_CLUSTER_NAME=airflow-jobs`, `POD_LOCATION=us-west2`), so nothing schedules onto these pools. `max_node_count` is preserved (2 and 3 respectively) so autoscale-up still works if anything ever lands on them again.

Works toward #5332.  After confirmed dead we can delete them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Ran `terraform plan` locally in `iac/cal-itp-data-infra/gke/us/`. Plan showed only the two expected `min_node_count` diffs on `jobs-v1` and `gtfsrt-v4`, no other drift.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After the apply workflow runs, verify the pools drain:

- `kubectl get nodes -l cloud.google.com/gke-nodepool=jobs-v1` → 0 nodes within ~10 min
- `kubectl get nodes -l cloud.google.com/gke-nodepool=gtfsrt-v4` → 0 nodes within ~10 min
- Spot-check Composer DAGs for any failures referencing these pools