### PR TITLE
Materialize fct_tides_vehicle_locations incrementally by service_date

### DIFF
--- a/warehouse/dbt_project.yml
+++ b/warehouse/dbt_project.yml
@@ -26,7 +26,7 @@ vars:
   GTFS_SCHEDULE_START: "{{ '2021-04-16' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   GTFS_RT_START: "{{ '2022-09-15' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   KUBA_DEVICE_START: '2025-08-11'
-  TIDES_PRODUCT_START: "{{ '2025-12-16' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
+  TIDES_PRODUCT_START: "{{ '2025-12-01' if target.name == 'prod' else (modules.datetime.datetime.now() - modules.datetime.timedelta(days=7)).strftime('%Y-%m-%d') }}"
   INCREMENTAL_MAX_DT: ''
   DBT_ALL_INCREMENTAL_LOOKBACK_DAYS: 5
   DBT_DAILY_INCREMENTAL_LOOKBACK_DAYS: 1

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -46,12 +46,10 @@ vehicle_per_trip AS (
         trip_id_performed,
         APPROX_TOP_COUNT(vehicle_id, 1)[OFFSET(0)].value AS vehicle_id
     FROM {{ ref('fct_tides_vehicle_locations') }}
-    -- we load this by dt rather than service date
-    -- this is ok for the min date because t-X days for service date will be fully covered by t-X days for dt
-    -- add one to the incremental max date because we need to get one extra UTC dt to ensure overlap with service date
-    WHERE dt
+    -- now partitioned by service_date, so filter on it directly to prune partitions
+    WHERE service_date
         BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("TIDES_PRODUCT_START")) }}
-            AND {{ ranged_incremental_max_date() }} + 1
+            AND {{ ranged_incremental_max_date() }}
       AND vehicle_id IS NOT NULL
     GROUP BY 1, 2
 ),

--- a/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
+++ b/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
@@ -1,6 +1,14 @@
 {{
     config(
-        materialized='view',
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partition_by={
+            'field': 'service_date',
+            'data_type': 'date',
+            'granularity': 'day',
+        },
+        cluster_by=['service_date', 'base64_url'],
+        on_schema_change='append_new_columns',
         tags=['tides_product'],
     )
 }}
@@ -8,6 +16,13 @@
 WITH source_vehicle_locations AS (
     SELECT *
     FROM {{ ref('fct_vehicle_locations') }}
+    -- fct_vehicle_locations is partitioned by dt (UTC); we partition by
+    -- service_date (local). A service_date appears in dt = service_date and
+    -- dt = service_date + 1, so read one extra trailing UTC day to fully cover
+    -- the local window, then trim back to the exact service_date range below.
+    WHERE dt
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("TIDES_PRODUCT_START")) }}
+            AND {{ ranged_incremental_max_date() }} + 1
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY `key`, service_date, base64_url
         ORDER BY _extract_ts DESC
@@ -55,6 +70,11 @@ tides_vehicle_locations AS (
         vp.gtfs_dataset_key,
         vp.organization_source_record_id
     FROM filtered_vehicle_locations AS vp
+    -- Trim the dt+1 read back to the exact service_date partition window so
+    -- insert_overwrite only rewrites partitions it has fully recomputed.
+    WHERE vp.service_date
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("TIDES_PRODUCT_START")) }}
+            AND {{ ranged_incremental_max_date() }}
 )
 
 SELECT * FROM tides_vehicle_locations


### PR DESCRIPTION
# Description

`fct_tides_vehicle_locations` was a **view** over the `dt`-partitioned `fct_vehicle_locations`.
The `generate_tides` DAG exports one Parquet file **per feed per day**, filtering the model by
`service_date` + `base64_url` (`TIDESBigQueryToParquetOperator`). Because the model was a view,
that `service_date` filter could not prune the `dt`-partitioned upstream, so every feed/day export
**full-scanned** `fct_vehicle_locations` (and would hard-error if `require_partition_filter` were
set on the upstream).

This materializes `fct_tides_vehicle_locations` as an **`insert_overwrite` incremental table
partitioned by `service_date`** (clustered by `service_date, base64_url`), mirroring its sibling
`fct_tides_trips_performed`. To bridge the UTC→local offset it reads the upstream by
`dt BETWEEN min AND max + 1`, then trims output to `service_date BETWEEN min AND max` so
`insert_overwrite` only rewrites fully-recomputed partitions.

Also in this PR:
- `fct_tides_trips_performed`: the `vehicle_per_trip` CTE now filters that table by `service_date`
  (prunes the new partition) instead of the old `dt + 1` workaround. Output is unchanged.
- `dbt_project.yml`: prod `TIDES_PRODUCT_START` `2025-12-16` → `2025-12-01`, so both TIDES marts
  share one start floor matching the `generate_tides` DAG `start_date`.

**Performance:** a single feed/day export drops from a **~3.69 GB** full scan to a **~1.66 MB**
single-partition prune (~2,200×).

I consider this a hotfix. Design problem: which agencies propagate is gated by a hand-maintained
seed (`tides_publication_keys`, used as an *exclusion* list). 24 public-facing fixed-route orgs pass
the filter, of which only ~3 currently have VP pings actually flowing through.  If we added agencies, this whole table needs to get rebuilt.

Works toward #5352.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Built and tested on **staging** (`--target staging`):

```
# materialize
$ dbt run -s fct_tides_vehicle_locations --target staging
OK created sql incremental model mart_tides.fct_tides_vehicle_locations
  [CREATE TABLE (12.4m rows, 22.6 GiB processed) in 8.67s]

# tests
$ dbt build -s fct_tides_vehicle_locations --target staging
PASS=8 WARN=0 ERROR=0 SKIP=0   (not_null, unique_proportion, accepted_values,
                                relationships trips_performed.vehicle_id -> vehicle_locations)

# downstream still builds, now pruned
$ dbt run -s fct_tides_trips_performed --target staging
OK created sql incremental model mart_tides.fct_tides_trips_performed
  [SCRIPT (39.3 MiB processed) in 8.93s]
```


## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)


`deploy-dbt.yml` full-refreshes changed models on merge, so both `fct_tides_vehicle_locations` and
`fct_tides_trips_performed` rebuild from 2025-12-01 automatically — no manual backfill. Action:
monitor that deploy run. The `fct_tides_vehicle_locations` full-refresh is a single ~1.82 TB scan
(prod has no `maximum_bytes_billed` cap; model timeout is 16200s), so it should be fine but is worth
watching the first time.

----

Design note: why `insert_overwrite` over `microbatch`?

The repo default is `microbatch` (46 models vs 6 `insert_overwrite`), and this model used microbatch
before it became a view. We chose `insert_overwrite` deliberately: `microbatch` auto-filters
upstream refs by *their* `event_time` (`fct_vehicle_locations.dt`), so a `service_date` batch would
filter `dt = service_date` and **miss the `dt = service_date + 1` overlap** a local service day
needs. `insert_overwrite` + the `ranged_incremental_*` macros lets us read `dt ∈ [min, max+1]`
explicitly — matching the other dt↔service_date facts (`fct_tides_trips_performed`,
`fct_observed_trips`, `fct_vehicle_locations_path`, `fct_trip_updates_trip_summaries`).
