### PR TITLE
Add GCS buckets for the Frankenforce project

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/variables.tf
@@ -4,6 +4,7 @@ locals {
     "calitp-staging-airtable",
     "calitp-staging-amplitude-benefits-events",
     "calitp-staging-analysis-output-models",
+    "calitp-staging-frankenforce",
     "calitp-staging-gtfs-rt-archiver",
     "calitp-staging-gtfs-download-config",
     "calitp-staging-gtfs-download-config-test",

--- a/iac/cal-itp-data-infra/gcs/us/variables.tf
+++ b/iac/cal-itp-data-infra/gcs/us/variables.tf
@@ -1,5 +1,6 @@
 locals {
   environment_buckets = toset([
+    "calitp-frankenforce",
     "calitp-gtfs-schedule-manual",
     "calitp-kuba",
     "calitp-gtfs-rt-archiver",


### PR DESCRIPTION
# Description

Two catch-all GCS buckets for the Frankenforce project, appended to the `environment_buckets` set in the `gcs/us` modules:

  - `calitp-frankenforce` (prod)
  - `calitp-staging-frankenforce` (staging)
Resolves #5644

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested - Check the terraform

## Post-merge follow-ups

- [x] No action required

