### PR TITLE
Set gusty DAG catchup at metadata top level and remove dead catchup override

### DIFF
--- a/airflow/dags/airtable_loader_v2/METADATA.yml
+++ b/airflow/dags/airtable_loader_v2/METADATA.yml
@@ -2,11 +2,11 @@ description: "Load data from Airtable"
 schedule_interval: "0 2 * * *"
 tags:
   - airtable
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-06-01"
-    catchup: False
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/copy_production_to_staging/METADATA.yml
+++ b/airflow/dags/copy_production_to_staging/METADATA.yml
@@ -2,11 +2,11 @@ description: Copies data from production buckets to staging buckets
 schedule_interval: "@daily"
 tags:
   - production
+catchup: False
 default_args:
   owner: airflow
   depends_on_past: False
   start_date: "2025-08-22"
-  catchup: False
   email_on_failure: True
   pool: default_pool
   max_active_dag_runs: 1

--- a/airflow/dags/create_external_tables/METADATA.yml
+++ b/airflow/dags/create_external_tables/METADATA.yml
@@ -3,11 +3,11 @@ description: "Creates all external tables in BigQuery"
 schedule_interval: "0 11 * * *" # 11am UTC (4am PDT/3am PST) every day
 tags:
   - external_tables
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: True
     email_on_retry: False
     retries: 0

--- a/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
+++ b/airflow/dags/download_gtfs_schedule_v2/METADATA.yml
@@ -3,11 +3,11 @@ schedule_interval: null
 tags:
   - gtfs
   - airtable
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: True
     email_on_retry: False
     retries: 0

--- a/airflow/dags/ntd_report_from_blackcat/METADATA.yml
+++ b/airflow/dags/ntd_report_from_blackcat/METADATA.yml
@@ -3,11 +3,11 @@ schedule_interval: "0 10 * * 1" #10 am every Monday
 tags:
   - ntd
   - blackcat
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/parse_elavon/METADATA.yml
+++ b/airflow/dags/parse_elavon/METADATA.yml
@@ -3,11 +3,11 @@ schedule_interval: "0 2 * * *"
 tags:
   - elavon
   - payments
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/parse_enghouse/METADATA.yml
+++ b/airflow/dags/parse_enghouse/METADATA.yml
@@ -3,11 +3,11 @@ schedule_interval: "0 13 * * *"
 tags:
   - enghouse
   - payments
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2026-04-29"
-    catchup: False
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/parse_littlepay_v3/METADATA.yml
+++ b/airflow/dags/parse_littlepay_v3/METADATA.yml
@@ -3,11 +3,11 @@ schedule_interval: "30 * * * *"
 tags:
   - littlepay
   - payments
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: False
     email_on_retry: False
     max_active_dag_runs: 6

--- a/airflow/dags/scrape_feed_aggregators/METADATA.yml
+++ b/airflow/dags/scrape_feed_aggregators/METADATA.yml
@@ -2,11 +2,11 @@ description: "Scrape GTFS (and other) feed URLs present in validators"
 schedule_interval: "0 0 * * *"
 tags:
   - gtfs
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: False
     email_on_retry: False
     retries: 2

--- a/airflow/dags/scrape_state_geoportal/METADATA.yml
+++ b/airflow/dags/scrape_state_geoportal/METADATA.yml
@@ -2,11 +2,11 @@ description: "Scrape State Highway Network from State Geoportal"
 schedule_interval: "0 4 1 * *" # 4am UTC first day of every month
 tags:
   - geoportal
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/sync_elavon/METADATA.yml
+++ b/airflow/dags/sync_elavon/METADATA.yml
@@ -3,11 +3,11 @@ schedule_interval: "0 0 * * *"
 tags:
   - elavon
   - payments
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/sync_kuba/METADATA.yml
+++ b/airflow/dags/sync_kuba/METADATA.yml
@@ -2,11 +2,11 @@ description: "Capture the Kuba API to GCS"
 schedule_interval: "0 * * * *"
 tags:
   - kuba
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-14"
-    catchup: False
     email_on_failure: True
     pool: default_pool
     concurrency: 50

--- a/airflow/dags/sync_littlepay_v3/METADATA.yml
+++ b/airflow/dags/sync_littlepay_v3/METADATA.yml
@@ -3,11 +3,11 @@ schedule_interval: "0 * * * *"
 tags:
   - littlepay
   - payments
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: False
     email_on_retry: False
     retries: 0

--- a/airflow/dags/sync_ntd_data_api/METADATA.yml
+++ b/airflow/dags/sync_ntd_data_api/METADATA.yml
@@ -2,11 +2,11 @@ description: "Scrape NTD endpoints from DOT API monthly"
 schedule_interval: "0 9 * * 3" # 9am UTC (2am PDT/1am PST) every Wednesday
 tags:
   - ntd
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2025-07-06"
-    catchup: False
     email_on_failure: True
     email_on_retry: False
     retries: 1

--- a/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
+++ b/airflow/dags/unzip_and_validate_gtfs_schedule_hourly/METADATA.yml
@@ -2,11 +2,11 @@ description: "Unzips and validates GTFS Schedule data"
 schedule_interval: null
 tags:
   - gtfs
+catchup: False
 default_args:
     owner: airflow
     depends_on_past: False
     start_date: "2024-01-01"
-    catchup: False
     email_on_failure: False
     email_on_retry: False
     max_active_dag_runs: 6

--- a/iac/cal-itp-data-infra-staging/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra-staging/composer/us/environment.tf
@@ -41,7 +41,6 @@ resource "google_composer_environment" "calitp-staging-composer3" {
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4
-        core-catchup_by_default                    = false
         core-dag_file_processor_timeout            = 600
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true

--- a/iac/cal-itp-data-infra/composer/us/environment.tf
+++ b/iac/cal-itp-data-infra/composer/us/environment.tf
@@ -154,7 +154,6 @@ resource "google_composer_environment" "calitp-composer3" {
 
       airflow_config_overrides = {
         celery-worker_concurrency                  = 4
-        core-catchup_by_default                    = false
         core-dag_file_processor_timeout            = 600
         core-dagbag_import_timeout                 = 600
         core-dags_are_paused_at_creation           = true


### PR DESCRIPTION
# Description

The gusty DAGs (built from `METADATA.yml`) had `catchup: False` nested under `default_args`, where Airflow/gusty ignore it — so on the fresh Composer 3 metadata DB they fell back to the global default `catchup_by_default = true` and backfilled from their start dates. This moves `catchup: False` to the top level of each `METADATA.yml` so gusty passes it directly to `DAG(catchup=False)`. It also removes the dead / incorrect `core-catchup_by_default` override added in #5425, which targeted the wrong airflow.cfg section (`[core]` instead of `[scheduler]`) and was a no-op.

Works toward #5412

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Validated locally and on staging composer3:
- Local A/B in the composer-local-dev runtime: a gusty DAG with `catchup` under `default_args` backfilled 10 runs under the global default `true`; moving `catchup: False` to the top level produced 1 run.
- Deployed to staging composer3 via the `staging/5412-gusty-catchup` branch.

## Post-merge follow-ups

- [] No action required
- [x] Actions required (specified below)
Keep working on #5412 