### PR TITLE
fix: roll up GTFS download failure alerts

### DIFF
--- a/airflow/dags/download_parse_and_validate_gtfs.py
+++ b/airflow/dags/download_parse_and_validate_gtfs.py
@@ -16,9 +16,12 @@ from operators.validate_gtfs_to_gcs_operator import ValidateGTFSToGCSOperator
 
 from airflow import XComArg
 from airflow.decorators import dag, task
+from airflow.exceptions import AirflowException
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.latest_only import LatestOnlyOperator
+from airflow.operators.python import get_current_context
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.utils.state import TaskInstanceState
 from airflow.utils.trigger_rule import TriggerRule
 
 GTFS_SCHEDULE_FILENAMES = {
@@ -106,6 +109,8 @@ def download_parse_and_validate_gtfs():
 
     downloads = DownloadConfigToGCSOperator.partial(
         task_id="download_config_to_gcs",
+        email_on_failure=False,
+        on_failure_callback=None,
         retries=1,
         retry_delay=timedelta(seconds=10),
         dt="{{ dag_run.start_date | ds }}",
@@ -216,11 +221,32 @@ def download_parse_and_validate_gtfs():
         pool="schedule_parse_pool",
     ).expand_kwargs(unzip.output.map(list_unzipped_files))
 
+    @task(trigger_rule=TriggerRule.ALL_DONE)
+    def check_download_failures():
+        context = get_current_context()
+        dag_run = context["dag_run"]
+
+        failed_downloads = [
+            ti
+            for ti in dag_run.get_task_instances(state=[TaskInstanceState.FAILED])
+            if ti.task_id == "download_config_to_gcs"
+        ]
+
+        if len(failed_downloads) > 10:
+            raise AirflowException(
+                f"{len(failed_downloads)} GTFS schedule downloads failed; "
+                "threshold is 10."
+            )
+
+    download_failure_check = check_download_failures()
+
     (latest_only >> download_config_exists >> (download_config, skip_download_config))
 
     ((download_config, skip_download_config) >> schedule_download_configs)
 
     (schedule_download_configs >> downloads >> (validate, (unzip >> convert)))
+
+    downloads >> download_failure_check
 
 
 download_parse_and_validate_gtfs_instance = download_parse_and_validate_gtfs()

--- a/airflow/dags/download_parse_and_validate_gtfs.py
+++ b/airflow/dags/download_parse_and_validate_gtfs.py
@@ -232,10 +232,10 @@ def download_parse_and_validate_gtfs():
             if ti.task_id == "download_config_to_gcs"
         ]
 
-        if len(failed_downloads) > 2:
+        if len(failed_downloads) > 10:
             raise AirflowException(
                 f"{len(failed_downloads)} GTFS schedule downloads failed; "
-                "threshold is 2."
+                "threshold is 10."
             )
 
     download_failure_check = check_download_failures()

--- a/airflow/dags/download_parse_and_validate_gtfs.py
+++ b/airflow/dags/download_parse_and_validate_gtfs.py
@@ -232,10 +232,10 @@ def download_parse_and_validate_gtfs():
             if ti.task_id == "download_config_to_gcs"
         ]
 
-        if len(failed_downloads) > 10:
+        if len(failed_downloads) > 2:
             raise AirflowException(
                 f"{len(failed_downloads)} GTFS schedule downloads failed; "
-                "threshold is 10."
+                "threshold is 2."
             )
 
     download_failure_check = check_download_failures()


### PR DESCRIPTION
# Description

Reduces alert noise from download_parse_and_validate_gtfs by suppressing individual email and Slack notifications for failed download_config_to_gcs mapped tasks.

A new check_download_failures task rolls up the failures and only triggers the normal Airflow failure notifications when there are more than 10 failed GTFS downloads.

Other task failures in the DAG continue to use the existing email and Slack alerting behavior.

Resolves #5236

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested end-to-end in staging Airflow.

- 284 GTFS schedule downloads were processed.
- 280 downloads succeeded and 4 failed.
- `check_download_failures` completed successfully because the number of failures was below the threshold of 10.
- The individual download failures did not generate unnecessary Slack/email notifications.
- Downstream validation, unzip, and JSONL conversion tasks continued to run successfully, confirming the existing DAG processing behavior remained intact.

<img width="1729" height="946" alt="image" src="https://github.com/user-attachments/assets/255c23ad-6160-4c8f-beab-0572efd629e2" />


## Post-merge follow-ups

- [X] No action required
- [ ] Actions required (specified below)
