### PR TITLE
feat(payments): Expose `dt` and `_line_number` in Enghouse Staging and Mart Tables

### DIFF
--- a/warehouse/models/docs/_docs_enghouse.md
+++ b/warehouse/models/docs/_docs_enghouse.md
@@ -98,6 +98,10 @@ Date partition parsed from the GCS path, corresponding to the date in the source
 Surrogate key derived from id and operator_id. Uniquely identifies one transaction.
 {% enddocs %}
 
+{% docs enghouse_line_number %}
+Line number of this record within its source delivery file. Retained for lineage and data quality inspection.
+{% enddocs %}
+
 {% docs enghouse_content_hash %}
 Hash of all data columns. Retained for data quality inspection; deduplication uses _payments_key.
 {% enddocs %}

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -824,6 +824,10 @@ models:
         description: Only relevant for time-based tickets.
       - name: ticket_code
         description: Additional information for the ticket or ticket type.
+      - name: dt
+        description: '{{ doc("enghouse_dt") }}'
+      - name: _line_number
+        description: '{{ doc("enghouse_line_number") }}'
       - name: mapping_terminal_id
         description: Not relevant for US projects.
       - name: mapping_merchant_id
@@ -971,5 +975,9 @@ models:
         description: '{{ doc("enghouse_settlement_type") }}'
       - name: end_of_month_date_pacific
       - name: end_of_month_date_utc
+      - name: dt
+        description: '{{ doc("enghouse_dt") }}'
+      - name: _line_number
+        description: '{{ doc("enghouse_line_number") }}'
       - name: _content_hash
         description: '{{ doc("enghouse_content_hash") }}'

