### PR TITLE
Revert #5392 to unblock dbt_all

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__gtfs_datasets_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__gtfs_datasets_dim.sql
@@ -40,8 +40,6 @@ WITH int_transit_database__gtfs_datasets_dim AS (
            type,
            private_dataset,
            analysis_name,
-           has_authentication,
-           authentication_contact_details,
            _is_current,
            _valid_from,
            _valid_to

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -356,12 +356,6 @@ models:
       - *valid_from_actual
       - *valid_to_actual
       - *is_current_actual
-      - name: has_authentication
-        description: |
-          Authenticaion flag name for GTFS-feed level analyses and dashboards.
-      - name: authentication_contact_details
-        description: |
-          Authenticaion contact details for GTFS-feed level analyses and dashboards.
   - name: dim_gtfs_service_data
     description: '{{ doc("gtfs_service_data_table") }}'
     data_tests: *mutually_exclusive_ranges

--- a/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
+++ b/warehouse/models/mart/transit_database/dim_gtfs_datasets.sql
@@ -33,8 +33,6 @@ dim_gtfs_datasets AS (
         base64_url,
         private_dataset,
         analysis_name,
-        has_authentication,
-        authentication_contact_details,
         _is_current,
         _valid_from,
         _valid_to

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -103,8 +103,6 @@ stg_transit_database__gtfs_datasets AS (
         END AS type,
         private_dataset,
         analysis_name,
-        has_authentication,
-        authentication_contact_details,
         ts,
         dt
     FROM construct_base64_url


### PR DESCRIPTION
# Description

Reverts #5392, which broke `dbt_all`. It added `has_authentication` and `authentication_contact_details` to the staging model and consumed them in `int_transit_database__gtfs_datasets_dim` / `dim_gtfs_datasets`, but the intermediate `int_gtfs_datasets` was never updated, so the columns didn't propagate and the dim run failed with `Unrecognized name: has_authentication`.

Works toward #5310

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Revert of a previously-merged change; restores the prior passing state of `dbt_all`.

## Post-merge follow-ups

- [x] No action required
