### PR TITLE
refactor(gtfs): incrementally build daily service alerts

### DIFF
--- a/warehouse/models/mart/gtfs/fct_daily_service_alerts.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_service_alerts.sql
@@ -1,13 +1,26 @@
 {{
     config(
-        materialized='table',
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partition_by={
+            'field': 'active_date',
+            'data_type': 'date',
+            'granularity': 'day',
+        },
         cluster_by='base64_url',
+        on_schema_change='append_new_columns',
     )
 }}
 
 WITH service_alerts AS (
     SELECT *
     FROM {{ ref('int_gtfs_rt__service_alerts_day_map_grouping') }}
+    WHERE active_date
+        BETWEEN {{ ranged_incremental_min_date(
+            default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"),
+            data_earliest_start=var("GTFS_RT_START")
+        ) }}
+        AND {{ ranged_incremental_max_date() }}
 ),
 
 header_timestamps AS (


### PR DESCRIPTION
## Description

Closes #5551.

Converts `fct_daily_service_alerts` from a full table rebuild to an incremental `insert_overwrite` model partitioned by `active_date`.

The upstream `int_gtfs_rt__service_alerts_day_map_grouping` model is microbatched by `dt`, while this model's existing grain is based on `active_date`. To preserve that grain, this implementation follows the existing incremental pattern of using `insert_overwrite` with a ranged incremental filter on the downstream date field rather than microbatching this model on `dt`.

This avoids rebuilding the full history on routine warehouse runs while preserving the existing model grain and output.

## Changes

- Changed `fct_daily_service_alerts` from `materialized='table'` to `materialized='incremental'`.
- Uses `incremental_strategy='insert_overwrite'`.
- Partitions the model by `active_date`.
- Added the existing ranged incremental `active_date` filter using `DBT_ALL_INCREMENTAL_LOOKBACK_DAYS`.
- Added `on_schema_change='append_new_columns'`.
- Preserved the existing `base64_url` clustering.

## Cost impact

This change prevents `fct_daily_service_alerts` from rebuilding its full history on every routine warehouse build. Instead, only the configured recent `active_date` lookback window is rebuilt.

This reduces unnecessary historical scanning while preserving the existing output grain.

## How has this been tested?

Tested the new `insert_overwrite` / `active_date` incremental pattern in my dev schema using `2026-08-06` as a controlled active-date partition.

The upstream data confirmed why preserving `active_date` as the downstream partition is important. For `active_date = 2026-08-06`, records came from multiple upstream `dt` partitions:

- `dt = 2026-08-06`: **4,141 rows**
- `dt = 2026-08-07`: **3,420 rows**

The resulting `2026-08-06` partition was then compared against the current production table:

- Production row count: **4,878**
- Development row count: **4,878**
- Production distinct keys: **4,878**
- Development distinct keys: **4,878**

<!-- Paste production/dev row-count comparison screenshot here -->

A full row-for-row comparison was also performed using `EXCEPT DISTINCT`:

- Production-only rows: **0**
- Development-only rows: **0**

The incremental build therefore reconciles row-for-row with the current production full-refresh output for the tested `active_date`, while preserving the model's existing grain.