### PR TITLE
Publish TIDES reference data in the TIDES bucket

### DIFF
--- a/airflow/dags/create_external_tables/tides/reference_outcomes.yml
+++ b/airflow/dags/create_external_tables/tides/reference_outcomes.yml
@@ -1,0 +1,20 @@
+operator: operators.ExternalTable
+bucket: "{{ env_var('CALITP_BUCKET__TIDES') }}"
+source_objects:
+  - "reference_outcomes/*.jsonl"
+destination_project_dataset_table: "external_tides.reference_outcomes"
+source_format: NEWLINE_DELIMITED_JSON
+use_bq_client: true
+hive_options:
+  mode: CUSTOM
+  require_partition_filter: false
+  source_uri_prefix: "reference_outcomes/{dt:DATE}/{ts:TIMESTAMP}"
+schema_fields:
+  - name: dataset_name
+    type: STRING
+  - name: table_name
+    type: STRING
+  - name: destination_parquet_path
+    type: STRING
+  - name: destination_csv_path
+    type: STRING

--- a/airflow/dags/publish_tides_reference.py
+++ b/airflow/dags/publish_tides_reference.py
@@ -1,0 +1,77 @@
+import os
+from datetime import datetime, timedelta
+
+from dags import email_on_failure, log_failure_to_slack
+from operators.dbt_manifest_to_models_operator import DBTManifestToModelsOperator
+from operators.tides_reference_export_operator import TIDESReferenceExportOperator
+
+from airflow.decorators import dag
+from airflow.operators.latest_only import LatestOnlyOperator
+
+
+@dag(
+    # Every Monday at 4pm Pacific (midnight UTC Tuesday), after the dbt_all
+    # runs -- same cadence as publish_gtfs
+    schedule="0 0 * * 2",
+    start_date=datetime(2026, 7, 16),
+    catchup=False,
+    tags=["tides", "open-data"],
+    default_args={
+        "email": os.getenv("CALITP_NOTIFY_EMAIL"),
+        "email_on_failure": email_on_failure(),
+        "email_on_retry": False,
+        "on_failure_callback": log_failure_to_slack,
+    },
+)
+def publish_tides_reference():
+    """Publishes the TIDES reference tables to the TIDES bucket.
+
+    The tables that resolve the opaque IDs on the published TIDES facts
+    (organizations, provider_gtfs_data, gtfs_datasets, services, agency) are
+    modeled as dbt models tagged `tides_reference` (warehouse/models/mart/
+    tides). This DAG discovers the tagged models from the dbt manifest and
+    exports each one in full to the TIDES bucket as parquet + CSV:
+
+      * *_latest models  -> reference/<model>/ (stable path, overwritten)
+      * history models   -> reference/<model>/dt=<run date>/
+    """
+    latest_only = LatestOnlyOperator(task_id="latest_only", depends_on_past=False)
+
+    reference_models = DBTManifestToModelsOperator(
+        task_id="list_reference_models",
+        bucket_name=os.getenv("CALITP_BUCKET__DBT_DOCS"),
+        object_name="manifest.json",
+        tag="tides_reference",
+    )
+
+    def create_export_kwargs(model):
+        if model["name"].endswith("_latest"):
+            destination_path_prefix = os.path.join("reference", model["name"]) + "/"
+        else:
+            destination_path_prefix = (
+                os.path.join("reference", model["name"], "dt={{ ds }}") + "/"
+            )
+        return {
+            "dataset_name": model["schema"],
+            "table_name": model["name"],
+            "destination_path_prefix": destination_path_prefix,
+            "report_path": (
+                "reference_outcomes/dt={{ ds }}/ts={{ ts }}/"
+                f"{model['name']}_outcomes.jsonl"
+            ),
+        }
+
+    export_reference_models = TIDESReferenceExportOperator.partial(
+        task_id="export_reference_models",
+        retries=1,
+        retry_delay=timedelta(seconds=10),
+        ts="{{ ts }}",
+        destination_bucket=os.environ.get("CALITP_BUCKET__TIDES"),
+        user_project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+        map_index_template="{{ task.table_name }}",
+    ).expand_kwargs(reference_models.output.map(create_export_kwargs))
+
+    latest_only >> reference_models >> export_reference_models
+
+
+publish_tides_reference = publish_tides_reference()

--- a/airflow/dags/publish_tides_reference.py
+++ b/airflow/dags/publish_tides_reference.py
@@ -3,7 +3,14 @@ from datetime import datetime, timedelta
 
 from dags import email_on_failure, log_failure_to_slack
 from operators.dbt_manifest_to_models_operator import DBTManifestToModelsOperator
-from operators.tides_reference_export_operator import TIDESReferenceExportOperator
+from operators.tides_dcat_metadata_operator import TIDESDCATMetadataOperator
+from operators.tides_frictionless_metadata_operator import (
+    TIDESFrictionlessMetadataOperator,
+)
+from operators.tides_reference_export_operator import (
+    TIDESReferenceExportOperator,
+    reference_destination_prefix,
+)
 
 from airflow.decorators import dag
 from airflow.operators.latest_only import LatestOnlyOperator
@@ -34,6 +41,10 @@ def publish_tides_reference():
 
       * *_latest models  -> reference/<model>/ (stable path, overwritten)
       * history models   -> reference/<model>/dt=<run date>/
