### PR TITLE
Create Outcomes table for TIDES Audit Dashboard

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -230,6 +230,11 @@ models:
           domain: mart
           dataset: tides
         schema: mart_tides
+      tides_audit:
+        +labels:
+          domain: mart
+          dataset: tides_audit
+        schema: mart_tides_audit
       payments:
         +materialized: table
         +labels:

--- a/warehouse/models/mart/tides_audit/_mart_tides_audit.yml
+++ b/warehouse/models/mart/tides_audit/_mart_tides_audit.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: dim_tides_vehicle_location_outcomes
+    description: Outcomes from converting GTFS Vehicle Location to TIDES (Transit Integrated Data Exchange Specification)
+    columns:
+      - name: display_name
+      - name: organization_source_record_id
+      - name: base64_url
+      - name: dataset_name
+      - name: table_name
+      - name: destination_path
+      - name: dt
+      - name: ts

--- a/warehouse/models/mart/tides_audit/dim_tides_vehicle_location_outcomes.sql
+++ b/warehouse/models/mart/tides_audit/dim_tides_vehicle_location_outcomes.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='table') }}
+
+WITH dim_tides_vehicle_location_outcomes AS (
+    SELECT DISTINCT
+           display_name,
+           organization_source_record_id,
+           base64_url,
+           dataset_name,
+           table_name,
+           destination_path,
+           dt,
+           ts
+      FROM {{ source('external_tides', 'vehicle_location_outcomes') }}
+)
+
+SELECT * FROM dim_tides_vehicle_location_outcomes


### PR DESCRIPTION
# Description

This PR creates `mart_tides_audit.dim_tides_vehicle_location_outcomes` table for TIDES Audit Dashboard (#4840).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running dbt locally and dbt run on deploy dbt workflow.

```
 ❯ uv run dbt run -s models/mart/tides_audit/dim_tides_vehicle_location_outcomes.sql --target
staging
15:09:58  Running with dbt=1.10.8
15:09:59  Registered adapter: bigquery=1.10.2
15:10:00  Unable to do partial parsing because config vars, config profile, or config target have changed
15:10:00  Unable to do partial parsing because profile has changed
15:10:05  Found 632 models, 183 data tests, 17 seeds, 228 sources, 5 exposures, 1064 macros
15:10:05
15:10:05  Concurrency: 8 threads (target='staging')
15:10:05
15:10:10  1 of 1 START sql table model mart_tides_audit.dim_tides_vehicle_location_outcomes  [RUN]
15:10:13  1 of 1 OK created sql table model mart_tides_audit.dim_tides_vehicle_location_outcomes  [CREATE TABLE (36.0 rows, 19.7 KiB processed) in 3.30s]
15:10:13
15:10:13  Finished running 1 table model in 0 hours 0 minutes and 8.84 seconds (8.84s).
15:10:14
15:10:14  Completed successfully
15:10:14
15:10:14  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
