### PR TITLE
Remove unused service accounts cc-jarvus-airflow, amplitude, and local-airflow-dev

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/outputs.tf
@@ -94,14 +94,6 @@ output "google_project_iam_member_tfer--roles-002F-editorserviceAccount-003A-473
   value = google_project_iam_member.tfer--roles-002F-editorserviceAccount-003A-473674835135-compute-0040-developer-002E-gserviceaccount-002E-com.id
 }
 
-output "google_project_iam_member_tfer--roles-002F-ownerserviceAccount-003A-amplitude-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com_id" {
-  value = google_project_iam_member.tfer--roles-002F-ownerserviceAccount-003A-amplitude-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com.id
-}
-
-output "google_project_iam_member_tfer--roles-002F-ownerserviceAccount-003A-local-airflow-dev-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com_id" {
-  value = google_project_iam_member.tfer--roles-002F-ownerserviceAccount-003A-local-airflow-dev-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com.id
-}
-
 output "google_project_iam_member_tfer--roles-002F-pubsub-002E-serviceAgentserviceAccount-003A-service-473674835135-0040-gcp-sa-pubsub-002E-iam-002E-gserviceaccount-002E-com_id" {
   value = google_project_iam_member.tfer--roles-002F-pubsub-002E-serviceAgentserviceAccount-003A-service-473674835135-0040-gcp-sa-pubsub-002E-iam-002E-gserviceaccount-002E-com.id
 }
@@ -124,14 +116,6 @@ output "google_project_iam_member_tfer--roles-002F-storage-002E-objectViewerserv
 
 output "google_service_account_tfer--101455296324690994963_id" {
   value = google_service_account.tfer--101455296324690994963.id
-}
-
-output "google_service_account_tfer--111242760977002129583_id" {
-  value = google_service_account.tfer--111242760977002129583.id
-}
-
-output "google_service_account_tfer--111824761856041678305_id" {
-  value = google_service_account.tfer--111824761856041678305.id
 }
 
 output "google_service_account_tfer--111881979116192190399_id" {

--- a/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/project_iam_member.tf
@@ -136,18 +136,6 @@ resource "google_project_iam_member" "tfer--roles-002F-editorserviceAccount-003A
   role    = "roles/editor"
 }
 
-resource "google_project_iam_member" "tfer--roles-002F-ownerserviceAccount-003A-amplitude-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com" {
-  member  = "serviceAccount:amplitude@cal-itp-data-infra-staging.iam.gserviceaccount.com"
-  project = "cal-itp-data-infra-staging"
-  role    = "roles/viewer"
-}
-
-resource "google_project_iam_member" "tfer--roles-002F-ownerserviceAccount-003A-local-airflow-dev-0040-cal-itp-data-infra-staging-002E-iam-002E-gserviceaccount-002E-com" {
-  member  = "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com"
-  project = "cal-itp-data-infra-staging"
-  role    = "roles/viewer"
-}
-
 resource "google_project_iam_member" "tfer--roles-002F-pubsub-002E-serviceAgentserviceAccount-003A-service-473674835135-0040-gcp-sa-pubsub-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:service-473674835135@gcp-sa-pubsub.iam.gserviceaccount.com"
   project = "cal-itp-data-infra-staging"

--- a/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account.tf
@@ -6,19 +6,6 @@ resource "google_service_account" "tfer--101455296324690994963" {
   project      = "cal-itp-data-infra-staging"
 }
 
