### PR TITLE
reduce the downloader timeout from 30 to 10 secs

### DIFF
--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/.terraform.lock.hcl
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.7.1"
   hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
     "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
@@ -20,29 +21,11 @@ provider "registry.terraform.io/hashicorp/archive" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.3.5"
-  hashes = [
-    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
-    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
-    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
-    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
-    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
-    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
-    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
-    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
-    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
-    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
-    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/google" {
   version     = "6.41.0"
   constraints = "~> 6.41.0"
   hashes = [
+    "h1:ecCCOOF2ZDP1vLT/PDVNcL0+1PbtG2auHg8KcSyXI8Y=",
     "h1:f5F5LlkVvFqfmM/oWmqUDZEa8NieeHoAoEW7iNMwFVo=",
     "zh:0a375c4f37599de566b6dd19d1953f70f6f88f089bb7cf97d1fa1287b2ebf41c",
     "zh:2309a75bf6bd6f97ccae0c8348bb560eb893518786150cb634bc7795898d38f9",

--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
@@ -98,7 +98,7 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
     environment_variables = {
       CALITP_BUCKET__GTFS_RT_RAW = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-staging-gtfs-rt-raw-v2_name}"
       REQUEST_CONNECT_TIMEOUT    = 1
-      REQUEST_READ_TIMEOUT       = 30
+      REQUEST_READ_TIMEOUT       = 10
     }
   }
 

--- a/iac/cal-itp-data-infra/gtfs-rt-archiver/us/service.tf
+++ b/iac/cal-itp-data-infra/gtfs-rt-archiver/us/service.tf
@@ -100,7 +100,7 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
     environment_variables = {
       CALITP_BUCKET__GTFS_RT_RAW = "gs://${data.terraform_remote_state.gcs.outputs.google_storage_bucket_calitp-gtfs-rt-raw-v2_name}"
       REQUEST_CONNECT_TIMEOUT    = 1
-      REQUEST_READ_TIMEOUT       = 30
+      REQUEST_READ_TIMEOUT       = 10
     }
   }
 


### PR DESCRIPTION
# Description

reduce the downloader timeout from 30 to 10 secs.

Resolves #5565 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
