### PR TITLE
Enable 60 day multi-region backups for Metabase Staging

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/README.md
+++ b/iac/cal-itp-data-infra-staging/metabase/us/README.md
@@ -1,0 +1,107 @@
+# Metabase database backups
+
+This documents how backups work for the Cloud SQL Postgres instance that backs
+the **staging** Metabase. The backup configuration lives in
+[`sql.tf`](./sql.tf).
+
+> **Scope:** this was rolled out to staging first (per the recommendation on
+> [issue #5098](https://github.com/cal-itp/data-infra/issues/5098)). Production
+> (`cal-itp-data-infra/metabase/us/sql.tf`) still uses the older policy and is a
+> planned follow-up. See [Current state](#current-state) below.
+
+## What is backed up
+
+The Cloud SQL instance holds Metabase's **application metadata** — dashboards,
+questions/cards, collections, users, permissions, and settings. It does **not**
+hold the analytics data those dashboards query; that lives in BigQuery. So a
+backup restore brings back the Metabase app state, not warehouse data.
+
+## Current state
+
+| Environment | Project | Instance | Retention | Backup location |
+| --- | --- | --- | --- | --- |
+| Staging | `cal-itp-data-infra-staging` | `metabase-staging` | 60 backups | `us` (multi-region) |
+| Production | `cal-itp-data-infra` | `metabase` | 7 backups | `us-west2` (single region) |
+
+Production is intentionally unchanged for now; the plan is to apply the same
+configuration there once it has been validated in staging.
+
+## How backups are configured
+
+In [`sql.tf`](./sql.tf), the `backup_configuration` block controls backups:
+
+```hcl
+backup_configuration {
+  location = "us"      # multi-region storage (geo-redundant)
+  enabled  = true      # daily automated backups
+
+  backup_retention_settings {
+    retained_backups = 60
+    retention_unit   = "COUNT"
+  }
+}
+```
+
+- **`enabled = true`** — Cloud SQL takes an **automated daily backup**. Each
+  backup is a full snapshot of the instance (Google stores them incrementally
+  under the hood). Google picks the backup time unless a `start_time` is set.
+- **`location = "us"`** — backups are stored in the `us` **multi-region**, so
+  they are replicated across multiple US regions. If `us-west2` (where the
+  instance lives) has a regional outage, the backups survive. The backup
+  storage location is independent of where you restore to.
+- **`retained_backups = 60` / `retention_unit = "COUNT"`** — Cloud SQL keeps
+  the **60 most recent automated backups**. This is a *count*, not a number of
+  days. With the default daily cadence, 60 backups ≈ 60 days of history. When
+  the 61st backup is taken, the oldest is dropped.
+
+`deletion_protection = true` on the instance prevents it from being accidentally
+deleted via Terraform or `gcloud`.
+
+> The instance is pinned to `edition = "ENTERPRISE"`, the standard (default)
+> Cloud SQL edition. It is set explicitly to document intent and because it is
+> the edition that supports the shared-core `db-f1-micro` tier this instance
+> uses. Up to 365 automated backups can be retained, so 60 leaves plenty of
+> headroom if we ever want a longer window.
+
+## What is NOT enabled
+
+- **Point-in-time recovery (PITR).** PITR (`enable_point_in_time_recovery`) lets
+  you restore to *any* moment using transaction logs, not just to a nightly
+  snapshot. It is currently off, so the available restore points are the daily
+  automated backups only. Enabling it would add more granular recovery at the
+  cost of extra storage for write-ahead logs.
+
+## How to restore
+
+Restores are a manual, deliberate operation done with `gcloud` (or the Cloud
+Console). **Restoring onto an existing instance overwrites it**, so prefer
+restoring into a new/temporary instance to inspect data first.
+
+List available backups for the staging instance:
+
+```bash
+gcloud sql backups list \
+  --instance=metabase-staging \
+  --project=cal-itp-data-infra-staging
+```
+
+Restore a chosen backup onto a target instance:
+
+```bash
+gcloud sql backups restore BACKUP_ID \
+  --restore-instance=metabase-staging \
+  --project=cal-itp-data-infra-staging
+```
+
+The number of backups you can choose from is governed by `retained_backups`
+(60) and the daily schedule — multi-region storage does not add extra restore
+points, it only makes the same set more durable.
+
+## Changing the backup policy
+
+Backups are managed entirely through Terraform. Edit the `backup_configuration`
+block in `sql.tf`, open a PR, and the `Terraform Plan` workflow will post the
+plan as a PR comment. On merge to `main`, `Terraform Apply` applies it.
+
+Note: changing `location` does **not** retroactively copy existing backups to
+the new location; the new policy applies to backups taken going forward.

--- a/iac/cal-itp-data-infra-staging/metabase/us/sql.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/sql.tf
@@ -1,11 +1,23 @@
 resource "google_sql_database_instance" "metabase-staging" {
-  name             = "metabase-staging"
-  database_version = "POSTGRES_18"
-  region           = "us-west2"
-  settings {
-    tier = "db-f1-micro"
-  }
+  name                = "metabase-staging"
+  database_version    = "POSTGRES_18"
+  region              = "us-west2"
   deletion_protection = true
+
+  settings {
+    edition = "ENTERPRISE"
+    tier    = "db-f1-micro"
+
+    backup_configuration {
+      location = "us"
+      enabled  = true
+
+      backup_retention_settings {
+        retained_backups = 60
+        retention_unit   = "COUNT"
+      }
+    }
+  }
 }
 
 resource "google_sql_database" "metabase-staging" {

--- a/services/metabase/BACKUP_CLOUD_SQL.md
+++ b/services/metabase/BACKUP_CLOUD_SQL.md
@@ -1,8 +1,8 @@
-# Metabase database backups
+# Metabase backups: Cloud SQL automated backups
 
 This documents how backups work for the Cloud SQL Postgres instance that backs
 the **staging** Metabase. The backup configuration lives in
-[`sql.tf`](./sql.tf).
+[`sql.tf`](../../iac/cal-itp-data-infra-staging/metabase/us/sql.tf).
 
 > **Scope:** this was rolled out to staging first (per the recommendation on
 > [issue #5098](https://github.com/cal-itp/data-infra/issues/5098)). Production
@@ -18,17 +18,17 @@ backup restore brings back the Metabase app state, not warehouse data.
 
 ## Current state
 
-| Environment | Project | Instance | Retention | Backup location |
-| --- | --- | --- | --- | --- |
-| Staging | `cal-itp-data-infra-staging` | `metabase-staging` | 60 backups | `us` (multi-region) |
-| Production | `cal-itp-data-infra` | `metabase` | 7 backups | `us-west2` (single region) |
+| Environment | Project                      | Instance           | Retention  | Backup location            |
+| ----------- | ---------------------------- | ------------------ | ---------- | -------------------------- |
+| Staging     | `cal-itp-data-infra-staging` | `metabase-staging` | 60 backups | `us` (multi-region)        |
+| Production  | `cal-itp-data-infra`         | `metabase`         | 7 backups  | `us-west2` (single region) |
 
 Production is intentionally unchanged for now; the plan is to apply the same
 configuration there once it has been validated in staging.
 
 ## How backups are configured
 
-In [`sql.tf`](./sql.tf), the `backup_configuration` block controls backups:
+In [`sql.tf`](../../iac/cal-itp-data-infra-staging/metabase/us/sql.tf), the `backup_configuration` block controls backups:
 
 ```hcl
 backup_configuration {


### PR DESCRIPTION
# Description

The staging Metabase Cloud SQL instance previously had no explicit backup
configuration and only a 7-backup window. This extends backups well beyond
that, addressing the concern that we have too little backup coverage.

What backs this database: it holds Metabase's **application metadata**
(dashboards, questions, collections, users, permissions, settings) — not the
BigQuery analytics data the dashboards query.

This PR, on the **staging** instance only:
- Enables daily automated backups (`enabled = true`)
- Retains the 60 most recent backups (~60 days) instead of 7
- Stores them in the `us` multi-region for geo-redundancy, so a single-region
  outage in `us-west2` can't take out both the instance and its backups
- Pins the instance to the standard `ENTERPRISE` edition (the default; set
  explicitly for clarity)
- Adds a co-located README documenting backup behavior, retention semantics,
  restore steps, and the (not-yet-enabled) point-in-time recovery option

Per the recommendation on the issue, this is applied to staging first.
Production (`cal-itp-data-infra/metabase/us/sql.tf`) is unchanged and will
follow in a separate PR once validated.

Refs #5098

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

- `terraform fmt -check` passes locally for the changed file.
- No dbt models were changed, so the dbt run/test steps are N/A.
- The `Terraform Plan` workflow posts the plan on this PR — confirm it's an
  **in-place update**, not a destroy/recreate of the instance, before merge.
- On merge to `main`, `Terraform Apply` applies the change automatically; the
  first automated backup appears after the next daily backup window.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- Roll out the same backup configuration to **production** in a separate PR
  (keeping #5098 open to track this).
- Confirm the first automated staging backup lands:
  `gcloud sql backups list --instance=metabase-staging --project=cal-itp-data-infra-staging`