### PR TITLE
fix(gtfs-rt-archiver): deploy service changes to production

### DIFF
--- a/.github/workflows/gtfs-rt-archiver.yml
+++ b/.github/workflows/gtfs-rt-archiver.yml
@@ -19,10 +19,15 @@ concurrency:
 env:
   PYTHON_VERSION: '3.11'
   UV_VERSION: '0.11.5'
+
   SERVICE_ACCOUNT: github-actions-service-account@cal-itp-data-infra-staging.iam.gserviceaccount.com
   TERRAFORM_SERVICE_ACCOUNT: github-actions-terraform@cal-itp-data-infra-staging.iam.gserviceaccount.com
   WORKLOAD_IDENTITY_PROVIDER: projects/473674835135/locations/global/workloadIdentityPools/github-actions/providers/data-infra
   PROJECT_ID: cal-itp-data-infra-staging
+
+  PRODUCTION_TERRAFORM_SERVICE_ACCOUNT: github-actions-terraform@cal-itp-data-infra.iam.gserviceaccount.com
+  PRODUCTION_WORKLOAD_IDENTITY_PROVIDER: projects/1005246706141/locations/global/workloadIdentityPools/github-actions/providers/data-infra
+  PRODUCTION_PROJECT_ID: cal-itp-data-infra
 
 jobs:
   test:
@@ -56,7 +61,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version:  ${{ env.UV_VERSION }}
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
           cache-python: true
@@ -91,7 +96,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [targets]
 
-    # If there are changes to composer iac files `terraform-plan` workflow will take care
+    # If there are changes to the staging IaC files,
+    # the general terraform-plan workflow will handle them.
     if: ${{ github.ref != 'refs/heads/main' && (needs.targets.outputs.staging == '[]' || needs.targets.outputs.staging == '') }}
 
     permissions:
@@ -124,7 +130,8 @@ jobs:
     needs: [targets]
     runs-on: ubuntu-latest
 
-    # If there are changes to composer iac files `terraform-apply` workflow will take care
+    # If there are changes to the staging IaC files,
+    # the general terraform-apply workflow will handle them.
     if: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/staging')) && (needs.targets.outputs.staging == '[]' || needs.targets.outputs.staging == '') }}
 
     permissions:
@@ -145,6 +152,8 @@ jobs:
 
       - name: Setup GCloud utilities
         uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ env.PROJECT_ID }}
 
       - name: Terraform Apply
         uses: dflook/terraform-apply@v1
@@ -153,3 +162,38 @@ jobs:
         with:
           path: iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us
           auto_approve: ${{ contains(github.ref, 'refs/heads/staging') }}
+
+  production-apply:
+    name: Production Apply
+    needs: [staging-apply]
+    runs-on: ubuntu-latest
+
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate Google Service Account
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.PRODUCTION_PROJECT_ID }}
+          workload_identity_provider: ${{ env.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.PRODUCTION_TERRAFORM_SERVICE_ACCOUNT }}
+
+      - name: Setup GCloud utilities
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ env.PRODUCTION_PROJECT_ID }}
+
+      - name: Terraform Apply
+        uses: dflook/terraform-apply@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: iac/cal-itp-data-infra/gtfs-rt-archiver/us


### PR DESCRIPTION
## Description

Adds a production Terraform apply job to the GTFS-RT Archiver workflow.

The workflow currently deploys changes under `services/gtfs-rt-archiver/**` to staging, but does not deploy the same source changes to the production GTFS-RT Archiver. This caused the recently added `trip_modifications` support to be available in staging but not production.

The new production job:

- Runs only after a successful staging deployment.
- Runs only on `main`.
- Uses the production Terraform service account and Workload Identity provider.
- Applies the production GTFS-RT Archiver Terraform configuration at `iac/cal-itp-data-infra/gtfs-rt-archiver/us`.

ref: https://github.com/cal-itp/data-infra/issues/5527

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How has this been tested?

- Confirmed the existing workflow successfully deploys service-code changes to staging.
- Confirmed the workflow currently has no production apply job.
- Confirmed production did not receive the recent `trip_modifications` source-code update.
