### PR TITLE
Add Public/Conditional Operating Column to Dim Tables

### DIFF
--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__organizations_dim.sql
@@ -56,6 +56,7 @@ int_transit_database__organizations_dim AS (
         mpo,
         public_currently_operating,
         public_currently_operating_fixed_route,
+        public_conditional_currently_operating,
         _is_current,
         _valid_from,
         _valid_to

--- a/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__services_dim.sql
+++ b/warehouse/models/intermediate/transit_database/dimensions/int_transit_database__services_dim.sql
@@ -44,6 +44,7 @@ int_transit_database__services_dim AS (
         is_public,
         public_currently_operating,
         public_currently_operating_fixed_route,
+        public_conditional_currently_operating,
         start_date,
         operational_status,
         _is_current,

--- a/warehouse/models/mart/transit_database/_mart_transit_database.yml
+++ b/warehouse/models/mart/transit_database/_mart_transit_database.yml
@@ -175,6 +175,12 @@ models:
         description: |
           Formula in source system returns true value under same conditions as `public_currently_operating`
           plus additional requirement that service has `fixed_route = true` (for organizations, only at least one managed service must meet this criterion).
+      - name: public_conditional_currently_operating
+        description: |
+          Fromula in source system returns true value if there is at least one service that has all of the following:
+            A. is currently operating
+            B. rideable by the general public or conditional subset of the public, and
+            C. is either an NTD reporter (indicated by non-empty NTD ID column) or is a public entity.
       - &org_is_public_entity
         name: is_public_entity
         description: |
@@ -259,6 +265,12 @@ models:
           Formula in source system returns "Yes" value if the rider requirement of "Public" has been set in the `rider_requirements` column.
       - *public_currently_operating
       - *public_currently_operating_fixed_route
+      - name: public_conditional_currently_operating
+        description: |
+          Formula in source system returns true value if the following criteria are met:
+            A. is currently operating
+            B. rideable by the general public or conditional subset of the public, and
+            C. is either an NTD reporter (indicated by non-empty NTD ID column) or is a public entity.
       - name: operational_status
         description: |
           Formula in source system automatically calculates the operational status based on the following criteria:

--- a/warehouse/models/mart/transit_database/dim_organizations.sql
+++ b/warehouse/models/mart/transit_database/dim_organizations.sql
@@ -46,6 +46,7 @@ dim_organizations AS (
         mr_mpo.name AS mpo_name,
         public_currently_operating,
         public_currently_operating_fixed_route,
+        public_conditional_currently_operating,
         _is_current,
         _valid_from,
         _valid_to

--- a/warehouse/models/mart/transit_database/dim_services.sql
+++ b/warehouse/models/mart/transit_database/dim_services.sql
@@ -22,6 +22,7 @@ dim_services AS (
         is_public,
         public_currently_operating,
         public_currently_operating_fixed_route,
+        public_conditional_currently_operating,
         start_date,
         operational_status,
         reservation_methods,

--- a/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__organizations.sql
@@ -45,6 +45,7 @@ stg_transit_database__organizations AS (
         unnested_mpo as mpo,
         public_currently_operating = "Yes" AS public_currently_operating,
         public_currently_operating_fixed_route = "Yes" AS public_currently_operating_fixed_route,
+        public_conditional_currently_operating = "Yes" AS public_conditional_currently_operating
     FROM once_daily_organizations
     LEFT JOIN UNNEST(once_daily_organizations.ntd_id) as unnested_ntd_records
     LEFT JOIN UNNEST(once_daily_organizations.rtpa) AS unnested_rtpa

--- a/warehouse/models/staging/transit_database/stg_transit_database__services.sql
+++ b/warehouse/models/staging/transit_database/stg_transit_database__services.sql
@@ -19,6 +19,7 @@ stg_transit_database__services AS (
         is_public,
         public_currently_operating = "Yes" AS public_currently_operating,
         public_currently_operating_fixed_route = "Yes" AS public_currently_operating_fixed_route,
+        public_conditional_currently_operating = "Yes" AS public_conditional_currently_operating,
         start_date,
         operational_status,
         -- demand response and paratransit fields


### PR DESCRIPTION
# Description

This PR adds Public/Conditional Currently Operating column to 

- `stg_transit_database__services`
- `stg_transit_database__organizations`
- `int_transit_database__services_dim`
- `int_transit_database__organizations_dim`
- `dim_services`
- `dim_organizations`

and updates the yaml file accordingly.

This enable users to identify transit services available to a conditional subset of the public.

Resolves #5605 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`uv run dbt run -s stg_transit_database__services`

```
21:22:45  Running with dbt=1.10.8
21:22:51  Registered adapter: bigquery=1.10.2
21:22:55  Found 610 models, 218 data tests, 16 seeds, 218 sources, 5 exposures, 1067 macros
21:22:55  
21:22:55  Concurrency: 8 threads (target='dev')
21:22:55  
21:22:58  1 of 1 START sql view model jiaxi_staging.stg_transit_database__services ....... [RUN]
21:23:00  1 of 1 OK created sql view model jiaxi_staging.stg_transit_database__services .. [CREATE VIEW (0 processed) in 1.76s]
21:23:00  
21:23:00  Finished running 1 view model in 0 hours 0 minutes and 4.60 seconds (4.60s).
21:23:02  
21:23:02  Completed successfully
21:23:02  
21:23:02  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s stg_transit_database__organizations`

```
21:27:01  Running with dbt=1.10.8
21:27:05  Registered adapter: bigquery=1.10.2
21:27:10  Found 610 models, 218 data tests, 16 seeds, 218 sources, 5 exposures, 1067 macros
21:27:10  
21:27:10  Concurrency: 8 threads (target='dev')
21:27:10  
21:27:12  1 of 1 START sql view model jiaxi_staging.stg_transit_database__organizations .. [RUN]
21:27:13  1 of 1 OK created sql view model jiaxi_staging.stg_transit_database__organizations  [CREATE VIEW (0 processed) in 1.34s]
21:27:13  
21:27:13  Finished running 1 view model in 0 hours 0 minutes and 3.70 seconds (3.70s).
21:27:15  
21:27:15  Completed successfully
21:27:15  
21:27:15  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s int_transit_database__services_dim`

```
21:58:34  Running with dbt=1.10.8
21:58:39  Registered adapter: bigquery=1.10.2
21:58:43  Found 610 models, 218 data tests, 16 seeds, 218 sources, 5 exposures, 1067 macros
21:58:43  
21:58:43  Concurrency: 8 threads (target='dev')
21:58:43  
21:58:45  1 of 1 START sql table model jiaxi_staging.int_transit_database__services_dim .. [RUN]
21:58:50  1 of 1 OK created sql table model jiaxi_staging.int_transit_database__services_dim  [CREATE TABLE (1.5k rows, 818.4 MiB processed) in 4.10s]
21:58:50  
21:58:50  Finished running 1 table model in 0 hours 0 minutes and 6.56 seconds (6.56s).
21:58:51  
21:58:51  Completed successfully
21:58:51  
21:58:51  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s int_transit_database__organizations_dim`

```
22:11:24  Running with dbt=1.10.8
22:11:29  Registered adapter: bigquery=1.10.2
22:11:33  Found 610 models, 218 data tests, 16 seeds, 218 sources, 5 exposures, 1067 macros
22:11:33  
22:11:33  Concurrency: 8 threads (target='dev')
22:11:33  
22:11:35  1 of 1 START sql table model jiaxi_staging.int_transit_database__organizations_dim  [RUN]
22:11:40  1 of 1 OK created sql table model jiaxi_staging.int_transit_database__organizations_dim  [CREATE TABLE (3.1k rows, 1.1 GiB processed) in 4.12s]
22:11:40  
22:11:40  Finished running 1 table model in 0 hours 0 minutes and 6.66 seconds (6.66s).
22:11:41  
22:11:41  Completed successfully
22:11:41  
22:11:41  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s dim_services`

```
22:23:17  Running with dbt=1.10.8
22:23:22  Registered adapter: bigquery=1.10.2
22:23:26  Found 610 models, 218 data tests, 16 seeds, 218 sources, 5 exposures, 1067 macros
22:23:26  
22:23:26  Concurrency: 8 threads (target='dev')
22:23:26  
22:23:28  1 of 1 START sql table model jiaxi_mart_transit_database.dim_services .......... [RUN]
22:23:31  1 of 1 OK created sql table model jiaxi_mart_transit_database.dim_services ..... [CREATE TABLE (1.5k rows, 337.1 KiB processed) in 2.28s]
22:23:31  
22:23:31  Finished running 1 table model in 0 hours 0 minutes and 4.53 seconds (4.53s).
22:23:32  
22:23:32  Completed successfully
22:23:32  
22:23:32  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

`uv run dbt run -s dim_organizations`

```
22:24:01  Running with dbt=1.10.8
22:24:05  Registered adapter: bigquery=1.10.2
22:24:10  Found 610 models, 218 data tests, 16 seeds, 218 sources, 5 exposures, 1067 macros
22:24:10  
22:24:10  Concurrency: 8 threads (target='dev')
22:24:10  
22:24:12  1 of 1 START sql table model jiaxi_mart_transit_database.dim_organizations ..... [RUN]
22:24:14  1 of 1 OK created sql table model jiaxi_mart_transit_database.dim_organizations  [CREATE TABLE (3.1k rows, 681.4 KiB processed) in 2.26s]
22:24:14  
22:24:14  Finished running 1 table model in 0 hours 0 minutes and 4.54 seconds (4.54s).
22:24:16  
22:24:16  Completed successfully
22:24:16  
22:24:16  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
