### PR TITLE
fix(schedule): preserve download exception on manual fallback

### DIFF
--- a/airflow/plugins/operators/download_config_to_gcs_operator.py
+++ b/airflow/plugins/operators/download_config_to_gcs_operator.py
@@ -210,9 +210,13 @@ class DownloadConfigToGCSOperator(BaseOperator):
     def execute(self, context: Context) -> dict:
         ti = context["task_instance"]
         extract = self.download().extract()
-        exception = (
+
+        download_exception = (
             str(self.download().exception) if self.download().exception else None
         )
+
+        task_exception = download_exception
+
         schedule_feed_path = os.path.join(
             self.destination_path,
             self.download().filename(),
@@ -233,15 +237,19 @@ class DownloadConfigToGCSOperator(BaseOperator):
             )
 
         if (
-            exception is not None and not ti.try_number - 1 == ti.max_tries
+            download_exception is not None and not ti.try_number - 1 == ti.max_tries
         ):  # last retry
             schedule_feed_path = os.path.join(
                 self.destination_path,
                 self.manual_download().filename(),
             )
             extract = self.manual_download().extract()
-            exception = None
+
+            # The source download failed, but the manual fallback allows
+            # downstream processing to continue successfully.
+            task_exception = None
             download_type = "Manual Download"
+
             self.gcs_hook().upload(
                 bucket_name=self.destination_name(),
                 object_name=schedule_feed_path,
@@ -254,8 +262,8 @@ class DownloadConfigToGCSOperator(BaseOperator):
 
         download_schedule_feed_results = {
             "backfilled": False,
-            "success": exception is None,
-            "exception": exception,
+            "success": task_exception is None,
+            "exception": download_exception,
             "config": self.download_config,
             "extract": extract,
             "download_type": download_type,
@@ -279,8 +287,8 @@ class DownloadConfigToGCSOperator(BaseOperator):
             },
         )
 
-        if exception is not None:
-            raise AirflowException(exception)
+        if task_exception is not None:
+            raise AirflowException(task_exception)
 
         return {
             "dt": self.dt,

--- a/airflow/tests/operators/test_download_config_to_gcs_operator.py
+++ b/airflow/tests/operators/test_download_config_to_gcs_operator.py
@@ -744,6 +744,7 @@ class TestDownloadConfigToGCSOperator:
         task = manual_download_dag.get_task("manual_gtfs_download_config_to_gcs")
         task_instance = TaskInstance(task, execution_date=execution_date)
         xcom_value = task_instance.xcom_pull()
+        download_exception = "404:Not Found"
         assert xcom_value == {
             "dt": "2025-06-02",
             "ts": "2025-06-02T00:00:00+00:00",
@@ -758,7 +759,7 @@ class TestDownloadConfigToGCSOperator:
             "download_schedule_feed_results": {
                 "backfilled": False,
                 "config": manual_download_config,
-                "exception": None,
+                "exception": download_exception,
                 "download_type": "Manual Download",
                 "extract": {
                     "filename": "gtfs.zip",
@@ -801,7 +802,7 @@ class TestDownloadConfigToGCSOperator:
         result = json.loads(decompressed_result)
         assert result == {
             "success": True,
-            "exception": None,
+            "exception": download_exception,
             "download_type": "Manual Download",
             "config": manual_download_config,
             "extract": {


### PR DESCRIPTION
# Description

Preserves the original schedule download exception when a manual download fallback is used.
The manual download fallback was introduced in #4354 so that schedule processing can continue when an agency's GTFS feed cannot be downloaded from the source URL. However, when the fallback is used, the original download exception is currently cleared.

This causes the download to appear successful with no exception in the download results, which removes visibility into the underlying source download failure. Since TDQ monitoring uses the `download_exception` field to identify failed agency downloads, these failures can go unnoticed and do not get surfaced for analyst follow-up.

This change separates the source download exception from the task exception:

- The original download exception is preserved in the download results when the source URL fails.
- The task can still succeed when the manual fallback succeeds.
- `download_type` continues to indicate `"Manual Download"` when the fallback is used.
- Existing behavior for downloads without a successful fallback remains unchanged.
Tests were updated to verify that a successful manual fallback preserves the original source download exception while the overall download remains successful.

Resolves[ #\[5652\]](https://github.com/cal-itp/data-infra/issues/5652)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

```bash
uv run pytest tests/operators/test_download_config_to_gcs_operator.py -v

============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.11.10, pytest-9.0.3, pluggy-1.6.0 -- /home/jovyan/data-infra/airflow/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/jovyan/data-infra/airflow
configfile: pyproject.toml
plugins: dotenv-0.5.2, recording-0.13.4, freezegun-0.4.2, anyio-4.13.0
collected 5 items                                                                                                                                                                                            

tests/operators/test_download_config_to_gcs_operator.py::TestDownloadConfigToGCSOperator::test_execute PASSED                                                                                          [ 20%]
tests/operators/test_download_config_to_gcs_operator.py::TestDownloadConfigToGCSOperator::test_execute_file_as_basename PASSED                                                                         [ 40%]
tests/operators/test_download_config_to_gcs_operator.py::TestDownloadConfigToGCSOperator::test_execute_file_as_response_basename PASSED                                                                [ 60%]
tests/operators/test_download_config_to_gcs_operator.py::TestDownloadConfigToGCSOperator::test_execute_not_found PASSED                                                                                [ 80%]
tests/operators/test_download_config_to_gcs_operator.py::TestDownloadConfigToGCSOperator::test_manual_download_execute PASSED                                                                          [100%]
```
