### PR TITLE
Add CALITP_BUCKET__TIDES to composer3 staging env

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -207,6 +207,7 @@ resource "google_composer_environment" "calitp-staging-composer3" {
         "CALITP_BUCKET__GTFS_SCHEDULE_UNZIPPED_HOURLY"         = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-schedule-unzipped-hourly_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION"              = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-schedule-validation_name}",
         "CALITP_BUCKET__GTFS_SCHEDULE_VALIDATION_HOURLY"       = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-schedule-validation-hourly_name}",
+        "CALITP_BUCKET__TIDES"                                 = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-tides_name}",
         "CALITP_BUCKET__KUBA"                                  = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-kuba_name}",
         "CALITP_BUCKET__LITTLEPAY_PARSED"                      = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-payments-littlepay-parsed_name}",
         "CALITP_BUCKET__LITTLEPAY_PARSED_V3"                   = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-payments-littlepay-parsed-v3_name}",


### PR DESCRIPTION
# Description

`parse_tides` failed in `calitp-staging-composer3` (task `export_vehicle_locations_to_parquet`) with a `TypeError` because `CALITP_BUCKET__TIDES` was defined in the Composer 2 staging environment block but missing from the Composer 3 block in `environment.tf`.

This adds the missing `CALITP_BUCKET__TIDES` env var to the `calitp-staging-composer3` block, using the same `gcs` remote-state output the Composer 2 block already references, fixing the env-var drift between the two environments.

Resolves #5342

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested.  Check the Terraform plan.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
