### PR TITLE
Grant composer service account serviceUsageConsumer for requester-pays uploads

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -578,7 +578,8 @@ resource "google_project_iam_member" "composer-service-account" {
     "roles/cloudbuild.builds.viewer",
     "roles/composer.worker",
     "roles/secretmanager.secretAccessor",
-    "roles/secretmanager.viewer"
+    "roles/secretmanager.viewer",
+    "roles/serviceusage.serviceUsageConsumer"
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.composer-service-account.email}"


### PR DESCRIPTION
# Description

The prod `generate_tides` DAG uploads `_outcomes.jsonl` reports to `gs://calitp-tides`, which is a **requester-pays** bucket. The upload therefore passes `userProject=cal-itp-data-infra` to bill the request. GCS requires the caller to hold `serviceusage.services.use` on the billed project, but the prod composer service account's role set did not grant it, so every `export_vehicle_locations` task failed with:

```
403 ... composer-service-account@cal-itp-data-infra.iam.gserviceaccount.com does not have
serviceusage.services.use access to the Google Cloud project.
Permission 'serviceusage.services.use' denied on resource
```

This grants `roles/serviceusage.serviceUsageConsumer` (which contains `serviceusage.services.use`) to the prod composer SA. The parquet `EXPORT DATA` step already worked; only the requester-pays outcomes upload was blocked.

Staging does not need this: `calitp-staging` is not requester-pays, so `userProject` is never enforced there.

Resolves #5351

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not applied yet — terraform applies go through GitHub. This is a single additive IAM role binding (no removals). Plan should show one added `roles/serviceusage.serviceUsageConsumer` member on `google_project_iam_member.composer-service-account`.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

After the IAM apply lands, re-run / clear the failed `generate_tides` prod task instances and confirm `export_vehicle_locations` uploads succeed to `gs://calitp-tides`.
