### PR TITLE
fix(metabase-staging): Cloud Armor policy tuning for Metabase staging

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -3,6 +3,17 @@ resource "google_compute_security_policy" "metabase-staging" {
   description = "Cloud Armor policy protecting Metabase Cloud Run (staging)"
 
   rule {
+    priority    = 500
+    action      = "deny(403)"
+    description = "Geo-restrict to US and Canada"
+    match {
+      expr {
+        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA')"
+      }
+    }
+  }
+
+  rule {
     priority    = 1000
     action      = "deny(403)"
     description = "OWASP SQLi"

--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -74,7 +74,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "HTTP protocol attacks"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']})"
       }
     }
   }

--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -8,7 +8,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP SQLi"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('sqli-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']})"
       }
     }
   }

--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -8,7 +8,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP SQLi"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']})"
+        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }
@@ -19,7 +19,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP XSS"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('xss-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }
@@ -30,7 +30,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP RCE"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rce-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }
@@ -41,7 +41,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP local file inclusion"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('lfi-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('lfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }
@@ -52,7 +52,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP remote file inclusion"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rfi-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('rfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }
@@ -63,7 +63,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "Scanner / bot signatures"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }
@@ -74,7 +74,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "HTTP protocol attacks"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']})"
+        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }
@@ -85,7 +85,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "Session fixation"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable')"
+        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
       }
     }
   }


### PR DESCRIPTION
# Description

Follows #5275 (initial Cloud Armor policy).
Contributes to resolution of #5255

Adjust the staging Cloud Armor policy based on the staging soak: stop blocking legitimate Metabase traffic (WAF false positives), and add a geographic access restriction. Changes are scoped so in-scope legitimate traffic stays unblocked while non-query paths remain fully WAF-enforced.

**1. Opt out specific CRS signatures that misfire on normal (non-query) traffic**

| Rule | Opted-out signature | Why it false-positives |
|---|---|---|
| 1000 — SQLi | `owasp-crs-v030301-id942420-sqli` | "SQL character anomaly detection (cookie)" counts special characters in the `Cookie` header and denies past a threshold of 8. Metabase session cookies accumulate enough to trip it, blocking authenticated page loads (e.g. `GET /`). |
| 1600 — Protocol attack | `owasp-crs-v030301-id921170-protocolattack` | "HTTP Parameter Pollution" flags repeated query params. Metabase repeats params to pass lists (e.g. `?models=dashboard&models=card`), so search / collection / dashboard loads get blocked. |

**2. Exempt the SQL query endpoints from all WAF rules**

Metabase's `/api/dataset*` and `/api/card*` endpoints carry user-authored SQL by design. Because valid SQL is indistinguishable from injection/RCE/etc. to a WAF, these endpoints trip the content rules on legitimate queries — observed across SQLi (`942190`), RCE (`932200`), and more would follow (LFI/RFI/...). Rather than chase rules and signatures one at a time, all WAF rules (1000–1700) skip `/api/dataset` and `/api/card`. These endpoints are authenticated and SQL-by-design, so WAF content inspection there protects nothing; the rate-limit/throttle rules and every other path remain fully enforced.

**3. Restrict access to the US and Canada**

New rule at priority 500 (evaluated before the WAF rules) denies any request whose `origin.region_code` is not `US` or `CA`. Caltrans egress (`149.136.0.0/16`) is US, so internal users are unaffected.

Caveat: this matches on the IP's *registered* geolocation, not the operator's actual location — e.g. a scanner running on US-allocated hosting still geolocates as `US`. So it's a coarse filter that trims a large volume of foreign traffic as defense-in-depth, **not** a strong standalone control; the WAF remains the real protection. IPs with undeterminable geo (`ZZ`) are denied (fail-closed).

Per-rule threshold tuning and field-level exclusions aren't available in Cloud Armor's preconfigured WAF, so signature opt-outs and path scoping are the supported levers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

WAF false positives reproduced from load balancer logs under enforcement (test client browsing staging):

942420 GET / → 403 rule 1000 (cookie SQLi char-anomaly)
921170 GET /api/search?...&models=...&models=... → 403 rule 1600 (HTTP parameter pollution)
921170 GET /api/collection/27/items?models=... → 403 rule 1600 (HTTP parameter pollution)
942190 POST /api/dataset/query_metadata → 403 rule 1000 (SQLi on SQL body)
932200 POST /api/dataset/query_metadata → 403 rule 1200 (RCE on SQL body)

Applied to the live staging policy (via `gcloud`) and verified:
- Authenticated browsing, search, collection/dashboard loads, and the SQL editor no longer return `403`.
- No further WAF denials on `/api/dataset*` or `/api/card*`; no further `942420` / `921170` denials elsewhere.
- Non-query paths still enforce — a test SQLi payload to `/` still returns `403` at rule 1000.

Geo-restriction (rule 500):
- US/CA traffic — including Caltrans `149.136.0.0/16` — reaches the app normally.
- Non-US/CA requests are denied at rule 500 (confirmed via rule-500 `403`s for foreign source IPs in Cloud Logging).

_No dbt changes; dbt run/test steps N/A._

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

The changes were applied manually to the live staging policy to unblock testing; merging reconciles them via Terraform (apply should be a near no-op for these rules). After merge:
- Confirm staging browsing and the SQL editor remain unblocked and that the WAF denials above stay gone.
- Watch rule 500 for legitimate users being geo-blocked (remote/VPN, partners, automated integrations outside US/CA) and allowlist their source IPs if any appear.
- Continue the soak; add opt-outs for any further signatures that misfire on **non-query** traffic, following the same pattern.