### PR TITLE
Add columns to external_airtable.california_transit__services

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -332,4 +332,3 @@ schema_fields:
   - name: paratransit_exemption_notes
     type: STRING
     mode: NULLABLE
-    

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -146,6 +146,9 @@ schema_fields:
   - name: paratransit_for
     type: STRING
     mode: REPEATED
+  - name: complementary_paratransit_service
+    type: STRING
+    mode: REPEATED
   - name: gtfs_schedule_status
     type: STRING
     mode: NULLABLE
@@ -287,6 +290,15 @@ schema_fields:
   - name: public_currently_operating_fixed_route
     type: STRING
     mode: NULLABLE
+  - name: reservation_methods
+    type: STRING
+    mode: NULLABLE
+  - name: booking_lead_time
+    type: STRING
+    mode: NULLABLE
+  - name: paratransit_exemption_notes
+    type: STRING
+    mode: NULLABLE
   - name: holiday_schedule___veterans_day__observed_
     type: STRING
     mode: NULLABLE
@@ -318,17 +330,5 @@ schema_fields:
     type: STRING
     mode: NULLABLE
   - name: holiday_website_condition
-    type: STRING
-    mode: NULLABLE
-  - name: complementary_paratransit_service
-    type: STRING
-    mode: REPEATED
-  - name: reservation_methods
-    type: STRING
-    mode: NULLABLE
-  - name: booking_lead_time
-    type: STRING
-    mode: NULLABLE
-  - name: paratransit_exemption_notes
     type: STRING
     mode: NULLABLE

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -320,3 +320,16 @@ schema_fields:
   - name: holiday_website_condition
     type: STRING
     mode: NULLABLE
+  - name: complementary_paratransit_service
+    type: STRING
+    mode: REPEATED
+  - name: reservation_methods
+    type: STRING
+    mode: NULLABLE
+  - name: booking_lead_time
+    type: STRING
+    mode: NULLABLE
+  - name: paratransit_exemption_notes
+    type: STRING
+    mode: NULLABLE
+    


### PR DESCRIPTION
# Description

This PR adds columns related to demand response from Airtable services table to the warehouse services table.

The new columns will be used for adding demand response related columns to downstream services tables and replacing the bridge_paratransit_services table. (#4725)

Resolves #5595 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

No test is required for this PR.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
