### PR TITLE
Add daily GCS export backups for production Metabase Cloud SQL

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -287,6 +287,26 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-backups-grafana" {
 POLICY
 }
 
+# The Metabase GCS-export backups (see services/metabase/backup-gcs-export.md,
+# defined in iac/cal-itp-data-infra/metabase/us/backups.tf) have the prod Cloud
+# SQL instance export pg_dumps into this bucket's exports/ prefix. The export runs
+# as the Cloud SQL instance's own service identity, so that identity needs
+# objectAdmin here. (Write access to this bucket is not new: the backup-metabase
+# SA below has held objectAdmin since the old restic backups, which wrote as it.
+# The difference is that Cloud SQL's instances.export writes as the instance, not
+# as the invoking SA, so it is the instance identity that must be granted — added
+# here alongside backup-metabase, not replacing it.) Because this bucket's IAM is
+# authoritative (the
+# google_storage_bucket_iam_policy below owns the whole policy), the grant has to
+# be part of the policy_data rather than a separate additive iam_member, which the
+# policy would otherwise strip on the next apply. The instance lives in the
+# metabase module; its service account email is read live via this data source
+# (the instance already exists, so there is no cross-module apply ordering).
+data "google_sql_database_instance" "metabase" {
+  name    = "metabase"
+  project = "cal-itp-data-infra"
+}
+
 resource "google_storage_bucket_iam_policy" "tfer--calitp-backups-metabase" {
   bucket = "b/calitp-backups-metabase"
 
@@ -321,7 +341,8 @@ resource "google_storage_bucket_iam_policy" "tfer--calitp-backups-metabase" {
     },
     {
       "members": [
-        "serviceAccount:backup-metabase@cal-itp-data-infra.iam.gserviceaccount.com"
+        "serviceAccount:backup-metabase@cal-itp-data-infra.iam.gserviceaccount.com",
+        "serviceAccount:${data.google_sql_database_instance.metabase.service_account_email_address}"
       ],
       "role": "roles/storage.objectAdmin"
     }

--- a/iac/cal-itp-data-infra/metabase/us/backups.tf
+++ b/iac/cal-itp-data-infra/metabase/us/backups.tf
@@ -1,0 +1,76 @@
+# Portable GCS export backups for the Metabase Cloud SQL database.
+#
+# These are pg_dump exports written to GCS, and are independent of the Cloud SQL
+# automated backups configured in sql.tf. A daily Cloud Scheduler job invokes a
+# Cloud Workflow, which calls the Cloud SQL Admin instances.export API to dump
+# the live database to a timestamped .sql.gz object under the exports/ prefix of
+# the calitp-backups-metabase bucket.
+#
+# Unlike staging (which creates a dedicated bucket here), production reuses the
+# pre-existing calitp-backups-metabase bucket, which is managed in the gcs/us
+# module. The bucket IAM grant that lets the Cloud SQL instance write its dumps
+# therefore lives with that bucket in gcs/us (added to its authoritative IAM
+# policy), not in this module. Everything else (the runner service account, its
+# roles, the workflow, and the scheduler) lives here so it plans and applies
+# together.
+locals {
+  backup_source_path = "${path.module}/workflows"
+  backup_runner_sa   = google_service_account.metabase-backup.email
+  backup_bucket      = "calitp-backups-metabase"
+}
+
+# Identity the Cloud Scheduler job authenticates as and the Cloud Workflow runs
+# as. It calls the Cloud SQL Admin instances.export API and triggers the workflow
+# execution. Keyless: no JSON key is generated (auth is via GCP identity binding).
+resource "google_service_account" "metabase-backup" {
+  account_id   = "metabase-backup"
+  description  = "Service account for the scheduled Metabase Cloud SQL to GCS export workflow"
+  display_name = "metabase-backup"
+  project      = "cal-itp-data-infra"
+}
+
+resource "google_project_iam_member" "metabase-backup" {
+  for_each = toset([
+    "roles/cloudsql.editor",   # permission to call instances.export
+    "roles/workflows.invoker", # scheduler -> workflow execution
+  ])
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.metabase-backup.email}"
+  project = "cal-itp-data-infra"
+}
+
+resource "google_workflows_workflow" "metabase-backup" {
+  name            = "metabase-backup"
+  description     = "Daily Metabase Cloud SQL -> GCS pg_dump export"
+  region          = "us-west2"
+  project         = "cal-itp-data-infra"
+  service_account = local.backup_runner_sa
+
+  call_log_level          = "LOG_ALL_CALLS"
+  execution_history_level = "EXECUTION_HISTORY_DETAILED"
+
+  source_contents = templatefile("${local.backup_source_path}/metabase-backup.yaml", {
+    project  = "cal-itp-data-infra"
+    instance = google_sql_database_instance.metabase.name
+    database = google_sql_database.metabase.name
+    bucket   = local.backup_bucket
+  })
+}
+
+resource "google_cloud_scheduler_job" "metabase-backup" {
+  name        = "metabase-backup"
+  description = "Daily Metabase Cloud SQL -> GCS pg_dump export"
+  region      = "us-west2"
+  project     = "cal-itp-data-infra"
+  schedule    = "0 4 * * *"
+  time_zone   = "America/Los_Angeles"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.metabase-backup.id}/executions"
+
+    oauth_token {
+      service_account_email = local.backup_runner_sa
+    }
+  }
+}

