### PR TITLE
Adds support for `trip_modifications` as a GTFS dataset type in the transit database staging configuration.

### DIFF
--- a/warehouse/models/staging/transit_database/_stg_transit_database.yml
+++ b/warehouse/models/staging/transit_database/_stg_transit_database.yml
@@ -82,7 +82,7 @@ models:
       - name: data_quality_pipeline
       - name: type
         description: |
-          "data" labels mapped to "service_alerts", "vehicle_positions", "trip_updates",
+          "data" labels mapped to "service_alerts", "vehicle_positions", "trip_updates", "trip_modifications",
             and "schedule" (as opposed to "GTFS Alerts" etc.)
       - name: regional_feed_type
       - name: fares_v2_status

--- a/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__gtfs_datasets.sql
@@ -100,6 +100,7 @@ stg_transit_database__gtfs_datasets AS (
             WHEN data = "GTFS Alerts" THEN "service_alerts"
             WHEN data = "GTFS VehiclePositions" THEN "vehicle_positions"
             WHEN data = "GTFS TripUpdates" THEN "trip_updates"
+            WHEN data = "GTFS TripModifications" THEN "trip_modifications"
         END AS type,
         private_dataset,
         analysis_name,


### PR DESCRIPTION
# Description

This is the first step toward supporting GTFS-Realtime Trip Modifications in the RT archiver and downstream warehouse pipeline.

Ref: [#5527](https://github.com/cal-itp/data-infra/issues/5527)

## Changes

- Updated `stg_transit_database__gtfs_datasets.sql` to map the Trip Modifications Airtable value to `trip_modifications`.
- Updated `_stg_transit_database.yml` documentation accordingly.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Successfully ran:

```bash
uv run dbt run -s stg_transit_database__gtfs_datasets

