### PR TITLE
Fix NTD unnamed columns, add month-over-month change in monthly ridership

### DIFF
--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_summary_total.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_summary_total.sql
@@ -5,24 +5,22 @@ WITH staging_operating_and_capital_funding_time_series_summary_total AS (
 
 fct_operating_and_capital_funding_time_series_summary_total AS (
     SELECT
-        local_operating,
-        state_operating,
-        federal_operating,
-        other_operating,
-        national_operating,
-        year,
-        national_capital,
-        national_total,
-        federal_capital,
-        federal_total,
-        state_capital,
-        state_total,
-        local_capital,
-        local_total,
+        stg.year,
+        stg.national_operating,
+        stg.national_capital,
+        stg.national_total,
+        stg.federal_operating,
+        stg.federal_capital,
+        stg.federal_total,
+        stg.state_operating,
+        stg.state_capital,
+        stg.state_total,
+        stg.local_operating,
+        stg.local_capital,
+        stg.local_total,
+        stg.other_operating,
         stg.other_capital,
-        stg.other_total,
-
-
+        stg.other_total
 
     FROM staging_operating_and_capital_funding_time_series_summary_total AS stg
 )

--- a/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_summary_total.sql
+++ b/warehouse/models/mart/ntd_funding_and_expenses/fct_operating_and_capital_funding_time_series_summary_total.sql
@@ -5,24 +5,25 @@ WITH staging_operating_and_capital_funding_time_series_summary_total AS (
 
 fct_operating_and_capital_funding_time_series_summary_total AS (
     SELECT
-        stg.federal,
-        stg.state,
-        stg.local,
-        stg.other,
-        stg.national_total,
-        stg.unnamed__0,
-        stg.unnamed__2,
-        stg.unnamed__3,
-        stg.unnamed__5,
-        stg.unnamed__6,
-        stg.unnamed__8,
-        stg.unnamed__9,
-        stg.unnamed__11,
-        stg.unnamed__12,
-        stg.unnamed__14,
-        stg.unnamed__15,
-        stg.dt,
-        stg.execution_ts
+        local_operating,
+        state_operating,
+        federal_operating,
+        other_operating,
+        national_operating,
+        year,
+        national_capital,
+        national_total,
+        federal_capital,
+        federal_total,
+        state_capital,
+        state_total,
+        local_capital,
+        local_total,
+        stg.other_capital,
+        stg.other_total,
+
+
+
     FROM staging_operating_and_capital_funding_time_series_summary_total AS stg
 )
 

--- a/warehouse/models/mart/ntd_ridership/_mart_ntd_ridership.yml
+++ b/warehouse/models/mart/ntd_ridership/_mart_ntd_ridership.yml
@@ -59,33 +59,28 @@ models:
     columns:
       - name: key
         description: |
-          Surrogate key generated from ntd_id, mode, tos, period_month, and period_year.
+          Surrogate key generated from ntd_id, mode, type_of_service, month_first_day.
         data_tests:
           - not_null
           - unique
       - *ntd_id
       - *agency
-      - name: caltrans_district_current
-        description: |
-          Current Caltrans district number for the agency.
-      - name: caltrans_district_name_current
-        description: |
-          Current Caltrans district name for the agency.
       - name: date
         description: |
           The month (in Month-Year format) for which UPT, VRM, VRH and VOM was reported by the agency for the given Mode and TOS.
-      - name: period_month
+      - name: month_first_day
+        description: |
+          The first day of the month (in YYYY-MM-DD format) for which UPT, VRM, VRH and VOM was reported by the agency for the given Mode and TOS.
+      - name: month
         description: |
           The month portion extracted from the date field (MM format).
-      - name: period_year
+      - name: year
         description: |
           The year portion extracted from the date field (YYYY format).
-      - name: period_year_month
-        description: |
-          The year and month in YYYY-MM format extracted from the date field.
-      - *tos
+      - <<: *tos
+        name: type_of_service
       - *mode
-      - name: mode_name
+      - name: mode_full_name
         description: |
           Full name of the transit mode (e.g., "Bus" for mode "MB").
       - name: service_type

--- a/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates.sql
+++ b/warehouse/models/mart/ntd_ridership/fct_complete_monthly_ridership_with_adjustments_and_estimates.sql
@@ -36,10 +36,19 @@ fct_complete_monthly_ridership_with_adjustments_and_estimates AS (
         stg.mode_type_of_service_status,
         stg.vrh,
 
-        LAG(upt) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day) AS upt_prior_year_month,
-            upt - LAG(upt) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day) AS upt_change_1yr,
+        -- month-over-month change, change against prior month
+        LAG(upt, 1) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day) AS upt_prior_month,
+        upt - LAG(upt, 1) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day) AS upt_change_1mo,
         ROUND(SAFE_DIVIDE(
-            (upt - LAG(upt) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day)),
+            (upt - LAG(upt, 1) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day)),
+            LAG(upt) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day)
+        ), 4) AS upt_pct_change_1mo,
+
+        -- month-over-month change, change against last year-same month (Jan 2026 against Jan 2025)
+        LAG(upt, 12) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day) AS upt_prior_year, -- 12 months ago
+        upt - LAG(upt, 12) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day) AS upt_change_1yr,
+        ROUND(SAFE_DIVIDE(
+            (upt - LAG(upt, 12) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day)),
             LAG(upt) OVER (PARTITION BY ntd_id, mode, type_of_service ORDER BY month_first_day)
         ), 4) AS upt_pct_change_1yr,
 

