### PR TITLE
feat(metabase): enforce Cloud Armor WAF + rate-limit rules

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -19,7 +19,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP SQLi"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -30,7 +30,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP XSS"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -41,7 +41,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP RCE"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -52,7 +52,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP local file inclusion"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('lfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('lfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -63,7 +63,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP remote file inclusion"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('rfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -74,7 +74,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "Scanner / bot signatures"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id913101-scannerdetection']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -85,7 +85,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "HTTP protocol attacks"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -96,7 +96,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "Session fixation"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }

--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -129,7 +129,7 @@ resource "google_compute_security_policy" "metabase-staging" {
   rule {
     priority    = 9100
     action      = "throttle"
-    description = "Per-IP global throttle (600/min)"
+    description = "Per-IP global throttle (1200/min)"
     match {
       expr {
         expression = "!inIpRange(origin.ip, '149.136.0.0/16')"
@@ -140,7 +140,7 @@ resource "google_compute_security_policy" "metabase-staging" {
       exceed_action  = "deny(429)"
       enforce_on_key = "IP"
       rate_limit_threshold {
-        count        = 600
+        count        = 1200
         interval_sec = 60
       }
     }

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -129,7 +129,7 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 9100
     action      = "throttle"
-    description = "Per-IP global throttle (600/min)"
+    description = "Per-IP global throttle (1200/min)"
     match {
       expr {
         expression = "!inIpRange(origin.ip, '149.136.0.0/16')"
@@ -140,7 +140,7 @@ resource "google_compute_security_policy" "metabase" {
       exceed_action  = "deny(429)"
       enforce_on_key = "IP"
       rate_limit_threshold {
-        count        = 600
+        count        = 1200
         interval_sec = 60
       }
     }

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -16,11 +16,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1000
     action      = "deny(403)"
-    preview     = true
     description = "OWASP SQLi"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('sqli-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id942420-sqli']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -28,11 +27,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1100
     action      = "deny(403)"
-    preview     = true
     description = "OWASP XSS"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -40,11 +38,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1200
     action      = "deny(403)"
-    preview     = true
     description = "OWASP RCE"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -52,11 +49,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1300
     action      = "deny(403)"
-    preview     = true
     description = "OWASP local file inclusion"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('lfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('lfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -64,11 +60,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1400
     action      = "deny(403)"
-    preview     = true
     description = "OWASP remote file inclusion"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('rfi-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -76,11 +71,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1500
     action      = "deny(403)"
-    preview     = true
     description = "Scanner / bot signatures"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('scannerdetection-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id913101-scannerdetection']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -88,11 +82,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1600
     action      = "deny(403)"
-    preview     = true
     description = "HTTP protocol attacks"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('protocolattack-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id921170-protocolattack']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -100,11 +93,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 1700
     action      = "deny(403)"
-    preview     = true
     description = "Session fixation"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card')"
+        expression = "evaluatePreconfiguredWaf('sessionfixation-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }
@@ -112,7 +104,6 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 9000
     action      = "rate_based_ban"
-    preview     = true
     description = "Per-IP login rate limit (10/min then 10-min ban)"
     match {
       expr {
@@ -138,7 +129,6 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 9100
     action      = "throttle"
-    preview     = true
     description = "Per-IP global throttle (600/min)"
     match {
       expr {


### PR DESCRIPTION
# Description

Part of #5481. Follows #5483 (prod Cloud Armor preview deploy).

Move the Metabase Cloud Armor rules from preview to **enforce** in production — every rule **except geo-restriction (priority 500), which stays in preview** pending a separate access-policy decision. Staging already enforces these rules; this also brings its exemptions in line with prod. Enforcement is based on the #5481 preview-log soak (10k+ would-be-deny samples reviewed), which showed the enabled rules' matches were attacks/scanners, aside from two false positives fixed here.

**Changes**
- Flip `preview` off on prod rules `1000–1700` (WAF) and `9000`/`9100` (rate limits). Geo `500` stays in preview.
- **FP fix:** exempt `/api/dashboard` from the content rules (a dashboard save by internal staff tripped RCE), mirroring the existing `/api/dataset` + `/api/card` exemptions.
- **FP fix:** opt out scanner signature `913101` (flagged legitimate `python-requests`/`curl` API clients).
- **Raise the global throttle (`9100`) from 600 to 1200 req/min per IP** — see "Rate limits & heavy workloads" below.
- All changes applied to staging and prod.

### Enabled rules & exemptions

The rules below run in **enforce** mode. Geo-restriction (priority 500) is excluded — it remains in preview.

| Priority | Rule | Exemptions | Reason for exemption |
|---|---|---|---|
| 1000 | OWASP SQLi | authoring paths¹, signature `942420` | `942420` (SQL character-anomaly in cookies) matches the special characters in Metabase's own session cookie and would block normal authenticated requests |
| 1100 | OWASP XSS | authoring paths¹ | — |
| 1200 | OWASP RCE | authoring paths¹ | — |
| 1300 | OWASP LFI | authoring paths¹ | — |
| 1400 | OWASP RFI | authoring paths¹ | — |
| 1500 | Scanner detection | authoring paths¹, signature `913101` | `913101` matches scripting clients (`python-requests`, `curl`) used by legitimate Metabase API automation |
| 1600 | HTTP protocol attack | authoring paths¹, signature `921170` | `921170` (HTTP parameter pollution) matches Metabase's legitimate repeated query params, e.g. `?models=dashboard&models=card` |
| 1700 | Session fixation | authoring paths¹ | — |
| 9000 | Login rate limit (10/min per IP, `POST /api/session`) | IP range `149.136.0.0/16` | Caltrans NAT egress — many internal users share one public IP and would collectively trip the limit |
| 9100 | Global throttle (1200/min per IP) | IP range `149.136.0.0/16` | same shared-egress reason |

¹ **Authoring paths** = `/api/dataset`, `/api/card`, `/api/dashboard`. These authenticated endpoints legitimately carry user-written SQL and dashboard content that matches WAF injection signatures; inspecting them produces false positives that block normal queries and dashboard edits.

### Rate limits & heavy workloads

The rate-limit rules (`9000`, `9100`) exempt Caltrans egress (`149.136.0.0/16`). Two classes of legitimate high-volume traffic run from IPs that **can't** be exempted, which is why `9100`'s ceiling was doubled to **1200 req/min** rather than exempted by other means:

- **CI metadata sync** — the `deploy-dbt` "Sync Metabase" job pushes column docs via the Metabase API from **GitHub-hosted runners** (dynamic, shared egress; no static IP, can't route through Caltrans). It uses `dbt-metabase` 1.6, which is diff-based (only pushes changed columns), so normal runs are well under 1200/min; the higher ceiling covers occasional bulk-doc deploys.
- **Analyst API scripts** run off-network from unpredictable IPs.

A credential-based exemption (e.g. exempting requests carrying an API-key header) was **rejected**: header presence is trivially spoofable, and this repo is public, so it would be an advertised bypass, not a control. Since Cloud Armor can only trust the source IP, 1200/min gives legitimate automation headroom while still capping egregious single-IP floods.

**Operational guidance:** scripts with heavy workloads exceeding **1200 requests/minute** must be run from the Caltrans network — connect to the Caltrans VPN before running them — so their traffic is exempt from the throttle.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- **#5481 preview soak** (prod, `sample_rate = 1.0`): reviewed 10k+ `previewSecurityPolicy` deny samples. Denials on the enabled rules were attacks/scanners (e.g. `/api/geojson?url=file:///etc/passwd` LFI, `.env`/`.git` probes, `zgrab`), except two false positives fixed here:
  - RCE (`1200`) on `PUT /api/dashboard/…` from an internal user saving a dashboard → `/api/dashboard` exemption.
  - Scanner (`1500`) on `python-requests` API automation → `913101` opt-out.
- **Throttle (`9100`):** the only EXCEED in the sample was a single `python-requests`/`aiohttp` bot at 609 req/min; the 1200/min ceiling leaves legitimate automation clear of the limit.
- **CI sync reviewed:** `dbt-metabase` 1.6 is diff-based — it pushes only changed columns (out of ~4,500 documented), so normal deploys are far under 1200/min.
- Staging already enforces these rules; this PR adds the exemptions and the higher throttle there too.

_No dbt changes; dbt run/test steps N/A._

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- After apply, prod begins actively blocking on the WAF + rate-limit rules — watch Cloud Logging (`jsonPayload.enforcedSecurityPolicy.outcome="DENY"`) for unexpected denials on legitimate traffic, and `9100` `429`s.
- **Geo-restriction (500) stays in preview** — enforcing it is a separate access-policy decision (it would block non-allowlist public dashboard viewers), tracked under #5481.
- Share the heavy-script / Caltrans-VPN guidance (>1200 req/min → VPN) with the analyst team.