### PR TITLE
Allow terraform to publish to TIDES site through `tides.dds.dot.ca.gov` repo

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
@@ -4,6 +4,12 @@ resource "google_service_account_iam_member" "github-actions-terraform" {
   role               = "roles/iam.workloadIdentityUser"
 }
 
+resource "google_service_account_iam_member" "github-actions-terraform_tides-site" {
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.tides-site_github_repository_name}"
+  service_account_id = google_service_account.github-actions-terraform.id
+  role               = "roles/iam.workloadIdentityUser"
+}
+
 resource "google_service_account_iam_member" "github-actions-service-account_data-infra" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-infra_github_repository_name}"
   service_account_id = google_service_account.github-actions-service-account.id

--- a/iac/cal-itp-data-infra/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra/iam/us/variables.tf
@@ -4,4 +4,5 @@ locals {
   gtfs-calitp-org_github_repository_name = "cal-itp/gtfs.calitp.org"
   reports_github_repository_name         = "cal-itp/reports"
   analysis_github_repository_name        = "cal-itp/data-analyses"
+  tides-site_github_repository_name      = "cal-itp/tides.dds.dot.ca.gov"
 }


### PR DESCRIPTION
# Description

This PR allows Terraform service account to publish changes to TIDES site through `tides.dds.dot.ca.gov` repo.

Terraform plan and apply works locally with my user but fails on Github Actions.
Trying to fix the issue so changes to TIDES site can be deployed. Ref tickets https://github.com/cal-itp/data-infra/issues/5393 and https://github.com/cal-itp/data-infra/issues/5370.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Terraform plan works locally, but can't test if the workflow will run since I don't have permission to apply manually.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Rerun Terraform workflow on my PR https://github.com/cal-itp/tides.dds.dot.ca.gov/pull/1.