### PR TITLE
Fix dag_file_processor_timeout in the Composer 3 production rollout

### DIFF
--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -154,7 +154,7 @@ resource "google_composer_environment" "calitp-composer3" {
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4
-        core-dag_file_processor_timeout            = 1200
+        core-dag_file_processor_timeout            = 600
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true
         core-max_active_runs_per_dag               = 128


### PR DESCRIPTION
# Description

set `dag_file_processor_timeout` to 600 per the new constraints in composer3.

Resolves #5422 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)\

Need to configure pools as: (will do manually via the airflow UI)
<img width="1292" height="569" alt="image" src="https://github.com/user-attachments/assets/5dd6d78d-8065-43f2-b63d-b4066ce92889" />
