### PR TITLE
Revert heartbeat frequency change for staging composer3 airflow testing

### DIFF
--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/workflow.tf
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/workflow.tf
@@ -52,7 +52,7 @@ resource "google_cloud_scheduler_job" "gtfs-rt-archiver-staging-clock" {
   description = "GTFS-RT Archiver Heartbeat"
   region      = "us-west2"
   project     = "cal-itp-data-infra-staging"
-  schedule    = "0 * * * *"
+  schedule    = "* * * * *"
   time_zone   = "America/Los_Angeles"
 
   pubsub_target {


### PR DESCRIPTION
# Description

This PR reverts #5264 which reduced the gtfs-rt archiver heartbeat frequency in staging to once per hour. The change is being reverted for staging composer3 airflow testing.

Resolves #4706

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

N/A - this is a revert of infrastructure changes for testing purposes

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)

No action required for this revert.