### PR TITLE
feat(metabase): Cloud Armor for production in preview mode

### DIFF
--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -1,0 +1,171 @@
+resource "google_compute_security_policy" "metabase" {
+  name        = "metabase-armor"
+  description = "Cloud Armor policy protecting Metabase Cloud Run (production); rules in preview mode pending log review (#5481)"
+
+  rule {
+    priority    = 500
+    action      = "deny(403)"
+    preview     = true
+    description = "Geo-restrict to US and Canada"
+    match {
+      expr {
+        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1000
+    action      = "deny(403)"
+    preview     = true
+    description = "OWASP SQLi"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1100
+    action      = "deny(403)"
+    preview     = true
+    description = "OWASP XSS"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1200
+    action      = "deny(403)"
+    preview     = true
+    description = "OWASP RCE"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1300
+    action      = "deny(403)"
+    preview     = true
+    description = "OWASP local file inclusion"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('lfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1400
+    action      = "deny(403)"
+    preview     = true
+    description = "OWASP remote file inclusion"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('rfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1500
+    action      = "deny(403)"
+    preview     = true
+    description = "Scanner / bot signatures"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1600
+    action      = "deny(403)"
+    preview     = true
+    description = "HTTP protocol attacks"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 1700
+    action      = "deny(403)"
+    preview     = true
+    description = "Session fixation"
+    match {
+      expr {
+        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+      }
+    }
+  }
+
+  rule {
+    priority    = 9000
+    action      = "rate_based_ban"
+    preview     = true
+    description = "Per-IP login rate limit (10/min then 10-min ban)"
+    match {
+      expr {
+        expression = "request.path.startsWith('/api/session') && request.method == 'POST' && !inIpRange(origin.ip, '149.136.0.0/16')"
+      }
+    }
+    rate_limit_options {
+      conform_action   = "allow"
+      exceed_action    = "deny(429)"
+      enforce_on_key   = "IP"
+      ban_duration_sec = 600
+      rate_limit_threshold {
+        count        = 10
+        interval_sec = 60
+      }
+      ban_threshold {
+        count        = 10
+        interval_sec = 60
+      }
+    }
+  }
+
+  rule {
+    priority    = 9100
+    action      = "throttle"
+    preview     = true
+    description = "Per-IP global throttle (600/min)"
+    match {
+      expr {
+        expression = "!inIpRange(origin.ip, '149.136.0.0/16')"
+      }
+    }
+    rate_limit_options {
+      conform_action = "allow"
+      exceed_action  = "deny(429)"
+      enforce_on_key = "IP"
+      rate_limit_threshold {
+        count        = 600
+        interval_sec = 60
+      }
+    }
+  }
+
+  rule {
+    priority    = 2147483647
+    action      = "allow"
+    description = "Default allow"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+  }
+}

--- a/iac/cal-itp-data-infra/metabase/us/service.tf
+++ b/iac/cal-itp-data-infra/metabase/us/service.tf
@@ -157,8 +157,11 @@ module "lb-http" {
       }
 
       log_config = {
-        enable = false
+        enable      = true
+        sample_rate = 1.0
       }
+
+      security_policy = google_compute_security_policy.metabase.self_link
     }
   }
 }


### PR DESCRIPTION
# Description

Follows #5275 / #5468 (staging Cloud Armor policy + tuning).
Resolves #5480 (deploy prod Cloud Armor in preview mode).
Enables #5481 (review prod preview logs before enforcing).

Bring the Cloud Armor policy to **production** Metabase (`metabase.dds.dot.ca.gov`) in **preview mode**, per #5480. This mirrors the fully tuned staging policy — so prod starts with the staging-derived false-positive fixes already baked in — but every enforcing rule is `preview = true`, meaning **nothing is blocked**; matches are logged only. That produces the preview logs to review per #5481 before flipping to enforce (a later PR).

**Policy contents (mirror of tuned staging, #5275 + #5468)**
- **Geo-restriction (rule 500):** would deny non-US/CA traffic. Caltrans egress (`149.136.0.0/16`) is US, unaffected.
- **OWASP WAF (rules 1000–1700):** SQLi/XSS/RCE/LFI/RFI/scanner/protocol-attack/session-fixation, with the staging-derived signature opt-outs (`942420` cookie SQLi, `921170` HPP) and the `/api/dataset*` + `/api/card*` exclusions for SQL-bearing endpoints.
- **Rate limits (rules 9000/9100):** per-IP login `rate_based_ban` and global throttle, with the Caltrans `149.136.0.0/16` exemption.
- **Default allow** (max priority).

**Logging:** LB request logging enabled (`sample_rate = 1.0`) so the preview soak captures all would-be matches.

This satisfies #5480's done criteria: the prod backend has the policy attached in preview mode and Cloud Armor logs show matches without blocking.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

Preview mode is non-blocking, so there is no behavior change to prod traffic on merge.

## How has this been tested?

- Policy structure/expressions are identical to the tuned, soak-validated staging policy (#5275 + #5468), where these rules ran under enforcement against real usage.
- `terraform plan` (CI) shows the new `google_compute_security_policy.metabase`, logging enabled, and the policy attached to `metabase-backend-metabase`; no other resources change.
- Post-merge verification is the review itself (#5481): `jsonPayload.previewSecurityPolicy.outcome = "DENY"` entries are would-be blocks to vet.

_No dbt changes; dbt run/test steps N/A._

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- Review prod preview logs per #5481 (`resource.type="http_load_balancer" resource.labels.backend_service_name="metabase-backend-metabase" jsonPayload.previewSecurityPolicy.outcome="DENY"`); confirm no legitimate traffic would be blocked and list any prod-specific exemptions.
- Once clean, flip `preview = false` to enforce in a follow-up PR (tracked separately) and drop `sample_rate` to `0.1`.