### PR TITLE
Fix(Payments): Filter `DELETED` Littlepay Micropayments from Downstream Tables

### DIFF
--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -296,6 +296,16 @@ Possible values:
 * `REFUND`
 {% enddocs %}
 
+{%docs lp_mp_status %}
+The status of the micropayment. 
+
+Possible values: 
+* `CLOSED`
+* `CLOSING`
+* `DELETED`
+* `PENDING`
+{% enddocs %}
+
 -------------------------------- MICROPAYMENT ADJUSTMENTS TABLE --------------------------------
 
 {% docs lp_adj_type %}

--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -62,6 +62,34 @@ The file name from which this data was sourced (the name of the file that was in
 The timestamp at which the data was ingested from Littlepay.
 {% enddocs %}
 
+{% docs lp_export_date %}
+Date of the source file from Littlepay. Date is extracted from filenames, which generally have the
+structure {timestamp}_{data_type}.{file extension}.
+{% enddocs %}
+
+{% docs lp_export_ts %}
+Timestamp of the source file from Littlepay. Timestamp is extracted from filenames, which generally have the
+structure {timestamp}_{data_type}.{file extension}.
+{% enddocs %}
+
+{% docs lp_line_number %}
+Line number of this row in the source file.
+Some line numbers may be missing because we drop extra copies of rows that are full duplicates of another row.
+{% enddocs %}
+
+{% docs lp_input_row_key %}
+Synthetic key composed of Littlepay file date and line number to uniquely identify a row within source data.
+{% enddocs %}
+
+{% docs lp_payments_key %}
+Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
+{% enddocs %}
+
+{% docs lp_content_hash %}
+Hash of all data columns to uniquely identify row's content, mostly for debugging purposes.
+Should ideally be handled by uniqueness of `_payments_key` but surfaced for troubleshooting.
+{% enddocs %}
+
 
 -------------------------------- AGGREGATIONS/SUMMARIES --------------------------------
 

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -773,3 +773,78 @@ models:
         description: '{{ doc("customer_funding_source_principal_customer_id") }}'
       - *bin
       - *card_scheme
+  - name: int_payments__filtered_micropayments
+    data_tests:
+      - &littlepay_uniqueness
+        dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - instance
+              - extract_filename
+              - ts
+              - _line_number
+    description: This model makes the assumption that, in the case of duplicated micropayment_id values, the one with the latest transaction_time in the latest export file takes precedence.
+    columns:
+      - name: micropayment_id
+        description: '{{ doc("lp_micropayment_id") }}'
+        data_tests:
+          - dbt_utils.not_null_proportion:
+              arguments:
+                at_least: 0.9999
+          - unique_proportion:
+              arguments:
+                at_least: 0.9999
+      - name: aggregation_id
+        description: '{{ doc("lp_aggregation_id") }}'
+      - *participant_id
+      - name: customer_id
+        description: '{{ doc("lp_customer_id") }}'
+      - name: funding_source_vault_id
+        description: '{{ doc("lp_funding_source_vault_id") }}'
+      - name: transaction_time
+        description: '{{ doc("lp_transaction_time") }}'
+      - name: payment_liability
+        description: '{{ doc("lp_payment_liability") }}'
+      - name: charge_amount
+        description: '{{ doc("lp_charge_amount") }}'
+      - name: nominal_amount
+        description: '{{ doc("lp_nominal_amount") }}'
+      - name: currency_code
+        description: '{{ doc("lp_currency_code") }}'
+      - name: type
+        description: '{{ doc("lp_mp_type") }}'
+      - name: charge_type
+        description: '{{ doc("lp_charge_type") }}'
+      - name: littlepay_export_date
+        description: '{{ doc("lp_export_date") }}'
+      - name: littlepay_export_ts
+        description: '{{ doc("lp_export_ts") }}'
+      - name: _line_number
+        description: '{{ doc("lp_line_number") }}'
+      - name: _key
+        description: '{{ doc("lp_input_row_key") }}'
+        data_tests:
+          - not_null
+          - unique
+      - name: _content_hash
+        description: '{{ doc("lp_content_hash") }}'
+      - name: _payments_key
+        description: '{{ doc("lp_payments_key") }}'
+        data_tests:
+          - not_null
+          - unique
+      - name: instance
+        description: '{{ doc("lp_instance") }}'
+      - name: feed_version
+        description: '{{ doc("lp_feed_version") }}'
+      - name: extract_filename
+        description: '{{ doc("lp_extract_filename") }}'
+      - name: ts
+        description: '{{ doc("lp_ts") }}'
+      - name: status
+        description: '{{ doc("lp_mp_status") }}'
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["CLOSED", "CLOSING", "PENDING"]

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -844,7 +844,6 @@ models:
       - name: status
         description: '{{ doc("lp_mp_status") }}'
         data_tests:
-          - not_null
           - accepted_values:
               arguments:
                 values: ["CLOSED", "CLOSING", "PENDING"]

--- a/warehouse/models/intermediate/payments/int_payments__cleaned_micropayment_device_transactions.sql
+++ b/warehouse/models/intermediate/payments/int_payments__cleaned_micropayment_device_transactions.sql
@@ -9,7 +9,11 @@ WITH int_littlepay__unioned_micropayment_device_transactions AS (
 ),
 
 int_payments__filtered_micropayments AS (
-    SELECT * FROM {{ ref('int_payments__filtered_micropayments') }}
+    SELECT
+        micropayment_id,
+        charge_type,
+        type,
+    FROM {{ ref('int_payments__filtered_micropayments') }}
 ),
 
 deduped_micropayment_device_transaction_ids AS (

--- a/warehouse/models/intermediate/payments/int_payments__cleaned_micropayment_device_transactions.sql
+++ b/warehouse/models/intermediate/payments/int_payments__cleaned_micropayment_device_transactions.sql
@@ -8,8 +8,8 @@ WITH int_littlepay__unioned_micropayment_device_transactions AS (
     SELECT * FROM {{ ref('int_littlepay__unioned_micropayment_device_transactions') }}
 ),
 
-int_littlepay__unioned_micropayments AS (
-    SELECT * FROM {{ ref('int_littlepay__unioned_micropayments') }}
+int_payments__filtered_micropayments AS (
+    SELECT * FROM {{ ref('int_payments__filtered_micropayments') }}
 ),
 
 deduped_micropayment_device_transaction_ids AS (
@@ -27,7 +27,7 @@ join_transactions_to_micropayments AS (
         charge_type,
         type,
     FROM deduped_micropayment_device_transaction_ids
-    INNER JOIN int_littlepay__unioned_micropayments
+    INNER JOIN int_payments__filtered_micropayments
         USING(micropayment_id)
 ),
 
@@ -44,7 +44,7 @@ invalid_micropayment_device_transaction_ids AS (
     FROM join_transactions_to_micropayments AS first_transaction
     INNER JOIN deduped_micropayment_device_transaction_ids AS second_micropayment_device_transaction
         USING (littlepay_transaction_id)
-    INNER JOIN int_littlepay__unioned_micropayments AS second_micropayment
+    INNER JOIN int_payments__filtered_micropayments AS second_micropayment
         ON second_micropayment_device_transaction.micropayment_id = second_micropayment.micropayment_id
     WHERE first_transaction.micropayment_id != second_micropayment.micropayment_id
         AND first_transaction.charge_type = 'pending_charge_fare'

--- a/warehouse/models/intermediate/payments/int_payments__customers_vaults_to_aggregations.sql
+++ b/warehouse/models/intermediate/payments/int_payments__customers_vaults_to_aggregations.sql
@@ -5,7 +5,7 @@ with micropayment_aggregations_customer_map as (
         customer_id,
         funding_source_vault_id,
         transaction_time
-    from {{ ref('int_littlepay__unioned_micropayments') }}
+    from {{ ref('int_payments__filtered_micropayments') }}
 ),
 
 settlement_aggregations_customer_map as (

--- a/warehouse/models/intermediate/payments/int_payments__filtered_micropayments.sql
+++ b/warehouse/models/intermediate/payments/int_payments__filtered_micropayments.sql
@@ -1,14 +1,84 @@
 {{ config(materialized = "table") }}
 
 WITH micropayments AS (
-    SELECT *
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        customer_id,
+        funding_source_vault_id,
+        transaction_time,
+        payment_liability,
+        charge_amount,
+        nominal_amount,
+        currency_code,
+        type,
+        charge_type,
+        status,
+        _line_number,
+        instance,
+        feed_version,
+        extract_filename,
+        ts,
+        littlepay_export_ts,
+        littlepay_export_date,
+        _content_hash,
+        _key,
+        _payments_key,
     FROM {{ ref('int_littlepay__unioned_micropayments') }}
 ),
 
 int_payments__filtered_micropayments AS (
-    SELECT *
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        customer_id,
+        funding_source_vault_id,
+        transaction_time,
+        payment_liability,
+        charge_amount,
+        nominal_amount,
+        currency_code,
+        type,
+        charge_type,
+        status,
+        _line_number,
+        instance,
+        feed_version,
+        extract_filename,
+        ts,
+        littlepay_export_ts,
+        littlepay_export_date,
+        _content_hash,
+        _key,
+        _payments_key,
     FROM micropayments
     WHERE status != 'DELETED' OR status IS NULL
 )
 
-SELECT * FROM int_payments__filtered_micropayments
+SELECT
+    micropayment_id,
+    aggregation_id,
+    participant_id,
+    customer_id,
+    funding_source_vault_id,
+    transaction_time,
+    payment_liability,
+    charge_amount,
+    nominal_amount,
+    currency_code,
+    type,
+    charge_type,
+    status,
+    _line_number,
+    instance,
+    feed_version,
+    extract_filename,
+    ts,
+    littlepay_export_ts,
+    littlepay_export_date,
+    _content_hash,
+    _key,
+    _payments_key,
+FROM int_payments__filtered_micropayments

--- a/warehouse/models/intermediate/payments/int_payments__filtered_micropayments.sql
+++ b/warehouse/models/intermediate/payments/int_payments__filtered_micropayments.sql
@@ -1,0 +1,14 @@
+{{ config(materialized = "table") }}
+
+WITH micropayments AS (
+    SELECT *
+    FROM {{ ref('int_littlepay__unioned_micropayments') }}
+),
+
+int_payments__filtered_micropayments AS (
+    SELECT *
+    FROM micropayments
+    WHERE status != 'DELETED' OR status IS NULL
+)
+
+SELECT * FROM int_payments__filtered_micropayments

--- a/warehouse/models/intermediate/payments/int_payments__micropayments_adjustments_refunds_joined.sql
+++ b/warehouse/models/intermediate/payments/int_payments__micropayments_adjustments_refunds_joined.sql
@@ -1,5 +1,5 @@
 WITH debit_micropayments AS (
-    SELECT * FROM {{ ref('int_littlepay__unioned_micropayments') }}
+    SELECT * FROM {{ ref('int_payments__filtered_micropayments') }}
     WHERE type = 'DEBIT'
 ),
 

--- a/warehouse/models/intermediate/payments/int_payments__micropayments_adjustments_refunds_joined.sql
+++ b/warehouse/models/intermediate/payments/int_payments__micropayments_adjustments_refunds_joined.sql
@@ -1,5 +1,17 @@
 WITH debit_micropayments AS (
-    SELECT * FROM {{ ref('int_payments__filtered_micropayments') }}
+    SELECT
+        participant_id,
+        micropayment_id,
+        aggregation_id,
+        funding_source_vault_id,
+        customer_id,
+        charge_amount,
+        nominal_amount,
+        charge_type,
+        transaction_time,
+        type,
+        feed_version,
+    FROM {{ ref('int_payments__filtered_micropayments') }}
     WHERE type = 'DEBIT'
 ),
 
@@ -22,7 +34,12 @@ products AS (
 ),
 
 individual_refunds AS (
-    SELECT * FROM {{ ref('int_payments__refunds_deduped') }}
+    SELECT
+        aggregation_id,
+        micropayment_id,
+        participant_id,
+        refund_amount,
+    FROM {{ ref('int_payments__refunds_deduped') }}
 ),
 
 aggregation_refunds AS (

--- a/warehouse/models/intermediate/payments/int_payments__micropayments_to_aggregations.sql
+++ b/warehouse/models/intermediate/payments/int_payments__micropayments_to_aggregations.sql
@@ -6,7 +6,7 @@
 
 WITH micropayments AS (
     SELECT *
-    FROM {{ ref('int_littlepay__unioned_micropayments') }}
+    FROM {{ ref('int_payments__filtered_micropayments') }}
 ),
 
 -- flag micropayments that were adjusted

--- a/warehouse/models/intermediate/payments/int_payments__micropayments_to_aggregations.sql
+++ b/warehouse/models/intermediate/payments/int_payments__micropayments_to_aggregations.sql
@@ -5,7 +5,14 @@
 }}
 
 WITH micropayments AS (
-    SELECT *
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        charge_amount,
+        nominal_amount,
+        transaction_time,
+        charge_type,
     FROM {{ ref('int_payments__filtered_micropayments') }}
 ),
 

--- a/warehouse/models/intermediate/payments/int_payments__refunds_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__refunds_deduped.sql
@@ -5,7 +5,7 @@ WITH micropayment_device_transactions AS (
 ),
 
 micropayments_refunds AS (
-    SELECT * FROM {{ ref('int_littlepay__unioned_micropayments') }}
+    SELECT * FROM {{ ref('int_payments__filtered_micropayments') }}
     WHERE type = 'CREDIT'
 ),
 

--- a/warehouse/models/intermediate/payments/int_payments__refunds_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__refunds_deduped.sql
@@ -1,11 +1,33 @@
 {{ config(materialized = "table") }}
 
 WITH micropayment_device_transactions AS (
-    SELECT * FROM {{ ref('int_payments__cleaned_micropayment_device_transactions') }}
+    SELECT
+        littlepay_transaction_id,
+        micropayment_id,
+        _key,
+    FROM {{ ref('int_payments__cleaned_micropayment_device_transactions') }}
 ),
 
 micropayments_refunds AS (
-    SELECT * FROM {{ ref('int_payments__filtered_micropayments') }}
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        customer_id,
+        transaction_time,
+        charge_amount,
+        type,
+        _line_number,
+        currency_code,
+        instance,
+        extract_filename,
+        ts,
+        littlepay_export_ts,
+        littlepay_export_date,
+        _content_hash,
+        _key,
+        _payments_key,
+    FROM {{ ref('int_payments__filtered_micropayments') }}
     WHERE type = 'CREDIT'
 ),
 

--- a/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayments.sql
+++ b/warehouse/models/intermediate/payments/littlepay_feed_unions/int_littlepay__unioned_micropayments.sql
@@ -1,14 +1,60 @@
 {{ config(materialized = "table") }}
 
 WITH micropayments_v1 AS (
-    SELECT *
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        customer_id,
+        funding_source_vault_id,
+        transaction_time,
+        payment_liability,
+        charge_amount,
+        nominal_amount,
+        currency_code,
+        type,
+        charge_type,
+        status,
+        _line_number,
+        `instance`,
+        feed_version,
+        extract_filename,
+        ts,
+        littlepay_export_ts,
+        littlepay_export_date,
+        _content_hash,
+        _key,
+        _payments_key,
     FROM {{ ref('stg_littlepay__micropayments') }}
     -- For agencies that had v1 feeds, keep everything before cutover date
     WHERE littlepay_export_date <= '2025-05-16'
 ),
 
 micropayments_v3 AS (
-    SELECT *
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        customer_id,
+        funding_source_vault_id,
+        transaction_time,
+        payment_liability,
+        charge_amount,
+        nominal_amount,
+        currency_code,
+        type,
+        charge_type,
+        status,
+        _line_number,
+        `instance`,
+        feed_version,
+        extract_filename,
+        ts,
+        littlepay_export_ts,
+        littlepay_export_date,
+        _content_hash,
+        _key,
+        _payments_key,
     FROM {{ ref('stg_littlepay__micropayments_v3') }}
     WHERE
         -- Keep all records for agencies that didn't have a competing feed v1

--- a/warehouse/models/staging/payments/littlepay/_stg_littlepay.yml
+++ b/warehouse/models/staging/payments/littlepay/_stg_littlepay.yml
@@ -26,29 +26,21 @@ models:
       - name: authorisation_date_time_utc
       - &lp_export_date
         name: littlepay_export_date
-        description: |
-          Date of the source file from Littlepay. Date is extracted from filenames, which generally have the
-          structure {timestamp}_{data_type}.{file extension}.
+        description: '{{ doc("lp_export_date") }}'
       - &lp_export_ts
         name: littlepay_export_ts
-        description: |
-          Timestamp of the source file from Littlepay. Timestamp is extracted from filenames, which generally have the
-          structure {timestamp}_{data_type}.{file extension}.
+        description: '{{ doc("lp_export_ts") }}'
       - &lp_line_number
         name: _line_number
-        description: |
-          Line number of this row in the source file.
-          Some line numbers may be missing because we drop extra copies of rows that are full duplicates of another row.
+        description: '{{ doc("lp_line_number") }}'
       - &payments_input_row_key
         name: _key
-        description: |
-          Synthetic key composed of Littlepay file date and line number to uniquely identify a row within source data.
+        description: '{{ doc("lp_input_row_key") }}'
         data_tests:
           - not_null
           - unique
       - name: _payments_key
-        description: |
-          Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
+        description: '{{ doc("lp_payments_key") }}'
         data_tests:
           - not_null
           - unique_proportion:
@@ -60,9 +52,7 @@ models:
                 field: _payments_key
       - &_content_hash
         name: _content_hash
-        description: |
-          Hash of all data columns to uniquely identify row's content, mostly for debugging purposes.
-          Should ideally be handled by uniqueness of _payments_key but surfaced for troubleshooting.
+        description: '{{ doc("lp_content_hash") }}'
 
   - name: stg_littlepay__customer_funding_source
     columns:
@@ -109,8 +99,7 @@ models:
       - *payments_input_row_key
       - &payments_key_full_uniqueness
         name: _payments_key
-        description: |
-          Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
+        description: '{{ doc("lp_payments_key") }}'
         data_tests:
           - not_null
           - unique

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayments.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayments.sql
@@ -16,6 +16,7 @@ clean_columns AS (
         SAFE_CAST({{ trim_make_empty_string_null('currency_code') }} AS NUMERIC) AS currency_code,
         {{ trim_make_empty_string_null('type') }} AS type,
         {{ trim_make_empty_string_null('charge_type') }} AS charge_type,
+        SAFE_CAST(NULL AS STRING) AS status, --new v3 field, not defined in v1
         SAFE_CAST({{ trim_make_empty_string_null('_line_number') }} AS INTEGER) AS _line_number,
         `instance`,
         extract_filename,
@@ -63,6 +64,7 @@ stg_littlepay__micropayments AS (
         currency_code,
         type,
         charge_type,
+        status,
         _line_number,
         `instance`,
         'v1' AS feed_version,

--- a/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayments.sql
+++ b/warehouse/models/staging/payments/littlepay/stg_littlepay__micropayments.sql
@@ -1,5 +1,22 @@
 WITH source AS (
-    SELECT * FROM {{ source('external_littlepay', 'micropayments') }}
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        customer_id,
+        funding_source_vault_id,
+        transaction_time,
+        payment_liability,
+        charge_amount,
+        nominal_amount,
+        currency_code,
+        type,
+        charge_type,
+        _line_number,
+        `instance`,
+        extract_filename,
+        ts,
+    FROM {{ source('external_littlepay', 'micropayments') }}
 ),
 
 clean_columns AS (

--- a/warehouse/models/staging/payments/littlepay_v3/_stg_littlepay_v3.yml
+++ b/warehouse/models/staging/payments/littlepay_v3/_stg_littlepay_v3.yml
@@ -26,29 +26,21 @@ models:
       - name: authorisation_date_time_utc
       - &lp_export_date
         name: littlepay_export_date
-        description: |
-          Date of the source file from Littlepay. Date is extracted from filenames, which generally have the
-          structure {timestamp}_{data_type}.{file extension}.
+        description: '{{ doc("lp_export_date") }}'
       - &lp_export_ts
         name: littlepay_export_ts
-        description: |
-          Timestamp of the source file from Littlepay. Timestamp is extracted from filenames, which generally have the
-          structure {timestamp}_{data_type}.{file extension}.
+        description: '{{ doc("lp_export_ts") }}'
       - &lp_line_number
         name: _line_number
-        description: |
-          Line number of this row in the source file.
-          Some line numbers may be missing because we drop extra copies of rows that are full duplicates of another row.
+        description: '{{ doc("lp_line_number") }}'
       - &payments_input_row_key
         name: _key
-        description: |
-          Synthetic key composed of Littlepay file date and line number to uniquely identify a row within source data.
+        description: '{{ doc("lp_input_row_key") }}'
         data_tests:
           - not_null
           - unique
       - name: _payments_key
-        description: |
-          Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
+        description: '{{ doc("lp_payments_key") }}'
         data_tests:
           - not_null
           - unique_proportion:
@@ -60,9 +52,7 @@ models:
                 field: _payments_key
       - &_content_hash
         name: _content_hash
-        description: |
-          Hash of all data columns to uniquely identify row's content, mostly for debugging purposes.
-          Should ideally be handled by uniqueness of _payments_key but surfaced for troubleshooting.
+        description: '{{ doc("lp_content_hash") }}'
 
   - name: stg_littlepay__customer_funding_source_v3
     columns:
@@ -109,8 +99,7 @@ models:
       - *payments_input_row_key
       - &payments_key_full_uniqueness
         name: _payments_key
-        description: |
-          Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
+        description: '{{ doc("lp_payments_key") }}'
         data_tests:
           - not_null
           - unique
@@ -302,8 +291,7 @@ models:
       - *lp_line_number
       - *payments_input_row_key
       - name: _payments_key
-        description: |
-          Synthentic key composed of the elements that define a natural key within the source data (primary key according to Littlepay schema.)
+        description: '{{ doc("lp_payments_key") }}'
         data_tests:
           - not_null
           - unique_proportion:

--- a/warehouse/models/staging/payments/littlepay_v3/_stg_littlepay_v3.yml
+++ b/warehouse/models/staging/payments/littlepay_v3/_stg_littlepay_v3.yml
@@ -375,6 +375,13 @@ models:
       - *payments_input_row_key
       - *_content_hash
       - *payments_key_full_uniqueness
+      - name: status
+        description: '{{ doc("lp_mp_status") }}'
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["CLOSED", "CLOSING", "DELETED", "PENDING"]
 
   - name: stg_littlepay__product_data_v3
     columns:

--- a/warehouse/models/staging/payments/littlepay_v3/stg_littlepay__micropayments_v3.sql
+++ b/warehouse/models/staging/payments/littlepay_v3/stg_littlepay__micropayments_v3.sql
@@ -27,7 +27,7 @@ clean_columns AS (
 
         -- renamed funding_source_id in v3, this was funding_source_vault_id in v1
         {{ trim_make_empty_string_null('funding_source_id') }} AS funding_source_vault_id,
-
+        {{ trim_make_empty_string_null('status') }} AS status, -- new v3 field, needed for filtering
         -- these are new fields in v3, excluding for now to faciliate union with feed v1
         -- record_updated_timestamp_utc,
         -- channel,
@@ -100,6 +100,7 @@ stg_littlepay__micropayments_v3 AS (
         currency_code,
         type,
         charge_type,
+        status, -- new v3 field, needed for filtering
 
         -- these are new fields in v3, excluding for now to faciliate union with feed v1
         -- record_updated_timestamp_utc,

--- a/warehouse/models/staging/payments/littlepay_v3/stg_littlepay__micropayments_v3.sql
+++ b/warehouse/models/staging/payments/littlepay_v3/stg_littlepay__micropayments_v3.sql
@@ -1,5 +1,22 @@
 WITH source AS (
-    SELECT * FROM {{ source('external_littlepay_v3', 'micropayments') }}
+    SELECT
+        micropayment_id,
+        aggregation_id,
+        participant_id,
+        customer_id,
+        funding_source_id,
+        status,
+        payment_liability,
+        charge_amount,
+        nominal_amount,
+        currency_code,
+        type,
+        charge_type,
+        _line_number,
+        `instance`,
+        extract_filename,
+        ts,
+    FROM {{ source('external_littlepay_v3', 'micropayments') }}
 ),
 
 -- bringing this in identify transaction_time (removed in v3) by joining device_transactions -> micropayment_device_transactions -> micropayments

--- a/warehouse/tests/staging/payments/littlepay/test_micropayment_device_transactions.sql
+++ b/warehouse/tests/staging/payments/littlepay/test_micropayment_device_transactions.sql
@@ -15,9 +15,9 @@ with int_payments__cleaned_micropayment_device_transactions as (
 
 ),
 
-int_littlepay__unioned_micropayments as (
+int_payments__filtered_micropayments as (
 
-    select * from {{ ref('int_littlepay__unioned_micropayments') }}
+    select * from {{ ref('int_littlepay__filtered_micropayments') }}
 
 ),
 
@@ -25,7 +25,7 @@ multiple_debit_transaction_ids as (
 
     select littlepay_transaction_id
     from int_payments__cleaned_micropayment_device_transactions
-    inner join int_littlepay__unioned_micropayments as m using (micropayment_id)
+    inner join int_payments__filtered_micropayments as m using (micropayment_id)
     where m.type = 'DEBIT'
     group by 1
     having count(*) > 1
@@ -38,7 +38,7 @@ validate_cleaned_micropayment_device_transactions as (
         littlepay_transaction_id,
         m.*
     from int_payments__cleaned_micropayment_device_transactions
-    inner join int_littlepay__unioned_micropayments as m using (micropayment_id)
+    inner join int_payments__filtered_micropayments as m using (micropayment_id)
     inner join multiple_debit_transaction_ids using (littlepay_transaction_id)
     -- commented out the line below because I could not get rid of sqlfluff error L054
     -- order by transaction_time desc, littlepay_transaction_id asc, charge_type desc

--- a/warehouse/tests/staging/payments/littlepay/test_micropayment_device_transactions.sql
+++ b/warehouse/tests/staging/payments/littlepay/test_micropayment_device_transactions.sql
@@ -17,7 +17,7 @@ with int_payments__cleaned_micropayment_device_transactions as (
 
 int_payments__filtered_micropayments as (
 
-    select * from {{ ref('int_littlepay__filtered_micropayments') }}
+    select * from {{ ref('int_payments__filtered_micropayments') }}
 
 ),
 

--- a/warehouse/tests/staging/payments/littlepay/test_micropayment_transaction_time_order.sql
+++ b/warehouse/tests/staging/payments/littlepay/test_micropayment_transaction_time_order.sql
@@ -3,9 +3,9 @@
 -- The timestamp on micropayment records should be at least as late as its
 -- associated transactions timestamps.
 
-WITH int_littlepay__unioned_micropayments AS (
+WITH int_payments__filtered_micropayments AS (
 
-    SELECT * FROM {{ ref('int_littlepay__unioned_micropayments') }}
+    SELECT * FROM {{ ref('int_payments__filtered_micropayments') }}
 
 ),
 
@@ -24,16 +24,16 @@ int_littlepay__unioned_device_transactions AS (
 validate_cleaned_micropayment_transaction_time_order AS (
 
     SELECT
-        int_littlepay__unioned_micropayments.micropayment_id,
+        int_payments__filtered_micropayments.micropayment_id,
         cast(transaction_time AS TIMESTAMP) AS transaction_time,
         littlepay_transaction_id,
         cast(
             transaction_date_time_utc AS TIMESTAMP
         ) AS transaction_date_time_utc
-    FROM int_littlepay__unioned_micropayments
+    FROM int_payments__filtered_micropayments
     INNER JOIN
         int_payments__cleaned_micropayment_device_transactions ON
-            int_littlepay__unioned_micropayments.micropayment_id = int_payments__cleaned_micropayment_device_transactions.micropayment_id
+            int_payments__filtered_micropayments.micropayment_id = int_payments__cleaned_micropayment_device_transactions.micropayment_id
     INNER JOIN
         int_littlepay__unioned_device_transactions USING (littlepay_transaction_id)
     WHERE


### PR DESCRIPTION
# Description

Littlepay sends some transactions with status equal to `DELETED`, and has stated through support that these transactions should be filtered since the transaction has been processed with a different micropayment ID. This has led to dbt test failures, which this PR resolves by filtering those transactions from upstream tables.

Resolves #5168 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Re-generating Littlepay micropayment and downstream tables, then running dbt tests:
```
$ uv run dbt run --full-refresh -s stg_littlepay__micropayments stg_littlepay__micropayments_v3 intermediate.payments fct_payments_aggregations+ --vars 'GOOGLE_CLOUD_PROJECT: cal-itp-data-infra'
$ uv run dbt test -s stg_littlepay__micropayments stg_littlepay__micropayments_v3 int_payments__filtered_micropayments int_payments__cleaned_micropayment_device_transactions int_payments__customer_vau
lts_to_aggregations int_payments__micropayments_adjustments_refunds_joined int_payments__micropayments_to_aggregations int_payments
__refunds_deduped

19:28:19  Running with dbt=1.10.8
19:28:22  Registered adapter: bigquery=1.10.2
19:28:25  Found 633 models, 193 data tests, 17 seeds, 228 sources, 5 exposures, 1064 macros
19:28:25  The selection criterion 'int_payments__customer_vaults_to_aggregations' does not match any enabled nodes
19:28:25  
19:28:25  Concurrency: 8 threads (target='dev')
19:28:25  
19:28:28  1 of 40 START test accepted_values_int_payments__filtered_micropayments_status__CLOSED__CLOSING__PENDING  [RUN]
19:28:28  2 of 40 START test accepted_values_stg_littlepay__micropayments_v3_status__CLOSED__CLOSING__DELETED__PENDING  [RUN]
19:28:28  3 of 40 START test dbt_utils_expression_is_true_int_payments__micropayments_adjustments_refunds_joined_micropayment_refund_amount_charge_amount  [RUN]
19:28:28  4 of 40 START test dbt_utils_expression_is_true_int_payments__micropayments_to_aggregations_total_nominal_amount_dollars_net_micropayment_amount_dollars  [RUN]
19:28:28  5 of 40 START test dbt_utils_expression_is_true_int_payments__refunds_deduped_refund_amount_micropayments_refund_amount  [RUN]
19:28:28  6 of 40 START test dbt_utils_not_null_proportion_int_payments__filtered_micropayments_0_9999__micropayment_id  [RUN]
19:28:28  7 of 40 START test dbt_utils_not_null_proportion_stg_littlepay__micropayments_0_9999__micropayment_id  [RUN]
19:28:28  8 of 40 START test dbt_utils_not_null_proportion_stg_littlepay__micropayments_v3_0_9999__micropayment_id  [RUN]
19:28:29  6 of 40 PASS dbt_utils_not_null_proportion_int_payments__filtered_micropayments_0_9999__micropayment_id  [PASS in 0.81s]
19:28:29  5 of 40 PASS dbt_utils_expression_is_true_int_payments__refunds_deduped_refund_amount_micropayments_refund_amount  [PASS in 0.81s]
19:28:29  9 of 40 START test dbt_utils_unique_combination_of_columns_int_payments__cleaned_micropayment_device_transactions_micropayment_id__littlepay_transaction_id  [RUN]
19:28:29  10 of 40 START test dbt_utils_unique_combination_of_columns_int_payments__filtered_micropayments_instance__extract_filename__ts___line_number  [RUN]
19:28:29  1 of 40 PASS accepted_values_int_payments__filtered_micropayments_status__CLOSED__CLOSING__PENDING  [PASS in 0.83s]
19:28:29  4 of 40 PASS dbt_utils_expression_is_true_int_payments__micropayments_to_aggregations_total_nominal_amount_dollars_net_micropayment_amount_dollars  [PASS in 0.83s]
19:28:29  11 of 40 START test dbt_utils_unique_combination_of_columns_stg_littlepay__micropayments_instance__extract_filename__ts___line_number  [RUN]
19:28:29  12 of 40 START test dbt_utils_unique_combination_of_columns_stg_littlepay__micropayments_v3_instance__extract_filename__ts___line_number  [RUN]
19:28:29  3 of 40 PASS dbt_utils_expression_is_true_int_payments__micropayments_adjustments_refunds_joined_micropayment_refund_amount_charge_amount  [PASS in 1.08s]
19:28:29  13 of 40 START test not_null_int_payments__cleaned_micropayment_device_transactions_littlepay_transaction_id  [RUN]
19:28:30  10 of 40 PASS dbt_utils_unique_combination_of_columns_int_payments__filtered_micropayments_instance__extract_filename__ts___line_number  [PASS in 0.60s]
19:28:30  14 of 40 START test not_null_int_payments__filtered_micropayments__key ......... [RUN]
19:28:30  9 of 40 PASS dbt_utils_unique_combination_of_columns_int_payments__cleaned_micropayment_device_transactions_micropayment_id__littlepay_transaction_id  [PASS in 0.69s]
19:28:30  15 of 40 START test not_null_int_payments__filtered_micropayments__payments_key  [RUN]
19:28:30  13 of 40 PASS not_null_int_payments__cleaned_micropayment_device_transactions_littlepay_transaction_id  [PASS in 0.51s]
19:28:30  16 of 40 START test not_null_int_payments__micropayments_adjustments_refunds_joined_micropayment_id  [RUN]
19:28:30  7 of 40 PASS dbt_utils_not_null_proportion_stg_littlepay__micropayments_0_9999__micropayment_id  [PASS in 1.65s]
19:28:30  17 of 40 START test not_null_int_payments__micropayments_to_aggregations_aggregation_id  [RUN]
19:28:30  2 of 40 PASS accepted_values_stg_littlepay__micropayments_v3_status__CLOSED__CLOSING__DELETED__PENDING  [PASS in 1.66s]
19:28:30  18 of 40 START test not_null_stg_littlepay__micropayments__key ................. [RUN]
19:28:30  8 of 40 PASS dbt_utils_not_null_proportion_stg_littlepay__micropayments_v3_0_9999__micropayment_id  [PASS in 1.67s]
19:28:30  19 of 40 START test not_null_stg_littlepay__micropayments__payments_key ........ [RUN]
19:28:30  14 of 40 PASS not_null_int_payments__filtered_micropayments__key ............... [PASS in 0.53s]
19:28:30  20 of 40 START test not_null_stg_littlepay__micropayments_v3__key .............. [RUN]
19:28:30  15 of 40 PASS not_null_int_payments__filtered_micropayments__payments_key ...... [PASS in 0.55s]
19:28:30  21 of 40 START test not_null_stg_littlepay__micropayments_v3__payments_key ..... [RUN]
19:28:30  17 of 40 PASS not_null_int_payments__micropayments_to_aggregations_aggregation_id  [PASS in 0.55s]
19:28:30  12 of 40 PASS dbt_utils_unique_combination_of_columns_stg_littlepay__micropayments_v3_instance__extract_filename__ts___line_number  [PASS in 1.35s]
19:28:30  22 of 40 START test not_null_stg_littlepay__micropayments_v3_status ............ [RUN]
19:28:30  23 of 40 START test relationships_stg_littlepay__refunds_aggregation_id__aggregation_id__ref_int_payments__refunds_deduped_  [RUN]
19:28:31  16 of 40 PASS not_null_int_payments__micropayments_adjustments_refunds_joined_micropayment_id  [PASS in 0.85s]
19:28:31  24 of 40 START test relationships_stg_littlepay__refunds_retrieval_reference_number__retrieval_reference_number__ref_int_payments__refunds_deduped_  [RUN]
19:28:31  11 of 40 PASS dbt_utils_unique_combination_of_columns_stg_littlepay__micropayments_instance__extract_filename__ts___line_number  [PASS in 1.76s]
19:28:31  25 of 40 START test relationships_stg_littlepay__refunds_v3_aggregation_id__aggregation_id__ref_int_payments__refunds_deduped_  [RUN]
19:28:31  23 of 40 PASS relationships_stg_littlepay__refunds_aggregation_id__aggregation_id__ref_int_payments__refunds_deduped_  [PASS in 1.08s]
19:28:32  26 of 40 START test relationships_stg_littlepay__refunds_v3_retrieval_reference_number__retrieval_reference_number__ref_int_payments__refunds_deduped_  [RUN]
19:28:32  19 of 40 PASS not_null_stg_littlepay__micropayments__payments_key .............. [PASS in 1.91s]
19:28:32  27 of 40 START test test_micropayment_device_transactions ...................... [RUN]
19:28:32  24 of 40 PASS relationships_stg_littlepay__refunds_retrieval_reference_number__retrieval_reference_number__ref_int_payments__refunds_deduped_  [PASS in 1.31s]
19:28:32  18 of 40 PASS not_null_stg_littlepay__micropayments__key ....................... [PASS in 2.09s]
19:28:32  20 of 40 PASS not_null_stg_littlepay__micropayments_v3__key .................... [PASS in 1.80s]
19:28:32  21 of 40 PASS not_null_stg_littlepay__micropayments_v3__payments_key ........... [PASS in 1.70s]
19:28:32  28 of 40 START test test_micropayment_transaction_time_order ................... [RUN]
19:28:32  29 of 40 START test unique_int_payments__cleaned_micropayment_device_transactions_littlepay_transaction_id  [RUN]
19:28:32  30 of 40 START test unique_int_payments__filtered_micropayments__key ........... [RUN]
19:28:32  31 of 40 START test unique_int_payments__filtered_micropayments__payments_key .. [RUN]
19:28:32  25 of 40 PASS relationships_stg_littlepay__refunds_v3_aggregation_id__aggregation_id__ref_int_payments__refunds_deduped_  [PASS in 1.50s]
19:28:32  22 of 40 PASS not_null_stg_littlepay__micropayments_v3_status .................. [PASS in 1.91s]
19:28:32  32 of 40 START test unique_int_payments__micropayments_adjustments_refunds_joined_micropayment_id  [RUN]
19:28:32  33 of 40 START test unique_int_payments__micropayments_to_aggregations_aggregation_id  [RUN]
19:28:33  31 of 40 PASS unique_int_payments__filtered_micropayments__payments_key ........ [PASS in 1.15s]
19:28:33  30 of 40 PASS unique_int_payments__filtered_micropayments__key ................. [PASS in 1.16s]
19:28:33  26 of 40 PASS relationships_stg_littlepay__refunds_v3_retrieval_reference_number__retrieval_reference_number__ref_int_payments__refunds_deduped_  [PASS in 1.64s]
19:28:33  29 of 40 PASS unique_int_payments__cleaned_micropayment_device_transactions_littlepay_transaction_id  [PASS in 1.16s]
19:28:33  34 of 40 START test unique_proportion_int_payments__filtered_micropayments_0_9999__micropayment_id  [RUN]
19:28:33  35 of 40 START test unique_proportion_stg_littlepay__micropayments_0_9999__micropayment_id  [RUN]
19:28:33  36 of 40 START test unique_proportion_stg_littlepay__micropayments_v3_0_9999__micropayment_id  [RUN]
19:28:33  37 of 40 START test unique_stg_littlepay__micropayments__key ................... [RUN]
19:28:33  33 of 40 PASS unique_int_payments__micropayments_to_aggregations_aggregation_id  [PASS in 0.93s]
19:28:33  38 of 40 START test unique_stg_littlepay__micropayments__payments_key .......... [RUN]
19:28:34  32 of 40 WARN 1 unique_int_payments__micropayments_adjustments_refunds_joined_micropayment_id  [WARN 1 in 1.39s]
19:28:34  39 of 40 START test unique_stg_littlepay__micropayments_v3__key ................ [RUN]
19:28:34  34 of 40 PASS unique_proportion_int_payments__filtered_micropayments_0_9999__micropayment_id  [PASS in 0.80s]
19:28:34  40 of 40 START test unique_stg_littlepay__micropayments_v3__payments_key ....... [RUN]
19:28:35  35 of 40 PASS unique_proportion_stg_littlepay__micropayments_0_9999__micropayment_id  [PASS in 1.65s]
19:28:35  36 of 40 PASS unique_proportion_stg_littlepay__micropayments_v3_0_9999__micropayment_id  [PASS in 1.65s]
19:28:35  37 of 40 PASS unique_stg_littlepay__micropayments__key ......................... [PASS in 1.66s]
19:28:35  39 of 40 PASS unique_stg_littlepay__micropayments_v3__key ...................... [PASS in 1.28s]
19:28:35  38 of 40 PASS unique_stg_littlepay__micropayments__payments_key ................ [PASS in 1.82s]
19:28:35  40 of 40 PASS unique_stg_littlepay__micropayments_v3__payments_key ............. [PASS in 1.40s]
19:28:36  28 of 40 PASS test_micropayment_transaction_time_order ......................... [PASS in 3.53s]
19:28:36  27 of 40 PASS test_micropayment_device_transactions ............................ [PASS in 4.15s]
19:28:36  
19:28:36  Finished running 40 data tests in 0 hours 0 minutes and 11.27 seconds (11.27s).
19:28:37  
19:28:37  Completed with 1 warning:
19:28:37  
19:28:37  Warning in test unique_int_payments__micropayments_adjustments_refunds_joined_micropayment_id (models/intermediate/payments/_int_payments.yml)
19:28:37  Got 1 result, configured to warn if != 0
19:28:37  
19:28:37    compiled code at target/compiled/calitp_warehouse/models/intermediate/payments/_int_payments.yml/unique_int_payments__micropaym_bf5798b37889cb5f57ea74607e78c7db.sql
19:28:37  
19:28:37  Done. PASS=39 WARN=1 ERROR=0 SKIP=0 NO-OP=0 TOTAL=40
```

Checked that only the "deleted" status micropayments are removed. Expect all `participant_id`s to be `redwood-coast-transit` and to have `status` `DELETED`:
```
WITH filtered_micropayments AS (
  SELECT * FROM `cal-itp-data-infra-staging.ap_staging.int_payments__filtered_micropayments`
),
unioned_micropayments AS (
  SELECT * FROM `cal-itp-data-infra-staging.ap_staging.int_littlepay__unioned_micropayments`
)

SELECT participant_id, unioned.status AS unioned_status, filtered.status AS filtered_status, filtered.feed_version, count(*) AS ct
FROM filtered_micropayments as filtered
FULL OUTER JOIN unioned_micropayments as unioned USING (participant_id, micropayment_id)
WHERE filtered.micropayment_id IS NULL
GROUP BY participant_id, unioned.status, filtered.status, filtered.feed_version
```

Checked that `fct_payments_aggregations` did not have any recent missing rows, as an example of a downstream table that could have been affected. Expect this query to be empty or only to contain RCTA rows:

```
WITH prod AS (
  SELECT * FROM `cal-itp-data-infra`.`mart_payments`.`fct_payments_aggregations`
  WHERE end_of_month_date_utc > '2026-05-01'
),
ap_staging AS (
  SELECT * FROM `cal-itp-data-infra-staging`.`ap_mart_payments`.`fct_payments_aggregations`
  WHERE end_of_month_date_utc > '2026-05-01'
)

SELECT * FROM prod
FULL OUTER JOIN ap_staging USING(aggregation_id, participant_id)
WHERE ap_staging.aggregation_id IS NULL
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)

## Note
There may be value in ingesting the status field to mart tables - consider as topic for future issues