### PR TITLE
Upgrade Schedule Validator to v8.0.01 (#5331)

### DIFF
--- a/airflow/plugins/hooks/gtfs_validator_hook.py
+++ b/airflow/plugins/hooks/gtfs_validator_hook.py
@@ -114,7 +114,7 @@ class GTSFValidatorVersion:
             "filename": "gtfs-validator-7.1.0-cli.jar",
         },
         {
-            "version_date": pendulum.datetime(2026, 8, 28),
+            "version_date": pendulum.datetime(2026, 8, 27),
             "number": "8.0.1",
             "filename": "gtfs-validator-8.0.1-cli.jar",
         },

--- a/airflow/plugins/hooks/gtfs_validator_hook.py
+++ b/airflow/plugins/hooks/gtfs_validator_hook.py
@@ -114,7 +114,7 @@ class GTSFValidatorVersion:
             "filename": "gtfs-validator-7.1.0-cli.jar",
         },
         {
-            "version_date": pendulum.datetime(2026, 8, 28),
+            "version_date": pendulum.datetime(2026, 8, 31),
             "number": "8.0.1",
             "filename": "gtfs-validator-8.0.1-cli.jar",
         },

--- a/airflow/plugins/hooks/gtfs_validator_hook.py
+++ b/airflow/plugins/hooks/gtfs_validator_hook.py
@@ -114,7 +114,7 @@ class GTSFValidatorVersion:
             "filename": "gtfs-validator-7.1.0-cli.jar",
         },
         {
-            "version_date": pendulum.datetime(2026, 8, 23),
+            "version_date": pendulum.datetime(2026, 8, 28),
             "number": "8.0.1",
             "filename": "gtfs-validator-8.0.1-cli.jar",
         },

--- a/airflow/plugins/hooks/gtfs_validator_hook.py
+++ b/airflow/plugins/hooks/gtfs_validator_hook.py
@@ -114,7 +114,7 @@ class GTSFValidatorVersion:
             "filename": "gtfs-validator-7.1.0-cli.jar",
         },
         {
-            "version_date": pendulum.datetime(2026, 8, 27),
+            "version_date": pendulum.datetime(2026, 8, 23),
             "number": "8.0.1",
             "filename": "gtfs-validator-8.0.1-cli.jar",
         },

--- a/airflow/plugins/hooks/gtfs_validator_hook.py
+++ b/airflow/plugins/hooks/gtfs_validator_hook.py
@@ -113,6 +113,11 @@ class GTSFValidatorVersion:
             "number": "7.1.0",
             "filename": "gtfs-validator-7.1.0-cli.jar",
         },
+        {
+            "version_date": pendulum.datetime(2026, 8, 28),
+            "number": "8.0.1",
+            "filename": "gtfs-validator-8.0.1-cli.jar",
+        },
     ]
 
     def __init__(

--- a/airflow/tests/hooks/test_gtfs_validator_hook.py
+++ b/airflow/tests/hooks/test_gtfs_validator_hook.py
@@ -23,6 +23,14 @@ class TestGTFSValidatorHook:
             )
         )
 
+    def test_validator_8_0_1(self):
+        assert (
+            GTFSValidatorHook(current_date=pendulum.datetime(2026, 8, 29))
+            .version()
+            .number
+            == "8.0.1"
+        )
+
     def test_validator_7_1_0(self):
         assert (
             GTFSValidatorHook(current_date=pendulum.datetime(2026, 2, 26))

--- a/airflow/tests/hooks/test_gtfs_validator_hook.py
+++ b/airflow/tests/hooks/test_gtfs_validator_hook.py
@@ -25,7 +25,7 @@ class TestGTFSValidatorHook:
 
     def test_validator_8_0_1(self):
         assert (
-            GTFSValidatorHook(current_date=pendulum.datetime(2026, 8, 29))
+            GTFSValidatorHook(current_date=pendulum.datetime(2026, 8, 31, 3))
             .version()
             .number
             == "8.0.1"

--- a/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__schedule_validator_rule_details_unioned.sql
+++ b/warehouse/models/intermediate/gtfs_quality/int_gtfs_quality__schedule_validator_rule_details_unioned.sql
@@ -8,6 +8,7 @@ WITH unioned AS (
             ref('gtfs_schedule_validator_rule_details_v4_2_0'),
             ref('gtfs_schedule_validator_rule_details_v5_0_0'),
             ref('gtfs_schedule_validator_rule_details_v7_1_0'),
+            ref('gtfs_schedule_validator_rule_details_v8_0_1'),
         ],
     ) }}
 ),

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -115,10 +115,10 @@ models:
                 where: validation_validator_version = 'v5.0.0'
           - dbt_utils.accepted_range:
                 min_value: "DATE'2026-02-25'"
