### PR TITLE
feat(gtfs-rt-archiver): support trip modifications feeds

### DIFF
--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
@@ -10,7 +10,12 @@ from google.auth import default
 from google.cloud import pubsub_v1, storage
 
 PUBLISH_TIMEOUT = int(os.environ.get("PUBLISH_TIMEOUT", "10"))
-GTFS_RT_FEED_TYPES = ["service_alerts", "trip_updates", "vehicle_positions"]
+GTFS_RT_FEED_TYPES = [
+    "service_alerts",
+    "trip_updates",
+    "vehicle_positions",
+    "trip_modifications",
+]
 
 
 class Heartbeat:


### PR DESCRIPTION
## Description

Adds `trip_modifications` to the list of supported GTFS-RT feed types in the heartbeat service.

This allows Trip Modifications download configurations to be published to the archiver so they can be downloaded and archived in the raw bucket.

Ref #<[5527](https://github.com/cal-itp/data-infra/issues/5527)>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- Ran the existing heartbeat unit tests:

```bash
uv run pytest tests/test_heartbeat.py -v
jovyan@jupyter-fsalemi:~/data-infra/services/gtfs-rt-archiver$ uv run pytest tests/test_heartbeat.py -v
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.11.10, pytest-9.0.2, pluggy-1.6.0 -- /home/jovyan/data-infra/services/gtfs-rt-archiver/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/jovyan/data-infra/services/gtfs-rt-archiver
configfile: pyproject.toml
plugins: mock-3.15.1, dotenv-0.5.2, recording-0.13.4, anyio-4.13.0
collected 2 items                                                                                                                                                                                   

tests/test_heartbeat.py::TestHeartbeat::test_heartbeat_reads_download_configs PASSED                                                                                                          [ 50%]
tests/test_heartbeat.py::TestHeartbeat::test_heartbeat_enqueues_message PASSED                                                                                                                [100%]

======================================================================================== 2 passed in 23.11s =========================================================================================
```