### PR TITLE
TIDES external tables `trips_performed_outcomes` and `vehicle_positions_outcomes`

### DIFF
--- a/airflow/dags/create_external_tables/tides/trips_performed_outcomes.yml
+++ b/airflow/dags/create_external_tables/tides/trips_performed_outcomes.yml
@@ -1,0 +1,24 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__TIDES') }}"
+source_objects:
+  - "trips_performed_outcomes/*.jsonl"
+destination_project_dataset_table: "external_tides.trips_performed_outcomes"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "trips_performed_outcomes/{dt:DATE}/{ts:TIMESTAMP}/{organization_source_record_id:STRING}"
+schema_fields:
+  - name: display_name
+    type: STRING
+  - name: dataset_name
+    type: STRING
+  - name: table_name
+    type: STRING
+  - name: base64_url
+    type: STRING
+  - name: destination_path
+    type: STRING
+  - name: service_date
+    type: DATE

--- a/airflow/dags/create_external_tables/tides/vehicle_locations_outcomes.yml
+++ b/airflow/dags/create_external_tables/tides/vehicle_locations_outcomes.yml
@@ -1,14 +1,14 @@
 operator: operators.ExternalTable
 bucket: "{{ env_var('CALITP_BUCKET__TIDES') }}"
 source_objects:
-  - "vehicle_location_outcomes/*.jsonl"
-destination_project_dataset_table: "external_tides.vehicle_location_outcomes"
+  - "vehicle_locations_outcomes/*.jsonl"
+destination_project_dataset_table: "external_tides.vehicle_locations_outcomes"
 source_format: NEWLINE_DELIMITED_JSON
 use_bq_client: true
 hive_options:
   mode: CUSTOM
   require_partition_filter: false
-  source_uri_prefix: "vehicle_location_outcomes/{dt:DATE}/{ts:TIMESTAMP}/{organization_source_record_id:STRING}"
+  source_uri_prefix: "vehicle_locations_outcomes/{dt:DATE}/{ts:TIMESTAMP}/{organization_source_record_id:STRING}"
 schema_fields:
   - name: display_name
     type: STRING
@@ -20,3 +20,5 @@ schema_fields:
     type: STRING
   - name: destination_path
     type: STRING
+  - name: service_date
+    type: DATE

--- a/warehouse/models/mart/tides_audit/_mart_tides_audit.yml
+++ b/warehouse/models/mart/tides_audit/_mart_tides_audit.yml
@@ -1,8 +1,8 @@
 version: 2
 
 models:
-  - name: dim_tides_vehicle_location_outcomes
-    description: Outcomes from converting GTFS Vehicle Location to TIDES (Transit Integrated Data Exchange Specification)
+  - name: dim_tides_vehicle_locations_outcomes
+    description: Outcomes from converting GTFS-RT Vehicle Position to TIDES (Transit Integrated Data Exchange Specification)
     columns:
       - name: display_name
       - name: organization_source_record_id
@@ -10,5 +10,6 @@ models:
       - name: dataset_name
       - name: table_name
       - name: destination_path
+      - name: service_date
       - name: dt
       - name: ts

--- a/warehouse/models/mart/tides_audit/_mart_tides_audit.yml
+++ b/warehouse/models/mart/tides_audit/_mart_tides_audit.yml
@@ -1,6 +1,18 @@
 version: 2
 
 models:
+  - name: dim_tides_trips_performed_outcomes
+    description: Outcomes from converting GTFS-RT Trip Updates to TIDES (Transit Integrated Data Exchange Specification)
+    columns:
+      - name: display_name
+      - name: organization_source_record_id
+      - name: base64_url
+      - name: dataset_name
+      - name: table_name
+      - name: destination_path
+      - name: service_date
+      - name: dt
+      - name: ts
   - name: dim_tides_vehicle_locations_outcomes
     description: Outcomes from converting GTFS-RT Vehicle Position to TIDES (Transit Integrated Data Exchange Specification)
     columns:

--- a/warehouse/models/mart/tides_audit/dim_tides_trips_performed_outcomes.sql
+++ b/warehouse/models/mart/tides_audit/dim_tides_trips_performed_outcomes.sql
@@ -1,0 +1,17 @@
+{{ config(materialized='table') }}
+
+WITH dim_tides_trips_performed_outcomes AS (
+    SELECT DISTINCT
+           display_name,
+           organization_source_record_id,
+           base64_url,
+           dataset_name,
+           table_name,
+           destination_path,
+           service_date,
+           dt,
+           ts
+      FROM {{ source('external_tides', 'trips_performed_outcomes') }}
+)
+
+SELECT * FROM dim_tides_trips_performed_outcomes

--- a/warehouse/models/mart/tides_audit/dim_tides_vehicle_locations_outcomes.sql
+++ b/warehouse/models/mart/tides_audit/dim_tides_vehicle_locations_outcomes.sql
@@ -1,6 +1,6 @@
 {{ config(materialized='table') }}
 
-WITH dim_tides_vehicle_location_outcomes AS (
+WITH dim_tides_vehicle_locations_outcomes AS (
     SELECT DISTINCT
            display_name,
            organization_source_record_id,
@@ -8,9 +8,10 @@ WITH dim_tides_vehicle_location_outcomes AS (
            dataset_name,
            table_name,
            destination_path,
+           service_date,
            dt,
            ts
-      FROM {{ source('external_tides', 'vehicle_location_outcomes') }}
+      FROM {{ source('external_tides', 'vehicle_locations_outcomes') }}
 )
 
-SELECT * FROM dim_tides_vehicle_location_outcomes
+SELECT * FROM dim_tides_vehicle_locations_outcomes

--- a/warehouse/models/staging/tides/_src_tides.yaml
+++ b/warehouse/models/staging/tides/_src_tides.yaml
@@ -6,8 +6,19 @@ sources:
     database: "{{ env_var('GOOGLE_CLOUD_PROJECT', var('GOOGLE_CLOUD_PROJECT')) }}"
     schema: external_tides
     tables:
-      - name: vehicle_location_outcomes
-        description: Outcomes from converting GTFS Vehicle Location to TIDES (Transit Integrated Data Exchange Specification)
+      - name: vehicle_locations_outcomes
+        description: Outcomes from converting GTFS-RT Vehicle Position to TIDES (Transit Integrated Data Exchange Specification)
+        columns:
+          - name: display_name
+          - name: dataset_name
+          - name: table_name
+          - name: organization_source_record_id
+          - name: base64_url
+          - name: destination_path
+          - name: dt
+          - name: ts
+      - name: trips_performed_outcomes
+        description: Outcomes from converting GTFS-RT Trip Updates to TIDES (Transit Integrated Data Exchange Specification)
         columns:
           - name: display_name
           - name: dataset_name


### PR DESCRIPTION
# Description

This PR creates `trips_performed_outcomes` and renames `vehicle_position_outcomes` to `vehicle_positions_outcomes`.
Part of issue #4840 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running Airflow locally created the external table:
<img width="1376" height="527" alt="image" src="https://github.com/user-attachments/assets/58a1f6f2-8e32-4982-b5d7-72528d3a61da" />

<img width="671" height="517" alt="image" src="https://github.com/user-attachments/assets/c85062bc-1238-4f79-babf-0885b9bea12e" />

<img width="714" height="489" alt="image" src="https://github.com/user-attachments/assets/71aae519-6e54-4037-a2b3-39879d60a85a" />


## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Run external tables on Airflow after merging PR.