### PR TITLE
Reduce gtfs-rt archiver heartbeat frequency in staging to once per hour

### DIFF
--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/workflow.tf
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/workflow.tf
@@ -52,7 +52,7 @@ resource "google_cloud_scheduler_job" "gtfs-rt-archiver-staging-clock" {
   description = "GTFS-RT Archiver Heartbeat"
   region      = "us-west2"
   project     = "cal-itp-data-infra-staging"
-  schedule    = "* * * * *"
+  schedule    = "0 * * * *"
   time_zone   = "America/Los_Angeles"
 
   pubsub_target {


### PR DESCRIPTION
# Description

This reverts PR #5340, which had reverted PR #5264. PR #5340 increased the GTFS-RT archiver heartbeat frequency in staging back to once per minute (`* * * * *`) for composer3 testing. Now that testing is complete, this returns the staging heartbeat to once per hour (`0 * * * *`) to reduce load on 511.

Works toward #5372

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

N/A - this is a revert of an infrastructure scheduling change.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
