### PR TITLE
feat(metabase): geo-restrict to US/CA/GB/NL/HU (staging + prod)

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -5,10 +5,10 @@ resource "google_compute_security_policy" "metabase-staging" {
   rule {
     priority    = 500
     action      = "deny(403)"
-    description = "Geo-restrict to US and Canada"
+    description = "Geo-restrict to US/CA/GB/NL/HU"
     match {
       expr {
-        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA')"
+        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA' || origin.region_code == 'GB' || origin.region_code == 'NL' || origin.region_code == 'HU')"
       }
     }
   }

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -6,10 +6,10 @@ resource "google_compute_security_policy" "metabase" {
     priority    = 500
     action      = "deny(403)"
     preview     = true
-    description = "Geo-restrict to US and Canada"
+    description = "Geo-restrict to US/CA/GB/NL/HU"
     match {
       expr {
-        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA')"
+        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA' || origin.region_code == 'GB' || origin.region_code == 'NL' || origin.region_code == 'HU')"
       }
     }
   }

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -5,7 +5,6 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 500
     action      = "deny(403)"
-    preview     = true
     description = "Geo-restrict to US/CA/GB/NL/HU"
     match {
       expr {


### PR DESCRIPTION
# Description

Part of #5481. Follows #5483 (prod Cloud Armor preview deploy).

**Enforce** geo-restriction on Metabase — allow only **US, CA, GB, NL, HU** (rule priority 500) — in staging and prod. Requests geolocated outside these countries receive a `403`.

- **Prod:** geo rule moves from **preview → enforce**, and the allowlist widens from US/CA to US/CA/GB/NL/HU.
- **Staging:** was already enforcing geo; the allowlist widens to match prod.

The allowlist covers where Metabase's users are — US-based staff/analysts plus confirmed UK/EU users (GB/NL/HU added on that basis). Published dashboards are intentionally allowlist-scoped: there are **no path carve-outs** for public/embedded dashboards, so viewers outside these countries are blocked. This is the deliberate access policy.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

Geo-restriction now actively blocks out-of-allowlist access, including public dashboard viewers outside US/CA/GB/NL/HU — an intentional access-policy change, flagged as breaking because it removes access that previously worked for out-of-region viewers.

## How has this been tested?

- **#5481 preview soak** (prod, `sample_rate = 1.0`): the geo rule ran in preview against real traffic. Its would-be denials were overwhelmingly bots/scanners, plus out-of-region public-dashboard views that this policy intentionally blocks. The rule only matches non-allowlist regions, so in-allowlist traffic (US/CA/GB/NL/HU) is unaffected.
- `terraform plan` shows only the rule-500 change in each workspace (prod: `preview` removed + allowlist widened; staging: allowlist widened); no other resources.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- On apply, prod begins returning `403` to non-US/CA/GB/NL/HU requests. Watch Cloud Logging (`jsonPayload.enforcedSecurityPolicy.priority=500` / `outcome="DENY"`) for denials from *expected* regions (misgeolocation, or a newly-relevant country) and extend the allowlist if needed.
- The WAF + rate-limit rules are enforced separately in the `enforce-waf` PR; when both land, ensure the final policy keeps this **widened + enforced** geo rule (that branch still carries the older US/CA-preview geo rule).