+
+    Machine-readable metadata (SAM 5160.1) is published in the same run: a
+    Frictionless datapackage.json next to each exported table, and a DCAT-US
+    data.json catalog covering the reference tables plus the fact tables.
     """
     latest_only = LatestOnlyOperator(task_id="latest_only", depends_on_past=False)
 
@@ -45,16 +56,12 @@ def publish_tides_reference():
     )
 
     def create_export_kwargs(model):
-        if model["name"].endswith("_latest"):
-            destination_path_prefix = os.path.join("reference", model["name"]) + "/"
-        else:
-            destination_path_prefix = (
-                os.path.join("reference", model["name"], "dt={{ ds }}") + "/"
-            )
         return {
             "dataset_name": model["schema"],
             "table_name": model["name"],
-            "destination_path_prefix": destination_path_prefix,
+            "destination_path_prefix": reference_destination_prefix(
+                model["name"], "{{ ds }}"
+            ),
             "report_path": (
                 "reference_outcomes/dt={{ ds }}/ts={{ ts }}/"
                 f"{model['name']}_outcomes.jsonl"
@@ -71,7 +78,49 @@ def publish_tides_reference():
         map_index_template="{{ task.table_name }}",
     ).expand_kwargs(reference_models.output.map(create_export_kwargs))
 
-    latest_only >> reference_models >> export_reference_models
+    def create_datapackage_kwargs(model):
+        return {
+            "model_name": model["name"],
+            "destination_path_prefix": reference_destination_prefix(
+                model["name"], "{{ ds }}"
+            ),
+        }
+
+    write_datapackages = TIDESFrictionlessMetadataOperator.partial(
+        task_id="write_datapackages",
+        retries=1,
+        retry_delay=timedelta(seconds=10),
+        bucket_name=os.getenv("CALITP_BUCKET__DBT_DOCS"),
+        destination_bucket=os.environ.get("CALITP_BUCKET__TIDES"),
+        user_project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+        map_index_template="{{ task.model_name }}",
+    ).expand_kwargs(reference_models.output.map(create_datapackage_kwargs))
+
+    write_dcat_catalog = TIDESDCATMetadataOperator(
+        task_id="write_dcat_catalog",
+        retries=1,
+        retry_delay=timedelta(seconds=10),
+        bucket_name=os.getenv("CALITP_BUCKET__DBT_DOCS"),
+        models=reference_models.output,
+        extra_datasets=[
+            {
+                "model_name": "fct_tides_vehicle_locations",
+                "prefix": "vehicle_locations/",
+                "formats": ["parquet"],
+            },
+            {
+                "model_name": "fct_tides_trips_performed",
+                "prefix": "trips_performed/",
+                "formats": ["parquet"],
+            },
+        ],
+        destination_bucket=os.environ.get("CALITP_BUCKET__TIDES"),
+        user_project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+    )
+
+    latest_only >> reference_models
+    export_reference_models >> write_datapackages
+    export_reference_models >> write_dcat_catalog
 
 
 publish_tides_reference = publish_tides_reference()

--- a/airflow/plugins/operators/dbt_manifest_to_models_operator.py
+++ b/airflow/plugins/operators/dbt_manifest_to_models_operator.py
@@ -1,0 +1,63 @@
+import json
+from typing import Sequence
+
+from airflow.models import BaseOperator
+from airflow.models.taskinstance import Context
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+
+class DBTManifestToModelsOperator(BaseOperator):
+    """Lists the dbt models carrying a given tag, straight from manifest.json.
+
+    Returns one dict per tagged model: {"name": ..., "schema": ...}. Used by
+    export DAGs that are tag-driven (e.g. tides_reference) instead of parsing
+    a dbt exposure.
+    """
+
+    template_fields: Sequence[str] = (
+        "bucket_name",
+        "object_name",
+        "tag",
+        "gcp_conn_id",
+    )
+
+    def __init__(
+        self,
+        bucket_name: str,
+        object_name: str,
+        tag: str,
+        gcp_conn_id: str = "google_cloud_default",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.bucket_name = bucket_name
+        self.object_name = object_name
+        self.tag = tag
+        self.gcp_conn_id = gcp_conn_id
+
+    def gcs_hook(self) -> GCSHook:
+        return GCSHook(gcp_conn_id=self.gcp_conn_id)
+
+    def read_manifest(self) -> dict:
+        manifest = self.gcs_hook().download(
+            bucket_name=self.bucket_name.replace("gs://", ""),
+            object_name=self.object_name,
+        )
+        return json.loads(manifest)
+
+    def models(self) -> list[dict]:
+        return sorted(
+            (
+                {"name": node["name"], "schema": node["schema"]}
+                for node in self.read_manifest().get("nodes", {}).values()
+                if node.get("resource_type") == "model"
+                and self.tag in (node.get("tags") or [])
+            ),
+            key=lambda model: model["name"],
+        )
+
+    def execute(self, context: Context) -> list[dict]:
+        models = self.models()
+        self.log.info("found %d models tagged %s", len(models), self.tag)
+        return models

--- a/airflow/plugins/operators/tides_dcat_metadata_operator.py
+++ b/airflow/plugins/operators/tides_dcat_metadata_operator.py
@@ -1,0 +1,154 @@
+import json
+import os
+from typing import Sequence
+
+from operators.tides_reference_export_operator import reference_destination_prefix
+
+from airflow.models import BaseOperator
+from airflow.models.taskinstance import Context
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+MEDIA_TYPES = {
+    "parquet": "application/vnd.apache.parquet",
+    "csv": "text/csv",
+}
+
+
+class TIDESDCATMetadataOperator(BaseOperator):
+    """Writes a DCAT-US data.json catalog for the published TIDES datasets.
+
+    One dcat:Dataset entry per published table -- the tides_reference models
+    passed in via XCom plus the fact tables passed as extra_datasets --
+    matching the machine-readable metadata format data.ca.gov publishes
+    (Project Open Data v1.1 / SAM 5160.1). Titles and descriptions come from
+    manifest.json.
+    """
+
+    template_fields: Sequence[str] = (
+        "bucket_name",
+        "manifest_object_name",
+        "models",
+        "extra_datasets",
+        "destination_bucket",
+        "destination_object_name",
+        "modified",
+        "user_project",
+        "gcp_conn_id",
+    )
+
+    def __init__(
+        self,
+        bucket_name: str,
+        models: list[dict],
+        destination_bucket: str,
+        user_project: str,
+        extra_datasets: list[dict] = None,
+        destination_object_name: str = "metadata/data.json",
+        manifest_object_name: str = "manifest.json",
+        modified: str = "{{ ds }}",
+        gcp_conn_id: str = "google_cloud_default",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self._gcs_hook: GCSHook = None
+        self.bucket_name = bucket_name
+        self.models = models
+        self.destination_bucket = destination_bucket
+        self.user_project = user_project
+        self.extra_datasets = extra_datasets or []
+        self.destination_object_name = destination_object_name
+        self.manifest_object_name = manifest_object_name
+        self.modified = modified
+        self.gcp_conn_id = gcp_conn_id
+
+    def gcs_hook(self) -> GCSHook:
+        if self._gcs_hook is None:
+            self._gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
+        return self._gcs_hook
+
+    def destination_name(self) -> str:
+        return self.destination_bucket.replace("gs://", "")
+
+    def read_manifest(self) -> dict:
+        return json.loads(
+            self.gcs_hook().download(
+                bucket_name=self.bucket_name.replace("gs://", ""),
+                object_name=self.manifest_object_name,
+            )
+        )
+
+    def dataset_specs(self) -> list[dict]:
+        specs = [
+            {
+                "model_name": model["name"],
+                "prefix": reference_destination_prefix(model["name"], "*"),
+                "formats": ["parquet", "csv"],
+            }
+            for model in self.models
+        ]
+        specs.extend(self.extra_datasets)
+        return specs
+
+    def dataset_entry(self, spec: dict, manifest_nodes: dict) -> dict:
+        node = manifest_nodes.get(f"model.calitp_warehouse.{spec['model_name']}", {})
+        access_url = os.path.join(self.destination_bucket, spec["prefix"])
+        return {
+            "@type": "dcat:Dataset",
+            "identifier": access_url,
+            "title": spec["model_name"],
+            "description": node.get("description", ""),
+            "keyword": ["transit", "TIDES", "GTFS", "California"],
+            "modified": self.modified,
+            "publisher": {"@type": "org:Organization", "name": "Caltrans"},
+            "contactPoint": {
+                "@type": "vcard:Contact",
+                "fn": "Cal-ITP / Caltrans Data & Digital Services",
+                "hasEmail": "mailto:hello@calitp.org",
+            },
+            "accessLevel": "public",
+            "license": "https://creativecommons.org/licenses/by/4.0/",
+            "rights": (
+                "Requester-pays Google Cloud Storage bucket; downloads are "
+                "billed to the requester's GCP project."
+            ),
+            "distribution": [
+                {
+                    "@type": "dcat:Distribution",
+                    "format": extension,
+                    "mediaType": MEDIA_TYPES[extension],
+                    "accessURL": access_url,
+                }
+                for extension in spec["formats"]
+            ],
+        }
+
+    def catalog(self) -> dict:
+        manifest_nodes = self.read_manifest().get("nodes", {})
+        return {
+            "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+            "@type": "dcat:Catalog",
+            "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+            "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+            "dataset": [
+                self.dataset_entry(spec, manifest_nodes)
+                for spec in self.dataset_specs()
+            ],
+        }
+
+    def execute(self, context: Context) -> dict:
+        catalog = self.catalog()
+
+        self.gcs_hook().upload(
+            bucket_name=self.destination_name(),
+            object_name=self.destination_object_name,
+            data=json.dumps(catalog, indent=2),
+            mime_type="application/json",
+            gzip=False,
+            user_project=self.user_project,
+        )
+
+        return {
+            "destination_path": self.destination_object_name,
+            "dataset_count": len(catalog["dataset"]),
+        }

--- a/airflow/plugins/operators/tides_frictionless_metadata_operator.py
+++ b/airflow/plugins/operators/tides_frictionless_metadata_operator.py
@@ -1,0 +1,171 @@
+import json
+import os
+from typing import Sequence
+
+from airflow.models import BaseOperator
+from airflow.models.taskinstance import Context
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+# BigQuery -> Frictionless Table Schema types
+# (https://specs.frictionlessdata.io/table-schema/)
+FRICTIONLESS_TYPES = {
+    "STRING": "string",
+    "BYTES": "string",
+    "INT64": "integer",
+    "INTEGER": "integer",
+    "FLOAT64": "number",
+    "FLOAT": "number",
+    "NUMERIC": "number",
+    "BIGNUMERIC": "number",
+    "BOOL": "boolean",
+    "BOOLEAN": "boolean",
+    "TIMESTAMP": "datetime",
+    "DATETIME": "datetime",
+    "DATE": "date",
+    "TIME": "time",
+    "GEOGRAPHY": "string",
+}
+
+
+class TIDESFrictionlessMetadataOperator(BaseOperator):
+    """Writes a Frictionless datapackage.json next to an exported table.
+
+    The machine-readable data dictionary for one published TIDES reference
+    table (SAM 5160.1): field names and types from the dbt catalog.json,
+    field and table descriptions from manifest.json -- so the column docs in
+    _mart_tides_reference.yml are the single source of the dictionary. The
+    package's resources are the actual exported data files under the table's
+    bucket prefix.
+    """
+
+    template_fields: Sequence[str] = (
+        "bucket_name",
+        "manifest_object_name",
+        "catalog_object_name",
+        "model_name",
+        "destination_bucket",
+        "destination_path_prefix",
+        "user_project",
+        "gcp_conn_id",
+    )
+
+    def __init__(
+        self,
+        bucket_name: str,
+        model_name: str,
+        destination_bucket: str,
+        destination_path_prefix: str,
+        user_project: str,
+        manifest_object_name: str = "manifest.json",
+        catalog_object_name: str = "catalog.json",
+        gcp_conn_id: str = "google_cloud_default",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self._gcs_hook: GCSHook = None
+        self.bucket_name = bucket_name
+        self.model_name = model_name
+        self.destination_bucket = destination_bucket
+        self.destination_path_prefix = destination_path_prefix
+        self.user_project = user_project
+        self.manifest_object_name = manifest_object_name
+        self.catalog_object_name = catalog_object_name
+        self.gcp_conn_id = gcp_conn_id
+
+    def gcs_hook(self) -> GCSHook:
+        if self._gcs_hook is None:
+            self._gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
+        return self._gcs_hook
+
+    def destination_name(self) -> str:
+        return self.destination_bucket.replace("gs://", "")
+
+    def read_json(self, object_name: str) -> dict:
+        return json.loads(
+            self.gcs_hook().download(
+                bucket_name=self.bucket_name.replace("gs://", ""),
+                object_name=object_name,
+            )
+        )
+
+    def node_key(self) -> str:
+        return f"model.calitp_warehouse.{self.model_name}"
+
+    def manifest_node(self) -> dict:
+        return self.read_json(self.manifest_object_name)["nodes"][self.node_key()]
+
+    def catalog_node(self) -> dict:
+        return self.read_json(self.catalog_object_name)["nodes"][self.node_key()]
+
+    def fields(self) -> list[dict]:
+        manifest_columns = self.manifest_node().get("columns", {})
+        catalog_columns = self.catalog_node().get("columns", {})
+        fields = []
+        for name, column in sorted(
+            catalog_columns.items(), key=lambda item: item[1]["index"]
+        ):
+            field = {
+                "name": name,
+                "type": FRICTIONLESS_TYPES.get(column["type"].upper(), "any"),
+            }
+            description = manifest_columns.get(name, {}).get("description")
+            if description:
+                field["description"] = description
+            fields.append(field)
+        return fields
+
+    def data_file_names(self) -> list[str]:
+        client = self.gcs_hook().get_conn()
+        bucket = client.bucket(self.destination_name(), user_project=self.user_project)
+        return sorted(
+            blob.name.removeprefix(self.destination_path_prefix)
+            for blob in client.list_blobs(bucket, prefix=self.destination_path_prefix)
+            if blob.name.rsplit(".", 1)[-1] in ("parquet", "csv")
+        )
+
+    def datapackage(self, file_names: list[str], fields: list[dict]) -> dict:
+        return {
+            "profile": "tabular-data-package",
+            "name": self.model_name,
+            "title": self.model_name,
+            "description": self.manifest_node().get("description", ""),
+            "licenses": [
+                {
+                    "name": "CC-BY-4.0",
+                    "title": "Creative Commons Attribution 4.0",
+                    "path": "https://creativecommons.org/licenses/by/4.0/",
+                }
+            ],
+            "contributors": [
+                {
+                    "title": "Cal-ITP / Caltrans Data & Digital Services",
+                    "email": "hello@calitp.org",
+                    "role": "publisher",
+                }
+            ],
+            "resources": [
+                {
+                    "name": file_name.replace(".", "-").lower(),
+                    "path": file_name,
+                    "format": file_name.rsplit(".", 1)[-1],
+                    "schema": {"fields": fields},
+                }
+                for file_name in file_names
+            ],
+        }
+
+    def execute(self, context: Context) -> dict:
+        datapackage = self.datapackage(self.data_file_names(), self.fields())
+
+        object_name = os.path.join(self.destination_path_prefix, "datapackage.json")
+        self.gcs_hook().upload(
+            bucket_name=self.destination_name(),
+            object_name=object_name,
+            data=json.dumps(datapackage, indent=2),
+            mime_type="application/json",
+            gzip=False,
+            user_project=self.user_project,
+        )
+
+        return {"destination_path": object_name}

--- a/airflow/plugins/operators/tides_reference_export_operator.py
+++ b/airflow/plugins/operators/tides_reference_export_operator.py
@@ -1,0 +1,139 @@
+import json
+import os
+from typing import Sequence
+
+from airflow.models import BaseOperator
+from airflow.models.taskinstance import Context
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+
+class TIDESReferenceExportOperator(BaseOperator):
+    """Exports one whole reference table to the TIDES bucket, parquet + CSV.
+
+    Sibling of TIDESBigQueryToParquetOperator, minus the per-feed-day filter:
+    reference tables (the tides_reference dbt models) are small crosswalk /
+    naming dims exported in full. Writes a JSONL outcome report alongside,
+    mirroring the fact exports.
+    """
+
+    template_fields: Sequence[str] = (
+        "ts",
+        "dataset_name",
+        "table_name",
+        "destination_bucket",
+        "destination_path_prefix",
+        "report_path",
+        "user_project",
+        "gcp_conn_id",
+    )
+
+    def __init__(
+        self,
+        ts: str,
+        dataset_name: str,
+        table_name: str,
+        destination_bucket: str,
+        destination_path_prefix: str,
+        report_path: str,
+        user_project: str,
+        gcp_conn_id: str = "google_cloud_default",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self._gcs_hook: GCSHook = None
+        self._big_query_hook: BigQueryHook = None
+        self.ts: str = ts
+        self.dataset_name: str = dataset_name
+        self.table_name: str = table_name
+        self.destination_bucket: str = destination_bucket
+        self.destination_path_prefix: str = destination_path_prefix
+        self.report_path: str = report_path
+        self.user_project: str = user_project
+        self.gcp_conn_id: str = gcp_conn_id
+
+    def location(self) -> str:
+        return os.getenv("CALITP_BQ_LOCATION")
+
+    def destination_name(self) -> str:
+        return self.destination_bucket.replace("gs://", "")
+
+    def destination_path(self, extension: str) -> str:
+        return os.path.join(
+            self.destination_path_prefix,
+            f"data_*.{extension}",
+        )
+
+    def gcs_hook(self) -> GCSHook:
+        if self._gcs_hook is None:
+            self._gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
+        return self._gcs_hook
+
+    def bigquery_hook(self) -> BigQueryHook:
+        if self._big_query_hook is None:
+            self._big_query_hook = BigQueryHook(
+                gcp_conn_id=self.gcp_conn_id,
+                location=self.location(),
+                use_legacy_sql=False,
+            )
+        return self._big_query_hook
+
+    def report_metadata(self) -> dict:
+        return {
+            "dataset_name": self.dataset_name,
+            "table_name": self.table_name,
+            "destination_parquet_path": self.destination_path("parquet"),
+            "destination_csv_path": self.destination_path("csv"),
+            "ts": self.ts,
+        }
+
+    def queries(self) -> list[str]:
+        parquet_template = """
+            EXPORT DATA OPTIONS(
+            uri='{uri}',
+            format='PARQUET',
+            compression='SNAPPY',
+            overwrite=true
+            ) AS SELECT * FROM `{dataset}.{table}`
+        """
+        csv_template = """
+            EXPORT DATA OPTIONS(
+            uri='{uri}',
+            format='CSV',
+            header=true,
+            overwrite=true
+            ) AS SELECT * FROM `{dataset}.{table}`
+        """
+        return [
+            template.format(
+                uri=os.path.join(
+                    self.destination_bucket,
+                    self.destination_path(extension),
+                ),
+                dataset=self.dataset_name,
+                table=self.table_name,
+            )
+            for template, extension in (
+                (parquet_template, "parquet"),
+                (csv_template, "csv"),
+            )
+        ]
+
+    def execute(self, context: Context) -> dict:
+        for query in self.queries():
+            self.bigquery_hook().get_client().query_and_wait(query=query)
+
+        self.gcs_hook().upload(
+            bucket_name=self.destination_name(),
+            object_name=self.report_path,
+            data=json.dumps(
+                self.report_metadata(),
+                default=str,
+            ),
+            mime_type="application/jsonl",
+            gzip=False,
+            user_project=self.user_project,
+        )
+
+        return self.report_metadata()

--- a/airflow/plugins/operators/tides_reference_export_operator.py
+++ b/airflow/plugins/operators/tides_reference_export_operator.py
@@ -8,6 +8,18 @@ from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
 
+def reference_destination_prefix(model_name: str, dt: str) -> str:
+    """The bucket prefix a reference model is exported to.
+
+    *_latest models live at a stable path that is overwritten each run;
+    history models are stamped per run date (pass a template like
+    "{{ ds }}", or "*" to build a matching pattern).
+    """
+    if model_name.endswith("_latest"):
+        return os.path.join("reference", model_name) + "/"
+    return os.path.join("reference", model_name, f"dt={dt}") + "/"
+
+
 class TIDESReferenceExportOperator(BaseOperator):
     """Exports one whole reference table to the TIDES bucket, parquet + CSV.
 