--- a/warehouse/models/mart/payments/fct_payments_rides_enghouse.sql
+++ b/warehouse/models/mart/payments/fct_payments_rides_enghouse.sql
@@ -79,6 +79,8 @@ join_orgs AS (
         ticket_results.start_dttm,
         ticket_results.end_dttm,
         ticket_results.ticket_code,
+        ticket_results.dt,
+        ticket_results._line_number,
 
         taps.mapping_terminal_id,
         taps.mapping_merchant_id,
@@ -166,6 +168,8 @@ fct_payments_rides_enghouse AS (
         start_dttm,
         end_dttm,
         ticket_code,
+        dt,
+        _line_number,
         mapping_terminal_id,
         mapping_merchant_id,
         terminal,

--- a/warehouse/models/mart/payments/fct_payments_settlements_enghouse.sql
+++ b/warehouse/models/mart/payments/fct_payments_settlements_enghouse.sql
@@ -19,6 +19,8 @@ WITH deduped_transactions AS (
         par,
         brand,
         settlement_type,
+        dt,
+        _line_number,
         _content_hash,
     FROM {{ ref('stg_enghouse__deduped_transactions') }}
 ),
@@ -59,6 +61,8 @@ join_orgs AS (
         deduped_transactions.par,
         deduped_transactions.brand,
         deduped_transactions.settlement_type,
+        deduped_transactions.dt,
+        deduped_transactions._line_number,
         deduped_transactions._content_hash,
         dim_orgs.name AS organization_name,
         direct_map.organization_source_record_id,
@@ -96,6 +100,8 @@ fct_payments_settlements_enghouse AS (
         organization_source_record_id,
         LAST_DAY(EXTRACT(DATE FROM timestamp AT TIME ZONE "America/Los_Angeles"), MONTH) AS end_of_month_date_pacific,
         LAST_DAY(EXTRACT(DATE FROM timestamp), MONTH) AS end_of_month_date_utc,
+        dt,
+        _line_number,
         _content_hash
     FROM join_orgs
 )
@@ -121,5 +127,7 @@ SELECT
     organization_source_record_id,
     end_of_month_date_pacific,
     end_of_month_date_utc,
+    dt,
+    _line_number,
     _content_hash
 FROM fct_payments_settlements_enghouse

--- a/warehouse/models/staging/payments/enghouse/_enghouse.yml
+++ b/warehouse/models/staging/payments/enghouse/_enghouse.yml
@@ -107,6 +107,8 @@ models:
         description: Agency identifier parsed from the GCS path partition (e.g., "ventura", "raba", "camarillo").
       - name: dt
         description: Date partition parsed from the GCS path, corresponding to the date in the source filename.
+      - name: _line_number
+        description: Line number of this record within its source delivery file. Retained for lineage and data quality inspection.
       - name: _payments_key
         description: Surrogate key derived from tap_id and operator_id. Uniquely identifies one tap.
       - name: _content_hash
@@ -156,6 +158,8 @@ models:
         description: Agency identifier parsed from the GCS path partition (e.g., "ventura", "raba", "camarillo").
       - name: dt
         description: Date partition parsed from the GCS path, corresponding to the date in the source filename.
+      - name: _line_number
+        description: Line number of this record within its source delivery file. Retained for lineage and data quality inspection.
       - name: _payments_key
         description: Surrogate key derived from id and operator_id. Uniquely identifies one ticket result.
       - name: _content_hash
@@ -218,6 +222,8 @@ models:
         description: '{{ doc("enghouse_agency") }}'
       - name: dt
         description: '{{ doc("enghouse_dt") }}'
+      - name: _line_number
+        description: '{{ doc("enghouse_line_number") }}'
       - name: _payments_key
         description: '{{ doc("enghouse_payments_key") }}'
       - name: _content_hash
@@ -297,6 +303,8 @@ models:
         description: '{{ doc("enghouse_agency") }}'
       - name: dt
         description: '{{ doc("enghouse_dt") }}'
+      - name: _line_number
+        description: '{{ doc("enghouse_line_number") }}'
       - name: _payments_key
         description: '{{ doc("enghouse_payments_key") }}'
       - name: _content_hash
@@ -346,6 +354,8 @@ models:
         description: Agency identifier parsed from the GCS path partition (e.g., "ventura", "raba", "camarillo").
       - name: dt
         description: Date partition parsed from the GCS path, corresponding to the date in the source filename.
+      - name: _line_number
+        description: Line number of this record within its source delivery file. Retained for lineage and data quality inspection.
       - name: _payments_key
         description: Surrogate key derived from id and operator_id. Uniquely identifies one pay window.
       - name: _content_hash

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__deduped_transactions.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__deduped_transactions.sql
@@ -21,6 +21,7 @@ WITH transactions AS (
         brand,
         agency,
         dt,
+        _line_number,
         _payments_key,
         _content_hash
     FROM {{ ref('stg_enghouse__transactions') }}
@@ -74,6 +75,7 @@ SELECT
     settlement_type,
     agency,
     dt,
+    _line_number,
     _payments_key,
     _content_hash
 FROM stg_enghouse__deduped_transactions

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__pay_windows.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__pay_windows.sql
@@ -17,6 +17,7 @@ clean_columns AS (
         SAFE_CAST(close_date AS TIMESTAMP) AS close_date,
         agency,
         dt,
+        SAFE_CAST(_line_number AS INT64) AS _line_number,
         {{ dbt_utils.generate_surrogate_key(['id', 'operator_id']) }} AS _payments_key,
         {{ dbt_utils.generate_surrogate_key(['operator_id', 'id', 'token', 'amount_settled', 'amount_to_settle',
             'debt_settled', 'stage', 'payment_reference', 'terminal_id', 'open_date', 'close_date']) }} AS _content_hash
@@ -48,6 +49,7 @@ stg_enghouse__pay_windows AS (
         close_date,
         agency,
         dt,
+        _line_number,
         _payments_key,
         _content_hash
     FROM deduplicated

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__taps.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__taps.sql
@@ -47,6 +47,7 @@ clean_columns AS (
         {{ trim_make_empty_string_null('driver_id') }} AS driver_id,
         agency,
         dt,
+        SAFE_CAST(_line_number AS INT64) AS _line_number,
         {{ dbt_utils.generate_surrogate_key(['tap_id', 'operator_id']) }} AS _payments_key,
         {{ dbt_utils.generate_surrogate_key([ 'operator_id', 'tap_id', 'mapping_terminal_id', 'mapping_merchant_id', 'terminal', 'token',
             'masked_pan', 'server_date', 'terminal_date', 'tx_number', 'tx_status', 'payment_reference',
@@ -112,6 +113,7 @@ stg_enghouse__taps AS (
         driver_id,
         agency,
         dt,
+        _line_number,
         _payments_key,
         _content_hash
     FROM deduplicated

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__ticket_results.sql
@@ -22,6 +22,7 @@ clean_columns AS (
         {{ trim_make_empty_string_null('ticket_code') }} AS ticket_code,
         agency,
         dt,
+        SAFE_CAST(_line_number AS INT64) AS _line_number,
         {{ dbt_utils.generate_surrogate_key(['id', 'operator_id']) }} AS _payments_key,
         {{ dbt_utils.generate_surrogate_key(['operator_id', 'id', 'ticket_id', 'station_name', 'amount', 'clearing_id',
             'reason', 'tap_id', 'ticket_type', 'created_dttm', 'line', 'start_station', 'end_station', 'start_dttm',
@@ -62,6 +63,7 @@ stg_enghouse__ticket_results AS (
         ticket_code,
         agency,
         dt,
+        _line_number,
         _payments_key,
         _content_hash
     FROM deduplicated

--- a/warehouse/models/staging/payments/enghouse/stg_enghouse__transactions.sql
+++ b/warehouse/models/staging/payments/enghouse/stg_enghouse__transactions.sql
@@ -25,6 +25,7 @@ clean_columns AS (
         {{ trim_make_empty_string_null('brand') }} AS brand,
         agency,
         dt,
+        SAFE_CAST(_line_number AS INT64) AS _line_number,
         {{ dbt_utils.generate_surrogate_key(['id', 'operatorid']) }} AS _payments_key,
         {{ dbt_utils.generate_surrogate_key(['operatorid', 'id', 'operation', 'terminal_id', 'mapping_terminal_id', 'mapping_merchant_id',
             'timestamp', 'amount', 'payment_reference', 'spdh_response', 'response_type', 'response_message', 'token', 'issuer_response',
@@ -68,6 +69,7 @@ stg_enghouse__transactions AS (
         brand,
         agency,
         dt,
+        _line_number,
         _payments_key,
         _content_hash
     FROM deduplicated


### PR DESCRIPTION
# Description

Littlepay tables such as [fct_payments_settlements](https://dbt-docs.dds.dot.ca.gov/#!/model/model.calitp_warehouse.fct_payments_settlements) (mart) and [stg_littlepay__micropayment_adjustments_v3](https://dbt-docs.dds.dot.ca.gov/#!/model/model.calitp_warehouse.stg_littlepay__micropayment_adjustments_v3) (staging) expose export date and line number fields to help observability. Update enghouse tables to match

Resolves #4912

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
uv run dbt run -s staging.payments.enghouse intermediate.payments.enghouse mart.payments
uv run dbt test -s staging.payments.enghouse intermediate.payments.enghouse mart.payments
```
No failures were observed

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
