### PR TITLE
refactor(gtfs): microbatch daily RT validation notices

### DIFF
--- a/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
+++ b/warehouse/models/mart/gtfs_quality/fct_daily_rt_feed_validation_notices.sql
@@ -1,4 +1,19 @@
-{{ config(materialized='table') }}
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='microbatch',
+        event_time='date',
+        batch_size='day',
+        begin=var('GTFS_RT_START'),
+        lookback=var('DBT_ALL_INCREMENTAL_LOOKBACK_DAYS'),
+        partition_by={
+            'field': 'date',
+            'data_type': 'date',
+            'granularity': 'day',
+        },
+        full_refresh=false,
+    )
+}}
 
 WITH
 outcomes_notices AS (


### PR DESCRIPTION
## Description

Converts `fct_daily_rt_feed_validation_notices` from a full table rebuild to an incremental microbatch model.

The model is now partitioned by `date` and uses the standard GTFS-RT incremental lookback configuration.

Based on the analysis in #4602, this change reduces the amount of data scanned from approximately **1.87 TiB per run** to only the configured incremental lookback window, eliminating unnecessary full-history rebuilds. This is expected to save approximately **$129/month** in BigQuery query costs and is part of the Production Cost Controls effort.

Refs #4602

## How has this been tested?

Ran `+fct_daily_rt_feed_validation_notices` for `2026-08-01` in my dev schema using a one-day microbatch window.

The model completed successfully and processed **2.7 GiB**, compared to approximately **1.87 TiB** for a full historical rebuild.

Compared the resulting partition against production:
- Row count matched exactly: **26,448**
- Distinct key count matched exactly: **26,448**
- `total_notices IS NULL` matched exactly: **855**
- `total_notices = 0` matched exactly: **24,348**

<img width="609" height="159" alt="image" src="https://github.com/user-attachments/assets/1232a21a-3277-4ebb-8760-acb37cb75fc9" />