--- a/airflow/tests/operators/test_dbt_manifest_to_models_operator.py
+++ b/airflow/tests/operators/test_dbt_manifest_to_models_operator.py
@@ -1,0 +1,78 @@
+import os
+
+import pytest
+from operators.dbt_manifest_to_models_operator import DBTManifestToModelsOperator
+
+
+class TestDBTManifestToModelsOperator:
+    @pytest.fixture
+    def manifest(self) -> dict:
+        return {
+            "nodes": {
+                "model.calitp_warehouse.tides_organizations": {
+                    "resource_type": "model",
+                    "name": "tides_organizations",
+                    "schema": "mart_tides",
+                    "tags": ["tides_reference"],
+                },
+                "model.calitp_warehouse.tides_organizations_latest": {
+                    "resource_type": "model",
+                    "name": "tides_organizations_latest",
+                    "schema": "mart_tides",
+                    "tags": ["tides_reference"],
+                },
+                "model.calitp_warehouse.fct_tides_vehicle_locations": {
+                    "resource_type": "model",
+                    "name": "fct_tides_vehicle_locations",
+                    "schema": "mart_tides",
+                    "tags": ["tides_product"],
+                },
+                "model.calitp_warehouse.dim_agency": {
+                    "resource_type": "model",
+                    "name": "dim_agency",
+                    "schema": "mart_gtfs",
+                    "tags": [],
+                },
+                "test.calitp_warehouse.not_null_tides_organizations_key": {
+                    "resource_type": "test",
+                    "name": "not_null_tides_organizations_key",
+                    "schema": "mart_tides",
+                    "tags": ["tides_reference"],
+                },
+            }
+        }
+
+    @pytest.fixture
+    def operator(self) -> DBTManifestToModelsOperator:
+        return DBTManifestToModelsOperator(
+            task_id="list_reference_models",
+            bucket_name=os.environ.get("CALITP_BUCKET__DBT_DOCS"),
+            object_name="manifest.json",
+            tag="tides_reference",
+        )
+
+    def test_models_filters_by_tag_and_resource_type(
+        self, operator: DBTManifestToModelsOperator, manifest: dict, monkeypatch
+    ):
+        monkeypatch.setattr(operator, "read_manifest", lambda: manifest)
+
+        assert operator.models() == [
+            {"name": "tides_organizations", "schema": "mart_tides"},
+            {"name": "tides_organizations_latest", "schema": "mart_tides"},
+        ]
+
+    def test_models_handles_missing_tags(
+        self, operator: DBTManifestToModelsOperator, monkeypatch
+    ):
+        manifest = {
+            "nodes": {
+                "model.calitp_warehouse.some_model": {
+                    "resource_type": "model",
+                    "name": "some_model",
+                    "schema": "mart_tides",
+                },
+            }
+        }
+        monkeypatch.setattr(operator, "read_manifest", lambda: manifest)
+
+        assert operator.models() == []

