### PR TITLE
Add bucket usage logs to TIDES data bucket

### DIFF
--- a/iac/cal-itp-data-infra/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra/gcs/us/outputs.tf
@@ -1963,6 +1963,10 @@ output "google_storage_bucket_calitp-tides_name" {
   value = google_storage_bucket.calitp-requester-pays["calitp-tides"].name
 }
 
+output "google_storage_bucket_calitp-tides-logs_name" {
+  value = google_storage_bucket.calitp-tides-logs.name
+}
+
 output "google_storage_bucket_calitp-tides-site_name" {
   value = google_storage_bucket.calitp-site["calitp-tides-site"].name
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -1259,4 +1259,22 @@ resource "google_storage_bucket" "calitp-tides" {
   requester_pays              = "true"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  logging {
+    log_bucket        = google_storage_bucket.calitp-tides-logs.name
+    log_object_prefix = "calitp-tides"
+  }
+}
+
+resource "google_storage_bucket" "calitp-tides-logs" {
+  name     = "calitp-tides-logs"
+  project  = "cal-itp-data-infra"
+  location = "US-WEST2"
+
+  default_event_based_hold    = "false"
+  force_destroy               = "false"
+  public_access_prevention    = "enforced"
+  requester_pays              = "false"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = "true"
 }

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_member.tf
@@ -400,6 +400,12 @@ resource "google_storage_bucket_iam_member" "calitp-tides" {
   member = "allUsers"
 }
 
+resource "google_storage_bucket_iam_member" "calitp-tides-logs-storage-analytics" {
+  bucket = google_storage_bucket.calitp-tides-logs.name
+  role   = "roles/storage.objectCreator"
+  member = "group:cloud-storage-analytics@google.com"
+}
+
 resource "google_storage_bucket_iam_member" "calitp-site" {
   for_each = local.site_buckets
   bucket   = google_storage_bucket.calitp-site[each.key].name


### PR DESCRIPTION
ref: #5394

# Description

Captures usage logs for the public facing TIDES data. From here we can query and understand usage.
