### PR TITLE
Add Reconciliation Category and Update Tests for Duplicate RRNs (#5459, #5278)

### DIFF
--- a/warehouse/models/intermediate/payments/_int_payments.yml
+++ b/warehouse/models/intermediate/payments/_int_payments.yml
@@ -71,7 +71,11 @@ models:
       - name: retrieval_reference_number
         data_tests:
           - not_null
-          - unique
+          # see issue #5278
+          - unique:
+              arguments:
+                config:
+                  where: "latest_update_timestamp >= TIMESTAMP('2026-06-01')"
       - &participant_id
         name: participant_id
         description: '{{ doc("lp_participant_id") }}'

--- a/warehouse/models/intermediate/payments/int_payments__settlements_to_aggregations.sql
+++ b/warehouse/models/intermediate/payments/int_payments__settlements_to_aggregations.sql
@@ -39,6 +39,15 @@ summarize_overall AS (
     GROUP BY 1, 2, 3
 ),
 
+-- group by rrn to detect duplicates
+summarize_by_rrn AS (
+    SELECT
+        retrieval_reference_number,
+        COUNT(*) as n_retrieval_reference_number_copies
+    FROM summarize_overall
+    GROUP BY 1
+),
+
 int_payments__settlements_to_aggregations AS (
     SELECT
         summary.participant_id,
@@ -54,7 +63,8 @@ int_payments__settlements_to_aggregations AS (
         COALESCE(credit.total_amount,0) AS credit_amount,
         credit.is_settled AS credit_is_settled,
         COALESCE(credit.settled_amount,0) AS littlepay_settled_credit_amount,
-        COALESCE(credit.unsettled_amount,0) AS littlepay_unsettled_credit_amount
+        COALESCE(credit.unsettled_amount,0) AS littlepay_unsettled_credit_amount,
+        summary_rrn.n_retrieval_reference_number_copies
     FROM summarize_overall AS summary
     LEFT JOIN summarize_by_type AS debit
         ON summary.aggregation_id = debit.aggregation_id
@@ -64,6 +74,8 @@ int_payments__settlements_to_aggregations AS (
         ON summary.aggregation_id = credit.aggregation_id
         AND summary.retrieval_reference_number = credit.retrieval_reference_number
         AND credit.settlement_type = "CREDIT"
+    LEFT JOIN summarize_by_rrn AS summary_rrn
+        ON summary.retrieval_reference_number = summary_rrn.retrieval_reference_number
 )
 
 SELECT * FROM int_payments__settlements_to_aggregations

--- a/warehouse/models/mart/payments/_payments.yml
+++ b/warehouse/models/mart/payments/_payments.yml
@@ -351,6 +351,16 @@ models:
         description: |
           Category for reconciliation purposes (whether the aggregation is settled and whether it has an Elavon match.)
 
+          Possible Values:
+          - `Zero-dollar value sales`: Indicates that the aggregation has 0 value, so no charge is expected
+          - `Settled non-zero sales (with Elavon match)`: Indicates that the aggregation is flagged as settled in the Littlepay data and appears in the Elavon data.
+          - `Settled non-sero sales (no Elavon match)`: Indicates that the aggregation is flagged as settled in the Littlepay data, but does not appear in the Elavon data.
+          - `Unsettled non-zero sales`: Indicates that the aggregation is flagged as unsettled in the Littlepay data with a status that does not correspond to a declined transaction.
+          - `Declined Sales`: Indicates that the aggregation is flagged as unsettled in the Littlepay data with a status that corresponds to a declined transaction.
+          - `Duplicate RRN`: Indicates that the Retrieval Reference Number (RRN) associated with this transaction appears in another aggregation.
+          - `UNKNOWN`: None of these conditions are met
+
+
   - name: fct_payments_settlements
     description: Littlepay settlements (completed transactions.) One row per settlement, carrying its most recent record.
     data_tests:

--- a/warehouse/models/mart/payments/fct_payments_aggregations.sql
+++ b/warehouse/models/mart/payments/fct_payments_aggregations.sql
@@ -168,6 +168,7 @@ fct_payments_aggregations AS (
         debit_is_settled,
         credit_is_settled,
         CASE
+            WHEN n_retrieval_reference_number_copies > 1 THEN 'Duplicate RRN'
             WHEN net_micropayment_amount_dollars = 0 THEN 'Zero-dollar value sales'
             WHEN net_micropayment_amount_dollars > 0 AND aggregation_is_settled AND elavon_purch_id IS NOT NULL THEN 'Settled non-zero sales (with Elavon match)'
             WHEN net_micropayment_amount_dollars > 0 AND aggregation_is_settled AND elavon_purch_id IS NULL THEN 'Settled non-zero sales (no Elavon match)'


### PR DESCRIPTION
# Description

- Add a new value of `Reconciliation_Category` to detect duplicate RRN columns
- Update dbt tests to remove errors for Duplicate RRNs before June 2026

See [Metabase](https://metabase.dds.dot.ca.gov/question/6954-duplicate-rrn-results) for values.

Resolves #5459, #5278

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

### Run on prod data 

```
uv run dbt run -s staging.payments intermediate.payments mart.payments --vars 'GOOGLE_CLOUD_PROJECT: cal-itp-data-infra'
uv run dbt test -s int_payments__settlements_to_aggregations fct_payments_aggregations
```

Validate that there are no new failing tests

### Check that new Reconciliation Category values are appearing

[See Metabase](https://metabase.dds.dot.ca.gov/question/6935-prod-v-staging-reconciliation-category)

### Check that there are no missing values due to the join in `int_payments__settlements_to_aggregations `

[See Metabase](https://metabase.dds.dot.ca.gov/question/6953-missing-staging-aggregation-entries)

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a full refresh of some incremental model in dbt). If these actions will take more than a few hours after the merge or if they will be completed by someone other than the PR author, please create a dedicated follow-up issue and link it here to track resolution._

- [ ] No action required
- [x] Actions required (specified below)

Add this category to the reconciliation dashboard, and send to all agencies