### PR TITLE
chore(gtfs-rt-archiver): force staging redeploy

### DIFF
--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
@@ -10,6 +10,7 @@ from google.auth import default
 from google.cloud import pubsub_v1, storage
 
 PUBLISH_TIMEOUT = int(os.environ.get("PUBLISH_TIMEOUT", "10"))
+# Supports all currently archived GTFS-Realtime feed types.
 GTFS_RT_FEED_TYPES = [
     "service_alerts",
     "trip_updates",


### PR DESCRIPTION
## Description

Adds a no-op comment to the GTFS-RT Archiver source to force a new deployment package hash.

This is intended to trigger a redeployment of the staging Cloud Functions after an earlier deployment failed due to a `cloudfunctions.functions.update` permission error. The workflow has since been fixed to use the correct Terraform service account, but Terraform now reports no infrastructure changes and does not redeploy the functions.

This change is functionally a no-op and is only intended to force creation of a new source archive and Cloud Function revision.

Ref #<https://github.com/cal-itp/data-infra/issues/5527>

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Chore / Infrastructure

## How has this been tested?

- Verified the GTFS-RT Archiver unit tests pass.
- Verified this change does not modify application behavior.