### PR TITLE
feat(payments): Add Settled and Unsettled Credit Amount Columns (#5597)

### DIFF
--- a/warehouse/models/docs/_docs_littlepay.md
+++ b/warehouse/models/docs/_docs_littlepay.md
@@ -170,6 +170,19 @@ Numbers in this column are negative because they represent amounts credited (ref
 i.e., these values represent costs for the participant (agency).
 {% enddocs %}
 
+{% docs lp_littlepay_settled_credit_amount %}
+The portion of this aggregation's credit (refund) settlement amount that has `settlement_status = SETTLED`.
+
+Numbers in this column are negative, like the total credit amount.
+{% enddocs %}
+
+{% docs lp_littlepay_unsettled_credit_amount %}
+The portion of this aggregation's credit (refund) settlement amount whose `settlement_status` is present but is not `SETTLED`
+(i.e., `PENDING`, `REJECTED`, or `FAILED`).
+
+Numbers in this column are negative, like the total credit amount.
+{% enddocs %}
+
 {% docs lp_aggregation_is_settled %}
 Boolean indicating whether all settlements in this aggregation have `settlement_status = SETTLED`.
 

--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -94,6 +94,10 @@ models:
         description: '{{ doc("lp_settlement_debit_amount") }}'
       - name: credit_amount
         description: '{{ doc("lp_settlement_credit_amount") }}'
+      - name: littlepay_settled_credit_amount
+        description: '{{ doc("lp_littlepay_settled_credit_amount") }}'
+      - name: littlepay_unsettled_credit_amount
+        description: '{{ doc("lp_littlepay_unsettled_credit_amount") }}'
       - name: aggregation_is_settled
         description: '{{ doc("lp_aggregation_is_settled") }}'
       - name: debit_is_settled

--- a/warehouse/models/intermediate/payments/int_payments__settlements_to_aggregations.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_to_aggregations.sql
@@ -17,7 +17,9 @@ summarize_by_type AS (
         LOGICAL_OR(imputed_type) AS type_contains_imputed_type,
         MAX(record_updated_timestamp_utc) AS type_latest_update_timestamp,
         SUM(transaction_amount) AS total_amount,
-        LOGICAL_AND(settlement_status = "SETTLED") AS is_settled
+        LOGICAL_AND(settlement_status = "SETTLED") AS is_settled,
+        SUM(CASE WHEN settlement_status = "SETTLED" THEN transaction_amount ELSE 0 END) AS settled_amount,
+        SUM(CASE WHEN settlement_status != "SETTLED" THEN transaction_amount ELSE 0 END) AS unsettled_amount
     FROM settlements
     GROUP BY 1, 2, 3, 4
 ),
@@ -50,7 +52,9 @@ int_payments__settlements_to_aggregations AS (
         COALESCE(debit.total_amount,0) AS debit_amount,
         debit.is_settled AS debit_is_settled,
         COALESCE(credit.total_amount,0) AS credit_amount,
-        credit.is_settled AS credit_is_settled
+        credit.is_settled AS credit_is_settled,
+        COALESCE(credit.settled_amount,0) AS littlepay_settled_credit_amount,
+        COALESCE(credit.unsettled_amount,0) AS littlepay_unsettled_credit_amount
     FROM summarize_overall AS summary
     LEFT JOIN summarize_by_type AS debit
         ON summary.aggregation_id = debit.aggregation_id

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -322,6 +322,10 @@ models:
         description: '{{ doc("lp_settlement_debit_amount") }}'
       - name: settlement_credit_amount
         description: '{{ doc("lp_settlement_credit_amount") }}'
+      - name: littlepay_settled_credit_amount
+        description: '{{ doc("lp_littlepay_settled_credit_amount") }}'
+      - name: littlepay_unsettled_credit_amount
+        description: '{{ doc("lp_littlepay_unsettled_credit_amount") }}'
       - name: aggregation_is_settled
         description: '{{ doc("lp_aggregation_is_settled") }}'
       - name: debit_is_settled

--- a/warehouse/models/mart/payments/fct_payments_aggregations.sql
+++ b/warehouse/models/mart/payments/fct_payments_aggregations.sql
@@ -158,6 +158,8 @@ fct_payments_aggregations AS (
         contains_refund AS settlement_contains_refund,
         debit_amount AS settlement_debit_amount,
         credit_amount AS settlement_credit_amount,
+        littlepay_settled_credit_amount,
+        littlepay_unsettled_credit_amount,
         debit_amount > 0 AS contains_nonzero_sales,
         CASE
             WHEN aggregation_is_settled IS NOT NULL THEN aggregation_is_settled


### PR DESCRIPTION
# Description

Add columns `littlepay_settled_credit_amount` and `littlepay_unsettled_credit_amount`. This resolves an edge case where the "Unsettled Refunds" and "Settled Refunds" tabs on the Reconciliation Dashboard would display incorrect information, because an aggregation would contain both settled and unsettled refunds but be marked as either fully settled or fully settled.

Resolves #5597

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

### Generate the tables and test

Note that an expansive query is necessary here, because this issue only occurs for very few rows and they only appear if run on the full production data.

```
uv run dbt run -s staging.payments intermediate.payments mart.payments --vars 'GOOGLE_CLOUD_PROJECT: cal-itp-data-infra'
uv run dbt test -s +fct_payments_aggregations
```

### Validate that the edge case is now handled correctly

See this [Metabase query](https://metabase.dds.dot.ca.gov/question/6934-validate-settled-and-unsettled-aggregation-ids) confirming a previously incorrect row now displays correctly. Note that this is just a smoke test, but is acceptable due to the extremely low risk.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [x] No action required
- [ ] Actions required (specified below)