--- a/airflow/tests/operators/test_tides_dcat_metadata_operator.py
+++ b/airflow/tests/operators/test_tides_dcat_metadata_operator.py
@@ -1,0 +1,80 @@
+import os
+
+import pytest
+from operators.tides_dcat_metadata_operator import TIDESDCATMetadataOperator
+
+
+class TestTIDESDCATMetadataOperator:
+    @pytest.fixture
+    def manifest(self) -> dict:
+        return {
+            "nodes": {
+                "model.calitp_warehouse.tides_organizations": {
+                    "name": "tides_organizations",
+                    "description": "Organization reference, all versions.",
+                },
+                "model.calitp_warehouse.tides_organizations_latest": {
+                    "name": "tides_organizations_latest",
+                    "description": "Current-version cut of tides_organizations.",
+                },
+                "model.calitp_warehouse.fct_tides_vehicle_locations": {
+                    "name": "fct_tides_vehicle_locations",
+                    "description": "TIDES vehicle_locations.",
+                },
+            }
+        }
+
+    @pytest.fixture
+    def operator(self, manifest: dict, monkeypatch) -> TIDESDCATMetadataOperator:
+        operator = TIDESDCATMetadataOperator(
+            task_id="write_dcat_catalog",
+            bucket_name=os.environ.get("CALITP_BUCKET__DBT_DOCS"),
+            models=[
+                {"name": "tides_organizations", "schema": "mart_tides"},
+                {"name": "tides_organizations_latest", "schema": "mart_tides"},
+            ],
+            extra_datasets=[
+                {
+                    "model_name": "fct_tides_vehicle_locations",
+                    "prefix": "vehicle_locations/",
+                    "formats": ["parquet"],
+                },
+            ],
+            destination_bucket=os.environ.get("CALITP_BUCKET__TIDES"),
+            user_project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+            modified="2026-07-16",
+        )
+        monkeypatch.setattr(operator, "read_manifest", lambda: manifest)
+        return operator
+
+    def test_catalog(self, operator: TIDESDCATMetadataOperator):
+        catalog = operator.catalog()
+
+        assert catalog["@type"] == "dcat:Catalog"
+        assert catalog["conformsTo"] == "https://project-open-data.cio.gov/v1.1/schema"
+        assert [d["title"] for d in catalog["dataset"]] == [
+            "tides_organizations",
+            "tides_organizations_latest",
+            "fct_tides_vehicle_locations",
+        ]
+
+    def test_dataset_entries(self, operator: TIDESDCATMetadataOperator):
+        bucket = os.environ.get("CALITP_BUCKET__TIDES")
+        history, latest, fact = operator.catalog()["dataset"]
+
+        # history models are dt-stamped, latest models live at a stable path
+        assert history["identifier"] == f"{bucket}/reference/tides_organizations/dt=*/"
+        assert latest["identifier"] == f"{bucket}/reference/tides_organizations_latest/"
+        assert fact["identifier"] == f"{bucket}/vehicle_locations/"
+
+        assert latest["description"] == "Current-version cut of tides_organizations."
+        assert latest["accessLevel"] == "public"
+        assert latest["modified"] == "2026-07-16"
+        assert latest["contactPoint"]["hasEmail"] == "mailto:hello@calitp.org"
+        assert latest["publisher"]["name"] == "Caltrans"
+
+        assert [d["format"] for d in latest["distribution"]] == ["parquet", "csv"]
+        assert [d["format"] for d in fact["distribution"]] == ["parquet"]
+        assert (
+            latest["distribution"][0]["mediaType"] == "application/vnd.apache.parquet"
+        )

--- a/airflow/tests/operators/test_tides_frictionless_metadata_operator.py
+++ b/airflow/tests/operators/test_tides_frictionless_metadata_operator.py
@@ -1,0 +1,110 @@
+import os
+
+import pytest
+from operators.tides_frictionless_metadata_operator import (
+    TIDESFrictionlessMetadataOperator,
+)
+
+
+class TestTIDESFrictionlessMetadataOperator:
+    @pytest.fixture
+    def manifest(self) -> dict:
+        return {
+            "nodes": {
+                "model.calitp_warehouse.tides_organizations_latest": {
+                    "resource_type": "model",
+                    "name": "tides_organizations_latest",
+                    "schema": "mart_tides",
+                    "description": "Current-version cut of tides_organizations.",
+                    "columns": {
+                        "source_record_id": {
+                            "name": "source_record_id",
+                            "description": "Airtable source record ID.",
+                        },
+                        "name": {"name": "name", "description": "Organization name."},
+                    },
+                }
+            }
+        }
+
+    @pytest.fixture
+    def catalog(self) -> dict:
+        return {
+            "nodes": {
+                "model.calitp_warehouse.tides_organizations_latest": {
+                    "columns": {
+                        "name": {"name": "name", "type": "STRING", "index": 2},
+                        "source_record_id": {
+                            "name": "source_record_id",
+                            "type": "STRING",
+                            "index": 1,
+                        },
+                        "_valid_from": {
+                            "name": "_valid_from",
+                            "type": "TIMESTAMP",
+                            "index": 3,
+                        },
+                        "is_public_entity": {
+                            "name": "is_public_entity",
+                            "type": "BOOL",
+                            "index": 4,
+                        },
+                    }
+                }
+            }
+        }
+
+    @pytest.fixture
+    def operator(self, manifest: dict, catalog: dict, monkeypatch):
+        operator = TIDESFrictionlessMetadataOperator(
+            task_id="write_datapackages",
+            bucket_name=os.environ.get("CALITP_BUCKET__DBT_DOCS"),
+            model_name="tides_organizations_latest",
+            destination_bucket=os.environ.get("CALITP_BUCKET__TIDES"),
+            destination_path_prefix="reference/tides_organizations_latest/",
+            user_project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+        )
+        monkeypatch.setattr(
+            operator,
+            "read_json",
+            lambda object_name: (
+                manifest if object_name == "manifest.json" else catalog
+            ),
+        )
+        return operator
+
+    def test_fields_merge_catalog_types_and_manifest_descriptions(
+        self, operator: TIDESFrictionlessMetadataOperator
+    ):
+        assert operator.fields() == [
+            {
+                "name": "source_record_id",
+                "type": "string",
+                "description": "Airtable source record ID.",
+            },
+            {"name": "name", "type": "string", "description": "Organization name."},
+            {"name": "_valid_from", "type": "datetime"},
+            {"name": "is_public_entity", "type": "boolean"},
+        ]
+
+    def test_datapackage(self, operator: TIDESFrictionlessMetadataOperator):
+        datapackage = operator.datapackage(
+            file_names=["data_000000000000.csv", "data_000000000000.parquet"],
+            fields=operator.fields(),
+        )
+
+        assert datapackage["profile"] == "tabular-data-package"
+        assert datapackage["name"] == "tides_organizations_latest"
+        assert (
+            datapackage["description"] == "Current-version cut of tides_organizations."
+        )
+        assert datapackage["licenses"][0]["name"] == "CC-BY-4.0"
+        assert datapackage["contributors"][0]["email"] == "hello@calitp.org"
+
+        assert [r["path"] for r in datapackage["resources"]] == [
+            "data_000000000000.csv",
+            "data_000000000000.parquet",
+        ]
+        assert [r["format"] for r in datapackage["resources"]] == ["csv", "parquet"]
+        for resource in datapackage["resources"]:
+            assert resource["schema"]["fields"] == operator.fields()

