### PR TITLE
Skip Metabase sync job on Dependabot PRs

### DIFF
--- a/.github/workflows/deploy-dbt.yml
+++ b/.github/workflows/deploy-dbt.yml
@@ -250,7 +250,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compile, dbt-run]
 
-    if: ${{ !failure() && !cancelled() }}
+    # Skip on Dependabot PRs: Dependabot runs see a separate secrets
+    # namespace, so METABASE_API_KEY expands to "" and the sync step 401s.
+    if: ${{ !failure() && !cancelled() && github.actor != 'dependabot[bot]' }}
 
     permissions:
       contents: read


### PR DESCRIPTION
# Description

Skip the `Sync Metabase` job in `.github/workflows/deploy-dbt.yml` when the workflow is triggered by Dependabot.

Dependabot-triggered runs see a separate secrets namespace from regular Actions runs, so `secrets.METABASE_STAGING_API_KEY` expands to an empty string. The `Discover Payments Metabase databases` step then calls Metabase with an empty `x-api-key` header and gets HTTP 401, failing the workflow with `exit code 22`. This blocks every Dependabot PR touching `warehouse/**` (most recent example: [#5323](https://github.com/cal-itp/data-infra/pull/5323), failing run [26481102601](https://github.com/cal-itp/data-infra/actions/runs/26481102601/job/78156984094)).

The fix gates the `metabase` job on `github.actor != 'dependabot[bot]'`. Metabase metadata sync isn't meaningful for dependency bumps; the `compile`, `dbt-changed`, and `dbt-run` jobs are unchanged and still run on Dependabot PRs.

Resolves #5345

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Verified locally that the `if:` expression parses and that the change is the only diff against `main`. End-to-end validation depends on a future Dependabot PR: the next Dependabot-opened PR touching `warehouse/**` should show `Sync Metabase` as **Skipped** rather than failing on the curl 401. A non-Dependabot PR (e.g. this one) should continue to run the job normally.

## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)
