### PR TITLE
remove staging composer2 bucket

### DIFF
--- a/iac/cal-itp-data-infra-staging/airflow/us/storage_bucket_object.tf
+++ b/iac/cal-itp-data-infra-staging/airflow/us/storage_bucket_object.tf
@@ -1,39 +1,3 @@
-resource "google_storage_bucket_object" "calitp-staging-composer" {
-  for_each = local.composer_files
-  name     = each.value
-  source   = "../../../../airflow/${each.value}"
-  bucket   = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-composer_id
-}
-
-resource "google_storage_bucket_object" "calitp-staging-composer-dags" {
-  for_each = local.warehouse_files
-  name     = "data/warehouse/${each.value}"
-  source   = "../../../../warehouse/${each.value}"
-  bucket   = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-composer_id
-}
-
-resource "google_storage_bucket_object" "calitp-staging-composer-manifest" {
-  name         = "data/warehouse/target/manifest.json"
-  content      = data.google_storage_bucket_object_content.calitp-staging-dbt-manifest.content
-  bucket       = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-composer_id
-  content_type = "application/json"
-}
-
-resource "google_storage_bucket_object" "calitp-staging-composer-catalog" {
-  name         = "data/warehouse/target/catalog.json"
-  content      = data.google_storage_bucket_object_content.calitp-staging-dbt-catalog.content
-  bucket       = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-composer_id
-  content_type = "application/json"
-}
-
-resource "google_storage_bucket_object" "calitp-staging-composer-index" {
-  name         = "data/warehouse/target/index.html"
-  content      = data.google_storage_bucket_object_content.calitp-staging-dbt-index.content
-  bucket       = data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-composer_id
-  content_type = "text/html; charset=utf-8"
-}
-
-# duplicate all above to calitp-staging-composer3 bucket
 resource "google_storage_bucket_object" "calitp-staging-composer3" {
   for_each = local.composer_files
   name     = each.value

--- a/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/outputs.tf
@@ -106,15 +106,6 @@ output "google_storage_bucket_calitp-staging-cal-bc_name" {
   value = google_storage_bucket.calitp-staging-cal-bc.name
 }
 
-output "google_storage_bucket_calitp-staging-composer_name" {
-  value = google_storage_bucket.calitp-staging-composer.name
-}
-
-output "google_storage_bucket_calitp-staging-composer_id" {
-  value = google_storage_bucket.calitp-staging-composer.id
-}
-
-# bucket for airflow managed by composer3
 output "google_storage_bucket_calitp-staging-composer3_name" {
   value = google_storage_bucket.calitp-staging-composer3.name
 }

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -122,22 +122,6 @@ resource "google_storage_bucket" "calitp-staging-cal-bc" {
   }
 }
 
-resource "google_storage_bucket" "calitp-staging-composer" {
-  default_event_based_hold    = "false"
-  force_destroy               = "true"
-  location                    = "US-WEST2"
-  name                        = "calitp-staging-composer"
-  project                     = "cal-itp-data-infra-staging"
-  public_access_prevention    = "inherited"
-  requester_pays              = "false"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = "true"
-
-  lifecycle {
-    ignore_changes = [labels]
-  }
-}
-
 # bucket for airflow managed by composer3
 resource "google_storage_bucket" "calitp-staging-composer3" {
   default_event_based_hold    = "false"

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_binding.tf
@@ -28,12 +28,6 @@ resource "google_storage_bucket_iam_binding" "tfer--calitp-staging-gcp-component
   role    = "roles/storage.legacyObjectReader"
 }
 
-resource "google_storage_bucket_iam_binding" "calitp-staging-composer-composer-service-account" {
-  bucket  = google_storage_bucket.calitp-staging-composer.name
-  members = ["projectEditor:cal-itp-data-infra-staging", "projectOwner:cal-itp-data-infra-staging", "serviceAccount:${data.terraform_remote_state.iam.outputs.google_service_account_composer-service-account_email}"]
-  role    = "roles/storage.legacyBucketOwner"
-}
-
 resource "google_storage_bucket_iam_binding" "calitp-staging-composer3-composer-service-account" {
   bucket  = google_storage_bucket.calitp-staging-composer3.name
   members = ["projectEditor:cal-itp-data-infra-staging", "projectOwner:cal-itp-data-infra-staging", "serviceAccount:${data.terraform_remote_state.iam.outputs.google_service_account_composer-service-account_email}"]

--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket_iam_member.tf
@@ -34,12 +34,6 @@ resource "google_storage_bucket_iam_member" "calitp-staging-dbt-docs" {
   role   = "roles/storage.objectViewer"
 }
 
-resource "google_storage_bucket_iam_member" "calitp-staging-composer" {
-  bucket = google_storage_bucket.calitp-staging-composer.name
-  member = "projectEditor:cal-itp-data-infra-staging"
-  role   = "roles/storage.legacyBucketOwner"
-}
-
 resource "google_storage_bucket_iam_member" "calitp-staging-composer3" {
   bucket = google_storage_bucket.calitp-staging-composer3.name
   member = "projectEditor:cal-itp-data-infra-staging"


### PR DESCRIPTION
# Description

Take down the bucket used by staging airflow composer 2. The bucket is not in use anymore.

Resolves #5409 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
