### PR TITLE
fix(metabase): opt out RCE signature 932200 (dashboard filter-name fa…

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -41,7 +41,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP RCE"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id932200-rce']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -41,7 +41,7 @@ resource "google_compute_security_policy" "metabase" {
     description = "OWASP RCE"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('rce-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
+        expression = "evaluatePreconfiguredWaf('rce-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id932200-rce']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }


### PR DESCRIPTION
# Description

Part of #5482.

A valid user on the Caltrans VPN got a `403` loading a Metabase dashboard, blocked by RCE rule 1200 / signature `owasp-crs-v030301-id932200-rce`.

**Cause:** Metabase filter names with parentheses — e.g. "Payment Date (Elavon)" — appear in the URL as `…?payment_date_%28elavon%29=…`. CRS `932200` treats `(` / `)` as shell metacharacters, so any dashboard/question with parenthesized filters is flagged. It's URL-based, not browser-specific (Firefox just had the filtered URL loaded).

**Fix:** opt out `932200` on rule 1200 in staging and prod — same pattern as the existing `942420` / `921170` / `913101` opt-outs. The rest of the RCE ruleset stays enforcing.

**Tradeoff:** `932200` also catches scanner RCE probes (Log4Shell `${jndi:…}` etc.). Accepted — it was blocking real users, the other RCE signatures (`932100/932130/932160`) still enforce, and current Metabase isn't exploitable by those payloads anyway.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Reproduced from the enforced denial (`403`, rule 1200 / `932200`, `GET /dashboard/287-…?payment_date_%28elavon%29=…` from Caltrans IP `149.136.17.248`). With `932200` opted out the request is allowed; other RCE signatures still fire on scanner probes. `terraform plan` shows only the rule-1200 change per workspace.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Confirm the affected user (and parenthesized-filter dashboards generally) load without a `403`.