### PR TITLE
Pin urllib3<2.0 to fix Composer 3 gzip decode crash

### DIFF
--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pyairtable==2.2.1",
     "sentry-sdk>=2.44.0",
     "typer==0.4.1",
-    "urllib3<2.0.0",
+    "urllib3<2.0",
 ]
 
 [dependency-groups]

--- a/airflow/requirements-c3.txt
+++ b/airflow/requirements-c3.txt
@@ -10,3 +10,4 @@ platformdirs>=2.5
 pyairtable==2.2.1
 sentry-sdk>=2.44.0
 typer==0.4.1
+urllib3<2.0

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -10,3 +10,4 @@ platformdirs>=2.5
 pyairtable==2.2.1
 sentry-sdk>=2.44.0
 typer==0.4.1
+urllib3<2.0

--- a/airflow/tests/test_urllib3_gzip_regression.py
+++ b/airflow/tests/test_urllib3_gzip_regression.py
@@ -1,0 +1,40 @@
+"""Regression test for #5334 — Composer 3 ships a Google-patched urllib3
+whose _GzipDecoder.decompress() rejects the max_length kwarg urllib3
+itself passes, breaking every gzip'd GCS download (e.g. manifest.json
+via GCSHook). The urllib3<2.0 pin avoids that build; these tests fail
+if it sneaks back in."""
+
+import gzip
+import io
+
+import pytest
+from urllib3.response import HTTPResponse
+
+
+def _gzipped(data: bytes) -> bytes:
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+        f.write(data)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def gzipped_response():
+    payload = b'{"nodes": [' + b'{"k":"v"},' * 1000 + b"{}]}"
+    return payload, HTTPResponse(
+        body=io.BytesIO(_gzipped(payload)),
+        headers={"Content-Encoding": "gzip"},
+        preload_content=False,
+    )
+
+
+def test_gzip_decode_via_data_property(gzipped_response):
+    """resp.data path — preload + decode in one shot."""
+    payload, resp = gzipped_response
+    assert resp.data == payload
+
+
+def test_gzip_decode_via_stream(gzipped_response):
+    """resp.stream(decode_content=True) — the path GCSHook.download uses."""
+    payload, resp = gzipped_response
+    assert b"".join(resp.stream(8192, decode_content=True)) == payload

--- a/airflow/uv.lock
+++ b/airflow/uv.lock
@@ -1149,7 +1149,7 @@ requires-dist = [
     { name = "pyairtable", specifier = "==2.2.1" },
     { name = "sentry-sdk", specifier = ">=2.44.0" },
     { name = "typer", specifier = "==0.4.1" },
-    { name = "urllib3", specifier = "<2.0.0" },
+    { name = "urllib3", specifier = "<2.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
# Description

Composer 3's image (`composer-3-airflow-2.10.5-build.36`) ships a Google-patched
urllib3 whose `_GzipDecoder.decompress()` does not accept the `max_length` kwarg
that urllib3's own `_decode()` passes in. This crashes every GCS download of a
gzip-compressed response — including `manifest.json` reads via `GCSHook.download()`,
which is the first task in `publish_gtfs` (`dbt_manifest_to_metadata`). The DAG
aborts before any downstream CKAN task runs.

Pinning `urllib3<2.0` resolves to `1.26.20`, which Composer leaves alone instead
of overlaying its broken patched build. The pin is applied in all three files
Composer/uv read:

- `airflow/requirements.txt` — consumed by `iac/.../composer/us/variables.tf` (Composer 2)
- `airflow/requirements-c3.txt` — consumed by the same module for Composer 3
- `airflow/pyproject.toml` — local dev via `uv`

### Why `<2.0` and not a newer bound

| Constraint | Resolved | Tests passed | Tests failed |
|---|---|---|---|
| `urllib3<2.0` (this PR) | 1.26.20 | 113 | 5 (pre-existing, #5338) |
| `urllib3<2.6` | 2.5.0 | 93 | 25 (**+20**) |
| `urllib3>=2.7` | 2.7.0 | 88 | 25 (**+20**) |

urllib3 2.x is broadly incompatible with our current dependency chain
(ckanapi, requests, soda hook, ntd xlsx hook, airtable, BigQuery, mobility
database, manifest operators). Moving to 2.x is a separate, larger effort —
tracked under the dependency epic #5231; this PR documents `urllib3<2.0` as a
known constraint there.

Resolves #5334

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

**Local Composer 3 environment** (built from `composer-3-airflow-2.10.5-build.36`):

1. Added `urllib3<2.0` to `requirements-dev.txt`
2. `make teardown && make setup && make sync && make start`
3. `docker exec ... pip show urllib3` → **1.26.20** (downgraded from C3's broken build)
4. Triggered `publish_gtfs` via Airflow API
5. `dbt_manifest_to_metadata`: **success** (previously crashed on C3 staging)
6. All downstream tasks progressed normally

**Regression tests** — new `airflow/tests/test_urllib3_gzip_regression.py` covers
the two real code paths used in production:

- `test_gzip_decode_via_data_property` — `resp.data` (preload + decode)
- `test_gzip_decode_via_stream` — `resp.stream(decode_content=True)`, the path
  `GCSHook.download` uses

Both pass on `urllib3==1.26.20` and exercise the call site that fails against
C3's bundled build.

**Full suite:** `uv run pytest tests/ --ignore=tests/test_download_failure_summary.py`
→ 113 passed, 5 failed (all pre-existing assertion drift, tracked in #5338).

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- Close/comment on the open dependabot PR (#5299) bumping urllib3 → 2.7.0 in `/airflow`, linking this PR + #5334 so the wound doesn't silently re-open.
- Note `urllib3<2.0` as a documented constraint in #5231 (dependency/security epic) so the next dep-update pass doesn't repeat the investigation.
- #5338 tracks the 5 pre-existing GTFS validator test failures uncovered here — not addressed in this PR (scope).