### PR TITLE
Add tides.dds.dot.ca.gov to the CDN

### DIFF
--- a/iac/cal-itp-data-infra/cdn/us/backend_bucket.tf
+++ b/iac/cal-itp-data-infra/cdn/us/backend_bucket.tf
@@ -7,6 +7,7 @@ resource "google_compute_managed_ssl_certificate" "calitp" {
       "gtfs.dds.dot.ca.gov.",
       "reports.dds.dot.ca.gov.",
       "analysis.dds.dot.ca.gov.",
+      "tides.dds.dot.ca.gov.",
     ]
   }
 }
@@ -67,6 +68,20 @@ resource "google_compute_backend_bucket" "calitp-analysis" {
   }
 }
 
+resource "google_compute_backend_bucket" "calitp-tides" {
+  name        = "calitp-tides-backend-bucket"
+  bucket_name = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-tides-site_name
+  enable_cdn  = true
+  cdn_policy {
+    cache_mode        = "CACHE_ALL_STATIC"
+    client_ttl        = 3600
+    default_ttl       = 3600
+    max_ttl           = 86400
+    negative_caching  = true
+    serve_while_stale = 86400
+  }
+}
+
 resource "google_compute_url_map" "calitp-https" {
   name            = "calitp-https-load-balancer"
   default_service = google_compute_backend_bucket.calitp-dbt-docs.id
@@ -89,6 +104,11 @@ resource "google_compute_url_map" "calitp-https" {
   host_rule {
     path_matcher = "analysis"
     hosts        = ["analysis.dds.dot.ca.gov"]
+  }
+
+  host_rule {
+    path_matcher = "tides"
+    hosts        = ["tides.dds.dot.ca.gov"]
   }
 
   path_matcher {
@@ -128,6 +148,16 @@ resource "google_compute_url_map" "calitp-https" {
     path_rule {
       paths   = ["/*"]
       service = google_compute_backend_bucket.calitp-analysis.id
+    }
+  }
+
+  path_matcher {
+    name            = "tides"
+    default_service = google_compute_backend_bucket.calitp-tides.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_bucket.calitp-tides.id
     }
   }
 }


### PR DESCRIPTION
# Description

This PR adds `tides.dds.dot.ca.gov` to the CDN

Relates to #4693 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor `terraform apply`