--- a/airflow/tests/operators/test_tides_reference_export_operator.py
+++ b/airflow/tests/operators/test_tides_reference_export_operator.py
@@ -1,0 +1,54 @@
+import os
+
+import pytest
+from operators.tides_reference_export_operator import TIDESReferenceExportOperator
+
+
+class TestTIDESReferenceExportOperator:
+    @pytest.fixture
+    def operator(self) -> TIDESReferenceExportOperator:
+        return TIDESReferenceExportOperator(
+            task_id="export_reference_models",
+            ts="2026-07-16T00:00:00+00:00",
+            dataset_name="mart_tides",
+            table_name="tides_organizations_latest",
+            destination_bucket=os.environ.get("CALITP_BUCKET__TIDES"),
+            destination_path_prefix="reference/tides_organizations_latest/",
+            report_path="reference_outcomes/dt=2026-07-16/ts=2026-07-16T00:00:00+00:00/tides_organizations_latest_outcomes.jsonl",
+            user_project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+            gcp_conn_id="google_cloud_default",
+        )
+
+    def test_queries_export_parquet_and_csv(
+        self, operator: TIDESReferenceExportOperator
+    ):
+        parquet_query, csv_query = operator.queries()
+
+        bucket = os.environ.get("CALITP_BUCKET__TIDES")
+        assert "format='PARQUET'" in parquet_query
+        assert "compression='SNAPPY'" in parquet_query
+        assert (
+            f"uri='{bucket}/reference/tides_organizations_latest/data_*.parquet'"
+            in parquet_query
+        )
+
+        assert "format='CSV'" in csv_query
+        assert "header=true" in csv_query
+        assert (
+            f"uri='{bucket}/reference/tides_organizations_latest/data_*.csv'"
+            in csv_query
+        )
+
+        for query in (parquet_query, csv_query):
+            assert "SELECT * FROM `mart_tides.tides_organizations_latest`" in query
+            assert "overwrite=true" in query
+            assert "WHERE" not in query
+
+    def test_report_metadata(self, operator: TIDESReferenceExportOperator):
+        assert operator.report_metadata() == {
+            "dataset_name": "mart_tides",
+            "table_name": "tides_organizations_latest",
+            "destination_parquet_path": "reference/tides_organizations_latest/data_*.parquet",
+            "destination_csv_path": "reference/tides_organizations_latest/data_*.csv",
+            "ts": "2026-07-16T00:00:00+00:00",
+        }

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -259,7 +259,8 @@ resource "google_project_iam_member" "composer-service-account" {
     "roles/composer.ServiceAgentV2Ext",
     "roles/composer.worker",
     "roles/secretmanager.secretAccessor",
-    "roles/secretmanager.viewer"
+    "roles/secretmanager.viewer",
+    "roles/serviceusage.serviceUsageConsumer"
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.composer-service-account.email}"

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -247,7 +247,8 @@ resource "google_project_iam_member" "composer-service-account" {
     "roles/composer.ServiceAgentV2Ext",
     "roles/composer.worker",
     "roles/secretmanager.secretAccessor",
-    "roles/secretmanager.viewer"
+    "roles/secretmanager.viewer",
+    "roles/serviceusage.serviceUsageConsumer"
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.composer-service-account.email}"

