### PR TITLE
Add calitp-tides-site to host a static page for TIDES

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -2013,3 +2013,7 @@ output "google_storage_bucket_calitp-elavon-raw-v2_name" {
 output "google_storage_bucket_calitp-tides_name" {
   value = google_storage_bucket.calitp-tides.name
 }
+
+output "google_storage_bucket_calitp-tides-site_name" {
+  value = google_storage_bucket.calitp["calitp-tides-site"].name
+}

--- a/iac/cal-itp-data-infra/gcs/us/provider.tf
+++ b/iac/cal-itp-data-infra/gcs/us/provider.tf
@@ -1,5 +1,7 @@
 provider "google" {
-  project = "cal-itp-data-infra"
+  project               = "cal-itp-data-infra"
+  billing_project       = "cal-itp-data-infra"
+  user_project_override = true
 }
 
 terraform {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -300,7 +300,7 @@ resource "google_storage_bucket_iam_binding" "tfer--gtfs-data-reports" {
 
 resource "google_storage_bucket_iam_binding" "tfer--gtfs-data-test" {
   bucket  = "b/gtfs-data-test"
-  members = ["serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com", "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"]
+  members = ["serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com", "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"]
   role    = "roles/storage.objectAdmin"
 }
 
@@ -348,7 +348,7 @@ resource "google_storage_bucket_iam_binding" "tfer--test-calitp-gtfs-download-co
 
 resource "google_storage_bucket_iam_binding" "tfer--test-calitp-gtfs-rt-raw" {
   bucket  = "b/test-calitp-gtfs-rt-raw"
-  members = ["serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:gtfs-rt-archiver-v3@cal-itp-data-infra.iam.gserviceaccount.com"]
+  members = ["serviceAccount:gtfs-rt-archiver-v3@cal-itp-data-infra.iam.gserviceaccount.com"]
   role    = "roles/storage.objectAdmin"
 }
 

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -1940,7 +1940,6 @@ resource "google_storage_bucket_iam_policy" "tfer--gtfs-data-test" {
     {
       "members": [
         "serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com",
-        "serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com",
         "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com",
         "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"
       ],
@@ -2251,7 +2250,6 @@ resource "google_storage_bucket_iam_policy" "tfer--test-calitp-gtfs-rt-raw" {
     },
     {
       "members": [
-        "serviceAccount:gtfs-rt-archiver-test@cal-itp-data-infra.iam.gserviceaccount.com",
         "serviceAccount:gtfs-rt-archiver-v3@cal-itp-data-infra.iam.gserviceaccount.com"
       ],
       "role": "roles/storage.objectAdmin"

--- a/iac/cal-itp-data-infra/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra/gcs/us/variables.tf
@@ -2,7 +2,8 @@ locals {
   environment_buckets = toset([
     "calitp-gtfs-schedule-manual",
     "calitp-kuba",
-    "calitp-gtfs-rt-archiver"
+    "calitp-gtfs-rt-archiver",
+    "calitp-tides-site"
   ])
 }
 


### PR DESCRIPTION
# Description

This PR adds a bucket for the TIDES static site, which will eventually be hosted at tides.dds.dot.ca.gov

Resolves #4693 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`