-                max_value: "DATE'2026-08-26'"
+                max_value: "DATE'2026-08-22'"
                 where: validation_validator_version = 'v7.1.0'
           - dbt_utils.accepted_range:
-                min_value: "DATE'2026-08-27'"
+                min_value: "DATE'2026-08-23'"
                 where: validation_validator_version = 'v8.0.1'
       - &schedule_feed_key
         name: feed_key

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -115,10 +115,10 @@ models:
                 where: validation_validator_version = 'v5.0.0'
           - dbt_utils.accepted_range:
                 min_value: "DATE'2026-02-25'"
-                max_value: "DATE'2026-08-27'"
+                max_value: "DATE'2026-08-30'"
                 where: validation_validator_version = 'v7.1.0'
           - dbt_utils.accepted_range:
-                min_value: "DATE'2026-08-28'"
+                min_value: "DATE'2026-08-31'"
                 where: validation_validator_version = 'v8.0.1'
       - &schedule_feed_key
         name: feed_key

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -114,9 +114,12 @@ models:
                 max_value: "DATE'2026-02-24'"
                 where: validation_validator_version = 'v5.0.0'
           - dbt_utils.accepted_range:
-              arguments:
                 min_value: "DATE'2026-02-25'"
+                max_value: "DATE'2026-08-27'"
                 where: validation_validator_version = 'v7.1.0'
+          - dbt_utils.accepted_range:
+                min_value: "DATE'2026-08-28'"
+                where: validation_validator_version = 'v8.0.1'
       - &schedule_feed_key
         name: feed_key
         data_tests:
@@ -144,7 +147,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['v2.0.0', 'v3.1.1', 'v4.0.0', 'v4.1.0', 'v4.2.0', 'v5.0.0', 'v7.1.0']
+                values: ['v2.0.0', 'v3.1.1', 'v4.0.0', 'v4.1.0', 'v4.2.0', 'v5.0.0', 'v7.1.0', 'v8.0.1']
       - &schedule_validator_code
         name: code
         description: |

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -115,10 +115,10 @@ models:
                 where: validation_validator_version = 'v5.0.0'
           - dbt_utils.accepted_range:
                 min_value: "DATE'2026-02-25'"
-                max_value: "DATE'2026-08-22'"
+                max_value: "DATE'2026-08-27'"
                 where: validation_validator_version = 'v7.1.0'
           - dbt_utils.accepted_range:
-                min_value: "DATE'2026-08-23'"
+                min_value: "DATE'2026-08-28'"
                 where: validation_validator_version = 'v8.0.1'
       - &schedule_feed_key
         name: feed_key

--- a/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
+++ b/warehouse/models/mart/gtfs_quality/_mart_gtfs_quality.yml
@@ -115,10 +115,10 @@ models:
                 where: validation_validator_version = 'v5.0.0'
           - dbt_utils.accepted_range:
                 min_value: "DATE'2026-02-25'"
-                max_value: "DATE'2026-08-27'"
+                max_value: "DATE'2026-08-26'"
                 where: validation_validator_version = 'v7.1.0'
           - dbt_utils.accepted_range:
-                min_value: "DATE'2026-08-28'"
+                min_value: "DATE'2026-08-27'"
                 where: validation_validator_version = 'v8.0.1'
       - &schedule_feed_key
         name: feed_key