--- a/warehouse/models/mart/tides/_mart_tides_reference.yml
+++ b/warehouse/models/mart/tides/_mart_tides_reference.yml
@@ -1,0 +1,372 @@
+version: 2
+
+# Reference tables for the published TIDES dataset (tag: tides_reference).
+#
+# These models resolve the opaque IDs carried on the published TIDES facts
+# (fct_tides_vehicle_locations / fct_tides_trips_performed) to human-readable
+# organizations, feeds, services, and agencies.
+#
+# The tides_reference tag drives the bucket export DAG: every tagged model is
+# exported to the TIDES bucket.
+
+models:
+  - name: tides_publication_organizations
+    description: |
+      Membership set for the TIDES reference publication: every organization
+      that has actually appeared in the published TIDES facts. Observed, not
+      eligibility-based -- an organization published in the past remains
+      resolvable even if it later leaves TIDES. Internal driver view (not
+      exported); every tides_* reference model filters through it.
+    columns:
+      - name: organization_source_record_id
+        description: |
+          Airtable source record ID of the organization, as carried on the
+          TIDES facts.
+        data_tests:
+          - unique
+          - not_null
+
+  - name: tides_organizations
+    description: |
+      Organization reference for the published TIDES dataset: every version of
+      every organization that appears in the TIDES facts. Resolves the
+      `organization_source_record_id` on vehicle_locations / trips_performed
+      to a human-readable organization for any service date
+      (_valid_from <= service_date < _valid_to). Columns follow the set
+      already published to data.ca.gov for
+      dim_organizations_latest_with_caltrans_district.
+    columns:
+      - name: key
+        description: Synthetic version surrogate; unique per organization version.
+        data_tests:
+          - unique
+          - not_null
+      - name: source_record_id
+        description: |
+          Airtable source record ID of the organization. Join key from the
+          TIDES facts' `organization_source_record_id`.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('tides_publication_organizations')
+                field: organization_source_record_id
+      - name: name
+        description: Organization name.
+        data_tests:
+          - not_null
+      - name: organization_type
+        description: Type of organization (e.g. city/town, county, independent agency, JPA).
+      - name: website
+        description: Organization website URL.
+      - name: is_public_entity
+        description: Whether the organization is a public entity.
+      - name: ntd_id
+        description: National Transit Database ID of the organization.
+      - name: ntd_agency_info_key
+        description: Key to NTD agency information for this organization.
+      - name: ntd_id_2022
+        description: 2022-era National Transit Database ID, where it differs from `ntd_id`.
+      - name: rtpa_key
+        description: Key of the Regional Transportation Planning Agency this organization belongs to.
+      - name: rtpa_name
+        description: Name of the Regional Transportation Planning Agency this organization belongs to.
+      - name: mpo_key
+        description: Key of the Metropolitan Planning Organization this organization belongs to.
+      - name: mpo_name
+        description: Name of the Metropolitan Planning Organization this organization belongs to.
+      - name: public_currently_operating
+        description: Whether the organization currently operates public transit service.
+      - name: public_currently_operating_fixed_route
+        description: Whether the organization currently operates public fixed-route transit service.
+      - name: caltrans_district
+        description: Caltrans district number of the organization's headquarters county.
+      - name: caltrans_district_name
+        description: Caltrans district name of the organization's headquarters county.
+      - name: _valid_from
+        description: Timestamp from which this record version is valid (inclusive).
+        data_tests:
+          - not_null
+      - name: _valid_to
+        description: Timestamp until which this record version is valid.
+        data_tests:
+          - not_null
+      - name: _is_current
+        description: Whether this is the current version of the record.
+
+  - name: tides_organizations_latest
+    description: |
+      Current-version cut of tides_organizations (`WHERE _is_current`).
+      Exported to the TIDES bucket at a stable path as the latest
+      organization reference snapshot.
+
+  - name: tides_provider_gtfs_data
+    description: |
+      Organization <-> GTFS feed crosswalk for the published TIDES dataset:
+      every version of every provider record belonging to an organization that
+      appears in the TIDES facts. Links an `organization_source_record_id` to
+      the organization's schedule / vehicle-positions / trip-updates /
+      service-alerts feeds for any service date
+      (_valid_from <= service_date < _valid_to). Columns follow the set
+      already published to data.ca.gov for dim_provider_gtfs_data_latest, plus
+      the four *_gtfs_dataset_key columns so the facts' `gtfs_dataset_key`
+      joins directly to tides_gtfs_datasets.
+    columns:
+      - name: key
+        description: Synthetic version surrogate; unique per record version.
+        data_tests:
+          - unique
+          - not_null
+      - name: organization_source_record_id
+        description: |
+          Airtable source record ID of the organization. Join key from the
+          TIDES facts' `organization_source_record_id`.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('tides_publication_organizations')
+                field: organization_source_record_id
+      - name: organization_name
+        description: Organization name.
+      - name: organization_ntd_id
+        description: National Transit Database ID of the organization.
+      - name: service_source_record_id
+        description: |
+          Airtable source record ID of the service. Joins to
+          tides_services.source_record_id.
+      - name: service_name
+        description: Service name.
+      - name: gtfs_service_data_customer_facing
+        description: Whether the GTFS service data relationship is customer facing.
+      - name: regional_feed_type
+        description: Type of regional feed relationship, if any (e.g. Combined Regional Feed).
+      - name: public_customer_facing_fixed_route
+        description: Whether this record is public, customer-facing, fixed-route service.
+      - name: public_customer_facing_or_regional_subfeed_fixed_route
+        description: |
+          Whether this record is public fixed-route service that is either
+          customer-facing or a regional subfeed. This is the eligibility flag
+          used to select feeds for TIDES publication.
+      - name: schedule_source_record_id
+        description: Airtable source record ID of the schedule GTFS dataset.
+      - name: schedule_gtfs_dataset_name
+        description: Name of the schedule GTFS dataset.
+      - name: schedule_gtfs_dataset_key
+        description: Version surrogate of the schedule GTFS dataset; joins to tides_gtfs_datasets.key.
+      - name: service_alerts_source_record_id
+        description: Airtable source record ID of the service alerts GTFS dataset.
+      - name: service_alerts_gtfs_dataset_name
+        description: Name of the service alerts GTFS dataset.
+      - name: service_alerts_gtfs_dataset_key
+        description: Version surrogate of the service alerts GTFS dataset; joins to tides_gtfs_datasets.key.
+      - name: vehicle_positions_source_record_id
+        description: Airtable source record ID of the vehicle positions GTFS dataset.
+      - name: vehicle_positions_gtfs_dataset_name
+        description: Name of the vehicle positions GTFS dataset.
+      - name: vehicle_positions_gtfs_dataset_key
+        description: |
+          Version surrogate of the vehicle positions GTFS dataset; joins to
+          tides_gtfs_datasets.key and matches the `gtfs_dataset_key` carried
+          on the TIDES facts.
+      - name: trip_updates_source_record_id
+        description: Airtable source record ID of the trip updates GTFS dataset.
+      - name: trip_updates_gtfs_dataset_name
+        description: Name of the trip updates GTFS dataset.
+      - name: trip_updates_gtfs_dataset_key
+        description: Version surrogate of the trip updates GTFS dataset; joins to tides_gtfs_datasets.key.
+      - name: _valid_from
+        description: Timestamp from which this record version is valid (inclusive).
+        data_tests:
+          - not_null
+      - name: _valid_to
+        description: Timestamp until which this record version is valid.
+        data_tests:
+          - not_null
+      - name: _is_current
+        description: Whether this is the current version of the record.
+
+  - name: tides_provider_gtfs_data_latest
+    description: |
+      Current-version cut of tides_provider_gtfs_data (`WHERE _is_current`).
+      Exported to the TIDES bucket at a stable path as the latest
+      organization <-> feed crosswalk snapshot.
+
+  - name: tides_gtfs_datasets
+    description: |
+      GTFS dataset (feed) reference for the published TIDES dataset: every
+      version of every dataset referenced by a member organization's provider
+      records or observed in the published facts. Resolves the
+      `gtfs_dataset_key` / `base64_url` on vehicle_locations /
+      trips_performed to a named feed for any service date
+      (_valid_from <= service_date < _valid_to). Columns follow the set
+      already published to data.ca.gov for dim_gtfs_datasets_latest;
+      `private_dataset` records are excluded from all versions, and feed URLs
+      are credential-scrubbed upstream before encoding.
+    columns:
+      - name: key
+        description: |
+          Synthetic version surrogate; unique per dataset version. Matches the
+          `gtfs_dataset_key` carried on the TIDES facts and the
+          *_gtfs_dataset_key columns on tides_provider_gtfs_data.
+        data_tests:
+          - unique
+          - not_null
+      - name: source_record_id
+        description: Airtable source record ID of the GTFS dataset.
+        data_tests:
+          - not_null
+      - name: name
+        description: GTFS dataset name.
+      - name: type
+        description: Feed type (schedule, vehicle_positions, trip_updates, service_alerts).
+      - name: regional_feed_type
+        description: Type of regional feed relationship, if any.
+      - name: base64_url
+        description: |
+          URL-safe base64 encoding of the feed URL, with authentication query
+          parameters stripped before encoding. Matches the `base64_url`
+          carried on the TIDES facts.
+        data_tests:
+          - not_null
+      - name: url
+        description: Decoded feed URL (convenience decode of `base64_url`).
+      - name: has_authentication
+        description: Whether the feed requires authentication to download.
+      - name: authentication_contact_details
+        description: Contact details for requesting feed authentication credentials.
+      - name: deprecated_date
+        description: |
+          Date the dataset was deprecated, if any. Historical versions of
+          deprecated feeds are retained so past service dates stay resolvable.
+      - name: _valid_from
+        description: Timestamp from which this record version is valid (inclusive).
+        data_tests:
+          - not_null
+      - name: _valid_to
+        description: Timestamp until which this record version is valid.
+        data_tests:
+          - not_null
+      - name: _is_current
+        description: Whether this is the current version of the record.
+
+  - name: tides_gtfs_datasets_latest
+    description: |
+      Current-version cut of tides_gtfs_datasets (`WHERE _is_current`).
+      Exported to the TIDES bucket at a stable path as the latest feed
+      reference snapshot.
+
+  - name: tides_services
+    description: |
+      Service reference for the published TIDES dataset: every version of
+      every service referenced by a member organization's provider records.
+      Gives the `service_source_record_id` on tides_provider_gtfs_data a
+      human-readable service for any service date
+      (_valid_from <= service_date < _valid_to). Columns follow the set
+      already published to data.ca.gov for dim_services_latest; array columns
+      are flattened to comma-separated strings.
+    columns:
+      - name: key
+        description: Synthetic version surrogate; unique per service version.
+        data_tests:
+          - unique
+          - not_null
+      - name: source_record_id
+        description: |
+          Airtable source record ID of the service. Join key from
+          tides_provider_gtfs_data.service_source_record_id.
+        data_tests:
+          - not_null
+      - name: name
+        description: Service name.
+      - name: service_type
+        description: Comma-separated service types (e.g. fixed-route, demand-response).
+      - name: mode
+        description: Comma-separated transit modes (e.g. bus, rail, ferry).
+      - name: operating_counties
+        description: Comma-separated counties in which the service operates.
+      - name: fixed_route
+        description: Whether the service is fixed route.
+      - name: is_public
+        description: Whether the service is public.
+      - name: public_currently_operating
+        description: Whether the service is currently operating public transit.
+      - name: public_currently_operating_fixed_route
+        description: Whether the service is currently operating public fixed-route transit.
+      - name: operational_status
+        description: Operational status of the service.
+      - name: _valid_from
+        description: Timestamp from which this record version is valid (inclusive).
+        data_tests:
+          - not_null
+      - name: _valid_to
+        description: Timestamp until which this record version is valid.
+        data_tests:
+          - not_null
+      - name: _is_current
+        description: Whether this is the current version of the record.
+
+  - name: tides_services_latest
+    description: |
+      Current-version cut of tides_services (`WHERE _is_current`). Exported to
+      the TIDES bucket at a stable path as the latest service reference
+      snapshot.
+
+  - name: tides_agency
+    description: |
+      GTFS agency reference for the published TIDES dataset: every version of
+      every agency.txt row from the schedule feeds of member organizations.
+      Provides the human-readable agency name behind a feed for any service
+      date (_valid_from <= service_date < _valid_to; validity comes from the
+      schedule feed version, dim_schedule_feeds). Columns follow the set
+      already published to data.ca.gov for dim_agency_latest.
+    columns:
+      - name: key
+        description: Synthetic row surrogate; unique per agency row per feed version.
+        data_tests:
+          - unique
+          - not_null
+      - name: feed_key
+        description: |
+          Surrogate key of the schedule feed version this agency row came
+          from (dim_schedule_feeds.key).
+        data_tests:
+          - not_null
+      - name: base64_url
+        description: |
+          URL-safe base64 encoding of the schedule feed URL. Joins to
+          tides_gtfs_datasets.base64_url.
+        data_tests:
+          - not_null
+      - name: agency_id
+        description: '{{ doc("gtfs_agency__agency_id") }}'
+      - name: agency_name
+        description: '{{ doc("gtfs_agency__agency_name") }}'
+      - name: agency_url
+        description: '{{ doc("gtfs_agency__agency_url") }}'
+      - name: agency_timezone
+        description: '{{ doc("gtfs_agency__agency_timezone") }}'
+      - name: agency_lang
+        description: '{{ doc("gtfs_agency__agency_lang") }}'
+      - name: agency_phone
+        description: '{{ doc("gtfs_agency__agency_phone") }}'
+      - name: agency_fare_url
+        description: '{{ doc("gtfs_agency__agency_fare_url") }}'
+      - name: agency_email
+        description: '{{ doc("gtfs_agency__agency_email") }}'
+      - name: _valid_from
+        description: Timestamp from which this feed version is valid (inclusive).
+        data_tests:
+          - not_null
+      - name: _valid_to
+        description: Timestamp until which this feed version is valid.
+        data_tests:
+          - not_null
+      - name: _is_current
+        description: Whether this is the current version of the schedule feed.
+
+  - name: tides_agency_latest
+    description: |
+      Current-version cut of tides_agency (`WHERE _is_current`). Exported to
+      the TIDES bucket at a stable path as the latest agency reference
+      snapshot.

--- a/warehouse/models/mart/tides/_mart_tides_reference.yml
+++ b/warehouse/models/mart/tides/_mart_tides_reference.yml
@@ -35,7 +35,7 @@ models:
       (_valid_from <= service_date < _valid_to). Columns follow the set
       already published to data.ca.gov for
       dim_organizations_latest_with_caltrans_district.
-    columns:
+    columns: &tides_organizations_columns
       - name: key
         description: Synthetic version surrogate; unique per organization version.
         data_tests:
@@ -99,6 +99,7 @@ models:
       Current-version cut of tides_organizations (`WHERE _is_current`).
       Exported to the TIDES bucket at a stable path as the latest
       organization reference snapshot.
+    columns: *tides_organizations_columns
 
   - name: tides_provider_gtfs_data
     description: |
@@ -111,7 +112,7 @@ models:
       already published to data.ca.gov for dim_provider_gtfs_data_latest, plus
       the four *_gtfs_dataset_key columns so the facts' `gtfs_dataset_key`
       joins directly to tides_gtfs_datasets.
-    columns:
+    columns: &tides_provider_gtfs_data_columns
       - name: key
         description: Synthetic version surrogate; unique per record version.
         data_tests:
@@ -191,6 +192,7 @@ models:
       Current-version cut of tides_provider_gtfs_data (`WHERE _is_current`).
       Exported to the TIDES bucket at a stable path as the latest
       organization <-> feed crosswalk snapshot.
