### PR TITLE
refactor(gtfs): incrementally build vehicle position trip summaries

### DIFF
--- a/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_summaries.sql
+++ b/warehouse/models/mart/gtfs/fct_vehicle_positions_trip_summaries.sql
@@ -1,12 +1,26 @@
 {{
     config(
-        materialized='table',
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partition_by={
+            'field': 'service_date',
+            'data_type': 'date',
+            'granularity': 'day',
+        },
         cluster_by='base64_url',
+        on_schema_change='append_new_columns',
     )
 }}
 
 WITH vehicle_positions AS ( --noqa: ST03
-    SELECT * FROM {{ ref('int_gtfs_rt__vehicle_positions_trip_day_map_grouping') }}
+    SELECT *
+    FROM {{ ref('int_gtfs_rt__vehicle_positions_trip_day_map_grouping') }}
+    WHERE service_date
+        BETWEEN {{ ranged_incremental_min_date(
+            default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"),
+            data_earliest_start=var("GTFS_RT_START")
+        ) }}
+        AND {{ ranged_incremental_max_date() }}
 ),
 
 vehicle_positions_no_lat_long AS ( --noqa: ST03


### PR DESCRIPTION
## Description

Closes #5550.

Converts `fct_vehicle_positions_trip_summaries` from a full table rebuild to an incremental `insert_overwrite` model partitioned by `service_date`.

The upstream `int_gtfs_rt__vehicle_positions_trip_day_map_grouping` model is microbatched by `dt`, while this model's grain is based on `service_date`. To preserve the existing grain, this implementation follows the same pattern already used by `fct_trip_updates_trip_summaries`: it retains `service_date` as the downstream partition and uses the existing ranged incremental filter to limit processing to the configured lookback window.

This avoids rebuilding the full history on routine warehouse runs while preserving the existing model grain.

## Changes

- Changed `fct_vehicle_positions_trip_summaries` from `materialized='table'` to `materialized='incremental'`.
- Uses `incremental_strategy='insert_overwrite'`.
- Partitions the model by `service_date`.
- Added the existing ranged incremental `service_date` filter using `DBT_ALL_INCREMENTAL_LOOKBACK_DAYS`.
- Added `on_schema_change='append_new_columns'`.
- Preserved the existing `base64_url` clustering.

## Cost impact

The issue reports that the current full-history build scans approximately **1.46 TiB per run**, costing approximately **$101/month**.

In testing, rebuilding a single `service_date` partition processed only **152.6 MiB**. Routine builds will therefore be limited to the configured lookback window rather than repeatedly scanning the model's full history.

## How has this been tested?

Tested the new `insert_overwrite` / `service_date` incremental pattern in my dev schema using `2026-08-06` as a controlled service-date partition.

The incremental rebuild completed successfully and processed **152.6 MiB**, compared with the approximately **1.46 TiB per-run full-history scan** reported in the issue.

The resulting `2026-08-06` partition was compared against the current production table:

- Production row count: **120,871**
- Development row count: **120,871**
- Production distinct keys: **120,871**
- Development distinct keys: **120,871**
- Production-only keys: **0**
- Development-only keys: **0**

<!-- Paste production/dev row-count comparison screenshot here -->

A full row comparison identified **44 differing rows out of 120,871 (~0.036%)**. Investigation showed that these differences were limited to existing first/last position and schedule-relationship selection behavior:

- **41** of the differing keys span multiple upstream `dt` partitions for the same `service_date`, consistent with the model's existing handling of trips crossing UTC date boundaries.
- The remaining **3** differences were in `starting_schedule_relationship` / `ending_schedule_relationship`. The production and development upstream records for these keys were identical; the differences result from the existing `FIRST_VALUE` / `LAST_VALUE` logic selecting among tied ordering values.

No missing or additional trip-summary keys were introduced by the incremental conversion.
