### PR TITLE
Partition dim_gtfs_schedule_file_parse_outcomes by dt for query pruning

### DIFF
--- a/warehouse/models/mart/gtfs_audit/_mart_gtfs_audit.yml
+++ b/warehouse/models/mart/gtfs_audit/_mart_gtfs_audit.yml
@@ -6,7 +6,47 @@ models:
   - name: dim_gtfs_schedule_download_outcomes
     description: Summary of each Download Dataset Zip File
   - name: dim_gtfs_schedule_file_parse_outcomes
-    description: Summary of each Parsed File
+    description: |
+      Each row is a distinct GTFS schedule file parse outcome for audit and Metabase
+      dashboards. Unions parse-outcome records from external_gtfs_schedule and flattens
+      nested feed and parsed-file metadata.
+
+      Grain: one row per feed download attempt (`extract_config_base64_url`, `ts`) and
+      parsed GTFS file (`parsed_gtfs_filename`), after deduplication.
+
+      Partitioned by `dt` so date-filtered queries against this mart can prune partitions.
+      The model remains a full-refresh table; partitioning improves query-time efficiency
+      but does not reduce daily build scan cost.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - extract_config_base64_url
+              - ts
+              - parsed_gtfs_filename
+    columns:
+      - name: dt
+        description: |
+          Hive partition date for the parse outcome record. Filter on this column when
+          querying this table in BigQuery.
+        data_tests:
+          - not_null
+      - name: ts
+        description: Timestamp associated with the parse outcome event.
+        data_tests:
+          - not_null
+      - name: success
+        description: '{{ doc("column_schedule_parse_success") }}'
+      - name: exception
+        description: '{{ doc("column_schedule_parse_exception") }}'
+      - name: extract_config_base64_url
+        description: '{{ doc("column_base64_url") }}'
+        data_tests:
+          - not_null
+      - name: parsed_gtfs_filename
+        description: '{{ doc("column_schedule_parse_gtfs_filename") }}'
+        data_tests:
+          - not_null
   - name: dim_gtfs_schedule_validation_notices
     description: Validation Notices from Dataset Files
   - name: dim_gtfs_schedule_validation_outcomes

--- a/warehouse/models/mart/gtfs_audit/dim_gtfs_schedule_file_parse_outcomes.sql
+++ b/warehouse/models/mart/gtfs_audit/dim_gtfs_schedule_file_parse_outcomes.sql
@@ -1,4 +1,11 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='table',
+    partition_by={
+        'field': 'dt',
+        'data_type': 'date',
+        'granularity': 'day',
+    },
+) }}
 
 WITH unioned_outcomes AS (
     {% for file_outcome_table in [


### PR DESCRIPTION
Add BigQuery day partitioning on `dt` for `dim_gtfs_schedule_file_parse_outcomes`, a full-refresh GTFS audit mart used for Metabase/dashboard exploration of schedule file parse outcomes.

**Context:** Cost/performance review flagged this table as missing `partition_by` despite having a `dt` column. Peer RT and schedule marts in `mart/gtfs` already partition on date; the six `gtfs_audit` table marts were built earlier as thin BI copies and never got that treatment.

**What changed:**
- `partition_by` on `dt` (day granularity) in model config — no SQL logic changes
- Expanded model description (grain, partition behavior, full-refresh caveat)
- Column docs using shared `doc()` blocks (`column_schedule_parse_*`, `column_base64_url`)
- Tests mirroring `stg_gtfs_schedule__file_parse_outcomes`: `unique_combination_of_columns` on `(extract_config_base64_url, ts, parsed_gtfs_filename)` plus `not_null` on grain/partition columns

**Why:** Date-filtered queries against this mart can prune BigQuery partitions. This does **not** reduce daily build cost (model still full-scans upstream external sources on rebuild).

**Dependencies:** None. No downstream dbt models reference this table.

Resolves #[issue]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

Local validation only — no BigQuery/GCP credentials available (Caltrans/DOT workforce SSO required).

```bash
cd warehouse
uv run dbt parse --target staging
# ✅ Passed

pre-commit run --files \
  warehouse/models/mart/gtfs_audit/dim_gtfs_schedule_file_parse_outcomes.sql \
  warehouse/models/mart/gtfs_audit/_mart_gtfs_audit.yml
# ✅ Passed (yaml, sqlfluff)
```

**Not run locally** (requires staging GCP access):

```bash
uv run dbt run -s dim_gtfs_schedule_file_parse_outcomes --target staging --full-refresh
uv run dbt test -s dim_gtfs_schedule_file_parse_outcomes --target staging
```

Request reviewer with staging access to run the above before merge if desired.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

The next `dbt_gtfs` daily run will **full-refresh** this table to apply partitioning in BigQuery (config-only change to an existing table layout). No incremental backfill or manual Airflow intervention expected beyond normal deploy — flag if the rebuild fails or Metabase dashboards behave unexpectedly.

**Expected benefit:** Query-time partition pruning on date-filtered reads; daily build scan cost unchanged.