### PR TITLE
Create tides-site pool provider for Terraform to plan and apply chang…

### DIFF
--- a/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
@@ -69,3 +69,20 @@ resource "google_iam_workload_identity_pool_provider" "analysis" {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
+
+resource "google_iam_workload_identity_pool_provider" "tides-site" {
+  workload_identity_pool_provider_id = "tides-site"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.tides-site_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}


### PR DESCRIPTION
# Description

This PR created pool provider as a complement of PR https://github.com/cal-itp/data-infra/pull/5506, to allow Terraform service account to run plan and apply and publish changes to TIDES site through `tides.dds.dot.ca.gov` repo.

Trying to fix the issue so changes to TIDES site can be deployed. Ref tickets https://github.com/cal-itp/data-infra/issues/5393 and https://github.com/cal-itp/data-infra/issues/5370.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Terraform plan works locally, but can't test if the workflow will run since I don't have permission to apply manually.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Rerun Terraform workflow on my PR https://github.com/cal-itp/tides.dds.dot.ca.gov/pull/1.