### PR TITLE
Switch calitp-tides bucket to public requester pays

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -1982,10 +1982,6 @@ output "google_storage_bucket_calitp-kuba_name" {
   value = google_storage_bucket.calitp["calitp-kuba"].name
 }
 
-output "google_storage_bucket_calitp-tides_name" {
-  value = google_storage_bucket.calitp["calitp-tides"].name
-}
-
 output "google_storage_bucket_calitp-gtfs-schedule-manual_name" {
   value = google_storage_bucket.calitp["calitp-gtfs-schedule-manual"].name
 }
@@ -2012,4 +2008,8 @@ output "google_storage_bucket_calitp-enghouse-parsed_name" {
 
 output "google_storage_bucket_calitp-elavon-raw-v2_name" {
   value = google_storage_bucket.calitp-elavon-raw-v2.name
+}
+
+output "google_storage_bucket_calitp-tides_name" {
+  value = google_storage_bucket.calitp-tides.name
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -1262,3 +1262,16 @@ resource "google_storage_bucket" "calitp" {
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
 }
+
+resource "google_storage_bucket" "calitp-tides" {
+  name                        = "calitp-tides"
+  project                     = "cal-itp-data-infra"
+  location                    = "US-WEST2"
+
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  public_access_prevention    = "inherited"
+  requester_pays              = "true"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -1264,9 +1264,9 @@ resource "google_storage_bucket" "calitp" {
 }
 
 resource "google_storage_bucket" "calitp-tides" {
-  name                        = "calitp-tides"
-  project                     = "cal-itp-data-infra"
-  location                    = "US-WEST2"
+  name     = "calitp-tides"
+  project  = "cal-itp-data-infra"
+  location = "US-WEST2"
 
   default_event_based_hold    = "false"
   force_destroy               = "false"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -401,9 +401,9 @@ resource "google_storage_bucket_iam_binding" "calitp-composer" {
 }
 
 resource "google_storage_bucket_iam_binding" "calitp-tides" {
-  bucket   = "calitp-tides"
-  members  = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
-  role     = "roles/storage.legacyObjectOwner"
+  bucket  = "calitp-tides"
+  members = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
+  role    = "roles/storage.legacyObjectOwner"
 }
 
 resource "google_storage_bucket_iam_binding" "calitp" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -400,6 +400,12 @@ resource "google_storage_bucket_iam_binding" "calitp-composer" {
   role    = "roles/storage.legacyBucketOwner"
 }
 
+resource "google_storage_bucket_iam_binding" "calitp-tides" {
+  bucket   = "calitp-tides"
+  members  = ["projectEditor:cal-itp-data-infra", "projectOwner:cal-itp-data-infra"]
+  role     = "roles/storage.legacyObjectOwner"
+}
+
 resource "google_storage_bucket_iam_binding" "calitp" {
   for_each = local.environment_buckets
   bucket   = google_storage_bucket.calitp[each.key].name

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -424,6 +424,12 @@ resource "google_storage_bucket_iam_member" "calitp-analysis" {
   member = "allUsers"
 }
 
+resource "google_storage_bucket_iam_member" "calitp-tides" {
+  bucket = google_storage_bucket.calitp-tides.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
 resource "google_storage_bucket_iam_member" "enghouse-raw-sftp-service-account" {
   bucket = google_storage_bucket.calitp-enghouse-raw.name
   role   = "roles/storage.objectAdmin"

--- a/iac/cal-itp-data-infra/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra/gcs/us/variables.tf
@@ -2,7 +2,6 @@ locals {
   environment_buckets = toset([
     "calitp-gtfs-schedule-manual",
     "calitp-kuba",
-    "calitp-tides",
     "calitp-gtfs-rt-archiver"
   ])
 }


### PR DESCRIPTION
# Description

This PR switches the `calitp-tides` bucket to be publicly accessible, and sets the `requester_pays`flag to `true`.

Resolves #4700 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`