+    columns: *tides_provider_gtfs_data_columns
 
   - name: tides_gtfs_datasets
     description: |
@@ -203,7 +205,7 @@ models:
       already published to data.ca.gov for dim_gtfs_datasets_latest;
       `private_dataset` records are excluded from all versions, and feed URLs
       are credential-scrubbed upstream before encoding.
-    columns:
+    columns: &tides_gtfs_datasets_columns
       - name: key
         description: |
           Synthetic version surrogate; unique per dataset version. Matches the
@@ -255,6 +257,7 @@ models:
       Current-version cut of tides_gtfs_datasets (`WHERE _is_current`).
       Exported to the TIDES bucket at a stable path as the latest feed
       reference snapshot.
+    columns: *tides_gtfs_datasets_columns
 
   - name: tides_services
     description: |
@@ -265,7 +268,7 @@ models:
       (_valid_from <= service_date < _valid_to). Columns follow the set
       already published to data.ca.gov for dim_services_latest; array columns
       are flattened to comma-separated strings.
-    columns:
+    columns: &tides_services_columns
       - name: key
         description: Synthetic version surrogate; unique per service version.
         data_tests:
@@ -311,6 +314,7 @@ models:
       Current-version cut of tides_services (`WHERE _is_current`). Exported to
       the TIDES bucket at a stable path as the latest service reference
       snapshot.
+    columns: *tides_services_columns
 
   - name: tides_agency
     description: |
@@ -320,7 +324,7 @@ models:
       date (_valid_from <= service_date < _valid_to; validity comes from the
       schedule feed version, dim_schedule_feeds). Columns follow the set
       already published to data.ca.gov for dim_agency_latest.
-    columns:
+    columns: &tides_agency_columns
       - name: key
         description: Synthetic row surrogate; unique per agency row per feed version.
         data_tests:
@@ -370,3 +374,4 @@ models:
       Current-version cut of tides_agency (`WHERE _is_current`). Exported to
       the TIDES bucket at a stable path as the latest agency reference
       snapshot.
+    columns: *tides_agency_columns

--- a/warehouse/models/mart/tides/_mart_tides_reference.yml
+++ b/warehouse/models/mart/tides/_mart_tides_reference.yml
@@ -202,9 +202,10 @@ models:
       `gtfs_dataset_key` / `base64_url` on vehicle_locations /
       trips_performed to a named feed for any service date
       (_valid_from <= service_date < _valid_to). Columns follow the set
-      already published to data.ca.gov for dim_gtfs_datasets_latest;
-      `private_dataset` records are excluded from all versions, and feed URLs
-      are credential-scrubbed upstream before encoding.
+      already published to data.ca.gov for dim_gtfs_datasets_latest.
+      `private_dataset` records are excluded from all versions, as are specific
+      historical feed versions whose URL carried an inline auth credential, so
+      no feed key is published to the open-data bucket.
     columns: &tides_gtfs_datasets_columns
       - name: key
         description: |

--- a/warehouse/models/mart/tides/tides_agency.sql
+++ b/warehouse/models/mart/tides/tides_agency.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized='table',
+        tags=['tides_reference'],
+    )
+}}
+
+-- GTFS agency reference for the published TIDES dataset from the schedule feeds of organizations
+
+WITH member_feed_urls AS (
+    SELECT DISTINCT base64_url
+    FROM {{ ref('tides_gtfs_datasets') }}
+),
+
+member_schedule_feeds AS (
+    SELECT
+        key,
+        _valid_from,
+        _valid_to,
+        _is_current
+    FROM {{ ref('dim_schedule_feeds') }}
+    WHERE base64_url IN (SELECT base64_url FROM member_feed_urls)
+),
+
+tides_agency AS (
+    SELECT
+        agency.key,
+        agency.feed_key,
+        agency.base64_url,
+        agency.agency_id,
+        agency.agency_name,
+        agency.agency_url,
+        agency.agency_timezone,
+        agency.agency_lang,
+        agency.agency_phone,
+        agency.agency_fare_url,
+        agency.agency_email,
+        feeds._valid_from,
+        feeds._valid_to,
+        feeds._is_current
+    FROM {{ ref('dim_agency') }} AS agency
+    INNER JOIN member_schedule_feeds AS feeds
+        ON agency.feed_key = feeds.key
+)
+
+SELECT * FROM tides_agency

--- a/warehouse/models/mart/tides/tides_agency_latest.sql
+++ b/warehouse/models/mart/tides/tides_agency_latest.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized='view',
+        tags=['tides_reference'],
+    )
+}}
+
+WITH tides_agency_latest AS (
+    SELECT * FROM {{ ref('tides_agency') }}
+    WHERE _is_current
+)
+
+SELECT * FROM tides_agency_latest

--- a/warehouse/models/mart/tides/tides_gtfs_datasets.sql
+++ b/warehouse/models/mart/tides/tides_gtfs_datasets.sql
@@ -1,0 +1,62 @@
+{{
+    config(
+        materialized='table',
+        tags=['tides_reference'],
+    )
+}}
+
+-- GTFS dataset reference for the published TIDES dataset:
+-- Resolves the `gtfs_dataset_key` / `base64_url` carried on
+-- vehicle_locations / trips_performed to a named feed, valid for a given
+-- service date:
+--     _valid_from <= service_date < _valid_to
+
+
+WITH provider_records AS (
+    SELECT * FROM {{ ref('tides_provider_gtfs_data') }}
+),
+
+referenced_dataset_keys AS (
+    SELECT DISTINCT gtfs_dataset_key
+    FROM (
+        SELECT schedule_gtfs_dataset_key AS gtfs_dataset_key FROM provider_records
+        UNION ALL
+        SELECT service_alerts_gtfs_dataset_key FROM provider_records
+        UNION ALL
+        SELECT vehicle_positions_gtfs_dataset_key FROM provider_records
+        UNION ALL
+        SELECT trip_updates_gtfs_dataset_key FROM provider_records
+        UNION ALL
+        -- belt and braces: dataset keys actually observed in the facts
+        SELECT gtfs_dataset_key FROM {{ ref('tides_publication_feeds') }}
+    )
+    WHERE gtfs_dataset_key IS NOT NULL
+),
+
+member_dataset_ids AS (
+    SELECT DISTINCT source_record_id
+    FROM {{ ref('dim_gtfs_datasets') }}
+    WHERE key IN (SELECT gtfs_dataset_key FROM referenced_dataset_keys)
+),
+
+tides_gtfs_datasets AS (
+    SELECT
+        key,
+        source_record_id,
+        name,
+        type,
+        regional_feed_type,
+        base64_url,
+        CAST(FROM_BASE64(REPLACE(REPLACE(base64_url, '-', '+'), '_', '/')) AS STRING) AS url,
+        has_authentication,
+        authentication_contact_details,
+        deprecated_date,
+        _valid_from,
+        _valid_to,
+        _is_current
+    FROM {{ ref('dim_gtfs_datasets') }}
+    WHERE source_record_id IN (SELECT source_record_id FROM member_dataset_ids)
+        AND private_dataset IS NOT TRUE
+)
+
+SELECT * FROM tides_gtfs_datasets

