### PR TITLE
Move authentication fields to correct model in transit_database_latest YAML

### DIFF
--- a/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
+++ b/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
@@ -79,9 +79,13 @@ models:
         meta:
           publish.include: true
       - name: has_authentication
+        description: |
+          Indicates whether authentication credentials are required to access this GTFS feed.
         meta:
           publish.include: true
       - name: authentication_contact_details
+        description: |
+          Contact information (such as an email address or web form) for requesting authentication credentials required to access the GTFS feed.
         meta:
           publish.include: true
 

--- a/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
+++ b/warehouse/models/mart/transit_database_latest/_transit_database_latest.yml
@@ -78,6 +78,13 @@ models:
           schedule_to_use_for_rt_validation_base64_url.
         meta:
           publish.include: true
+      - name: has_authentication
+        meta:
+          publish.include: true
+      - name: authentication_contact_details
+        meta:
+          publish.include: true
+
 
   - name: dim_organizations_latest_with_caltrans_district
     description: |
@@ -303,11 +310,5 @@ models:
         meta:
           publish.include: true
       - name: trip_updates_gtfs_dataset_name
-        meta:
-          publish.include: true
-      - name: has_authentication
-        meta:
-          publish.include: true
-      - name: authentication_contact_details
         meta:
           publish.include: true


### PR DESCRIPTION

# Description

The authentication fields were added under the wrong model in `_transit_database_latest.yml` in PR #5461.

This PR moves:

* `has_authentication`
* `authentication_contact_details`

to the correct model definition (`dim_gtfs_datasets_latest`) so they are published correctly to CKAN.

Resolves #5310

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Test is not necessary for this PR!

## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)
