### PR TITLE
Add authentication fields to Airtable GTFS datasets

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_gtfs_datasets.yml
@@ -175,3 +175,9 @@ schema_fields:
   - name: analysis_name
     type: STRING
     mode: NULLABLE
+  - name: has_authentication
+    type: BOOLEAN
+    mode: NULLABLE
+  - name: authentication_contact_details
+    type: STRING
+    mode: NULLABLE

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
@@ -30,5 +30,5 @@ WITH stg_gtfs_rt__service_alerts AS (
 
     FROM {{ source('external_gtfs_rt', 'service_alerts') }}
 )
-
+ 
 SELECT * FROM stg_gtfs_rt__service_alerts

--- a/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
+++ b/warehouse/models/staging/gtfs/stg_gtfs_rt__service_alerts.sql
@@ -30,5 +30,5 @@ WITH stg_gtfs_rt__service_alerts AS (
 
     FROM {{ source('external_gtfs_rt', 'service_alerts') }}
 )
- 
+
 SELECT * FROM stg_gtfs_rt__service_alerts


### PR DESCRIPTION
# Description

This PR adds two new fields to the Airtable external GTFS dataset config so that these fields flow into the warehouse. These fields will also be available to downstream systems CKAN tables.


Resolves #5310 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
