### PR TITLE
Add Rider Requirements Dimension Tables and Bridge Table

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/_int_transit_database_dimensions.yml
+++ b/warehouse/models/intermediate/transit_database/dimensions/_int_transit_database_dimensions.yml
@@ -141,3 +141,9 @@ models:
           this record.
           Because this table has not actually been fully versioned,
           this will always be True.
+  - name: int_transit_database__rider_requirements_dim
+    description: |
+        Rider requirements data in slowly-changing-dimension format.
+    data_tests: *mutually_exclusive_ranges
+    columns:
+        - *key

--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__rider_requirements_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__rider_requirements_dim.sql
@@ -1,0 +1,28 @@
+{{ config(materialized='table') }}
+
+WITH dim AS (
+    {{ transit_database_make_historical_dimension(
+        once_daily_staging_table = 'stg_transit_database__rider_requirements',
+        date_col = 'dt',
+        record_id_col = 'id',
+        array_cols = ['services',
+                      'eligibility_programs']
+        ) }}
+),
+int_transit_database__rider_requirements_dim AS (
+    SELECT
+        {{ dbt_utils.generate_surrogate_key(['id', '_valid_from']) }} AS key,
+        id AS source_record_id,
+        requirement,
+        category,
+        description,
+        services,
+        eligibility_programs,
+        _is_current,
+        _valid_from,
+        _valid_to
+    FROM dim
+)
+
+SELECT *
+FROM int_transit_database__rider_requirements_dim