-resource "google_service_account" "tfer--111242760977002129583" {
-  account_id   = "amplitude"
-  disabled     = "true"
-  display_name = "Amplitude"
-  project      = "cal-itp-data-infra-staging"
-}
-
-resource "google_service_account" "tfer--111824761856041678305" {
-  account_id = "local-airflow-dev"
-  disabled   = "false"
-  project    = "cal-itp-data-infra-staging"
-}
-
 resource "google_service_account" "tfer--111881979116192190399" {
   account_id   = "metabase"
   disabled     = "false"

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_binding.tf
@@ -282,7 +282,7 @@ resource "google_storage_bucket_iam_binding" "tfer--gtfs-data-reports" {
 
 resource "google_storage_bucket_iam_binding" "tfer--gtfs-data-test" {
   bucket  = "b/gtfs-data-test"
-  members = ["serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com", "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"]
+  members = ["serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com", "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"]
   role    = "roles/storage.objectAdmin"
 }
 

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket_iam_policy.tf
@@ -1835,7 +1835,6 @@ resource "google_storage_bucket_iam_policy" "tfer--gtfs-data-test" {
     {
       "members": [
         "serviceAccount:calitp-py-ci@cal-itp-data-infra.iam.gserviceaccount.com",
-        "serviceAccount:local-airflow-dev@cal-itp-data-infra-staging.iam.gserviceaccount.com",
         "serviceAccount:project-1005246706141@storage-transfer-service.iam.gserviceaccount.com"
       ],
       "role": "roles/storage.objectAdmin"

--- a/iac/cal-itp-data-infra/iam/us/outputs.tf
+++ b/iac/cal-itp-data-infra/iam/us/outputs.tf
@@ -246,10 +246,6 @@ output "google_project_iam_member_tfer--roles-002F-firestore-002E-serviceAgentse
   value = google_project_iam_member.tfer--roles-002F-firestore-002E-serviceAgentserviceAccount-003A-service-1005246706141-0040-gcp-sa-firestore-002E-iam-002E-gserviceaccount-002E-com.id
 }
 
-output "google_project_iam_member_tfer--roles-002F-ownerserviceAccount-003A-cc-jarvus-airflow-0040-cal-itp-data-infra-002E-iam-002E-gserviceaccount-002E-com_id" {
-  value = google_project_iam_member.tfer--roles-002F-ownerserviceAccount-003A-cc-jarvus-airflow-0040-cal-itp-data-infra-002E-iam-002E-gserviceaccount-002E-com.id
-}
-
 output "google_project_iam_member_tfer--roles-002F-run-002E-serviceAgentserviceAccount-003A-service-1005246706141-0040-serverless-robot-prod-002E-iam-002E-gserviceaccount-002E-com_id" {
   value = google_project_iam_member.tfer--roles-002F-run-002E-serviceAgentserviceAccount-003A-service-1005246706141-0040-serverless-robot-prod-002E-iam-002E-gserviceaccount-002E-com.id
 }
@@ -376,10 +372,6 @@ output "google_service_account_tfer--104296524238941538670_id" {
 
 output "google_service_account_tfer--104433253766206552796_id" {
   value = google_service_account.tfer--104433253766206552796.id
-}
-
-output "google_service_account_tfer--105781789064132478524_id" {
-  value = google_service_account.tfer--105781789064132478524.id
 }
 
 output "google_service_account_tfer--108192824187785555345_id" {

--- a/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/project_iam_member.tf
@@ -442,12 +442,6 @@ resource "google_project_iam_member" "tfer--roles-002F-firestore-002E-serviceAge
   role    = "roles/firestore.serviceAgent"
 }
 
-resource "google_project_iam_member" "tfer--roles-002F-ownerserviceAccount-003A-cc-jarvus-airflow-0040-cal-itp-data-infra-002E-iam-002E-gserviceaccount-002E-com" {
-  member  = "serviceAccount:cc-jarvus-airflow@cal-itp-data-infra.iam.gserviceaccount.com"
-  project = "cal-itp-data-infra"
-  role    = "roles/viewer"
-}
-
 resource "google_project_iam_member" "tfer--roles-002F-run-002E-serviceAgentserviceAccount-003A-service-1005246706141-0040-serverless-robot-prod-002E-iam-002E-gserviceaccount-002E-com" {
   member  = "serviceAccount:service-1005246706141@serverless-robot-prod.iam.gserviceaccount.com"
   project = "cal-itp-data-infra"

--- a/iac/cal-itp-data-infra/iam/us/service_account.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account.tf
@@ -69,14 +69,6 @@ resource "google_service_account" "tfer--104433253766206552796" {
   project      = "cal-itp-data-infra"
 }
 
-resource "google_service_account" "tfer--105781789064132478524" {
-  account_id   = "cc-jarvus-airflow"
-  description  = "Chris's service account for Airflow"
-  disabled     = "false"
-  display_name = "cc-jarvus-airflow"
-  project      = "cal-itp-data-infra"
-}
-
 resource "google_service_account" "tfer--108192824187785555345" {
   account_id   = "jupyterlab"
   description  = "warehouse access for jupyterlab cloud"


### PR DESCRIPTION
# Description

Second and final step of #4960. [#5262](https://github.com/cal-itp/data-infra/pull/5262) downgraded three unused service accounts from `roles/owner` to `roles/viewer` on 2026-05-06, with the plan to delete them after two weeks if nothing broke. Nothing broke — ~2.5 months later there is still no admin-activity in the audit logs for any of them.

This PR removes the three accounts entirely:

| Account | Project | Notes |
|---|---|---|
| `cc-jarvus-airflow` | `cal-itp-data-infra` | enabled, live 2021 user-managed key |
| `amplitude` | `cal-itp-data-infra-staging` | already GCP-disabled |
| `local-airflow-dev` | `cal-itp-data-infra-staging` | enabled, live 2021 key; also held `roles/storage.objectAdmin` on the prod `gtfs-data-test` bucket |

For each account this removes the `google_service_account` resource, its project-level `roles/viewer` IAM member, and the corresponding `outputs.tf` entries. For `local-airflow-dev` it also drops the account from the prod `gtfs-data-test` bucket's `objectAdmin` grant (both the `google_storage_bucket_iam_binding` and the authoritative `google_storage_bucket_iam_policy`).

Not touched: `amplitude-export@cal-itp-data-infra` (prod, `storage.admin`/`storage.objectAdmin`). #5262 intentionally left it, and its object-level writes wouldn't show in admin-activity logs — see follow-up below.

Resolves #4960

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Audited admin-activity logs for all three principals over the trailing 90 days (covers the entire post-downgrade window) — no entries for any of them:

```
gcloud logging read \
  'protoPayload.authenticationInfo.principalEmail="cc-jarvus-airflow@cal-itp-data-infra.iam.gserviceaccount.com"' \
  --project=cal-itp-data-infra --freshness=90d --limit=5
# (repeated for amplitude@ and local-airflow-dev@ in cal-itp-data-infra-staging) — all empty
```

`terraform fmt -check` is clean on the touched directories, and grep confirms no remaining references to any of the three accounts (or their terraformer resource IDs) anywhere in `iac/`.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)

- Confirm the three accounts are gone after apply and watch for any unexpected breakage.
- Consider a separate issue to review `amplitude-export@cal-itp-data-infra` and to do the project-wide unused-service-account scan mentioned in #4960's additional context.
