### PR TITLE
Disable catchup on parse_and_validate_rt and generate_tides for prod Composer 3 cutover

### DIFF
--- a/airflow/dags/generate_tides.py
+++ b/airflow/dags/generate_tides.py
@@ -11,8 +11,8 @@ from airflow.decorators import dag, task
 @dag(
     # Monday, Thursday at 10am PDT/9am PST (17pm UTC)
     schedule="0 17 * * 1,4",
-    start_date=datetime(2025, 12, 1),
-    catchup=True,
+    start_date=datetime(2026, 6, 10),
+    catchup=False,
     tags=["tides"],
     default_args={
         "email": os.getenv("CALITP_NOTIFY_EMAIL"),

--- a/airflow/dags/parse_and_validate_rt.py
+++ b/airflow/dags/parse_and_validate_rt.py
@@ -12,8 +12,8 @@ with DAG(
     tags=["gtfs", "gtfs-rt"],
     # Every hour at 15 minutes past the hour
     schedule="15 * * * *",
-    start_date=datetime(2025, 9, 2),
-    catchup=True,
+    start_date=datetime(2026, 6, 10),
+    catchup=False,
     default_args={
         "email": os.getenv("CALITP_NOTIFY_EMAIL"),
         "email_on_failure": email_on_failure(),


### PR DESCRIPTION
# Description

Set `catchup=False` and `start_date` to today on `parse_and_validate_rt` and `generate_tides` so they don't backfill from their old start dates when unpaused on the fresh prod Composer 3 environment. These are the only two DAGs with `catchup=True`.

Works toward #5412

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

NOT TESTED

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
