### PR TITLE
Add Public/Conditional Currently Operating col to external airtable

### DIFF
--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_organizations.yml
@@ -247,6 +247,9 @@ schema_fields:
   - name: public_currently_operating_fixed_route
     type: STRING
     mode: NULLABLE
+  - name: public_conditional_currently_operating
+    type: STRING
+    mode: NULLABLE
   - name: is_public_entity
     type: STRING
     mode: NULLABLE

--- a/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
+++ b/airflow/dags/create_external_tables/airtable/external_airtable_california_transit_services.yml
@@ -290,6 +290,9 @@ schema_fields:
   - name: public_currently_operating_fixed_route
     type: STRING
     mode: NULLABLE
+  - name: public_conditional_currently_operating
+    type: STRING
+    mode: NULLABLE
   - name: reservation_methods
     type: STRING
     mode: NULLABLE


### PR DESCRIPTION
# Description

This PR adds the Public/Conditional Currently Operating column to the external_airtable.california_transit__organizations and external_airtable.california_transit__services table, as the first step to bring the column to the downstream warehouse tables which will enable users to get an accurate count of demand response services.

Resolves #5605 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

No test required for this task.

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
