### PR TITLE
Add workload identity for `gtfs-curator/ntd-snapshot` repos for GH actions

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/iam_workload_identity.tf
@@ -52,3 +52,37 @@ resource "google_iam_workload_identity_pool_provider" "data-analyses" {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
+
+resource "google_iam_workload_identity_pool_provider" "gtfs-curator" {
+  workload_identity_pool_provider_id = "gtfs-curator"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.gtfs-curator_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_iam_workload_identity_pool_provider" "ntd-snapshot" {
+  workload_identity_pool_provider_id = "ntd-snapshot"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.ntd-snapshot_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}

--- a/iac/cal-itp-data-infra-staging/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/variables.tf
@@ -3,4 +3,6 @@ locals {
   data-infra_github_repository_name    = "cal-itp/data-infra"
   cal-bc_github_repository_name        = "cal-itp/cal-bc"
   data-analyses_github_repository_name = "cal-itp/data-analyses"
+  gtfs-curator_github_repository_name  = "cal-itp/gtfs-curator"
+  ntd-snapshot_github_repository_name  = "cal-itp/ntd-snapshot"
 }

--- a/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
+++ b/iac/cal-itp-data-infra/iam/us/iam_workload_identity.tf
@@ -86,3 +86,37 @@ resource "google_iam_workload_identity_pool_provider" "tides-site" {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
+
+resource "google_iam_workload_identity_pool_provider" "gtfs-curator" {
+  workload_identity_pool_provider_id = "gtfs-curator"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.gtfs-curator_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_iam_workload_identity_pool_provider" "ntd-snapshot" {
+  workload_identity_pool_provider_id = "ntd-snapshot"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github-actions.workload_identity_pool_id
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  attribute_condition = <<EOT
+    attribute.repository == "${local.ntd-snapshot_github_repository_name}"
+  EOT
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}

--- a/iac/cal-itp-data-infra/iam/us/variables.tf
+++ b/iac/cal-itp-data-infra/iam/us/variables.tf
@@ -5,4 +5,6 @@ locals {
   reports_github_repository_name         = "cal-itp/reports"
   analysis_github_repository_name        = "cal-itp/data-analyses"
   tides-site_github_repository_name      = "cal-itp/tides.dds.dot.ca.gov"
+  gtfs-curator_github_repository_name    = "cal-itp/gtfs-curator"
+  ntd-snapshot_github_repository_name    = "cal-itp/ntd-snapshot"
 }


### PR DESCRIPTION
# Description

- Adjust `iam_workload_identity.tf` and `variables.tf` for `cal-itp-data-infra` to include `gtfs-curator` and `ntd-snapshot` repos. This should allow GH action to deploy portfolio will work
- Adjust `iam_workload_identity.tf` and `variables.tf` for `cal-itp-data-infra-staging` to add these 2 repos, staging portfolio index also needs to be built
- did notice [this typo](https://github.com/cal-itp/data-infra/blob/add-workload-identity-for-new-repos/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf#L31) -- opting not to change because of prevalence of refs throughout.
* Resolves #5614 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

## Post-merge follow-ups

- [x] No action required here
- [ ] Check that `gtfs-curator` GH action can pass: https://github.com/cal-itp/gtfs-curator/pull/56
- [ ] Check that `ntd-snapshot` GH action can pass: https://github.com/cal-itp/ntd-snapshot/pull/15
