### PR TITLE
chore(metabase): bump to v0.58.28 (GHSA-r495-55cx-fjh7)

### DIFF
--- a/services/metabase/Dockerfile
+++ b/services/metabase/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabase/metabase:v0.58.24
+FROM metabase/metabase:v0.58.28
 
 RUN apk update && apk add --no-cache socat
 


### PR DESCRIPTION
# Description

Refs #4928.

> [!WARNING]
> **GHSA-r495-55cx-fjh7** — "Multiple vulnerabilities across query validation, permissions, and network exposure", **critical**, published 2026-08-11. Affects `>= x.58.0, < x.58.28`. Both environments currently run v0.58.24 and are in scope.

`v0.58.28` is the vendor-designated fix for the 58 line and is cumulative, so it also carries the CVE-2026-72898 fix deployed earlier today. Same minor line, so no prod-data rehearsal is required per the runbook.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

- CI builds the image on this PR without publishing (the gate from #5530) — that's what confirms the new base works with our layers.
- Verified `metabase/metabase:v0.58.28` is Alpine 3.23.5 with the same `/app/run_metabase.sh` entrypoint and the same 7-layer shape as v0.58.24, so the `socat` layer and `entrypoint.sh` are unaffected.
- Version confirmed against the advisory's own "Versions with the fix" list.

## Post-merge follow-ups

- [ ] No action required
- [x] Actions required (specified below)

Merging publishes `:staging` and `:production` at the new digest but **deploys neither environment** — there is no `.tf` change here, so `terraform-apply` doesn't trigger. Both services keep running v0.58.24 until deployed explicitly.

1. Deploy staging per step 5 of [`upgrade-metabase.md`](runbooks/workflow/upgrade-metabase.md); verify the digest and `/api/health`.
1. Soak, then deploy production the same way.