--- a/warehouse/models/mart/tides/tides_gtfs_datasets.sql
+++ b/warehouse/models/mart/tides/tides_gtfs_datasets.sql
@@ -41,7 +41,7 @@ member_dataset_ids AS (
 
 -- Historical feed versions whose URL carried an inline auth credential (?key=),
 -- excluded so no feed key reaches the open-data bucket. Only these versions are
--- dropped; current versions are clean. Guarded by the no_url_credentials test.
+-- dropped; current versions are clean.
 credential_bearing_versions AS (
     SELECT deny_source_record_id, deny_valid_from
     FROM UNNEST([

--- a/warehouse/models/mart/tides/tides_gtfs_datasets.sql
+++ b/warehouse/models/mart/tides/tides_gtfs_datasets.sql
@@ -39,6 +39,21 @@ member_dataset_ids AS (
     WHERE key IN (SELECT gtfs_dataset_key FROM referenced_dataset_keys)
 ),
 
+-- Historical feed versions whose URL carried an inline auth credential (?key=),
+-- excluded so no feed key reaches the open-data bucket. Only these versions are
+-- dropped; current versions are clean. Guarded by the no_url_credentials test.
+credential_bearing_versions AS (
+    SELECT deny_source_record_id, deny_valid_from
+    FROM UNNEST([
+        STRUCT('recYNhwWlgv0xEQvQ' AS deny_source_record_id, TIMESTAMP '2025-10-15 00:00:00+00' AS deny_valid_from),  -- Bear Alerts
+        STRUCT('rec50UrBVphNmIiTz', TIMESTAMP '2025-10-15 00:00:00+00'),  -- Bear Schedule
+        STRUCT('recVwM5CcUf67mOsz', TIMESTAMP '2025-10-15 00:00:00+00'),  -- Bear Trip Updates
+        STRUCT('reclEUVQ0e7JlwdB8', TIMESTAMP '2025-10-15 00:00:00+00'),  -- Bear Vehicle Positions
+        STRUCT('recYDXYPHTZXX17DI', TIMESTAMP '2022-06-29 00:00:00+00'),  -- San Diego Trip Updates (v1)
+        STRUCT('recYDXYPHTZXX17DI', TIMESTAMP '2022-08-09 00:00:00+00')   -- San Diego Trip Updates (v2)
+    ])
+),
+
 tides_gtfs_datasets AS (
     SELECT
         key,
@@ -57,6 +72,12 @@ tides_gtfs_datasets AS (
     FROM {{ ref('dim_gtfs_datasets') }}
     WHERE source_record_id IN (SELECT source_record_id FROM member_dataset_ids)
         AND private_dataset IS NOT TRUE
+        AND NOT EXISTS (
+            SELECT 1
+            FROM credential_bearing_versions
+            WHERE deny_source_record_id = source_record_id
+                AND deny_valid_from = _valid_from
+        )
 )
 
 SELECT * FROM tides_gtfs_datasets

--- a/warehouse/models/mart/tides/tides_gtfs_datasets_latest.sql
+++ b/warehouse/models/mart/tides/tides_gtfs_datasets_latest.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized='view',
+        tags=['tides_reference'],
+    )
+}}
+
+WITH tides_gtfs_datasets_latest AS (
+    SELECT * FROM {{ ref('tides_gtfs_datasets') }}
+    WHERE _is_current
+)
+
+SELECT * FROM tides_gtfs_datasets_latest

--- a/warehouse/models/mart/tides/tides_organizations.sql
+++ b/warehouse/models/mart/tides/tides_organizations.sql
@@ -1,0 +1,62 @@
+{{
+    config(
+        materialized='table',
+        tags=['tides_reference'],
+    )
+}}
+
+-- Organization reference for the published TIDES dataset: every organization that appears in the TIDES facts
+
+WITH member_organizations AS (
+    SELECT *
+    FROM {{ ref('dim_organizations') }}
+    WHERE source_record_id IN (
+        SELECT organization_source_record_id
+        FROM {{ ref('tides_publication_organizations') }}
+    )
+),
+
+bridge_hq_county AS (
+    SELECT * FROM {{ ref('bridge_organizations_x_headquarters_county_geography') }}
+),
+
+county_geography AS (
+    SELECT * FROM {{ ref('dim_county_geography') }}
+),
+
+tides_organizations AS (
+    SELECT
+        orgs.key,
+        orgs.source_record_id,
+        orgs.name,
+        orgs.organization_type,
+        orgs.website,
+        orgs.is_public_entity,
+        orgs.ntd_id,
+        orgs.ntd_agency_info_key,
+        orgs.ntd_id_2022,
+        orgs.rtpa_key,
+        orgs.rtpa_name,
+        orgs.mpo_key,
+        orgs.mpo_name,
+        orgs.public_currently_operating,
+        orgs.public_currently_operating_fixed_route,
+        county_geography.caltrans_district,
+        county_geography.caltrans_district_name,
+        orgs._valid_from,
+        orgs._valid_to,
+        orgs._is_current
+    FROM member_organizations AS orgs
+    LEFT JOIN bridge_hq_county
+        ON bridge_hq_county.organization_key = orgs.key
+            AND bridge_hq_county._valid_from < orgs._valid_to
+            AND orgs._valid_from < bridge_hq_county._valid_to
+    LEFT JOIN county_geography
+        ON county_geography.key = bridge_hq_county.county_geography_key
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY orgs.key
+        ORDER BY bridge_hq_county._valid_from DESC
+    ) = 1
+)
+
+SELECT * FROM tides_organizations

--- a/warehouse/models/mart/tides/tides_organizations_latest.sql
+++ b/warehouse/models/mart/tides/tides_organizations_latest.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized='view',
+        tags=['tides_reference'],
+    )
+}}
+
+WITH tides_organizations_latest AS (
+    SELECT * FROM {{ ref('tides_organizations') }}
+    WHERE _is_current
+)
+
+SELECT * FROM tides_organizations_latest

--- a/warehouse/models/mart/tides/tides_provider_gtfs_data.sql
+++ b/warehouse/models/mart/tides/tides_provider_gtfs_data.sql
@@ -1,0 +1,50 @@
+{{
+    config(
+        materialized='table',
+        tags=['tides_reference'],
+    )
+}}
+
+-- Organization <-> GTFS feed crosswalk for the published TIDES dataset: every
+-- version of every dim_provider_gtfs_data record belonging to an organization
+-- that appears in the TIDES facts.
+-- Links an `organization_source_record_id` observed in vehicle_locations /
+-- trips_performed to the organization's schedule / vehicle-positions /
+-- trip-updates / service-alerts feeds, valid for a given service date:
+--     _valid_from <= service_date < _valid_to
+
+WITH tides_provider_gtfs_data AS (
+    SELECT
+        key,
+        organization_source_record_id,
+        organization_name,
+        organization_ntd_id,
+        service_source_record_id,
+        service_name,
+        gtfs_service_data_customer_facing,
+        regional_feed_type,
+        public_customer_facing_fixed_route,
+        public_customer_facing_or_regional_subfeed_fixed_route,
+        schedule_source_record_id,
+        schedule_gtfs_dataset_name,
+        schedule_gtfs_dataset_key,
+        service_alerts_source_record_id,
+        service_alerts_gtfs_dataset_name,
+        service_alerts_gtfs_dataset_key,
+        vehicle_positions_source_record_id,
+        vehicle_positions_gtfs_dataset_name,
+        vehicle_positions_gtfs_dataset_key,
+        trip_updates_source_record_id,
+        trip_updates_gtfs_dataset_name,
+        trip_updates_gtfs_dataset_key,
+        _valid_from,
+        _valid_to,
+        _is_current
+    FROM {{ ref('dim_provider_gtfs_data') }}
+    WHERE organization_source_record_id IN (
+        SELECT organization_source_record_id
+        FROM {{ ref('tides_publication_organizations') }}
+    )
+)
+
+SELECT * FROM tides_provider_gtfs_data

--- a/warehouse/models/mart/tides/tides_provider_gtfs_data_latest.sql
+++ b/warehouse/models/mart/tides/tides_provider_gtfs_data_latest.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized='view',
+        tags=['tides_reference'],
+    )
+}}
+
+WITH tides_provider_gtfs_data_latest AS (
+    SELECT * FROM {{ ref('tides_provider_gtfs_data') }}
+    WHERE _is_current
+)
+
+SELECT * FROM tides_provider_gtfs_data_latest

--- a/warehouse/models/mart/tides/tides_publication_organizations.sql
+++ b/warehouse/models/mart/tides/tides_publication_organizations.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized='view',
+    )
+}}
+
+-- The TIDES reference-publication membership set: every organization that has
+-- actually appeared in the published TIDES facts (via tides_publication_feeds).
+
+
+SELECT DISTINCT organization_source_record_id
+FROM {{ ref('tides_publication_feeds') }}
+WHERE organization_source_record_id IS NOT NULL

--- a/warehouse/models/mart/tides/tides_services.sql
+++ b/warehouse/models/mart/tides/tides_services.sql
@@ -1,0 +1,43 @@
+{{
+    config(
+        materialized='table',
+        tags=['tides_reference'],
+    )
+}}
+
+-- Service reference for the published TIDES dataset: every service referenced
+-- by a member organization's provider records. Gives the
+-- `service_source_record_id` on tides_provider_gtfs_data a human-readable
+-- service, valid for a given service date:
+--     _valid_from <= service_date < _valid_to
+
+
+WITH member_service_ids AS (
+    SELECT DISTINCT service_source_record_id
+    FROM {{ ref('tides_provider_gtfs_data') }}
+    WHERE service_source_record_id IS NOT NULL
+),
+
+tides_services AS (
+    SELECT
+        key,
+        source_record_id,
+        name,
+        ARRAY_TO_STRING(service_type, ", ") AS service_type,
+        ARRAY_TO_STRING(mode, ", ") AS mode,
+        ARRAY_TO_STRING(operating_counties, ", ") AS operating_counties,
+        fixed_route,
+        is_public,
+        public_currently_operating,
+        public_currently_operating_fixed_route,
+        operational_status,
+        _valid_from,
+        _valid_to,
+        _is_current
+    FROM {{ ref('dim_services') }}
+    WHERE source_record_id IN (
+        SELECT service_source_record_id FROM member_service_ids
+    )
+)
+
+SELECT * FROM tides_services

--- a/warehouse/models/mart/tides/tides_services_latest.sql
+++ b/warehouse/models/mart/tides/tides_services_latest.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized='view',
+        tags=['tides_reference'],
+    )
+}}
+
+WITH tides_services_latest AS (
+    SELECT * FROM {{ ref('tides_services') }}
+    WHERE _is_current
+)
+
+SELECT * FROM tides_services_latest


### PR DESCRIPTION
# Description

Publishes the TIDES reference tables — the organization/feed crosswalk that resolves the opaque IDs on the published TIDES facts.
ref: #5477

Latest and historical org/feed crosswalk tables (org, provider_gtfs_data, gtfs_datasets, services)
ref: #5472, #5473

Machine-readable metadata generated in  Frictionless & DCAT-US                                                                                                                                                                                                                       
ref: #5476

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Locally w/ dbt run and airflow container as well as operator tests
Running on staging dataset

