### PR TITLE
Change the gtfs-rt-archiver function's event trigger to "RETRY_POLICY_DO_NOT_RETRY"

### DIFF
--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/service.tf
@@ -120,7 +120,7 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
     trigger_region        = "us-west2"
     event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
     pubsub_topic          = google_pubsub_topic.gtfs-rt-archiver-staging.id
-    retry_policy          = "RETRY_POLICY_RETRY"
+    retry_policy          = "RETRY_POLICY_DO_NOT_RETRY"
     service_account_email = data.terraform_remote_state.iam.outputs.google_service_account_gtfs-rt-archiver_email
   }
 }

--- a/iac/cal-itp-data-infra/gtfs-rt-archiver/us/service.tf
+++ b/iac/cal-itp-data-infra/gtfs-rt-archiver/us/service.tf
@@ -122,7 +122,7 @@ resource "google_cloudfunctions2_function" "gtfs-rt-archiver" {
     trigger_region        = "us-west2"
     event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
     pubsub_topic          = google_pubsub_topic.gtfs-rt-archiver.id
-    retry_policy          = "RETRY_POLICY_RETRY"
+    retry_policy          = "RETRY_POLICY_DO_NOT_RETRY"
     service_account_email = data.terraform_remote_state.iam.outputs.google_service_account_gtfs-rt-archiver_email
   }
 }


### PR DESCRIPTION
# Description

Change the gtfs-rt-archiver function's event trigger from retry_policy = "RETRY_POLICY_RETRY" to "RETRY_POLICY_DO_NOT_RETRY"

Resolves #5564 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`terraform plan` shows expected update only.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
