### PR TITLE
restore calitp-staging-elavon-parsed

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -274,6 +274,10 @@ output "google_storage_bucket_calitp-staging-enghouse-parsed_name" {
   value = google_storage_bucket.calitp-staging-enghouse-parsed.name
 }
 
+output "google_storage_bucket_calitp-staging-elavon-parsed_name" {
+  value = google_storage_bucket.calitp-staging-elavon-parsed.name
+}
+
 output "google_storage_bucket_calitp-staging-elavon-raw-v2_name" {
   value = google_storage_bucket.calitp-staging-elavon-raw-v2.name
 }

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -167,6 +167,18 @@ resource "google_storage_bucket" "calitp-staging-pytest" {
   uniform_bucket_level_access = "true"
 }
 
+resource "google_storage_bucket" "calitp-staging-elavon-parsed" {
+  default_event_based_hold    = "false"
+  force_destroy               = "true"
+  location                    = "US-WEST2"
+  name                        = "calitp-staging-elavon-parsed"
+  project                     = "cal-itp-data-infra-staging"
+  public_access_prevention    = "inherited"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
+}
+
 resource "google_storage_bucket" "calitp-staging-elavon-raw-v2" {
   default_event_based_hold    = "false"
   force_destroy               = "true"


### PR DESCRIPTION
# Description

restore calitp-staging-elavon-parsed bucket, required for staging airflow.

step 1 of 2 for #5496 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

A separate PR to add environment var back to airflow composer.
