### PR TITLE
Developer does not see an error when uploading TIDES trips perfomed

### DIFF
--- a/airflow/dags/generate_tides.py
+++ b/airflow/dags/generate_tides.py
@@ -97,6 +97,7 @@ def generate_tides():
         destination_bucket=os.environ.get("CALITP_BUCKET__TIDES"),
         destination_path_prefix="trips_performed/organization_source_record_id={{ task.organization_source_record_id }}/base64_url={{ task.base64_url }}/dt={{ task.dt }}/",
         report_path="trips_performed_outcomes/dt={{ task.dt }}/ts={{ ts }}/organization_source_record_id={{ task.organization_source_record_id }}/{{ task.base64_url }}_outcomes.jsonl",
+        user_project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
         map_index_template="{{ task.dt }} - {{ task.display_name }}",
     ).expand_kwargs(
         merged_publication_feeds.map(


### PR DESCRIPTION
# Description

This PR adds the missing `user_project` keyword to the `trips_performed` generation task when running `generate_tides`

Relates to #5351

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`pytest`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Monitor DAG execution