### PR TITLE
Disable catchup_by_default on prod composer3

### DIFF
--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -41,6 +41,7 @@ resource "google_composer_environment" "calitp-staging-composer3" {
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4
+        core-catchup_by_default                    = false
         core-dag_file_processor_timeout            = 600
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -154,6 +154,7 @@ resource "google_composer_environment" "calitp-composer3" {
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4
+        core-catchup_by_default                    = false
         core-dag_file_processor_timeout            = 600
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true


### PR DESCRIPTION
# Description

Set `core-catchup_by_default = false` on the prod `calitp-composer3` environment. The Gusty DAGs (built from `METADATA.yml`) put `catchup: False` under `default_args`, where Airflow ignores it (catchup is a DAG-level setting), so on the fresh Composer 3 metadata DB they all fall back to the default `catchup_by_default = true` and backfill from their start dates. This flips the global default to `false` so they don't. The two standalone Python DAGs that set catchup explicitly were already handled in #5424.

Works toward #5412

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Existing backfill DAG runs that were already created before this applies must be cleared by hand; this only prevents new catchup.
