### PR TITLE
Shrink apps-v2 node pool floor from 3 to 1

### DIFF
--- a/iac/cal-itp-data-infra/gke/us/container_node_pool.tf
+++ b/iac/cal-itp-data-infra/gke/us/container_node_pool.tf
@@ -1,10 +1,10 @@
 resource "google_container_node_pool" "tfer--data-infra-apps_apps-v2" {
   autoscaling {
     location_policy      = "BALANCED"
-    max_node_count       = "2"
-    min_node_count       = "1"
-    total_max_node_count = "0"
-    total_min_node_count = "0"
+    max_node_count       = "0"
+    min_node_count       = "0"
+    total_max_node_count = "3"
+    total_min_node_count = "1"
   }
 
   cluster            = google_container_cluster.tfer--data-infra-apps.name


### PR DESCRIPTION
# Description

Shrinks the `apps-v2` node pool floor from 3 nodes to 1 by switching it from **per-zone** autoscaling to a **regional total** (the same shape `jupyterhub-users` uses).

`apps-v2` runs only the JupyterHub control plane (`hub`, `proxy`, `user-scheduler`) — a handful of fractional-CPU pods that fit on one node. Its 3 running nodes were purely an artifact of `min_node_count = 1` being applied **per zone** across `us-west1-{a,b,c}` (1 × 3 = 3), not workload demand. Moving to `total_min_node_count = 1` keeps a single node and lets the autoscaler add more (up to 3) only on demand.

```hcl
  autoscaling {
    location_policy      = "BALANCED"
-   max_node_count       = "2"   # per-zone
-   min_node_count       = "1"   # per-zone → 1×3 zones = 3
-   total_max_node_count = "0"
-   total_min_node_count = "0"
+   max_node_count       = "0"
+   min_node_count       = "0"
+   total_max_node_count = "3"   # regional total
+   total_min_node_count = "1"   # regional total → 1 node
  }
```

Estimated savings ~$190/mo (2 fewer `n1-standard-4`). 

This became safe only after the old Elavon `sftp-server-0` StatefulSet was removed (#5035) — its zonal PVC pinned the us-west1-b node against scale-down.

Works toward #3713 (its "single pool of nodes that everyone shares" recommendation).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- `terraform plan` (local, prod backend) confirms an **in-place update, not a recreate**: `Plan: 0 to add, 1 to change, 0 to destroy` — only the `autoscaling` block changes; `node_count` shows no drift.
- `terraform fmt -check` passes.

## Post-merge follow-ups

- [x] Actions required (specified below)

- `terraform-apply` sets `total_min=1` on merge. The 2 extra nodes then **drain as they empty** (like the JupyterHub floor cut) — `proxy`/`user-scheduler` reschedule onto the surviving node (the `hub` pod's zonal PVC keeps one node in its zone). No pods are force-evicted; `BALANCED` may take a while on the last drain (an `OPTIMIZE_UTILIZATION` profile or a one-time cordon/drain would speed it).
- Optional later: re-family `n1-standard-4 → e2-standard-2` (~$50/mo) — separate, since `machine_type` is immutable (pool recreate / blue-green).