--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__rider_requirements_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__rider_requirements_dim.sql
@@ -6,7 +6,7 @@ WITH dim AS (
         date_col = 'dt',
         record_id_col = 'id',
         array_cols = ['services',
-                      'eligibility_programs']
+                      'programs']
         ) }}
 ),
 int_transit_database__rider_requirements_dim AS (
@@ -17,7 +17,7 @@ int_transit_database__rider_requirements_dim AS (
         category,
         description,
         services,
-        eligibility_programs,
+        programs,
         _is_current,
         _valid_from,
         _valid_to

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -1119,3 +1119,39 @@ models:
       - name: _is_current
       - name: _valid_from
       - name: _valid_to
+  - name: dim_rider_requirements
+    description: |
+        Rider requirements from the California Transit Database.
+    data_tests: *mutually_exclusive_ranges
+    columns:
+      - name: *key
+      - name: source_record_id
+      - name: requirement
+      - name: category
+      - name: description
+      - name: _is_current
+      - name: _valid_from
+      - name: _valid_to
+  - name: bridge_services_x_rider_requirements
+    description: |
+      Mapping table between services and their rider requirements.
+      This is a versioned, many-to-many relationship.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - service_key
+              - rider_requirement_key
+    columns:
+      - name: service_key
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_services')
+                field: key
+      - name: rider_requirement_key
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_rider_requirements')
+                field: key

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -1124,7 +1124,7 @@ models:
         Rider requirements from the California Transit Database.
     data_tests: *mutually_exclusive_ranges
     columns:
-      - name: *key
+      - name: key
       - name: source_record_id
       - name: requirement
       - name: category

--- a/warehouse/models/mart/transit_database/bridge_services_x_rider_requirements.sql
+++ b/warehouse/models/mart/transit_database/bridge_services_x_rider_requirements.sql
@@ -1,0 +1,46 @@
+{{ config(materialized='table') }}
+
+WITH services AS (
+    SELECT *
+    FROM {{ ref('int_transit_database__services_dim') }}
+),
+rider_requirements AS (
+    SELECT *
+    FROM {{ ref('int_transit_database__rider_requirements_dim') }}
+),
+bridge_services_x_rider_requirements AS (
+    {{ transit_database_many_to_many_versioned(
+    shared_start_date_name = '_valid_from',
+    shared_end_date_name = '_valid_to',
+    shared_current_name = '_is_current',
+    table_a = {'name': 'services',
+        'unversioned_key_col': 'source_record_id',
+        'versioned_key_col': 'key',
+        'key_col_name': 'service_key',
+        'name_col': 'name',
+        'name_col_name': 'service_name',
+        'unversioned_join_col': 'rider_requirements',
+        'start_date_col': '_valid_from',
+        'end_date_col': '_valid_to'},
+
+    table_b = {'name': 'rider_requirements',
+        'unversioned_key_col': 'source_record_id',
+        'versioned_key_col': 'key',
+        'key_col_name': 'rider_requirement_key',
+        'name_col': 'requirement',
+        'name_col_name': 'rider_requirement',
+        'unversioned_join_col': 'services',
+        'start_date_col': '_valid_from',
+        'end_date_col': '_valid_to'}
+    ) }}
+)
+
+SELECT
+    service_key,
+    service_name,
+    rider_requirement_key,
+    rider_requirement,
+    _valid_from,
+    _valid_to,
+    _is_current
+FROM bridge_services_x_rider_requirements

--- a/warehouse/models/mart/transit_database/bridge_services_x_rider_requirements.sql
+++ b/warehouse/models/mart/transit_database/bridge_services_x_rider_requirements.sql
@@ -1,10 +1,10 @@
 {{ config(materialized='table') }}
 
-WITH services AS (
+WITH services AS ( --noqa
     SELECT *
     FROM {{ ref('int_transit_database__services_dim') }}
 ),
-rider_requirements AS (
+rider_requirements AS ( --noqa
     SELECT *
     FROM {{ ref('int_transit_database__rider_requirements_dim') }}
 ),

--- a/warehouse/models/mart/transit_database/dim_rider_requirements.sql
+++ b/warehouse/models/mart/transit_database/dim_rider_requirements.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+WITH dim AS (
+    SELECT * FROM {{ ref('int_transit_database__rider_requirements_dim') }}
+),
+dim_rider_requirements AS (
+    SELECT
+        key,
+        source_record_id,
+        requirement,
+        category,
+        description,
+        _is_current,
+        _valid_from,
+        _valid_to
+    FROM dim
+)
+
+SELECT *
+FROM dim_rider_requirements

--- a/warehouse/models/staging/transit_database/stg_transit_database__rider_requirements.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__rider_requirements.sql
@@ -14,7 +14,7 @@ stg_transit_database__rider_requirements AS (
         category,
         description,
         services,
-        eligibility_programs,
+        programs,
         dt
     FROM once_daily_rider_requirements
 )

--- a/warehouse/models/staging/transit_database/stg_transit_database__rider_requirements.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__rider_requirements.sql
@@ -14,10 +14,9 @@ stg_transit_database__rider_requirements AS (
         category,
         description,
         services,
-        unnested_eligibility_programs AS eligibility_program_key,
+        eligibility_programs,
         dt
     FROM once_daily_rider_requirements
-    LEFT JOIN UNNEST(once_daily_rider_requirements.eligibility_programs) AS unnested_eligibility_programs
 )
 
 SELECT * FROM stg_transit_database__rider_requirements


### PR DESCRIPTION
# Description

This PR adds rider requirements models to the warehouse so rider requirements can be queried and used as a dimension table and linked to services through a bridge table.

Changes include:

- Update stg_transit_database__rider_requirements table. `eligibility_program` is removed and `programs` is added.
- Add int_transit_database__rider_requirements_dim
- Add dim_rider_requirements
- Add bridge_services_x_rider_requirements that links services and their rider requirements.
- Update yaml.

Resolves #5637 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`uv run dbt run -s stg_transit_database__rider_requirements`

```
20:58:55  Running with dbt=1.10.8
20:59:00  Registered adapter: bigquery=1.10.2
20:59:04  Found 614 models, 16 seeds, 218 data tests, 230 sources, 5 exposures, 1067 macros
20:59:04  
20:59:04  Concurrency: 8 threads (target='dev')
20:59:04  
20:59:07  1 of 1 START sql view model jiaxi_staging.stg_transit_database__rider_requirements  [RUN]
20:59:08  1 of 1 OK created sql view model jiaxi_staging.stg_transit_database__rider_requirements  [CREATE VIEW (0 processed) in 1.37s]
20:59:08  
20:59:08  Finished running 1 view model in 0 hours 0 minutes and 3.85 seconds (3.85s).
20:59:10  
20:59:10  Completed successfully
20:59:10  
20:59:10  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s int_transit_database__rider_requirements_dim`

```
21:01:46  Running with dbt=1.10.8
21:01:52  Registered adapter: bigquery=1.10.2
21:01:57  Found 614 models, 16 seeds, 218 data tests, 230 sources, 5 exposures, 1067 macros
21:01:57  
21:01:57  Concurrency: 8 threads (target='dev')
21:01:57  
21:02:00  1 of 1 START sql table model jiaxi_staging.int_transit_database__rider_requirements_dim  [RUN]
21:02:03  1 of 1 OK created sql table model jiaxi_staging.int_transit_database__rider_requirements_dim  [CREATE TABLE (99.0 rows, 8.1 MiB processed) in 3.88s]
21:02:03  
21:02:03  Finished running 1 table model in 0 hours 0 minutes and 6.34 seconds (6.34s).
21:02:05  
21:02:05  Completed successfully
21:02:05  
21:02:05  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s dim_rider_requirements`

```
21:03:00  Running with dbt=1.10.8
21:03:06  Registered adapter: bigquery=1.10.2
21:03:11  Found 614 models, 16 seeds, 218 data tests, 230 sources, 5 exposures, 1067 macros
21:03:11  
21:03:11  Concurrency: 8 threads (target='dev')
21:03:11  
21:03:14  1 of 1 START sql table model jiaxi_mart_transit_database.dim_rider_requirements  [RUN]
21:03:16  1 of 1 OK created sql table model jiaxi_mart_transit_database.dim_rider_requirements  [CREATE TABLE (99.0 rows, 10.5 KiB processed) in 1.95s]
21:03:16  
21:03:16  Finished running 1 table model in 0 hours 0 minutes and 5.23 seconds (5.23s).
21:03:18  
21:03:18  Completed successfully
21:03:18  
21:03:18  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s bridge_services_x_rider_requirements`

```
21:03:42  Running with dbt=1.10.8
21:03:47  Registered adapter: bigquery=1.10.2
21:03:53  Found 614 models, 16 seeds, 218 data tests, 230 sources, 5 exposures, 1067 macros
21:03:53  
21:03:53  Concurrency: 8 threads (target='dev')
21:03:53  
21:03:56  1 of 1 START sql table model jiaxi_mart_transit_database.bridge_services_x_rider_requirements  [RUN]
21:03:58  1 of 1 OK created sql table model jiaxi_mart_transit_database.bridge_services_x_rider_requirements  [CREATE TABLE (13.8k rows, 354.9 KiB processed) in 2.20s]
21:03:58  
21:03:58  Finished running 1 table model in 0 hours 0 minutes and 5.14 seconds (5.14s).
21:04:00  
21:04:00  Completed successfully
21:04:00  
21:04:00  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