--- a/iac/cal-itp-data-infra/metabase/us/workflows/metabase-backup.yaml
+++ b/iac/cal-itp-data-infra/metabase/us/workflows/metabase-backup.yaml
@@ -1,0 +1,21 @@
+main:
+  steps:
+    - init:
+        assign:
+          - timestamp: $${text.substring(time.format(sys.now()), 0, 10)}
+          - uri: $${"gs://${bucket}/exports/metabase-" + timestamp + ".sql.gz"}
+    - export:
+        call: googleapis.sqladmin.v1.instances.export
+        args:
+          project: "${project}"
+          instance: "${instance}"
+          body:
+            exportContext:
+              kind: "sql#exportContext"
+              fileType: "SQL"
+              uri: $${uri}
+              databases:
+                - "${database}"
+        result: exportResult
+    - done:
+        return: $${uri}

--- a/services/metabase/backup-gcs-export.md
+++ b/services/metabase/backup-gcs-export.md
@@ -8,17 +8,14 @@ This is **one of two independent backup mechanisms** for Metabase:
 
 | Doc                                            | Mechanism                              | What it produces                                                        |
 | ---------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------- |
-| [`BACKUP_CLOUD_SQL.md`](./BACKUP_CLOUD_SQL.md) | Cloud SQL **automated backups**        | Managed, in-place instance snapshots you restore *within* Cloud SQL     |
-| **`BACKUP_GCS_BUCKET.md`** (this doc)          | Cloud SQL **`instances.export`** → GCS | A portable `.sql.gz` dump you can download, inspect, or import anywhere |
+| [`backup-cloud-sql.md`](./backup-cloud-sql.md) | Cloud SQL **automated backups**        | Managed, in-place instance snapshots you restore *within* Cloud SQL     |
+| **`backup-gcs-export.md`** (this doc)          | Cloud SQL **`instances.export`** → GCS | A portable `.sql.gz` dump you can download, inspect, or import anywhere |
 
 They are complementary. Automated backups are the fast, low-effort recovery
 path; the GCS dumps are portable, long-lived, and survive even the loss of the
