### PR TITLE
fix(ntd): refresh browser request headers

### DIFF
--- a/airflow/plugins/hooks/ntd_xlsx_hook.py
+++ b/airflow/plugins/hooks/ntd_xlsx_hook.py
@@ -4,17 +4,25 @@ from airflow.hooks.base import BaseHook
 from airflow.hooks.http_hook import HttpHook
 
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/149.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,image/apng,*/*;q=0.8,"
+        "application/signed-exchange;v=b3;q=0.7"
+    ),
     "Accept-Language": "en-US,en;q=0.9",
     "Connection": "keep-alive",
     "Upgrade-Insecure-Requests": "1",
-    "Sec-Ch-Ua": '"Not:A-Brand";v="99", "Google Chrome";v="145", "Chromium";v="145',
+    "Sec-Ch-Ua": '"Google Chrome";v="149", "Chromium";v="149", "Not_A Brand";v="24"',
     "Sec-Fetch-Dest": "document",
     "Sec-Fetch-Mode": "navigate",
     "Sec-Fetch-Site": "cross-site",
     "Sec-Fetch-User": "?1",
-    "Cache-Control": "max-age=0",
+    "Cache-Control": "no-cache",
 }
 
 


### PR DESCRIPTION
## Description

Fixes the `download_and_parse_ntd_xlsx` DAG failing with HTTP 403 when downloading the NTD Annual Database XLSX.

The DAG was working through the June 29 run and began failing on the July 6 run with:

```
403 Client Error: Forbidden
```

Investigation showed that the NTD website now rejects requests using the existing browser headers, while the same requests succeed with updated browser request headers. This is similar to the issue previously addressed in PR #4826.

This PR refreshes the request headers in `airflow/plugins/hooks/ntd_xlsx_hook.py` to match a current Chrome browser.

Resolves #5534 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- Verified that the previous headers returned HTTP 403.
- Verified with `curl` that the updated headers return HTTP 200 for both the NTD product page and the XLSX download.
- Tested successfully in the staging Airflow environment by running the `download_and_parse_ntd_xlsx` DAG.

## Post-merge follow-ups

- [ ] No action required
- [x] Re-run the failed `download_and_parse_ntd_xlsx` DAG in production.