--- a/warehouse/seeds/gtfs_schedule_validator_rule_details_v8_0_1.csv
+++ b/warehouse/seeds/gtfs_schedule_validator_rule_details_v8_0_1.csv
@@ -1,0 +1,182 @@
+code,human_readable_description,version,severity
+attribution_without_role,Attribution with no role.,v8.0.1,WARNING
+bidirectional_exit_gate,Pathway is bidirectional and has mode 7 (exit gate).,v8.0.1,ERROR
+big_gap_in_service,A service has a gap of more than 13 days between active service dates.,v8.0.1,INFO
+block_trips_with_overlapping_stop_times,Trips with the same block id have overlapping stop times.,v8.0.1,ERROR
+csv_parsing_failed,Parsing of a CSV file failed.,v8.0.1,ERROR
+decreasing_or_equal_stop_time_distance,Decreasing or equal `shape_dist_traveled` in `stop_times.txt`.,v8.0.1,ERROR
+decreasing_shape_distance,Decreasing `shape_dist_traveled` in `shapes.txt`.,v8.0.1,ERROR
+duplicate_fare_media,Two distinct fare media have the same fare media name and type.,v8.0.1,WARNING
+duplicate_geo_json_key,A key in `locations.geojson` is duplicated.,v8.0.1,ERROR
+duplicate_geography_id,Geography id is duplicated across multiple files.,v8.0.1,ERROR
+duplicate_key,Duplicated entity.,v8.0.1,ERROR
+duplicate_route_name,"Two distinct routes have either the same `route_short_name`, the same `route_long_name`, or the same combination of `route_short_name` and `route_long_name`.",v8.0.1,WARNING
+duplicated_column,Duplicated column in CSV.,v8.0.1,ERROR
+empty_column_name,A column name is empty.,v8.0.1,ERROR
+empty_file,A CSV file is empty.,v8.0.1,ERROR
+empty_row,A row in the input file has only spaces.,v8.0.1,WARNING
+equal_shape_distance_diff_coordinates,Two consecutive points have equal `shape_dist_traveled` and different lat/lon coordinates in `shapes.txt` and the distance between the two points is greater than the 1.11m.,v8.0.1,ERROR
+equal_shape_distance_diff_coordinates_distance_below_threshold,Two consecutive points have equal `shape_dist_traveled` and different lat/lon coordinates in `shapes.txt` and the distance between the two points is greater than 0 but less than 1.11m.,v8.0.1,WARNING
+equal_shape_distance_same_coordinates,Two consecutive points have equal `shape_dist_traveled` and the same lat/lon coordinates in `shapes.txt`.,v8.0.1,WARNING
+expired_calendar,Dataset should not contain date ranges for services that have already expired.,v8.0.1,WARNING
+fare_product_with_multiple_default_rider_categories,This notice is generated when a fare product is associated with multiple rider categories that are marked as default.,v8.0.1,ERROR
+fare_transfer_rule_duration_limit_type_without_duration_limit,A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit_type` field but no `duration_limit` specified.,v8.0.1,ERROR
+fare_transfer_rule_duration_limit_without_type,A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit` field but no `duration_limit_type` specified.,v8.0.1,ERROR
+fare_transfer_rule_invalid_transfer_count,A row from GTFS file `fare_transfer_rules.txt` has a defined `transfer_count` with an invalid value.,v8.0.1,ERROR
+fare_transfer_rule_missing_transfer_count,"A row from `fare_transfer_rules.txt` has `from_leg_group_id` equal to `to_leg_group_id`, but has no `transfer_count` specified.",v8.0.1,ERROR
+fare_transfer_rule_with_forbidden_transfer_count,"A row from `fare_transfer_rules.txt` has `from_leg_group_id` not equal to `to_leg_group_id`, but has `transfer_count` specified.",v8.0.1,ERROR
+fare_transfer_rule_without_transfer_count,"A row from `fare_transfer_rules.txt` has `from_leg_group_id` equal to `to_leg_group_id`, but has no `transfer_count` specified.",v8.0.1,ERROR
+fast_travel_between_consecutive_stops,A transit vehicle moves too fast between two consecutive stops.,v8.0.1,WARNING
+fast_travel_between_far_stops,A transit vehicle moves too fast between two far stops.,v8.0.1,WARNING
+feed_expiration_date30_days,Dataset should cover at least the next 30 days of service.,v8.0.1,WARNING
+feed_expiration_date7_days,Dataset should be valid for at least the next 7 days.,v8.0.1,WARNING
+feed_info_lang_and_agency_lang_mismatch,Mismatching feed and agency language fields.,v8.0.1,WARNING
+feed_valid_beyond_total_service_window,The feed is valid 14 days beyond its total service window.,v8.0.1,INFO
+forbidden_arrival_or_departure_time,The arrival or departure times are provided alongside pickup or drop-off windows in `stop_times.txt`.,v8.0.1,ERROR
+forbidden_continuous_pickup_drop_off,"Continuous pickup or drop-off are forbidden when routes.continuous_pickup or routes.continuous_drop_off are 0, 2 or 3 and stop_times.start_pickup_drop_off_window or stop_times.end_pickup_drop_off_window are defined for any trip of this route.",v8.0.1,ERROR
+forbidden_drop_off_type,pickup_drop_off_window fields are forbidden when the drop_off_type is regularly scheduled (0).,v8.0.1,ERROR
+forbidden_geography_id,A stop_time entry has more than one geographical id defined.,v8.0.1,ERROR
+forbidden_pickup_type,pickup_drop_off_window fields are forbidden when the pickup_type is regularly scheduled (0) or must be coordinated with the driver (3).,v8.0.1,ERROR
+forbidden_prior_day_booking_field_value,A forbidden field value is present for a prior-day booking rule in `booking_rules.txt`,v8.0.1,ERROR
+forbidden_prior_notice_start_day,`prior_notice_start_day` value is forbidden when `prior_notice_duration_max` is set.,v8.0.1,ERROR
+forbidden_prior_notice_start_time,`prior_notice_start_time` value is forbidden when `prior_notice_start_day` value is not set in booking_rules.txt.,v8.0.1,ERROR
+forbidden_real_time_booking_field_value,A forbidden field value is present for a real-time booking rule in `booking_rules.txt`.,v8.0.1,ERROR
+forbidden_same_day_booking_field_value,A forbidden field value is present for a same-day booking rule in `booking_rules.txt`.,v8.0.1,ERROR
+forbidden_shape_dist_traveled,A stop_time entry has a `shape_dist_traveled` without a `stop_id` value.,v8.0.1,ERROR
+foreign_key_violation,Wrong foreign key.,v8.0.1,ERROR
+future_calendar,All services in the feed start in the future; no service covers today's date.,v8.0.1,INFO
+future_feed,The feed covers the future only.,v8.0.1,INFO
+geo_json_duplicated_element,Duplicated elements in locations.geojson file.,v8.0.1,ERROR
+geo_json_unknown_element,Unknown elements in locations.geojson file.,v8.0.1,INFO
+i_o_error,Error in IO operation.,v8.0.1,ERROR
+inconsistent_agency_lang,Inconsistent language among agencies.,v8.0.1,WARNING
+inconsistent_agency_timezone,Inconsistent Timezone among agencies.,v8.0.1,ERROR
+inconsistent_route_type_for_block_id,A block should have the same route mode.,v8.0.1,WARNING
+inconsistent_route_type_for_in_seat_transfer,An in-seat transfer should occur in the same route mode.,v8.0.1,WARNING
+invalid_character,"This field contains invalid characters, such as the replacement character (""�"").",v8.0.1,ERROR
+invalid_color,A field contains an invalid color value.,v8.0.1,ERROR
+invalid_currency,A field contains a wrong currency code.,v8.0.1,ERROR
+invalid_currency_amount,A currency amount field has a value that does not match the format of its corresponding currency code field.,v8.0.1,ERROR
+invalid_date,A field cannot be parsed as date.,v8.0.1,ERROR
+invalid_email,A field contains a malformed email address.,v8.0.1,ERROR
+invalid_float,A field cannot be parsed as a floating point number.,v8.0.1,ERROR
+invalid_geometry,A polygon in `locations.geojson` is unparsable or invalid.,v8.0.1,ERROR
+invalid_input_files_in_subfolder,At least 1 GTFS file is in a subfolder.,v8.0.1,ERROR
+invalid_integer,A field cannot be parsed as an integer.,v8.0.1,ERROR
+invalid_language_code,A field contains a wrong language code.,v8.0.1,ERROR
+invalid_phone_number,A field contains a malformed phone number.,v8.0.1,ERROR
+invalid_pickup_drop_off_window,The pickup/drop-off window in `stop_times.txt` is invalid.,v8.0.1,ERROR
+invalid_prior_notice_duration_min,An invalid `prior_notice_duration_min` value is present in a booking rule.,v8.0.1,ERROR
+invalid_row_length,Invalid csv row length.,v8.0.1,ERROR
+invalid_time,A field cannot be parsed as time.,v8.0.1,ERROR
+invalid_timezone,A field cannot be parsed as a timezone.,v8.0.1,ERROR
+invalid_url,A field contains a malformed URL.,v8.0.1,ERROR
+leading_or_trailing_whitespaces,The value in CSV file has leading or trailing whitespaces.,v8.0.1,WARNING
+location_with_unexpected_stop_time,A location in `stops.txt` that is not a stop is referenced by some `stop_times.stop_id`.,v8.0.1,ERROR
+location_without_parent_station,A location that must have `parent_station` field does not have it.,v8.0.1,ERROR
+malformed_json,A JSON file is malformed.,v8.0.1,ERROR
+missing_bike_allowance,Ferry trips should include bike allowance information.,v8.0.1,WARNING
+missing_calendar_and_calendar_date_files,Missing GTFS files `calendar.txt` and `calendar_dates.txt`.,v8.0.1,ERROR
+missing_feed_contact_email_and_url,Best Practices for `feed_info.txt` suggest providing at least one of `feed_contact_email` and `feed_contact_url`.,v8.0.1,WARNING
+missing_feed_info_date,"One of `feed_start_date` or `feed_end_date` is specified, but not both.",v8.0.1,WARNING
+missing_level_id,`stops.level_id` is conditionally required.,v8.0.1,ERROR
+missing_pickup_drop_off_booking_rule_id,pickup_booking_rule_id is recommended when pickup_type=2 and drop_off_booking_rule_id is recommended when drop_off_type=2.,v8.0.1,WARNING
+missing_pickup_or_drop_off_window,Either the start or end pickup/drop-off window is missing in `stop_times.txt`.,v8.0.1,ERROR
+missing_prior_day_booking_field_value,The `prior_notice_last_day` and the `prior_notice_last_time` values are required for prior day `booking_type` in booking_rules.txt.,v8.0.1,ERROR
+missing_prior_notice_duration_min,`prior_notice_duration_min` value is required for same day `booking_type` in booking_rules.txt.,v8.0.1,ERROR
+missing_prior_notice_last_day,The `prior_notice_last_day` is required when booking_type=2 (prior day booking) is specified in booking_rules.txt.,v8.0.1,ERROR
+missing_prior_notice_last_time,The `prior_notice_last_time` is required when booking_type=2 (prior day booking) is specified in booking_rules.txt.,v8.0.1,ERROR
+missing_prior_notice_start_time,`prior_notice_start_time` value is required when `prior_notice_start_day` value is set in booking_rules.txt.,v8.0.1,ERROR
+missing_recommended_column,A recommended column is missing in the input file.,v8.0.1,WARNING
+missing_recommended_field,A recommended field is missing.,v8.0.1,WARNING
+missing_recommended_file,A recommended file is missing.,v8.0.1,WARNING
+missing_required_agency_id,Agency id is required when there are multiple agencies.,v8.0.1,ERROR
+missing_required_column,A required column is missing in the input file.,v8.0.1,ERROR
+missing_required_element,A required element is missing in `locations.geojson`.,v8.0.1,ERROR
+missing_required_field,A required field is missing.,v8.0.1,ERROR
+missing_required_file,A required file is missing.,v8.0.1,ERROR
+missing_stop_name,"`stops.stop_name` is required for `location_type` equal to `0`, `1`, or `2`.",v8.0.1,ERROR
+missing_stop_times_record,Only one stop_times record is found where two are required.,v8.0.1,ERROR
+missing_timepoint_value,`stop_times.timepoint` value is missing for a record.,v8.0.1,WARNING
+missing_trip_edge,Missing trip edge `arrival_time` or `departure_time`.,v8.0.1,ERROR
+mixed_case_recommended_field,This field has customer-facing text and should use Mixed Case (should contain upper and lower case letters).,v8.0.1,WARNING
+more_than_one_entity,More than one row in CSV.,v8.0.1,WARNING
+new_line_in_value,New line or carriage return in a value in CSV file.,v8.0.1,ERROR
+non_ascii_or_non_printable_char,Non ascii or non printable char in ID field.,v8.0.1,WARNING
+number_out_of_range,Out of range value.,v8.0.1,ERROR
+overlapping_frequency,Trip frequencies overlap.,v8.0.1,ERROR
+overlapping_zone_and_pickup_drop_off_window,Two entities have overlapping pickup/drop-off windows and zones.,v8.0.1,ERROR
+pathway_dangling_generic_node,A generic node has only one incident location in a pathway graph.,v8.0.1,WARNING
+pathway_loop,A pathway starts and ends at the same location.,v8.0.1,WARNING
+pathway_to_platform_with_boarding_areas,A pathway has an endpoint that is a platform which has boarding areas.,v8.0.1,ERROR
+pathway_to_stop_with_access_outside_of_station_pathways,"A pathway has an endpoint that is a stop with stop_access=1, which should be accessible outside of the station’s pathways.",v8.0.1,ERROR
+pathway_to_wrong_location_type,A pathway has an endpoint that is a station.,v8.0.1,ERROR
+pathway_unreachable_location,A location is not reachable at least in one direction: from the entrances or to the exits.,v8.0.1,ERROR
+platform_without_parent_station,A platform has no `parent_station` field set.,v8.0.1,INFO
+point_near_origin,"A point is too close to origin `(0, 0)`.",v8.0.1,ERROR
+point_near_pole,A point is too close to the North or South Pole.,v8.0.1,ERROR
+prior_notice_last_day_after_start_day,Prior notice last day should not be greater than the prior notice start day in booking_rules.txt.,v8.0.1,ERROR
+route_both_short_and_long_name_missing,Both `route_short_name` and `route_long_name` are missing for a route.,v8.0.1,ERROR
+route_color_contrast,Insufficient route color contrast.,v8.0.1,WARNING
+route_long_name_contains_short_name,Long name should not contain short name for a single route.,v8.0.1,WARNING
+route_networks_specified_in_more_than_one_file,Indicates that route network identifiers are specified across multiple files.,v8.0.1,ERROR
+route_short_name_too_long,Short name of a route is too long (more than 12 characters).,v8.0.1,WARNING
+runtime_exception_in_loader_error,RuntimeException while loading GTFS dataset in memory.,v8.0.1,ERROR
+runtime_exception_in_validator_error,RuntimeException while validating GTFS archive.,v8.0.1,ERROR
+same_name_and_description_for_route,Same name and description for route.,v8.0.1,WARNING
+same_name_and_description_for_stop,Same name and description for stop.,v8.0.1,WARNING
+same_route_and_agency_url,Same `routes.route_url` and `agency.agency_url`.,v8.0.1,WARNING
+same_stop_and_agency_url,Same `stops.stop_url` and `agency.agency_url`.,v8.0.1,WARNING
+same_stop_and_route_url,Same `stops.stop_url` and `routes.route_url`.,v8.0.1,WARNING
+service_extends_far_in_the_future,A service end date is more than 2 years in the future.,v8.0.1,INFO
+service_has_no_active_day_of_the_week,A service is not valid for any day of the week.,v8.0.1,WARNING
+service_window_outside_feed_period,A service window is not covered by the feed's validity period.,v8.0.1,INFO
+single_shape_point,The shape within `shapes.txt` contains a single shape point.,v8.0.1,WARNING
+start_and_end_range_equal,Two date or time fields are equal.,v8.0.1,ERROR
+start_and_end_range_out_of_order,Two date or time fields are out of order.,v8.0.1,ERROR
+station_with_parent_station,A station has `parent_station` field set.,v8.0.1,ERROR
+stop_access_specified_for_incorrect_location,A location that is not a stop has stop_access specified.,v8.0.1,ERROR
+stop_access_specified_for_stop_with_no_parent_station,A stop without a value for parent station has stop_access specified.,v8.0.1,ERROR
+stop_has_too_many_matches_for_shape,"Stop entry that has many potential matches to the trip's path of travel, as defined by the shape entry in `shapes.txt`.",v8.0.1,WARNING
+stop_time_timepoint_without_times,`arrival_time` or `departure_time` not specified for timepoint.,v8.0.1,ERROR
+stop_time_with_arrival_before_previous_departure_time,Backwards time travel between stops in `stop_times.txt`,v8.0.1,ERROR
+stop_time_with_only_arrival_or_departure_time,Missing `stop_times.arrival_time` or `stop_times.departure_time`.,v8.0.1,ERROR
+stop_too_far_from_shape,Stop too far from trip shape.,v8.0.1,WARNING
+stop_too_far_from_shape_using_user_distance,Stop time too far from shape.,v8.0.1,WARNING
+stop_without_location,"`stop_lat` and/or `stop_lon` is missing for stop with `location_type` equal to`0`, `1`, or `2`",v8.0.1,ERROR
+stop_without_stop_time,A stop in `stops.txt` is not referenced by any `stop_times.stop_id`.,v8.0.1,WARNING
+stop_without_zone_id,Stop without value for `stops.zone_id` contained in a route with a zone-dependent fare rule.,v8.0.1,INFO
+stops_match_shape_out_of_order,Two stop entries are different than their arrival-departure order defined by `shapes.txt`.,v8.0.1,WARNING
+thread_execution_error,ExecutionException during multithreaded validation,v8.0.1,ERROR
+timeframe_only_start_or_end_time_specified,A row from `timeframes.txt` was found with only one of `start_time` and `end_time` specified.,v8.0.1,ERROR
+timeframe_overlap,Two entries in `timeframes.txt` with the same `timeframe_group_id` and `service_id` have overlapping time intervals.,v8.0.1,ERROR
+timeframe_start_or_end_time_greater_than_twenty_four_hours,A time in `timeframes.txt` is greater than `24:00:00`.,v8.0.1,ERROR
+too_many_rows,A CSV file has too many rows.,v8.0.1,ERROR
+transfer_distance_above_2_km,The transfer distance from stop to stop in `transfers.txt` is larger than 2 km.,v8.0.1,INFO
+transfer_distance_too_large,The transfer distance from stop to stop in `transfers.txt` is larger than 10 km.,v8.0.1,WARNING
+transfer_with_invalid_stop_location_type,A stop id field from GTFS file `transfers.txt` references a stop that has a `location_type` other than 0 or 1 (aka Stop/Platform or Station).,v8.0.1,ERROR
+transfer_with_invalid_trip_and_route,A trip id field from GTFS file `transfers.txt` references a route that does not match its `trips.txt` `route_id`.,v8.0.1,ERROR
+transfer_with_invalid_trip_and_stop,A trip id field from GTFS file `transfers.txt` references a stop that is not included in the referenced trip's stop-times.,v8.0.1,ERROR
+transfer_with_suspicious_mid_trip_in_seat,A trip id field from GTFS file `transfers.txt` with an in-seat transfer type references a stop that is not in the expected position in the trip's stop-times.,v8.0.1,WARNING
+translation_foreign_key_violation,An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.,v8.0.1,ERROR
+translation_unexpected_value,A field in a translations row has value but must be empty.,v8.0.1,ERROR
+translation_unknown_table_name,A translation references an unknown or missing GTFS table.,v8.0.1,WARNING
+trip_coverage_not_active_for_next7_days,Trips data should be valid for at least the next seven days.,v8.0.1,WARNING
+trip_distance_exceeds_shape_distance,The distance between the last shape point and last stop point is greater than or equal to the 11.1m threshold.,v8.0.1,ERROR
+trip_distance_exceeds_shape_distance_below_threshold,The distance between the last shape point and last stop point is greater than 0 but less than the 11.1m threshold.,v8.0.1,WARNING
+trip_headsign_matches_intermediate_stop,"Trip headsign matches the name of an intermediate stop, not the last stop.",v8.0.1,INFO
+trip_with_shape_dist_traveled_but_no_shape_distances,A trip has shape_dist_traveled values in stop_times.txt but the shape referenced by the trip's shape_id does not have shape_dist_traveled values on all of its points in shapes.txt.,v8.0.1,INFO
+u_r_i_syntax_error,A string could not be parsed as a URI reference.,v8.0.1,ERROR
+unexpected_enum_value,An enum has an unexpected value.,v8.0.1,WARNING
+unknown_column,A column name is unknown.,v8.0.1,INFO
+unknown_file,A file is unknown.,v8.0.1,INFO
+unsorted_stop_times,Stop times are not sorted by trip_id and stop_sequence.,v8.0.1,INFO
+unsupported_feature_type,An unsupported feature type is used in the `locations.geojson` file.,v8.0.1,ERROR
+unsupported_geo_json_type,An unsupported GeoJSON type is used in the `locations.geojson` file.,v8.0.1,ERROR
+unsupported_geometry_type,A GeoJSON feature has an unsupported geometry type in `locations.geojson`.,v8.0.1,ERROR
+unusable_trip,Trips must have more than one stop to be usable.,v8.0.1,WARNING
+unused_parent_station,Unused parent station.,v8.0.1,INFO
+unused_shape,Shape is not used in GTFS file `trips.txt`.,v8.0.1,WARNING
+unused_station,Unused station.,v8.0.1,INFO
+unused_trip,Trip is not be used in `stop_times.txt`,v8.0.1,WARNING
+wrong_parent_location_type,Incorrect type of the parent location.,v8.0.1,ERROR


