### PR TITLE
fix(metabase): remove CVE-2026-72898 WAF block; match staging probe budget to prod

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -13,23 +13,6 @@ resource "google_compute_security_policy" "metabase-staging" {
     }
   }
 
-  # Interim mitigation for CVE-2026-72898 (GHSA-vwf4-m7j8-wcjf): unauthenticated
-  # SQL injection via /api/session/reset_password leading to full admin access.
-  # Added out-of-band on 2026-08-11 and codified here so that a terraform apply
-  # cannot silently drop it while the service is still on a vulnerable version.
-  # Remove only after v0.58.24 is confirmed serving. Blocks self-serve password
-  # reset while in place.
-  rule {
-    priority    = 600
-    action      = "deny(403)"
-    description = "TEMP: block CVE-2026-72898 pending v0.58.24 upgrade"
-    match {
-      expr {
-        expression = "request.path.startsWith('/api/session/reset_password')"
-      }
-    }
-  }
-
   rule {
     priority    = 1000
     action      = "deny(403)"

--- a/iac/cal-itp-data-infra-staging/metabase/us/service.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/service.tf
@@ -38,10 +38,21 @@ resource "google_cloud_run_v2_service" "metabase-staging" {
         container_port = 3000
       }
 
+      # Metabase runs Liquibase schema migrations on first boot of a new version,
+      # and does not serve / until they finish. If the startup probe gives up
+      # mid-migration the container is killed while holding the
+      # DATABASECHANGELOGLOCK row, and the next boot hangs waiting on a lock
+      # nobody holds — recoverable only by clearing it by hand.
+      #
+      # failure_threshold * period_seconds is capped at 240s by Cloud Run, so
+      # 48 * 5 is the most probing time available; with the 60s initial delay
+      # that is a 300s budget, matching production. This is a ceiling, not a
+      # wait: a healthy container goes Ready on its first successful probe, so
+      # normal starts and autoscaling are unaffected.
       startup_probe {
         timeout_seconds       = 2
         period_seconds        = 5
-        failure_threshold     = 10
+        failure_threshold     = 48
         initial_delay_seconds = 60
 
         http_get {

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -13,23 +13,6 @@ resource "google_compute_security_policy" "metabase" {
     }
   }
 
-  # Interim mitigation for CVE-2026-72898 (GHSA-vwf4-m7j8-wcjf): unauthenticated
-  # SQL injection via /api/session/reset_password leading to full admin access.
-  # Added out-of-band on 2026-08-11 and codified here so that a terraform apply
-  # cannot silently drop it while the service is still on a vulnerable version.
-  # Remove only after v0.58.24 is confirmed serving. Blocks self-serve password
-  # reset while in place.
-  rule {
-    priority    = 600
-    action      = "deny(403)"
-    description = "TEMP: block CVE-2026-72898 pending v0.58.24 upgrade"
-    match {
-      expr {
-        expression = "request.path.startsWith('/api/session/reset_password')"
-      }
-    }
-  }
-
   rule {
     priority    = 1000
     action      = "deny(403)"


### PR DESCRIPTION
# Description

Refs #4928.

Two cleanups closing out the CVE-2026-72898 response.

**Remove the Cloud Armor block.** Both environments now run Metabase **v0.58.24**, which contains the fix, so the interim block on `/api/session/reset_password` is redundant and is costing users self-serve password reset.

| | Revision | Version | Digest |
| --- | --- | --- | --- |
| Production | `metabase-00009-hpq` | v0.58.24 | `sha256:5d9e1044…` |
| Staging | `metabase-staging-00009-4mw` | v0.58.24 | `sha256:5d9e1044…` |

The rule was added out-of-band on 2026-08-12 as the advisory's recommended workaround, then codified in #5647 / #5648 so the apply that shipped the upgrade could not delete it while the services were still vulnerable. With the patch in place that protection is no longer needed. Removing it through Terraform rather than `gcloud` because it now lives in configuration — deleting it live would only last until the next apply put it back.

**Match staging's startup probe to production.** Staging was left at the default 110s budget when production was widened to 300s in #5647. Metabase doesn't serve `/` until Liquibase migrations finish, and a probe expiring mid-migration kills the container while it holds `DATABASECHANGELOGLOCK`, leaving the next boot blocked on a lock nobody owns.

Staging's v0.58.7 → v0.58.24 migration took **65s of the old 110s budget**. That is uncomfortably close for the environment whose entire purpose is rehearsing production — and the mismatch made staging a weaker gate than it looked: an upgrade could pass there and still be at risk in prod, or fail there for a reason prod wouldn't hit. `failure_threshold * period_seconds` is capped at 240s by Cloud Run, so `48 * 5` is the maximum available and matches production exactly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- Both services confirmed reporting `v0.58.24` from `/api/session/properties` and serving the patched digest before removing the block.
- Rule 600 removed from both policies; the remaining 12 rules in each are untouched (geo-restriction, OWASP set, two rate limits, default allow).
- Probe values verified identical across both `service.tf` files after the change.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Merging triggers `terraform-apply` on both metabase modules.

> [!NOTE]
> **Staging will get a new revision and restart** — the probe change touches the Cloud Run template. It is already on v0.58.24, so no migration runs; it is a plain restart onto the same image. **Production does not redeploy** — its only change here is the security policy.

1. Confirm `POST /api/session/reset_password` no longer returns 403 on both hosts.
1. Confirm a real password reset completes end to end.
1. Confirm staging comes back healthy after its restart (`/api/health` → `ok`).