-Cloud SQL instance itself.
-
-> **Rollout status:** staging is implemented; production is a planned follow-up
-> that reuses the existing prod bucket (per the recommendation on
-> [issue #5098](https://github.com/cal-itp/data-infra/issues/5098)). See
-> [Per-environment configuration](#per-environment-configuration).
+Cloud SQL instance itself. Both staging and production are implemented (staging
+was rolled out first, per the recommendation on
+[issue #5098](https://github.com/cal-itp/data-infra/issues/5098)).
 
 ## What is backed up
 
@@ -60,11 +57,11 @@ finished dump.
 
 Three identities participate, per environment. Only the first is one we create.
 
-| Identity                                                | Role in the flow                                                                | Permission                                         | Where granted              |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------- |
-| `metabase-backup` (created)                             | Scheduler authenticates as it; workflow **runs as** it and calls the export API | `roles/workflows.invoker`, `roles/cloudsql.editor` | `…/metabase/us/backups.tf` |
-| Cloud SQL **instance** service account (Google-managed) | Performs the dump and **writes** the object to the bucket                       | `roles/storage.objectAdmin` on the bucket          | `…/metabase/us/backups.tf` |
-| Cloud Scheduler **service agent** (Google-managed)      | Mints the OAuth token for `metabase-backup` at fire time                        | auto (`cloudscheduler.serviceAgent`)               | —                          |
+| Identity                                                | Role in the flow                                                                | Permission                                         |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `metabase-backup` (created)                             | Scheduler authenticates as it; workflow **runs as** it and calls the export API | `roles/workflows.invoker`, `roles/cloudsql.editor` |
+| Cloud SQL **instance** service account (Google-managed) | Performs the dump and **writes** the object to the bucket                       | `roles/storage.objectAdmin` on the bucket          |
+| Cloud Scheduler **service agent** (Google-managed)      | Mints the OAuth token for `metabase-backup` at fire time                        | auto (`cloudscheduler.serviceAgent`)               |
 
 `metabase-backup` is **keyless** — no JSON key is generated or stored. Auth is
 entirely via GCP-managed identity binding (the workflow's `service_account` and
@@ -75,7 +72,7 @@ the scheduler's `oauth_token`). Each project (staging and prod) has its own
 
 |                        | Staging                                       | Production                                   |
 | ---------------------- | --------------------------------------------- | -------------------------------------------- |
-| **Status**             | Implemented                                   | Planned follow-up                            |
+| **Status**             | Implemented                                   | Implemented                                  |
 | **Project**            | `cal-itp-data-infra-staging`                  | `cal-itp-data-infra`                         |
 | **Instance**           | `metabase-staging`                            | `metabase`                                   |
 | **Destination bucket** | `calitp-backups-metabase-staging` (new)       | `calitp-backups-metabase` (existing, reused) |
@@ -97,22 +94,31 @@ Notes:
 
 ## Where it is configured (Terraform)
 
-Using staging paths as the example (prod mirrors these under
-`iac/cal-itp-data-infra/`):
+The runner service account, its project roles, the Workflow, and the Scheduler
+job all live in the `metabase` module so they plan and apply as a single unit.
+This is a deliberate deviation from the repo convention of defining service
+accounts in the `iam` module: keeping the SA here avoids a cross-module ordering
+dependency on a brand-new `iam`-module output that does not exist until `iam` is
+applied, which the parallel, unordered Terraform CI cannot guarantee.
 
-| Resource                                                                                           | File                                           |
-| -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| Service account `metabase-backup` + its project roles, bucket, bucket IAM, Workflow, Scheduler job | `…/metabase/us/backups.tf`                     |
-| Workflow definition (export step)                                                                  | `…/metabase/us/workflows/metabase-backup.yaml` |
+| Resource                                              | Staging                                        | Production                                     |
+| ----------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| `metabase-backup` SA + roles, Workflow, Scheduler job | `…/metabase/us/backups.tf`                     | `…/metabase/us/backups.tf`                     |
+| Workflow definition (export step)                     | `…/metabase/us/workflows/metabase-backup.yaml` | `…/metabase/us/workflows/metabase-backup.yaml` |
+| Destination bucket                                    | created in `…/metabase/us/backups.tf`          | reused; defined in `…/gcs/us`                  |
+| Cloud SQL SA → bucket `objectAdmin` grant             | `…/metabase/us/backups.tf` (own bucket)        | `…/gcs/us` authoritative bucket IAM policy     |
 
-All of these resources live in the `metabase` module so they plan and apply as a
-single unit. This is a deliberate deviation from the repo convention of defining
-service accounts in the `iam` module: keeping the SA here avoids a cross-module
-ordering dependency — otherwise the `metabase` module would have to read a
-brand-new `iam`-module output from remote state that does not exist until `iam`
-is applied, which the parallel, unordered Terraform CI cannot guarantee. The
-Cloud Run service still consumes `metabase-service-account` from the `iam` module
-via `data.terraform_remote_state.iam`, as before.
+The one structural difference: in staging the bucket is new and lives in the
+`metabase` module, so the write grant is a simple additive `iam_member` there. In
+production the bucket is the shared, pre-existing `calitp-backups-metabase`,
+whose IAM is **authoritative** (`google_storage_bucket_iam_policy` in `gcs/us`).
+Write access to that bucket is not new — the `backup-metabase` service account
+has held `objectAdmin` since the old restic backups wrote as it. What changes is
+the *writer*: Cloud SQL's `instances.export` writes as the **instance's** own
+service identity (not as the invoking SA), so that identity is what needs the
+grant. It is added directly to the authoritative policy (an additive
+`iam_member` would be stripped on the next `gcs/us` apply), alongside the
+existing `backup-metabase` binding rather than replacing it.
 
 ## How to restore
 
@@ -132,17 +138,6 @@ gcloud storage ls gs://calitp-backups-metabase-staging/exports/
 gcloud storage ls gs://calitp-backups-metabase/exports/
 ```
 
-## Changing the policy
-
-Everything is managed through Terraform. Edit `backups.tf` (or the workflow
-YAML), open a PR, and the `Terraform Plan` workflow posts the plan as a PR
-comment. On merge to `main`, `Terraform Apply` applies it.
-
-- **Schedule:** the `schedule` / `time_zone` on `google_cloud_scheduler_job`.
-- **Bucket:** the bucket `name` and `location` are **immutable** — changing
-  either means creating a new bucket. Existing dumps are not migrated.
-- **Destination naming:** the `exports/…` path is built in the workflow YAML.
-
 ## What is NOT enabled
 
 - **No lifecycle / retention policy.** Dumps are kept **forever** for now —
@@ -153,5 +148,7 @@ comment. On merge to `main`, `Terraform Apply` applies it.
   for 04:00 PT (low activity) to minimize the impact of the brief locking the
   dump requires. Serverless offload could be added if export load becomes a
   concern.
-- **Production is not wired up yet** — see
-  [Per-environment configuration](#per-environment-configuration).
+
+Everything is managed through Terraform: edit `backups.tf` (or the workflow
+YAML) and open a PR. The bucket `name` and `location` are immutable, and the
+`exports/…` object path is built in the workflow YAML.


### PR DESCRIPTION
# Description

Adds daily, portable `pg_dump` exports of the **production** Metabase Cloud SQL database to Cloud Storage, independent of the Cloud SQL automated backups. A Cloud Scheduler job triggers a Cloud Workflow that calls the Cloud SQL Admin `instances.export` API, writing a timestamped `.sql.gz` dump to `gs://calitp-backups-metabase/exports/`. This gives us portable, long-lived backups that survive even loss of the Cloud SQL instance, complementing the in-place automated backups.

This is the production rollout of #5363 (which did the same for staging). The Cloud SQL automated-backup retention extension for production is handled separately on `5098-extend-metabase-prod-backup-retention`. Refs #5098.

Details:
- New `metabase-backup` service account in `metabase/us/backups.tf`, granted `roles/cloudsql.editor` + `roles/workflows.invoker`. It runs the workflow and is the identity Cloud Scheduler authenticates as. (Kept in the `metabase` module — not `iam/us` — so the SA, its roles, the workflow, and the scheduler plan and apply as one unit, with no cross-module ordering dependency.)
- **Reuses the existing `calitp-backups-metabase` bucket** (`us-west1`, `NEARLINE`) under its `exports/` prefix — no new bucket is created (unlike staging, which created `calitp-backups-metabase-staging`).
- Bucket write access: the Cloud SQL instance's own (Google-managed) service identity is granted `roles/storage.objectAdmin`. Because this bucket's IAM is **authoritative** (`google_storage_bucket_iam_policy` in `gcs/us`), the grant is added directly to that policy rather than as an additive `iam_member` (which would be stripped on the next `gcs/us` apply). Write access to the bucket isn't new — the `backup-metabase` SA has held `objectAdmin` since the now-removed restic backups; what's new is granting the **instance** identity, since `instances.export` writes as the instance, not as the invoking SA. The instance SA email is read live via a `data "google_sql_database_instance"` source, so there's no cross-module apply ordering.
- Workflow + Cloud Scheduler job (daily 04:00 `America/Los_Angeles`) in `metabase/us/backups.tf`, with the export step in `metabase/us/workflows/metabase-backup.yaml`.
- Reference doc renamed to `services/metabase/backup-gcs-export.md` (lowercase kebab-case, per the staging review feedback), updated to mark production as implemented, document the prod bucket/IAM difference, and trim the generic Terraform-workflow section.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

This is infrastructure-as-code (Terraform) only — no dbt model changes. Validation is via the **Terraform Plan** CI workflow on this PR. The plan should show creation of the `metabase-backup` SA + its IAM bindings, the workflow, and the scheduler job, plus an **in-place update** to the `calitp-backups-metabase` bucket IAM policy in `gcs/us` (adding the Cloud SQL instance SA to the `objectAdmin` binding) — with **no new bucket** and no other unexpected changes to existing resources.

Locally, `terraform fmt -check` passes and `terraform validate` passes on the `gcs/us` module. (The `metabase/us` module can't be validated with the local Terraform version because of pre-existing write-only attributes in `secrets.tf` that need Terraform 1.11+; it mirrors the merged staging module and `fmt` passes.) No Terraform was applied locally.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- Verify the first scheduled export lands in `gs://calitp-backups-metabase/exports/` after 04:00 PT, or trigger the `metabase-backup` workflow manually to confirm sooner.
- **Companion PR:** the production Cloud SQL retention extension lands on `5098-extend-metabase-prod-backup-retention`. The two PRs share the kebab-renamed docs, so merge them together (or the retention one first) to avoid a window of broken doc links.