### PR TITLE
(chore) removed non-existing git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "iac/.engine"]
-	path = iac/.engine
-	url = https://github.com/JarvusInnovations/infra-components
-	branch = channels/engine/latest


### PR DESCRIPTION
# Description

Remove non-existing git submodule `iac/.engine`

Resolves #5436

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

No need to test as no code changes.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