--- a/warehouse/models/staging/ntd_funding_and_expenses/stg_ntd__operating_and_capital_funding_time_series__summary_total.sql
+++ b/warehouse/models/staging/ntd_funding_and_expenses/stg_ntd__operating_and_capital_funding_time_series__summary_total.sql
@@ -12,22 +12,24 @@ get_latest_extract AS(
 
 stg_ntd__operating_and_capital_funding_time_series__summary_total AS (
     SELECT
-        {{ trim_make_empty_string_null('local') }} AS local,
-        {{ trim_make_empty_string_null('state') }} AS state,
-        {{ trim_make_empty_string_null('federal') }} AS federal,
-        {{ trim_make_empty_string_null('other') }} AS other,
-        {{ trim_make_empty_string_null('national_total') }} AS national_total,
-        {{ trim_make_empty_string_null('unnamed__0') }} AS unnamed__0,
-        {{ trim_make_empty_string_null('unnamed__2') }} AS unnamed__2,
-        {{ trim_make_empty_string_null('unnamed__3') }} AS unnamed__3,
-        {{ trim_make_empty_string_null('unnamed__5') }} AS unnamed__5,
-        {{ trim_make_empty_string_null('unnamed__6') }} AS unnamed__6,
-        {{ trim_make_empty_string_null('unnamed__8') }} AS unnamed__8,
-        {{ trim_make_empty_string_null('unnamed__9') }} AS unnamed__9,
-        {{ trim_make_empty_string_null('unnamed__11') }} AS unnamed__11,
-        {{ trim_make_empty_string_null('unnamed__12') }} AS unnamed__12,
-        {{ trim_make_empty_string_null('unnamed__14') }} AS unnamed__14,
-        {{ trim_make_empty_string_null('unnamed__15') }} AS unnamed__15,
+        -- Excel merged cells created unnamed columns, use visual inspection to match columns
+        -- columns are operating total, capital total, grand total within each funding type
+        {{ trim_make_empty_string_null('local') }} AS local_operating,
+        {{ trim_make_empty_string_null('state') }} AS state_operating,
+        {{ trim_make_empty_string_null('federal') }} AS federal_operating,
+        {{ trim_make_empty_string_null('other') }} AS other_operating,
+        {{ trim_make_empty_string_null('national_total') }} AS national_operating,
+        {{ trim_make_empty_string_null('unnamed__0') }} AS year,
+        {{ trim_make_empty_string_null('unnamed__2') }} AS national_capital,
+        {{ trim_make_empty_string_null('unnamed__3') }} AS national_total,
+        {{ trim_make_empty_string_null('unnamed__5') }} AS federal_capital,
+        {{ trim_make_empty_string_null('unnamed__6') }} AS federal_total,
+        {{ trim_make_empty_string_null('unnamed__8') }} AS state_capital,
+        {{ trim_make_empty_string_null('unnamed__9') }} AS state_total,
+        {{ trim_make_empty_string_null('unnamed__11') }} AS local_capital,
+        {{ trim_make_empty_string_null('unnamed__12') }} AS local_total,
+        {{ trim_make_empty_string_null('unnamed__14') }} AS other_capital,
+        {{ trim_make_empty_string_null('unnamed__15') }} AS other_total,
         dt,
         execution_ts
     FROM get_latest_extract

--- a/warehouse/models/staging/ntd_ridership/_stg_ntd_ridership.yml
+++ b/warehouse/models/staging/ntd_ridership/_stg_ntd_ridership.yml
@@ -130,16 +130,17 @@ models:
       - name: date
         description: |
           The month (in Month-Year format) for which UPT, VRM, VRH and VOM was reported by the agency for the given Mode and TOS.
-      - name: period_month
+      - name: month_first_day
+        description: |
+          The first day of the month (in YYYY-MM-DD format) for which UPT, VRM, VRH and VOM was reported by the agency for the given Mode and TOS.
+      - name: month
         description: |
           The month portion extracted from the date field (MM format).
-      - name: period_year
+      - name: year
         description: |
           The year portion extracted from the date field (YYYY format).
-      - name: period_year_month
-        description: |
-          The year and month in YYYY-MM format extracted from the date field.
-      - *tos
+      - <<: *tos
+        name: type_of_service
       - *mode
       - name: agency_mode_tos_date
         description: |


### PR DESCRIPTION
# Description

* Missed one more table in `mart_ntd_funding_and_expenses` to change -- lots of unnamed columns in `stg` and `fct` due to Excel's merged cells. 
   * `stg_ntd__operating_and_capital_funding_time_series__summary_total`
   *  `fct_operating_and_capital_funding_time_series_summary_total` 
   * https://www.transit.dot.gov/ntd/data-product/ts12-operating-funding-time-series-3 - visually inspect using `Summary Total` sheet
* Visually inspect values and match up the columns
* For `mart_ntd_ridership`, have 2 sets of change columns
   * compared to prior month
   * compared to prior year (Jan 2025 compared to Jan 2026)
* Follow-up to #5523
* Resolves https://github.com/cal-itp/data-infra/issues/5522


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation - remove columns not needed in YAML

## How has this been tested?

* `uv run dbt run -s -s fct_complete_monthly_ridership_with_adjustments_and_estimates`

```
17:20:25  1 of 1 START sql table model tiffany_mart_ntd_ridership.fct_complete_monthly_ridership_with_adjustments_and_estimates  [RUN]
17:20:34  1 of 1 OK created sql table model tiffany_mart_ntd_ridership.fct_complete_monthly_ridership_with_adjustments_and_estimates  [CREATE TABLE (368.0k rows, 1.5 GiB processed) in 9.04s]
17:20:35  Finished running 1 table model in 0 hours 0 minutes and 24.81 seconds (24.81s).
17:20:36  Completed successfully
```
* `uv run dbt run -s stg_ntd__operating_and_capital_funding_time_series__summary_total` (view)
* `uv run dbt run -s -s fct_operating_and_capital_funding_time_series_summary_total`

## Post-merge follow-ups

- [x] No action required

