### PR TITLE
Reuse module-level storage and Secret Manager clients in the GTFS-RT archiver

### DIFF
--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/archiver.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/archiver.py
@@ -1,9 +1,27 @@
 import json
 import os
+import threading
 
 from google.cloud.storage import Bucket, Client
 from gtfs_rt_archiver.configuration import Configuration
 from gtfs_rt_archiver.downloader import Result
+
+# One GCS client per warm instance. It only ever talks to our own bucket with
+# this service's credentials (fetched once from the metadata server, then cached
+# and auto-refreshed), so reusing it across requests is safe and skips a
+# per-fetch token round-trip. The lock is belt-and-suspenders in case request
+# concurrency is ever raised above 1 (today it is 1, so there is no contention).
+_client: Client | None = None
+_client_lock = threading.Lock()
+
+
+def shared_client() -> Client:
+    global _client
+    if _client is None:
+        with _client_lock:
+            if _client is None:
+                _client = Client()
+    return _client
 
 
 class Archiver:
@@ -11,7 +29,7 @@ class Archiver:
         self.configuration: Configuration = configuration
 
     def client(self) -> Client:
-        return Client()
+        return shared_client()
 
     def destination_bucket(self) -> str:
         return self.configuration.destination_bucket.replace("gs://", "")

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/configuration.py
@@ -1,12 +1,30 @@
 import logging
 import math
 import os
+import threading
 from base64 import urlsafe_b64encode
 from datetime import datetime
 from typing import Self, Type
 
 from google.auth import default
 from google.cloud.secretmanager import SecretManagerServiceClient
+
+# One Secret Manager client per warm instance, same rationale as the GCS client
+# in archiver.py: single-tenant Google API calls with this service's own
+# credentials, so sharing it across requests is safe and avoids a per-read token
+# round-trip. Only auth feeds hit this path.
+_secret_client: SecretManagerServiceClient | None = None
+_secret_client_lock = threading.Lock()
+
+
+def shared_secret_client() -> SecretManagerServiceClient:
+    global _secret_client
+    if _secret_client is None:
+        with _secret_client_lock:
+            if _secret_client is None:
+                _secret_client = SecretManagerServiceClient()
+    return _secret_client
+
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
@@ -29,7 +47,7 @@ class Secret:
         self.name: str = name
 
     def client(self) -> SecretManagerServiceClient:
-        return SecretManagerServiceClient()
+        return shared_secret_client()
 
     def secret_name(self) -> str:
         return os.path.join(


### PR DESCRIPTION
# Description

The prod `gtfs-rt-archiver` builds a fresh `storage.Client()` on every fetch (and a `SecretManagerServiceClient` on every secret read, for auth feeds), so it pays a GCE metadata-server credential round-trip on each request — 1,400×/min. A 2026-08-05 dependency drift (`google-auth` 2.49.2 → 2.56.2, which added a per-credential `universe_domain` metadata lookup) made that round-trip heavier and doubled per-fetch latency and compute cost (~+$480/mo).

This reuses **one module-level `storage.Client()` and `SecretManagerServiceClient`** (lazy, double-checked-locked singletons) instead of one per fetch, so the credential/token is fetched once per warm instance rather than on every request. The outbound feed `requests.Session` is deliberately left per-fetch (it carries per-agency API keys and per-host TLS pinning with `assert_hostname=False`, so sharing it would be a security regression).

Resolves #5634

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Testing methodology, and cost breakdown: **[staging A/B write-up](https://drive.google.com/file/d/1lQ6IAdT8JW6ztT2KEb0Vt14EF3Q2MIJ0/view?usp=drive_link)**.

Soaked over the weekend in staging and it seemed to match prod's data results.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

2. **Add an alert** on `billable_instance_time` / sec-per-request at ~1.5× baseline so the next dependency drift is caught in hours rather than weeks.
