### PR TITLE
feat(airtable): add agency name to payment device mapping

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_payment_device_mapping.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_transit_tech_stacks_payment_device_mapping.yml
@@ -23,6 +23,9 @@ schema_fields:
   - name: agency
     type: STRING
     mode: REPEATED
+  - name: agency_name
+    type: STRING
+    mode: REPEATED
   - name: id
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION
# Description

Add the `agency_name` lookup field to the payment device mapping external table schema.

This provides a human-readable agency name alongside the linked Airtable record ID (`agency`) while retaining the record ID for downstream joins.

Ref #5462

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Schema update only. The field will be validated after the scheduled Airtable ingestion and external table creation jobs run in staging.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
