### PR TITLE
Expire partitions on `fct_tides_vehicle_locations` and `fct_tides_trips_performed` where service_date is older than 15 days

### DIFF
--- a/warehouse/models/mart/tides/_mart_tides.yml
+++ b/warehouse/models/mart/tides/_mart_tides.yml
@@ -8,6 +8,7 @@ models:
       (https://tides-transit.org/main/). Sourced from `fct_vehicle_locations`
       and filtered via `dim_provider_gtfs_data` to public, customer-facing or
       regional-subfeed fixed-route feeds.
+      Data available for the last 15 days.
     columns:
       - name: location_ping_id
         description: |
@@ -99,6 +100,7 @@ models:
       route metadata and to `fct_tides_vehicle_locations` for canonical
       vehicle_id per trip. Filtered upstream to `appeared_in_vp = TRUE` so
       every row has a derivable vehicle_id.
+      Data available for the last 15 days.
     columns:
       - name: service_date
         description: TIDES PK (with trip_id_performed). From `fct_observed_trips.service_date`.

--- a/warehouse/models/mart/tides/fct_tides_trips_performed.sql
+++ b/warehouse/models/mart/tides/fct_tides_trips_performed.sql
@@ -2,6 +2,7 @@
     config(
         materialized='incremental',
         incremental_strategy='insert_overwrite',
+        partition_expiration_days=15,
         partition_by={
             'field': 'service_date',
             'data_type': 'date',
@@ -73,7 +74,7 @@ filtered_observed AS (
         AND o.vp_min_ts BETWEEN d._valid_from AND d._valid_to
 ),
 
-tides_trips_performed AS (
+tides_trips_performed_dup AS (
     SELECT
         o.service_date,
         o.trip_id AS trip_id_performed,
@@ -104,9 +105,9 @@ tides_trips_performed AS (
        AND v.trip_id_performed = o.trip_id
 ),
 
-deduped AS (
+fct_tides_trips_performed AS (
     SELECT *
-    FROM tides_trips_performed
+    FROM tides_trips_performed_dup
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY service_date, trip_id_performed, gtfs_dataset_key
         ORDER BY actual_trip_end DESC NULLS LAST,
@@ -114,4 +115,4 @@ deduped AS (
     ) = 1
 )
 
-SELECT * FROM deduped
+SELECT * FROM fct_tides_trips_performed

--- a/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
+++ b/warehouse/models/mart/tides/fct_tides_vehicle_locations.sql
@@ -2,6 +2,7 @@
     config(
         materialized='incremental',
         incremental_strategy='insert_overwrite',
+        partition_expiration_days=15,
         partition_by={
             'field': 'service_date',
             'data_type': 'date',
@@ -49,7 +50,7 @@ filtered_vehicle_locations AS (
         AND vp._extract_ts BETWEEN d._valid_from AND d._valid_to
 ),
 
-tides_vehicle_locations AS (
+fct_tides_vehicle_locations AS (
     SELECT
         vp.key AS location_ping_id,
         vp.service_date,
@@ -77,4 +78,4 @@ tides_vehicle_locations AS (
             AND {{ ranged_incremental_max_date() }}
 )
 
-SELECT * FROM tides_vehicle_locations
+SELECT * FROM fct_tides_vehicle_locations


### PR DESCRIPTION
# Description

This PR sets a 15-day partition expiration on `mart_tides.fct_tides_vehicle_locations` and `mart_tides.fct_tides_trips_performed`.

The configuration is applied when the table is created, for future updates, if you don't want to drop the table, you can update it by running the following command in BigQuery:
```
ALTER TABLE `your_project.your_dataset.your_model_table`
SET OPTIONS (
    partition_expiration_days = 15 -- Set this to your desired number of days
);
```

Resolves https://github.com/cal-itp/data-infra/issues/5478

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

I deleted the table and recreated running `uv run dbt run -s fct_tides_vehicle_locations --target staging` and `uv run dbt run -s fct_tides_trips_performed --target staging`
Then looked at the table in BigQuery:
<img width="744" height="427" alt="image" src="https://github.com/user-attachments/assets/4633c149-b463-4410-9069-b40b7133bccc" />

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Run the table on Airflow to see if it adds the expiration days (Airflow staging is not working for me to test it).
If not, run on BigQuery:
```
ALTER TABLE `cal-itp-data-infra.mart_tides.fct_tides_trips_performed`
SET OPTIONS (
    partition_expiration_days = 15
);

ALTER TABLE `cal-itp-data-infra.mart_tides.fct_tides_vehicle_locations`
SET OPTIONS (
    partition_expiration_days = 15
);
```