### PR DESCRIPTION
# Description

Resolves https://github.com/cal-itp/data-infra/issues/5331

Updates the GTFS Schedule Validator from v7.1.0 to v8.0.1.

This follows the same general upgrade pattern as #4813:

- Add the MobilityData GTFS Validator v8.0.1 CLI JAR.
- Register v8.0.1 in the Airflow validator version configuration.
- Add/update tests for validator version selection.
- Add the v8.0.1 validator rule metadata seed.
- Include the new rule metadata in the schedule validator rule union model.
- Update the accepted validator versions and effective date ranges in the GTFS quality models.

The effective date for v8.0.1 is `2026-08-31`. No backfill is required.

v8.0.1 is used instead of v8.0.0 because v8.0.0 introduced an unintended breaking change for applications using the validator JAR API, which was corrected in v8.0.1.

## Changes

### Airflow

- Added:
  `airflow/plugins/gtfs_validator/gtfs-validator-8.0.1-cli.jar`
- Added v8.0.1 to `GTSFValidatorVersion`.
- Added test coverage for selecting v8.0.1 after its effective date.

### Warehouse

- Added:
  `warehouse/seeds/gtfs_schedule_validator_rule_details_v8_0_1.csv`
- Added the v8.0.1 rule seed to
  `int_gtfs_quality__schedule_validator_rule_details_unioned`.
