### PR TITLE
refactor(metabase): unify Dockerfile + add test-instance runbook; publish image tags only from main (takes over #5277)

### DIFF
--- a/.github/workflows/build-metabase.yml
+++ b/.github/workflows/build-metabase.yml
@@ -21,42 +21,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  changes:
-    name: Detect changes
-
+  build:
+    name: Build image
     runs-on: ubuntu-latest
-
-    outputs:
-      staging: ${{ steps.staging-changes.outputs.all_changed_files }}
-      production: ${{ steps.production-changes.outputs.all_changed_files }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Staging Changes
-        uses: tj-actions/changed-files@v46
-        id: staging-changes
-        with:
-          matrix: true
-          dir_names: true
-          files: 'services/metabase/Dockerfile.staging'
-
-      - name: Production Changes
-        uses: tj-actions/changed-files@v46
-        id: production-changes
-        with:
-          matrix: true
-          dir_names: true
-          files: 'services/metabase/Dockerfile.production'
-
-  staging:
-    name: Build staging image
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: ${{ needs.changes.outputs.staging != '[]' || needs.changes.outputs.staging != '' }}
 
     permissions:
       contents: read
@@ -79,41 +46,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: services/metabase
-          file: services/metabase/Dockerfile.staging
+          file: services/metabase/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}/metabase:staging
+          tags: |
+            ghcr.io/${{ github.repository }}/metabase:staging
+            ghcr.io/${{ github.repository }}/metabase:production
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/metabase:staging
-          cache-to: type=inline
-
-  production:
-    name: Build production image
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: ${{ needs.changes.outputs.production != '[]' || needs.changes.outputs.production != '' }}
-
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Login to GitHub Repository
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push
-        uses: docker/build-push-action@v6
-        with:
-          context: services/metabase
-          file: services/metabase/Dockerfile.production
-          push: true
-          tags: ghcr.io/${{ github.repository }}/metabase:production
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/metabase:production
           cache-to: type=inline

--- a/.github/workflows/build-metabase.yml
+++ b/.github/workflows/build-metabase.yml
@@ -47,7 +47,10 @@ jobs:
         with:
           context: services/metabase
           file: services/metabase/Dockerfile
-          push: true
+          # Build-only on PRs: the mutable :staging/:production tags are what live
+          # Cloud Run services re-resolve on redeploy, so they must only ever be
+          # published from reviewed code on main.
+          push: ${{ github.event_name == 'push' }}
           tags: |
             ghcr.io/${{ github.repository }}/metabase:staging
             ghcr.io/${{ github.repository }}/metabase:production

--- a/runbooks/workflow/metabase-test-instance-from-prod.md
+++ b/runbooks/workflow/metabase-test-instance-from-prod.md
@@ -1,0 +1,301 @@
+# Spinning up a Metabase test instance from a prod snapshot
+
+Provision a temporary, isolated Metabase deployment in `cal-itp-data-infra-staging` seeded with a recent snapshot of the prod application database. Useful for:
+
+- **Validating Metabase upgrades** before deploying to prod (the application's first-boot schema migration runs against real data, surfacing any incompatibilities).
+- **Validating the restore runbook** itself periodically (annual exercise — see [issue #4864](https://github.com/cal-itp/data-infra/issues/4864)).
+- **Investigating bugs or data anomalies** without touching production.
+
+For in-place disaster-recovery against the prod instance itself, see [`metabase-restore.md`](metabase-restore.md) instead.
+
+## When *not* to use this runbook
+
+- Don't use this for in-place rollback — `gcloud sql backups restore` against the prod instance is far simpler. See `metabase-restore.md`.
+- The existing `metabase-staging` deployment in `cal-itp-data-infra-staging` is **not** a prod snapshot — it's an empty staging environment used by the team for testing new dashboards. Don't destroy or re-seed it; spin up a separate temp instance per this runbook.
+
+## Prerequisites
+
+- `gcloud` CLI authenticated against both `cal-itp-data-infra` (prod, read-only for the export step) and `cal-itp-data-infra-staging` (write, for the temp resources).
+- The prod Metabase Cloud SQL service agent has `roles/storage.objectAdmin` on `gs://calitp-backups-metabase` (provisioned by [`iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf`](../../iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf)). Without this the export in step 1 fails.
+- The unified Metabase image is published at `ghcr.io/cal-itp/data-infra/metabase:staging` (built from [`services/metabase/Dockerfile`](../../services/metabase/Dockerfile)). It auto-creates the Cloud SQL Unix-socket symlink at runtime based on the `CLOUD_SQL_INSTANCE_CONNECTION_NAME` env var, so the same image works against any Cloud SQL instance.
+
+A throwaway temp instance like the one this runbook produces costs roughly **$2–5/day** (db-g1-small Cloud SQL + Cloud Run min=1) — tear it down promptly with the cleanup section.
+
+## Choose names and the connection name format
+
+Use a unique, descriptive name for each temp deployment so multiple validations can run in parallel without clashing. Throughout this runbook the placeholder is `metabase-restore-test`; replace with your own.
+
+```bash
+export PROJECT=cal-itp-data-infra-staging
+export INSTANCE=metabase-restore-test
+export REGION=us-west2
+export CONNECTION_NAME="${PROJECT}:${REGION}:${INSTANCE}"
+```
+
+## 1. Export prod database to GCS
+
+Server-side `pg_dump` from the prod Cloud SQL instance into the existing backups bucket. Off-peak hours (early morning Pacific) are best — the export reads the live database.
+
+### gcloud
+
+```bash
+gcloud sql export sql metabase \
+  "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql" \
+  --database=metabase \
+  --project=cal-itp-data-infra
+```
+
+### Console
+
+1. Open <https://console.cloud.google.com/sql/instances/metabase/overview?project=cal-itp-data-infra>.
+2. Click **Export** in the toolbar.
+3. **File format**: SQL.
+4. **Database for export**: `metabase`.
+5. **Storage path**: `calitp-backups-metabase/exports/metabase-<YYYY-MM-DD>.sql`.
+6. Click **Export** and wait for it to finish (status shows in the **Operations** tab).
+
+## 2. Create the temp Cloud SQL instance
+
+Match the prod tier and Postgres version so first-boot schema migration timing approximates what prod would experience. Backup config is enabled so you can also test the restore runbook against this instance later.
+
+### gcloud
+
+```bash
+gcloud sql instances create "$INSTANCE" \
+  --database-version=POSTGRES_18 \
+  --region="$REGION" \
+  --tier=db-g1-small \
+  --edition=ENTERPRISE \
+  --backup \
+  --backup-start-time=10:00 \
+  --retained-backups-count=7 \
+  --backup-location="$REGION" \
+  --project="$PROJECT"
+```
+
+### Console
+
+1. Open <https://console.cloud.google.com/sql/choose-instance-engine?project=cal-itp-data-infra-staging>, choose **PostgreSQL**.
+2. **Instance ID**: `metabase-restore-test`.
+3. **Database version**: `PostgreSQL 18`.
+4. **Edition**: Enterprise; **Preset**: Sandbox; **Machine type**: `db-g1-small`.
+5. **Region**: `us-west2`.
+6. Expand **Data Protection**, leave **Automated backups** enabled, set retention to 7.
+7. Click **Create instance** and wait until the state is **Runnable** (~2 minutes).
+
+## 3. Set the postgres user password
+
+Needed only for the import step's `--user=postgres` argument and for any direct `psql` introspection. Cloud Run won't use it (it talks to the instance via the mounted Unix socket and the unified image creates that automatically).
+
+### gcloud
+
+```bash
+POSTGRES_PASS=$(openssl rand -hex 24)
+echo "$POSTGRES_PASS" > "/tmp/${INSTANCE}-postgres-pass"
+chmod 600 "/tmp/${INSTANCE}-postgres-pass"
+
+gcloud sql users set-password postgres \
+  --instance="$INSTANCE" \
+  --password="$POSTGRES_PASS" \
+  --project="$PROJECT"
+```
+
+### Console
+
+1. From the temp instance page, open the **Users** tab.
+2. Find the `postgres` user, click the three-dot menu and choose **Change password**.
+3. Generate a password (or paste one), copy it somewhere local, and confirm.
+
+## 4. Create the metabase database
+
+### gcloud
+
+```bash
+gcloud sql databases create metabase \
+  --instance="$INSTANCE" \
+  --project="$PROJECT"
+```
+
+### Console
+
+1. From the temp instance page, open the **Databases** tab.
+2. Click **Create database**, name it `metabase`, click **Create**.
+
+## 5. Grant the temp instance read access to the prod export
+
+The temp Cloud SQL instance has its own per-instance service agent (a `p<staging-project-number>-…@gcp-sa-cloud-sql.iam.gserviceaccount.com` SA, distinct from the prod instance's). To import a SQL file from the prod project's GCS bucket, that staging-side service agent needs `roles/storage.objectViewer` on the bucket.
+
+This is intentionally a **manual, ephemeral** grant managed alongside the temp instance — the binding is removed in cleanup once the test instance is torn down. Persistent automation belongs in terraform if a use case justifies it.
+
+### gcloud
+
+```bash
+TEMP_SA=$(gcloud sql instances describe "$INSTANCE" \
+  --project="$PROJECT" \
+  --format='value(serviceAccountEmailAddress)')
+
+gcloud storage buckets add-iam-policy-binding gs://calitp-backups-metabase \
+  --member="serviceAccount:${TEMP_SA}" \
+  --role="roles/storage.objectViewer" \
+  --project=cal-itp-data-infra
+```
+
+### Console
+
+1. On the temp instance's **Overview** page, copy the **Service account** email under **Connect to this instance**.
+2. Open <https://console.cloud.google.com/storage/browser/calitp-backups-metabase;tab=permissions?project=cal-itp-data-infra>.
+3. Click **Grant access**.
+4. **New principals**: paste the service account email.
+5. **Role**: `Storage Object Viewer`.
+6. Click **Save**.
+
+## 6. Import the export
+
+### gcloud
+
+```bash
+gcloud sql import sql "$INSTANCE" \
+  "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql" \
+  --database=metabase \
+  --user=postgres \
+  --project="$PROJECT" \
+  --quiet
+```
+
+### Console
+
+1. From the temp instance page, click **Import** in the toolbar.
+2. **Source**: choose the SQL file in `gs://calitp-backups-metabase/exports/...`.
+3. **File format**: SQL.
+4. **Database**: `metabase`.
+5. **User**: `postgres`.
+6. Click **Import** and wait for the operation to finish.
+
+## 7. Deploy the Metabase Cloud Run service
+
+The unified image creates the Cloud SQL Unix-socket symlink at runtime from `CLOUD_SQL_INSTANCE_CONNECTION_NAME`. No per-instance image build is required.
+
+### gcloud
+
+```bash
+POSTGRES_PASS=$(cat "/tmp/${INSTANCE}-postgres-pass")
+
+gcloud run deploy "$INSTANCE" \
+  --image=us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/data-infra/metabase:staging \
+  --region="$REGION" \
+  --platform=managed \
+  --no-allow-unauthenticated \
+  --service-account=metabase-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com \
+  --add-cloudsql-instances="$CONNECTION_NAME" \
+  --set-env-vars="^@^MB_DB_TYPE=postgres@MB_DB_DBNAME=metabase@MB_DB_HOST=127.0.0.1@MB_DB_USER=postgres@MB_DB_PASS=${POSTGRES_PASS}@JAVA_OPTS=-Xmx2048m@CLOUD_SQL_INSTANCE_CONNECTION_NAME=${CONNECTION_NAME}" \
+  --min-instances=1 \
+  --memory=2Gi \
+  --cpu=1 \
+  --port=3000 \
+  --timeout=300 \
+  --project="$PROJECT"
+```
+
+### Console
+
+01. Open <https://console.cloud.google.com/run/create?project=cal-itp-data-infra-staging>.
+02. **Service name**: `metabase-restore-test`.
+03. **Region**: `us-west2`.
+04. **Container image URL**: `us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/data-infra/metabase:staging`.
+05. **Authentication**: Require authentication.
+06. **CPU allocation**: CPU is only allocated during request processing.
+07. Under **Containers → Edit container**:
+    - **Resources**: 1 CPU, 2 GiB memory.
+    - **Container port**: `3000`.
+    - **Environment variables**: set `MB_DB_TYPE=postgres`, `MB_DB_DBNAME=metabase`, `MB_DB_HOST=127.0.0.1`, `MB_DB_USER=postgres`, `MB_DB_PASS=<your password>`, `JAVA_OPTS=-Xmx2048m`, `CLOUD_SQL_INSTANCE_CONNECTION_NAME=cal-itp-data-infra-staging:us-west2:metabase-restore-test`.
+08. Under **Cloud SQL connections**, add the temp instance's connection name.
+09. Under **Networking** / Service account, choose `metabase-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com`.
+10. Under **Autoscaling**, set **Minimum number of instances** to `1`.
+11. Click **Create**.
+
+## 8. Wait for first-boot schema migration
+
+The first time Metabase connects to the imported database, it runs Liquibase migrations to bring the application schema in line with the running version. With prod-sized data this can take **5–10 minutes**.
+
+### gcloud
+
+```bash
+URL=$(gcloud run services describe "$INSTANCE" \
+  --region="$REGION" \
+  --project="$PROJECT" \
+  --format='value(status.url)')
+
+TOKEN=$(gcloud auth print-identity-token)
+until curl -s -H "Authorization: Bearer $TOKEN" "$URL/api/health" | grep -q '"ok"'; do
+  curl -s -H "Authorization: Bearer $TOKEN" "$URL/api/health"; echo
+  sleep 30
+done
+echo "Ready: $URL"
+```
+
+### Console
+
+1. From the Cloud Run service page, copy the service URL.
+2. With an authorized session (or a `gcloud auth print-identity-token` bearer header) hit `${URL}/api/health` and watch for `{"status":"ok"}`.
+3. Open the service URL in your browser to log into the temp instance once it's ready.
+
+## 9. Use it
+
+The temp instance has the same users, dashboards, and questions as prod at the moment of the export. You can log in with any prod user's credentials. Make whatever destructive changes you need — they are isolated to the temp instance.
+
+To exercise the **restore runbook** against this instance instead of prod, follow [`metabase-restore.md`](metabase-restore.md) substituting `metabase-restore-test` for the prod instance/service names.
+
+## 10. Tear down
+
+When the test is finished, remove all resources promptly to stop billing and avoid drift from the live IAM policy on `gs://calitp-backups-metabase`.
+
+### gcloud
+
+```bash
+gcloud run services delete "$INSTANCE" --region="$REGION" --project="$PROJECT" --quiet
+
+gcloud sql instances delete "$INSTANCE" --project="$PROJECT" --quiet
+
+gcloud storage buckets remove-iam-policy-binding gs://calitp-backups-metabase \
+  --member="serviceAccount:${TEMP_SA}" \
+  --role="roles/storage.objectViewer" \
+  --project=cal-itp-data-infra
+
+gsutil rm "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql"
+
+rm "/tmp/${INSTANCE}-postgres-pass"
+```
+
+### Console
+
+1. **Cloud Run** → `metabase-restore-test` → **Delete**.
+2. **Cloud SQL** → `metabase-restore-test` → **Delete**. (You may need to disable deletion protection first — see the **Edit** screen.)
+3. **GCS** → `calitp-backups-metabase` → **Permissions** tab → remove the temp instance's service account binding.
+4. **GCS** → `calitp-backups-metabase` → `exports/metabase-<date>.sql` → **Delete**.
+
+## Expected timeline
+
+Measured from the validation run on 2026-05-07 (prod metabase ~800 MB SQL export, db-g1-small temp Cloud SQL, db-g1-small Cloud Run with 1 vCPU / 2 GiB).
+
+| Phase                                      | Measured duration              |
+| ------------------------------------------ | ------------------------------ |
+| Export prod DB to GCS (step 1)             | ~56 s                          |
+| Create Cloud SQL instance (step 2)         | ~2:17                          |
+| Set password + create database (steps 3–4) | seconds each                   |
+| IAM grant for cross-project read (step 5)  | seconds                        |
+| Import (step 6)                            | ~56 s                          |
+| Cloud Run deploy (step 7)                  | ~45 s                          |
+| Metabase first-boot startup (step 8)       | **~25–50 minutes** — see below |
+| **Total wall-clock to ready instance**     | **~30–55 minutes**             |
+
+The "Metabase first-boot startup" range reflects three components, listed in their measured order of impact:
+
+1. **Driver feature checks against external databases**. Metabase tries to verify each configured external database (BigQuery, Payments DBs, etc.) by calling `supports?` on its driver, with a 5-second timeout per database. In a test instance these connections typically fail because the temp Cloud Run service does not have the BigQuery / Payments credentials or network reach that prod has. With a few hundred external databases configured (as in prod), this serializes into a many-minute stall — the dominant component of slow boot in the validation run.
+2. **Liquibase changelog reading + search index initialization**. Metabase logged "Metabase Initialization COMPLETE in 26.4 mins" on the first boot of the validation run. Liquibase reports "no unrun migrations" quickly when the source and target Metabase versions match; the bulk is search-index bootstrap and reading hundreds of changelog files.
+3. **Cloud Run cold-start churn**. Cloud Run's default request-driven CPU allocation can starve the JVM between probe requests, multiplying boot time. The validation run saw an additional ~20 min between successful deploy and JVM successfully reaching steady boot.
+
+If first-boot is consistently slow, deploy the temp service with `--cpu-boost` and/or `--no-cpu-throttling` to keep CPU allocated during boot — that addresses (3). Components (1) and (2) scale with the size of the application database and the number of external databases configured.
+
+Subsequent boots on the same instance after the data-restore loop is exercised do not re-run all of the above; expect ~1–2 min once the JVM warms.
+
+If you only need to inspect the application database state (counts, individual rows, reasoning about a regression) and don't need the Metabase web UI, a much faster path is to allowlist your IP on the temp Cloud SQL instance and connect with `psql` directly using the postgres password from step 3.

--- a/runbooks/workflow/metabase-test-instance-from-prod.md
+++ b/runbooks/workflow/metabase-test-instance-from-prod.md
@@ -16,7 +16,7 @@ For in-place disaster-recovery against the prod instance itself, see [`metabase-
 ## Prerequisites
 
 - `gcloud` CLI authenticated against both `cal-itp-data-infra` (prod, read-only for the export step) and `cal-itp-data-infra-staging` (write, for the temp resources).
-- The prod Metabase Cloud SQL service agent has `roles/storage.objectAdmin` on `gs://calitp-backups-metabase` (provisioned by [`iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf`](../../iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf)). Without this the export in step 1 fails.
+- The prod Metabase Cloud SQL service agent has `roles/storage.objectAdmin` on `gs://calitp-backups-metabase` (provisioned by [`iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf`](../../iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf)). Without this a manual export in step 1 fails; it is not needed when reusing a nightly dump.
 - The unified Metabase image is published at `ghcr.io/cal-itp/data-infra/metabase:staging` (built from [`services/metabase/Dockerfile`](../../services/metabase/Dockerfile)). It auto-creates the Cloud SQL Unix-socket symlink at runtime based on the `CLOUD_SQL_INSTANCE_CONNECTION_NAME` env var, so the same image works against any Cloud SQL instance.
 
 A throwaway temp instance like the one this runbook produces costs roughly **$2–5/day** (db-g1-small Cloud SQL + Cloud Run min=1) — tear it down promptly with the cleanup section.
@@ -32,15 +32,25 @@ export REGION=us-west2
 export CONNECTION_NAME="${PROJECT}:${REGION}:${INSTANCE}"
 ```
 
-## 1. Export prod database to GCS
+## 1. Pick a prod database dump
 
-Server-side `pg_dump` from the prod Cloud SQL instance into the existing backups bucket. Off-peak hours (early morning Pacific) are best — the export reads the live database.
+A scheduled workflow already exports the prod database nightly to `gs://calitp-backups-metabase/exports/metabase-<YYYY-MM-DD>.sql.gz` (see [`services/metabase/backup-gcs-export.md`](../../services/metabase/backup-gcs-export.md)). Reusing the latest nightly dump is preferred — it avoids an extra export against the live prod database. Set `DUMP_URI` and skip to step 2:
+
+```bash
+DUMP_URI=$(gcloud storage ls "gs://calitp-backups-metabase/exports/metabase-*.sql.gz" | tail -1)
+echo "$DUMP_URI"
+```
+
+(`gcloud sql import sql` in step 6 decompresses `.gz` transparently.)
+
+Take a manual export only if you need a snapshot fresher than last night's. Name it with an `-adhoc` suffix — the nightly `metabase-<YYYY-MM-DD>.sql.gz` objects are real prod backups and must not be touched by this runbook's cleanup. Off-peak hours (early morning Pacific) are best — the export reads the live database.
 
 ### gcloud
 
 ```bash
-gcloud sql export sql metabase \
-  "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql" \
+DUMP_URI="gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d)-adhoc.sql"
+
+gcloud sql export sql metabase "$DUMP_URI" \
   --database=metabase \
   --project=cal-itp-data-infra
 ```
@@ -51,7 +61,7 @@ gcloud sql export sql metabase \
 2. Click **Export** in the toolbar.
 3. **File format**: SQL.
 4. **Database for export**: `metabase`.
-5. **Storage path**: `calitp-backups-metabase/exports/metabase-<YYYY-MM-DD>.sql`.
+5. **Storage path**: `calitp-backups-metabase/exports/metabase-<YYYY-MM-DD>-adhoc.sql`.
 6. Click **Export** and wait for it to finish (status shows in the **Operations** tab).
 
 ## 2. Create the temp Cloud SQL instance
@@ -155,7 +165,7 @@ gcloud storage buckets add-iam-policy-binding gs://calitp-backups-metabase \
 
 ```bash
 gcloud sql import sql "$INSTANCE" \
-  "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql" \
+  "$DUMP_URI" \
   --database=metabase \
   --user=postgres \
   --project="$PROJECT" \
@@ -165,7 +175,7 @@ gcloud sql import sql "$INSTANCE" \
 ### Console
 
 1. From the temp instance page, click **Import** in the toolbar.
-2. **Source**: choose the SQL file in `gs://calitp-backups-metabase/exports/...`.
+2. **Source**: choose the dump picked in step 1 under `gs://calitp-backups-metabase/exports/...` (`.sql.gz` imports directly; no need to decompress).
 3. **File format**: SQL.
 4. **Database**: `metabase`.
 5. **User**: `postgres`.
@@ -241,7 +251,7 @@ echo "Ready: $URL"
 
 ## 9. Use it
 
-The temp instance has the same users, dashboards, and questions as prod at the moment of the export. You can log in with any prod user's credentials. Make whatever destructive changes you need — they are isolated to the temp instance.
+The temp instance has the same users, dashboards, and questions as prod at the moment the dump was taken. You can log in with any prod user's credentials. Make whatever destructive changes you need — they are isolated to the temp instance.
 
 To exercise the **restore runbook** against this instance instead of prod, follow [`metabase-restore.md`](metabase-restore.md) substituting `metabase-restore-test` for the prod instance/service names.
 
@@ -261,7 +271,10 @@ gcloud storage buckets remove-iam-policy-binding gs://calitp-backups-metabase \
   --role="roles/storage.objectViewer" \
   --project=cal-itp-data-infra
 
-gsutil rm "gs://calitp-backups-metabase/exports/metabase-$(date -u +%Y-%m-%d).sql"
+# Delete the dump only if you took a manual -adhoc export in step 1. The
+# nightly metabase-<YYYY-MM-DD>.sql.gz objects are real prod backups managed
+# by the scheduled workflow — never delete them here.
+if [[ "$DUMP_URI" == *-adhoc.sql ]]; then gcloud storage rm "$DUMP_URI"; fi
 
 rm "/tmp/${INSTANCE}-postgres-pass"
 ```
@@ -271,22 +284,22 @@ rm "/tmp/${INSTANCE}-postgres-pass"
 1. **Cloud Run** → `metabase-restore-test` → **Delete**.
 2. **Cloud SQL** → `metabase-restore-test` → **Delete**. (You may need to disable deletion protection first — see the **Edit** screen.)
 3. **GCS** → `calitp-backups-metabase` → **Permissions** tab → remove the temp instance's service account binding.
-4. **GCS** → `calitp-backups-metabase` → `exports/metabase-<date>.sql` → **Delete**.
+4. **GCS** → `calitp-backups-metabase` → `exports/metabase-<date>-adhoc.sql` → **Delete** — only if you took a manual export in step 1. Do **not** delete the nightly `metabase-<date>.sql.gz` objects; they are real prod backups.
 
 ## Expected timeline
 
 Measured from the validation run on 2026-05-07 (prod metabase ~800 MB SQL export, db-g1-small temp Cloud SQL, db-g1-small Cloud Run with 1 vCPU / 2 GiB).
 
-| Phase                                      | Measured duration              |
-| ------------------------------------------ | ------------------------------ |
-| Export prod DB to GCS (step 1)             | ~56 s                          |
-| Create Cloud SQL instance (step 2)         | ~2:17                          |
-| Set password + create database (steps 3–4) | seconds each                   |
-| IAM grant for cross-project read (step 5)  | seconds                        |
-| Import (step 6)                            | ~56 s                          |
-| Cloud Run deploy (step 7)                  | ~45 s                          |
-| Metabase first-boot startup (step 8)       | **~25–50 minutes** — see below |
-| **Total wall-clock to ready instance**     | **~30–55 minutes**             |
+| Phase                                                                  | Measured duration              |
+| ---------------------------------------------------------------------- | ------------------------------ |
+| Manual export of prod DB (step 1; skipped when reusing a nightly dump) | ~56 s                          |
+| Create Cloud SQL instance (step 2)                                     | ~2:17                          |
+| Set password + create database (steps 3–4)                             | seconds each                   |
+| IAM grant for cross-project read (step 5)                              | seconds                        |
+| Import (step 6)                                                        | ~56 s                          |
+| Cloud Run deploy (step 7)                                              | ~45 s                          |
+| Metabase first-boot startup (step 8)                                   | **~25–50 minutes** — see below |
+| **Total wall-clock to ready instance**                                 | **~30–55 minutes**             |
 
 The "Metabase first-boot startup" range reflects three components, listed in their measured order of impact:
 

--- a/services/metabase/Dockerfile
+++ b/services/metabase/Dockerfile
@@ -2,8 +2,6 @@ FROM metabase/metabase:v0.58.7
 
 RUN apk update && apk add --no-cache socat
 
-RUN ln -s /cloudsql/cal-itp-data-infra:us-west2:metabase/.s.PGSQL.5432 pg.sock
-
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/services/metabase/Dockerfile.staging
+++ b/services/metabase/Dockerfile.staging
@@ -1,9 +1,0 @@
-FROM metabase/metabase:v0.58.7
-
-RUN apk update && apk add --no-cache socat
-
-RUN ln -s /cloudsql/cal-itp-data-infra-staging:us-west2:metabase-staging/.s.PGSQL.5432 pg.sock
-
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-ENTRYPOINT ["/app/entrypoint.sh"]

--- a/services/metabase/README.md
+++ b/services/metabase/README.md
@@ -12,8 +12,10 @@ The service is deployed via Terraform in `iac/`:
 
 This directory holds the container build for the service:
 
-- [`Dockerfile.production`](./Dockerfile.production) / [`Dockerfile.staging`](./Dockerfile.staging) — image builds
-- [`entrypoint.sh`](./entrypoint.sh) — container entrypoint
+- [`Dockerfile`](./Dockerfile) — unified image build, tagged `:staging` and `:production`
+- [`entrypoint.sh`](./entrypoint.sh) — container entrypoint; resolves the Cloud SQL
+  Unix-socket symlink at runtime from `CLOUD_SQL_INSTANCE_CONNECTION_NAME` (or
+  auto-detects when a single instance is mounted at `/cloudsql/`)
 
 ## Backups
 

--- a/services/metabase/entrypoint.sh
+++ b/services/metabase/entrypoint.sh
@@ -1,7 +1,18 @@
-#! /bin/bash
+#!/bin/bash
+set -euo pipefail
 
-# Forward TCP:5432 to Cloud SQL Unix socket
-nohup socat -d -d TCP4-LISTEN:5432,fork UNIX-CONNECT:pg.sock &
+if [[ -z "${CLOUD_SQL_INSTANCE_CONNECTION_NAME:-}" ]]; then
+  detected=$(ls /cloudsql 2>/dev/null | head -1 || true)
+  if [[ -n "$detected" ]]; then
+    CLOUD_SQL_INSTANCE_CONNECTION_NAME="$detected"
+  else
+    echo "ERROR: CLOUD_SQL_INSTANCE_CONNECTION_NAME must be set, or a single Cloud SQL instance must be mounted at /cloudsql/" >&2
+    exit 1
+  fi
+fi
 
-# Runs Metabase
-/app/run_metabase.sh
+ln -sf "/cloudsql/${CLOUD_SQL_INSTANCE_CONNECTION_NAME}/.s.PGSQL.5432" /app/pg.sock
+
+nohup socat -d -d TCP4-LISTEN:5432,fork UNIX-CONNECT:/app/pg.sock &
+
+exec /app/run_metabase.sh


### PR DESCRIPTION
# Description

Takes over the still-applicable half of #5277. Chris Alfano's commits are cherry-picked with authorship preserved; two follow-up commits update the work for what has landed on `main` since his branch was created in May.

Refs #4864. Supersedes #5277.

**Carried over from #5277 (cherry-picked):**

- **`refactor(metabase)`** — unify `Dockerfile.production` / `Dockerfile.staging` into a single `Dockerfile`. The Cloud SQL Unix-socket symlink is now created at runtime by `entrypoint.sh` from `CLOUD_SQL_INSTANCE_CONNECTION_NAME` (auto-detected when exactly one instance is mounted at `/cloudsql/`, which covers the existing prod and staging services). The build workflow produces one image tagged both `:staging` and `:production`. This is what lets an operator deploy any Metabase instance from the same image — the capability the new runbook depends on. Existing services keep their pinned digests; the unified image is picked up at their next intentional redeploy.
- **`docs(runbooks)`** — add `metabase-test-instance-from-prod.md`: provision a disposable Metabase in `cal-itp-data-infra-staging` seeded with a prod dump, for upgrade rehearsal against real data, isolated investigation of prod data anomalies, and the periodic #4864 recovery exercise. Includes measured timings from the 2026-05-07 validation run.

**New in this PR:**

- **`docs(metabase)`** — update the runbook and `services/metabase/README.md` for post-May `main`: #5386 added nightly automated exports to the same `exports/` prefix the runbook's manual export used, so the runbook now prefers reusing the nightly `.sql.gz` dump, names manual exports `-adhoc`, and guards teardown so it can never delete a nightly backup. README's references to the split Dockerfiles (added by #5385 after #5277 branched) updated for the unified one.
- **`ci(metabase)`** — :warning: **behavior change**: publish the `:staging` / `:production` tags **only on push to `main`**; PRs build without publishing. Previously any same-repo PR touching metabase paths overwrote both mutable tags with unreviewed code — the old workflow's changed-files gates were tautologies (`!= '[]' || != ''` is always true), so the per-Dockerfile gating never actually gated. Live services pin digests at deploy time, but the restore runbook's reactivation step and test-instance deploys re-resolve the tags, so a redeploy after such a PR would ship the unreviewed image. This also fixes fork PRs failing at the push step on their read-only `GITHUB_TOKEN`. If anyone relies on PR-pushed tags, flag it here.

**Dropped relative to #5277:**

- The `feat(iac)` IAM grant — already landed via #5386 in the same form (and the likely source of #5277's merge conflicts).
- The `metabase-restore.md` rewrite — superseded by #5411, which covers the same in-place restore path plus restores from the GCS exports that #5385/#5386 added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## How has this been tested?

- The Dockerfile unification and the runbook were validated end-to-end in the 2026-05-07 exercise documented in #5277: the unified image was built and deployed against a temp Cloud SQL instance with `CLOUD_SQL_INSTANCE_CONNECTION_NAME` set explicitly; the runtime symlink + socat forwarding behaved correctly; timings are recorded in the runbook.
- Re-verified against current `main`: the unified Dockerfile's Metabase pin (`v0.58.7`) matches both split Dockerfiles it replaces; the runbook's `POSTGRES_18` / `db-g1-small` / Enterprise settings match prod's `sql.tf`; no repo references to the split Dockerfiles remain outside the files changed here.
- `mdformat` (repo pre-commit pin, with the gfm/frontmatter/footnote plugins) passes on the runbook.
- CI on this PR exercises the new publish gate: the workflow builds the image but does not push tags.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

- Close #5277 as superseded (this PR + #5386 + #5411 jointly cover its three parts).
- #4864 can be closed once this and #5411 have both landed.
- On the next intentional redeploy of the staging/prod Metabase services they pick up the unified image; the entrypoint auto-detect preserves current behavior per the #5277 validation.