### PR TITLE
restore elavon-parsed and elavon-raw buckets

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -1448,6 +1448,14 @@ output "google_storage_bucket_tfer--test-calitp-dbt-python-models_self_link" {
   value = google_storage_bucket.tfer--test-calitp-dbt-python-models.self_link
 }
 
+output "google_storage_bucket_tfer--calitp-elavon-parsed_name" {
+  value = google_storage_bucket.tfer--calitp-elavon-parsed.name
+}
+
+output "google_storage_bucket_tfer--calitp-elavon-parsed_self_link" {
+  value = google_storage_bucket.tfer--calitp-elavon-parsed.self_link
+}
+
 output "google_storage_bucket_tfer--test-calitp-gtfs-download-config_name" {
   value = google_storage_bucket.tfer--test-calitp-gtfs-download-config.name
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -246,6 +246,30 @@ resource "google_storage_bucket" "tfer--calitp-dbt-python-models" {
   uniform_bucket_level_access = "true"
 }
 
+resource "google_storage_bucket" "tfer--calitp-elavon-parsed" {
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "calitp-elavon-parsed"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "enforced"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
+resource "google_storage_bucket" "tfer--calitp-elavon-raw" {
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  location                    = "US-WEST2"
+  name                        = "calitp-elavon-raw"
+  project                     = "cal-itp-data-infra"
+  public_access_prevention    = "enforced"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
 resource "google_storage_bucket" "tfer--calitp-gtfs-download-config" {
   default_event_based_hold = "false"
   force_destroy            = "false"

--- a/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_default_object_acl.tf
@@ -56,6 +56,14 @@ resource "google_storage_default_object_acl" "tfer--calitp-dbt-python-models" {
   bucket = "calitp-dbt-python-models"
 }
 
+resource "google_storage_default_object_acl" "tfer--calitp-elavon-parsed" {
+  bucket = "calitp-elavon-parsed"
+}
+
+resource "google_storage_default_object_acl" "tfer--calitp-elavon-raw" {
+  bucket = "calitp-elavon-raw"
+}
+
 resource "google_storage_default_object_acl" "tfer--calitp-gtfs-download-config" {
   bucket = "calitp-gtfs-download-config"
 }


### PR DESCRIPTION
# Description

restore elavon-parsed and elavon-raw buckets on terraform files. Note that the #5068 meant to delete the buckets but it never succeeded because the buckets were not empty.  With this fix, it brings terraform back in sync with the state.

Work towards #5493 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

No changes in `terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Once this is applied, need to fix the composer environment to restore environment variable for elavon-parsed bucket.