- Added `v8.0.1` as an accepted validator version.
- Updated validator date ranges:
  - v7.1.0 through `2026-08-30`
  - v8.0.1 beginning `2026-08-31`

The v8.0.1 rule metadata contains 181 validator rules.

## How is this PR tested?

### Airflow hook

Tested `GTSFValidatorVersion.find()` to verify that the correct validator version is selected based on the effective date.

The tests confirm that:

- v7.1.0 is selected before the v8.0.1 effective date.
- v8.0.1 is selected beginning with the v8.0.1 effective date.

The hook tests passed successfully:

```
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_8_0_1 PASSED                                                                                            [  8%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_7_1_0 PASSED                                                                                            [ 16%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_5_0_0 PASSED                                                                                            [ 25%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_4_2_0 PASSED                                                                                            [ 33%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_4_1_0 PASSED                                                                                            [ 41%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_4_0_0 PASSED                                                                                            [ 50%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_3_1_1 PASSED                                                                                            [ 58%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_2_0_0 PASSED                                                                                            [ 66%]
tests/hooks/test_gtfs_validator_hook.py::TestGTFSValidatorHook::test_validator_path PASSED                                                                                             [ 75%]

```

### dbt staging

Loaded all schedule validator rule seeds, including the new v8.0.1 seed:

