### PR TITLE
Add workload identity for `gtfs-curator/ntd-snapshot` repos for GH actions - adjust `service_account_iam_member.tf`

### DIFF
--- a/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra-staging/iam/us/service_account_iam_member.tf
@@ -45,3 +45,15 @@ resource "google_service_account_iam_member" "github-actions-service-account_dat
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.data-analyses_github_repository_name}"
 }
+
+resource "google_service_account_iam_member" "github-actions-service-account_gtfs-curator" {
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.gtfs-curator_github_repository_name}"
+}
+
+resource "google_service_account_iam_member" "github-actions-service-account_ntd-snapshot" {
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.ntd-snapshot_github_repository_name}"
+}

--- a/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
+++ b/iac/cal-itp-data-infra/iam/us/service_account_iam_member.tf
@@ -63,3 +63,15 @@ resource "google_service_account_iam_member" "elavon-sftp-service-account" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:cal-itp-data-infra.svc.id.goog[default/elavon-sftp-service-account]"
 }
+
+resource "google_service_account_iam_member" "github-actions-service-account_gtfs-curator" {
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.gtfs-curator_github_repository_name}"
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+}
+
+resource "google_service_account_iam_member" "github-actions-service-account_ntd-snapshot" {
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github-actions.name}/attribute.repository/${local.ntd-snapshot_github_repository_name}"
+  service_account_id = google_service_account.github-actions-service-account.id
+  role               = "roles/iam.workloadIdentityUser"
+}


### PR DESCRIPTION
# Description

* Adjust `service_account_iam_member.tf` for `cal-itp-data-infra` to include `gtfs-curator` and `ntd-snapshot` repos. This should allow GH action to deploy portfolio will work
* Follow-up to #5615 
* Resolves #5614 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?


## Post-merge follow-ups

- [x] No action required here
- [ ] Check that `gtfs-curator` GH action can pass: https://github.com/cal-itp/gtfs-curator/pull/56
- [ ] Check that `ntd-snapshot` GH action can pass: https://github.com/cal-itp/ntd-snapshot/pull/15
