### PR TITLE
fix(payments): De-duplicate `fct_payments_settlements` Rows (#5884)

### DIFF
--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -580,7 +580,16 @@ models:
 
   - name: int_payments__settlements_deduped
     description: >
-      Settlements records deduplicated so that each `_payments_key` (`settlement_id`) appears only once.
+      Settlements records deduplicated so that each `settlement_id` appears only once, carrying its most
+      recent record. A settlement that was exported as `PENDING` and later as `SETTLED` collapses to the
+      `SETTLED` row. Note that this is deliberately *not* keyed on `_payments_key`, which for settlements
+      includes `settlement_status` and so differs between the two versions of one settlement.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - participant_id
+              - settlement_id
     columns:
       - name: settlement_id
         description: '{{ doc("lp_settlement_id") }}'

--- a/warehouse/models/intermediate/payments/int_payments__settlements_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_deduped.sql
@@ -7,12 +7,18 @@ int_payments__settlements_deduped AS (
     SELECT
         *
     FROM settlements_unioned
-    -- see: https://github.com/cal-itp/data-infra/issues/4552
+    -- see: https://github.com/cal-itp/data-infra/issues/4552 and
+    -- https://github.com/cal-itp/data-infra/issues/5584
     -- we have cases where same settlement comes in with two statuses
     -- only want to keep one instance -- the more recent one
+    -- partition on settlement_id directly rather than on _payments_key: the staging
+    -- _payments_key is generate_surrogate_key(['settlement_id', 'settlement_status']),
+    -- so partitioning on it puts the PENDING and SETTLED versions of one settlement in
+    -- separate partitions and both survive. transaction_amount is likewise excluded so
+    -- that a settlement whose amount changed between statuses still collapses to one row.
     QUALIFY ROW_NUMBER() OVER
-        (PARTITION BY participant_id, _payments_key, transaction_amount
-        ORDER BY record_updated_timestamp_utc DESC, _line_number ASC) = 1
+        (PARTITION BY participant_id, settlement_id
+        ORDER BY record_updated_timestamp_utc DESC, littlepay_export_ts DESC, _line_number ASC) = 1
 )
 
 SELECT * FROM int_payments__settlements_deduped

--- a/warehouse/models/intermediate/payments/int_payments__settlements_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_deduped.sql
@@ -11,17 +11,6 @@ int_payments__settlements_deduped AS (
     -- https://github.com/cal-itp/data-infra/issues/5584
     -- we have cases where same settlement comes in with two statuses
     -- only want to keep one instance -- the more recent one
-    -- partition on settlement_id directly rather than on _payments_key: the staging
-    -- _payments_key is generate_surrogate_key(['settlement_id', 'settlement_status']),
-    -- so partitioning on it puts the PENDING and SETTLED versions of one settlement in
-    -- separate partitions and both survive.
-    -- transaction_amount is excluded because settlement_id is already the entity grain
-    -- here: within one settlement_id the amount can only split versions of that single
-    -- settlement, it can never separate two distinct settlements. (Contrast the second
-    -- dedup in int_payments__refunds_deduped, where proposed_amount IS a partition key
-    -- because that partition is aggregation-level and coarser than the entity ID.)
-    -- Sales and their refunds are separate settlements with their own settlement_ids,
-    -- so collapsing on settlement_id does not merge a DEBIT with its CREDIT.
     QUALIFY ROW_NUMBER() OVER
         (PARTITION BY participant_id, settlement_id
         ORDER BY record_updated_timestamp_utc DESC, littlepay_export_ts DESC, _line_number ASC) = 1

--- a/warehouse/models/intermediate/payments/int_payments__settlements_deduped.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_deduped.sql
@@ -14,8 +14,14 @@ int_payments__settlements_deduped AS (
     -- partition on settlement_id directly rather than on _payments_key: the staging
     -- _payments_key is generate_surrogate_key(['settlement_id', 'settlement_status']),
     -- so partitioning on it puts the PENDING and SETTLED versions of one settlement in
-    -- separate partitions and both survive. transaction_amount is likewise excluded so
-    -- that a settlement whose amount changed between statuses still collapses to one row.
+    -- separate partitions and both survive.
+    -- transaction_amount is excluded because settlement_id is already the entity grain
+    -- here: within one settlement_id the amount can only split versions of that single
+    -- settlement, it can never separate two distinct settlements. (Contrast the second
+    -- dedup in int_payments__refunds_deduped, where proposed_amount IS a partition key
+    -- because that partition is aggregation-level and coarser than the entity ID.)
+    -- Sales and their refunds are separate settlements with their own settlement_ids,
+    -- so collapsing on settlement_id does not merge a DEBIT with its CREDIT.
     QUALIFY ROW_NUMBER() OVER
         (PARTITION BY participant_id, settlement_id
         ORDER BY record_updated_timestamp_utc DESC, littlepay_export_ts DESC, _line_number ASC) = 1

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -348,7 +348,13 @@ models:
           Category for reconciliation purposes (whether the aggregation is settled and whether it has an Elavon match.)
 
   - name: fct_payments_settlements
-    description: Littlepay settlements (completed transactions.)
+    description: Littlepay settlements (completed transactions.) One row per settlement, carrying its most recent record.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - participant_id
+              - settlement_id
     columns:
       - name: settlement_id
         description: '{{ doc("lp_settlement_id") }}'

--- a/warehouse/tests/intermediate/payments/test_settlement_id_has_single_settlement_type.sql
+++ b/warehouse/tests/intermediate/payments/test_settlement_id_has_single_settlement_type.sql
@@ -1,22 +1,12 @@
 {{ config(store_failures = true) }}
 
+-- Tests that there is never a case where a settlement id is duplicated for both a refund
+-- and a settlement.
+
 -- Guards the dedup grain in int_payments__settlements_deduped, which collapses to one row
 -- per (participant_id, settlement_id) and therefore assumes a settlement_id never spans more
 -- than one settlement_type. If a sale (DEBIT) and its refund (CREDIT) ever shared a
 -- settlement_id, that dedup would silently drop the refund.
---
--- This test deliberately runs against the dedup's INPUT rather than its output. The QUALIFY in
--- int_payments__settlements_deduped guarantees one row per settlement_id, so the uniqueness
--- test on that model would pass green even while a refund was being discarded -- the violation
--- is only observable upstream of the dedup.
---
--- settlement_type is nullable (fct_payments_settlements imputes it when missing), and a bare
--- COUNT(DISTINCT settlement_type) would skip those NULLs -- so a DEBIT row sharing a
--- settlement_id with an untyped refund would go unnoticed. NULL is therefore coalesced to a
--- sentinel and counted as its own type.
---
--- See https://github.com/cal-itp/data-infra/issues/5584 and, for the aggregation-grain
--- duplication that motivated the dedup in the first place, issue #4552.
 
 WITH settlements_unioned AS (
     SELECT * FROM {{ ref('int_littlepay__unioned_settlements') }}

--- a/warehouse/tests/intermediate/payments/test_settlement_id_has_single_settlement_type.sql
+++ b/warehouse/tests/intermediate/payments/test_settlement_id_has_single_settlement_type.sql
@@ -1,0 +1,39 @@
+{{ config(store_failures = true) }}
+
+-- Guards the dedup grain in int_payments__settlements_deduped, which collapses to one row
+-- per (participant_id, settlement_id) and therefore assumes a settlement_id never spans more
+-- than one settlement_type. If a sale (DEBIT) and its refund (CREDIT) ever shared a
+-- settlement_id, that dedup would silently drop the refund.
+--
+-- This test deliberately runs against the dedup's INPUT rather than its output. The QUALIFY in
+-- int_payments__settlements_deduped guarantees one row per settlement_id, so the uniqueness
+-- test on that model would pass green even while a refund was being discarded -- the violation
+-- is only observable upstream of the dedup.
+--
+-- settlement_type is nullable (fct_payments_settlements imputes it when missing), and a bare
+-- COUNT(DISTINCT settlement_type) would skip those NULLs -- so a DEBIT row sharing a
+-- settlement_id with an untyped refund would go unnoticed. NULL is therefore coalesced to a
+-- sentinel and counted as its own type.
+--
+-- See https://github.com/cal-itp/data-infra/issues/5584 and, for the aggregation-grain
+-- duplication that motivated the dedup in the first place, issue #4552.
+
+WITH settlements_unioned AS (
+    SELECT * FROM {{ ref('int_littlepay__unioned_settlements') }}
+),
+
+bad_rows AS (
+    SELECT
+        participant_id,
+        settlement_id,
+        COUNT(*) AS num_rows,
+        COUNT(DISTINCT COALESCE(settlement_type, '__MISSING__')) AS num_settlement_types,
+        COUNT(DISTINCT settlement_type) AS num_non_null_settlement_types,
+        COUNTIF(settlement_type IS NULL) AS num_untyped_rows,
+        COUNT(DISTINCT settlement_status) AS num_settlement_statuses
+    FROM settlements_unioned
+    GROUP BY participant_id, settlement_id
+    HAVING COUNT(DISTINCT COALESCE(settlement_type, '__MISSING__')) > 1
+)
+
+SELECT * FROM bad_rows


### PR DESCRIPTION
# Description

`fct_payments_settlements` contains duplicate rows for a single settlement: one row for the `PENDING` export and another for the `SETTLED` export of the same `settlement_id`, in a recurrence of #4552. This fixes the deduplication, and adds tests so the grain can't drift again silently.

- Fix the deduplication error by partitioning on the settlement's natural identity (`participant_id`, `settlement_id`) instead of on `_payments_key`
- Add new tests to `fct_payments_settlements`, `int_payments__settlements_deduped`, and `int_payments__settlements_unioned` to detect future recurrence

Resolves #5584 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```
uv run dbt run --full-refresh -s +fct_payments_settlements
uv run dbt test -s +fct_payments_settlements
```

Verify that no tests are failing

### Verifying the fix

**1. Duplicates are gone.** Expect zero rows:

```sql
SELECT
    participant_id,
    settlement_id,
    COUNT(*) AS num_rows,
    STRING_AGG(DISTINCT settlement_status ORDER BY settlement_status) AS statuses
FROM `cal-itp-data-infra-staging.ap_mart_payments.fct_payments_settlements`
GROUP BY participant_id, settlement_id
HAVING COUNT(*) > 1
ORDER BY num_rows DESC;
```

Produces an empty table

Before this change, the rows returned here are predominantly `PENDING,SETTLED` pairs.

**2. No `settlement_id`s were lost.** The fix removes rows, so the important check is that it removed only *redundant* ones. Anti-join every distinct settlement in the dedup's input against the mart — expect zero rows:

```sql
WITH input_ids AS (
    SELECT DISTINCT participant_id, settlement_id
    FROM `cal-itp-data-infra-staging.ap_staging.int_littlepay__unioned_settlements`
),

output_ids AS (
    SELECT DISTINCT participant_id, settlement_id
    FROM `cal-itp-data-infra-staging.ap_mart_payments.fct_payments_settlements`
)

SELECT input_ids.*
FROM input_ids
LEFT JOIN output_ids USING (participant_id, settlement_id)
WHERE output_ids.settlement_id IS NULL;
```

Yields an empty table

**3. Row-count shape.** `rows_out` should equal `distinct_ids_in`, and both should be lower than `rows_in`:

```sql
SELECT
    (SELECT COUNT(*) FROM `cal-itp-data-infra-staging.ap_staging.int_littlepay__unioned_settlements`) AS rows_in,
    (SELECT COUNT(*) FROM (
        SELECT DISTINCT participant_id, settlement_id
        FROM `cal-itp-data-infra-staging.ap_staging.int_littlepay__unioned_settlements`
    )) AS distinct_ids_in,
    (SELECT COUNT(*) FROM `cal-itp-data-infra-staging.ap_mart_payments.fct_payments_settlements`) AS rows_out;
```

Result:

```
rows_in	distinct_ids_in	rows_out
104015	103804	103804
```

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
