### PR TITLE
revert heartbeat.py

### DIFF
--- a/iac/cal-itp-data-infra/gtfs-rt-archiver/us/.terraform.lock.hcl
+++ b/iac/cal-itp-data-infra/gtfs-rt-archiver/us/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.7.1"
   hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
     "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/google" {
   version     = "7.10.0"
   constraints = "~> 7.10.0"
   hashes = [
+    "h1:5nI7o1CcDgcuj4E3l3L+7xs/hv0oAhRIh1BHMVcGzns=",
     "h1:itPAvjmGmV6R8KpBsDGnONKfi9AXPt0LCFThnDF/3+g=",
     "zh:40b90c1e6cc95cccfc935d4af4478590410bf2ce24d2cd7f6b583e7791b9b5b3",
     "zh:56f25840e253ea527ab196ffb5cc3f896ef129c6d0dbe795eb9dd305d84354cd",

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
@@ -10,13 +10,7 @@ from google.auth import default
 from google.cloud import pubsub_v1, storage
 
 PUBLISH_TIMEOUT = int(os.environ.get("PUBLISH_TIMEOUT", "10"))
-# Supports all currently archived GTFS-Realtime feed types.
-GTFS_RT_FEED_TYPES = [
-    "service_alerts",
-    "trip_updates",
-    "vehicle_positions",
-    "trip_modifications",
-]
+GTFS_RT_FEED_TYPES = ["service_alerts", "trip_updates", "vehicle_positions"]
 
 
 class Heartbeat:


### PR DESCRIPTION
not downloading `trip_modifications`

# Description

revert `heartbeat.py` to https://github.com/cal-itp/data-infra/blob/1d385a6707040f99e09399ec1134d06469343f6d/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py

Resolves #5621 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

reverting to older version. no need to test.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