```text
gtfs_schedule_validator_rule_details_v2_0_0       69 rows
gtfs_schedule_validator_rule_details_v3_1_1       92 rows
gtfs_schedule_validator_rule_details_v4_0_0      105 rows
gtfs_schedule_validator_rule_details_v4_1_0      113 rows
gtfs_schedule_validator_rule_details_v4_2_0      121 rows
gtfs_schedule_validator_rule_details_v5_0_0      124 rows
gtfs_schedule_validator_rule_details_v7_1_0      164 rows
gtfs_schedule_validator_rule_details_v8_0_1      181 rows
```

Successfully built the relevant downstream models, including:

```text
int_gtfs_quality__schedule_validator_rule_details_unioned
int_gtfs_quality__schedule_validation_severities
fct_daily_schedule_feed_validation_notices
```

### Airflow staging

Deployed the changes to staging Composer and reran one mapped `ValidateGTFSToGCSOperator` task for:

```text
Antelope Valley Transit Authority Schedule
```

The v8.0.1 validator completed successfully and produced the expected validation result:

```text
"filename":"validation_notices_v8-0-1.jsonl.gz"
"validator_version":"v8.0.1"
"success":true
"exception":null
```

The corresponding v8.0.1 validation notices were also successfully written and parsed using the expected notice structure:

```text
{'version': 'v8.0.1', 'code': 'fast_travel_between_consecutive_stops', 'severity': 'WARNING', 'totalNotices': 6146}
{'version': 'v8.0.1', 'code': 'missing_feed_contact_email_and_url', 'severity': 'WARNING', 'totalNotices': 1}
{'version': 'v8.0.1', 'code': 'stop_too_far_from_shape', 'severity': 'WARNING', 'totalNotices': 2}
{'version': 'v8.0.1', 'code': 'stop_too_far_from_shape_using_user_distance', 'severity': 'WARNING', 'totalNotices': 564}
```

This confirms that the v8.0.1 JAR executes successfully in Composer and that its validation output remains compatible with the existing Airflow and warehouse processing.