### PR TITLE
fix(metabase): opt out XSS signature 941340 (cookie/header false posi…

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -30,7 +30,7 @@ resource "google_compute_security_policy" "metabase-staging" {
     description = "OWASP XSS"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id941340-xss']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -30,7 +30,7 @@ resource "google_compute_security_policy" "metabase" {
     description = "OWASP XSS"
     match {
       expr {
-        expression = "evaluatePreconfiguredWaf('xss-v33-stable') && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
+        expression = "evaluatePreconfiguredWaf('xss-v33-stable', {'sensitivity': 1, 'opt_out_rule_ids': ['owasp-crs-v030301-id941340-xss']}) && !request.path.startsWith('/api/dataset') && !request.path.startsWith('/api/card') && !request.path.startsWith('/api/dashboard')"
       }
     }
   }


### PR DESCRIPTION
# Description

Part of #5482.

A Caltrans user (`149.136.17.253`, in-allowlist, Firefox) was denied on `GET /` — the bare homepage, no query string — by signature `941340`. With no URL payload, the signature is matching the request's cookies/headers (4425-byte request), the same failure mode as the `942420` cookie-SQLi opt-out on rule 1000.

This opts out `owasp-crs-v030301-id941340-xss` on rule 1100 in both staging and prod. It aligns rule 1100 with the sensitivity-1 + opt-out convention already used on rules 1000/1200/1500/1600 (net effect is strictly *less* aggressive, so it can't introduce a new false positive), and the `/api/dataset|card|dashboard` content-path exemptions are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- Root cause confirmed from the LB request log: `enforcedSecurityPolicy` priority `1100`, signature `owasp-crs-v030301-id941340-xss`, `outcome=DENY`, `GET https://metabase.dds.dot.ca.gov/`, status 403, from in-allowlist Caltrans IP `149.136.17.253`.
- `terraform fmt` clean on both changed directories; the dflook plan on this PR shows a single in-place update to each security policy (rule 1100 expression only).
- Post-apply verification: the previously-denied `GET /` from the Caltrans range returns 200.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)