### PR TITLE
Add a lifecycle rule to elevon-parsed

### DIFF
--- a/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra-staging/gcs/us/storage_bucket.tf
@@ -161,6 +161,22 @@ resource "google_storage_bucket" "calitp-staging-elavon-parsed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "14"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      matches_prefix             = ["transactions/"]
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "calitp-staging-elavon-raw-v2" {

--- a/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
+++ b/iac/cal-itp-data-infra/gcs/us/storage_bucket.tf
@@ -256,6 +256,22 @@ resource "google_storage_bucket" "tfer--calitp-elavon-parsed" {
   requester_pays              = "false"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = "true"
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age                        = "14"
+      created_before             = ""
+      days_since_custom_time     = "0"
+      days_since_noncurrent_time = "0"
+      matches_prefix             = ["transactions/"]
+      num_newer_versions         = "0"
+      with_state                 = "ANY"
+    }
+  }
 }
 
 resource "google_storage_bucket" "tfer--calitp-elavon-raw" {


### PR DESCRIPTION
Saves money on stg_elavon__transactions and storage

# Description

`QUALIFY DENSE_RANK() OVER (ORDER BY execution_ts DESC) = 1` 
(https://github.com/cal-itp/data-infra/blob/8c74d92c0c02a22e37f8dfb9fbec86bd6d13910d/warehouse/models/staging/payments/elavon/stg_elavon__transactions.sql#L14)

costs about $4 each day because it has to full scan the whole table to find the last execution. If we just drop old executions the table is much smaller and this line is pennies.

This is a simple alternative to the path suggested in the issue that would require rewriting the parse logic resulting in a flat output and then changing the staging model. This would have dropped execution history anyway so this seems harmless.

14 day retention is an arbitrary value here and open for change. I could see an argument for 30 days? or 3 days?

ref: #5548

## Type of change

cost reduction

