### PR TITLE
Scope metabase-backup workflows.invoker to its workflow

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/backups.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/backups.tf
@@ -24,14 +24,18 @@ resource "google_service_account" "metabase-backup" {
   project      = "cal-itp-data-infra-staging"
 }
 
-resource "google_project_iam_member" "metabase-backup" {
-  for_each = toset([
-    "roles/cloudsql.editor",   # permission to call instances.export
-    "roles/workflows.invoker", # scheduler -> workflow execution
-  ])
-  role    = each.key
+resource "google_project_iam_member" "metabase-backup-cloudsql" {
+  role    = "roles/cloudsql.editor"
   member  = "serviceAccount:${google_service_account.metabase-backup.email}"
   project = "cal-itp-data-infra-staging"
+}
+
+resource "google_workflows_workflow_iam_member" "metabase-backup-invoker" {
+  project  = "cal-itp-data-infra-staging"
+  location = google_workflows_workflow.metabase-staging-backup.region
+  workflow = google_workflows_workflow.metabase-staging-backup.name
+  role     = "roles/workflows.invoker"
+  member   = "serviceAccount:${google_service_account.metabase-backup.email}"
 }
 
 # Dedicated bucket for portable pg_dump exports. Single-region us-west2 (matches

--- a/iac/cal-itp-data-infra/metabase/us/backups.tf
+++ b/iac/cal-itp-data-infra/metabase/us/backups.tf
@@ -29,14 +29,18 @@ resource "google_service_account" "metabase-backup" {
   project      = "cal-itp-data-infra"
 }
 
-resource "google_project_iam_member" "metabase-backup" {
-  for_each = toset([
-    "roles/cloudsql.editor",   # permission to call instances.export
-    "roles/workflows.invoker", # scheduler -> workflow execution
-  ])
-  role    = each.key
+resource "google_project_iam_member" "metabase-backup-cloudsql" {
+  role    = "roles/cloudsql.editor"
   member  = "serviceAccount:${google_service_account.metabase-backup.email}"
   project = "cal-itp-data-infra"
+}
+
+resource "google_workflows_workflow_iam_member" "metabase-backup-invoker" {
+  project  = "cal-itp-data-infra"
+  location = google_workflows_workflow.metabase-backup.region
+  workflow = google_workflows_workflow.metabase-backup.name
+  role     = "roles/workflows.invoker"
+  member   = "serviceAccount:${google_service_account.metabase-backup.email}"
 }
 
 resource "google_workflows_workflow" "metabase-backup" {


### PR DESCRIPTION
# Description

Follow-up to #5386 addressing @vevetron's least-privilege review note. The `metabase-backup` service account was granted `roles/workflows.invoker` **project-wide**, but it only ever invokes its own workflow. This replaces the project-wide grant with a workflow-scoped `google_workflows_workflow_iam_member` on the `metabase-backup` workflow, applied to **both production and staging** so the two environments don't drift.

`roles/cloudsql.editor` stays a project-level `google_project_iam_member` — Cloud SQL has no per-instance IAM, so `instances.export` can only be granted at the project level. It simply moves from the old `for_each` block into its own resource; the only grant actually removed is the project-wide `workflows.invoker`.

Refs #5098

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

_Least-privilege IaC hardening — no functional or runtime change; none of the above categories fit cleanly._

## How has this been tested?

Infrastructure-as-code (Terraform) only — no dbt model changes. Validation is via the **Terraform Plan** CI workflow, which runs a plan for each changed directory (`iac/cal-itp-data-infra/metabase/us` and `iac/cal-itp-data-infra-staging/metabase/us`). Each should show **2 to add, 0 to change, 2 to destroy**: destroy the old `for_each` bindings `…metabase-backup["roles/cloudsql.editor"]` and `…["roles/workflows.invoker"]`, and create `google_project_iam_member.metabase-backup-cloudsql` plus the workflow-scoped `google_workflows_workflow_iam_member.metabase-backup-invoker`.

These are non-authoritative (additive) bindings, so the destroys only affect the `metabase-backup` SA's own grants. The `cloudsql.editor` destroy/create is a one-time address change with no net permission change; the `workflows.invoker` swap is the intended tightening (project-wide → single workflow). `terraform fmt -check` passes locally; no Terraform was applied locally.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)

The scheduled exports keep working through the apply — the SA retains invoke on its own workflow, just no longer project-wide. (Optional future tightening, not done here: narrow `cloudsql.editor` to a custom role limited to `cloudsql.instances.export` + `cloudsql.instances.get`.)