### PR TITLE
Lowers jupyterhub-users node floor 6 to 3

### DIFF
--- a/iac/cal-itp-data-infra/gke/us/container_node_pool.tf
+++ b/iac/cal-itp-data-infra/gke/us/container_node_pool.tf
@@ -67,7 +67,7 @@ resource "google_container_node_pool" "tfer--data-infra-apps_jupyterhub-users" {
     max_node_count       = "0"
     min_node_count       = "0"
     total_max_node_count = "12"
-    total_min_node_count = "6"
+    total_min_node_count = "3"
   }
 
   cluster            = google_container_cluster.tfer--data-infra-apps.name

--- a/kubernetes/apps/charts/jupyterhub/values.yaml
+++ b/kubernetes/apps/charts/jupyterhub/values.yaml
@@ -69,6 +69,13 @@ jupyterhub:
     userPods:
       nodeAffinity:
         matchNodePurpose: require
+  cull:
+    # Reclaim idle notebooks so their nodes can drain (chart default is 1h).
+    # 3h keeps a kernel alive over lunch / a long meeting while still freeing
+    # abandoned notebooks the same day. Works with the jupyterhub-users floor.
+    enabled: true
+    timeout: 10800   # 3h idle (chart default: 3600 = 1h)
+    every: 600       # check every 10m (chart default)
   hub:
     db:
       pvc:


### PR DESCRIPTION
# Description

Lowers the `jupyterhub-users` node-pool floor from 6 to 3 and sets an explicit 3h idle cull for JupyterHub.

The pool sat at a 6-node floor while measured usage is low (peak 6, zero on weekends), so the floor was 2–3× over-provisioned. Dropping it to 3 keeps headroom, is reversible, and evicts no running notebooks — the autoscaler just stops holding empty nodes. The 3h cull (up from the chart default of 1h) is what empties an idle notebook's node so the autoscaler can reclaim it, while still being long enough not to kill a kernel over lunch or a long meeting.

The floor change applies via `terraform-apply.yml` (same pipeline as #5332, which scaled the other pools' floors); the cull change deploys via `deploy-kubernetes.yml`.

Works toward #3713.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- Not tested, will test with terraform and watch

## Post-merge follow-ups

- [x] Actions required (specified below)

- Floor change auto-applies on merge via `terraform-apply.yml`; cull auto-deploys via `deploy-kubernetes.yml` — no manual action.
- Separate, out of scope here: right-size the `apps-v2` control-plane pool (3× n1-standard-4, near-empty), gated on removing the orphaned Elavon SFTP pod (#5035) which currently pins a node against scale-down.
- Optional: cluster `OPTIMIZE_UTILIZATION` autoscaling profile (cluster-wide) to reclaim emptied nodes faster.
