### PR TITLE
fix(gtfs-rt-archiver): use terraform service account

### DIFF
--- a/.github/workflows/gtfs-rt-archiver.yml
+++ b/.github/workflows/gtfs-rt-archiver.yml
@@ -20,6 +20,7 @@ env:
   PYTHON_VERSION: '3.11'
   UV_VERSION: '0.11.5'
   SERVICE_ACCOUNT: github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com
+  TERRAFORM_SERVICE_ACCOUNT: github-actions-terraform@cal-itp-data-infra-staging.iam.gserviceaccount.com
   WORKLOAD_IDENTITY_PROVIDER: projects/473674835135/locations/global/workloadIdentityPools/github-actions/providers/data-infra
   PROJECT_ID: cal-itp-data-infra-staging
 
@@ -108,7 +109,7 @@ jobs:
           create_credentials_file: true
           project_id: ${{ env.PROJECT_ID }}
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
+          service_account: ${{ env.TERRAFORM_SERVICE_ACCOUNT }}
 
       - name: Terraform Plan
         uses: dflook/terraform-plan@v1
@@ -140,7 +141,7 @@ jobs:
           create_credentials_file: true
           project_id: ${{ env.PROJECT_ID }}
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
+          service_account: ${{ env.TERRAFORM_SERVICE_ACCOUNT }}
 
       - name: Setup GCloud utilities
         uses: google-github-actions/setup-gcloud@v3


### PR DESCRIPTION
## Description

Updates the GTFS-RT Archiver GitHub Actions workflow to use the dedicated Terraform service account for Terraform plan and apply.

The workflow was previously using `github-actions-service-account`, which does not have permission to update the GTFS-RT Archiver Cloud Functions and resulted in:

`cloudfunctions.functions.update` permission denied.

This change uses `github-actions-terraform` for the Terraform deployment steps, consistent with the existing Terraform workflows.

Ref #<https://github.com/cal-itp/data-infra/issues/5527>

## Changes

- Add `TERRAFORM_SERVICE_ACCOUNT` for the staging Terraform service account.
- Update `staging-plan` to authenticate with `TERRAFORM_SERVICE_ACCOUNT`.
- Update `staging-apply` to authenticate with `TERRAFORM_SERVICE_ACCOUNT`.

## How has this been tested?

The issue was identified when the GTFS-RT Archiver staging deployment attempted to update the Cloud Functions and failed due to insufficient permissions.