### PR TITLE
Fix total arrivals per route type and time of day on `fct_daily_scheduled_stops`

### DIFF
--- a/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
+++ b/warehouse/models/mart/gtfs/fct_daily_scheduled_stops.sql
@@ -11,32 +11,7 @@
     )
 }}
 
-WITH fct_scheduled_trips AS (
-    SELECT
-        service_date,
-        feed_key,
-        feed_timezone,
-        trip_id,
-        contains_warning_duplicate_stop_times_primary_key,
-        contains_warning_duplicate_trip_primary_key,
-        contains_warning_missing_foreign_key_stop_id
-    FROM {{ ref('fct_scheduled_trips') }}
-    WHERE service_date
-        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_SCHEDULE_START")) }}
-            AND {{ ranged_incremental_max_date() }}
-),
-
-dim_stops AS (
-    SELECT *
-    FROM {{ ref('dim_stops') }}
-),
-
-dim_stop_arrivals AS (
-    SELECT *
-    FROM {{ ref('dim_stop_arrivals') }}
-),
-
-stops_on_day_by_route_and_hour AS (
+with stops_on_day_by_route_and_hour AS (
     SELECT
         trips.service_date,
         trips.feed_key,
@@ -67,12 +42,15 @@ stops_on_day_by_route_and_hour AS (
         ) AS contains_warning_duplicate_trip_primary_key,
         LOGICAL_OR(
             trips.contains_warning_missing_foreign_key_stop_id
-        ) AS contains_warning_missing_foreign_key_stop_id,
+        ) AS contains_warning_missing_foreign_key_stop_id
 
-    FROM fct_scheduled_trips AS trips
-    INNER JOIN dim_stop_arrivals
-        ON trips.feed_key = dim_stop_arrivals.feed_key
-        AND trips.trip_id = dim_stop_arrivals.trip_id
+    FROM {{ ref('fct_scheduled_trips') }} AS trips
+    INNER JOIN {{ ref('dim_stop_arrivals') }} AS dim_stop_arrivals
+       ON trips.feed_key = dim_stop_arrivals.feed_key
+      AND trips.trip_id = dim_stop_arrivals.trip_id
+    WHERE trips.service_date
+        BETWEEN {{ ranged_incremental_min_date(default_lookback=var("DBT_ALL_INCREMENTAL_LOOKBACK_DAYS"), data_earliest_start=var("GTFS_SCHEDULE_START")) }}
+            AND {{ ranged_incremental_max_date() }}
     GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9
 ),
 
@@ -100,7 +78,7 @@ stops_on_day AS (
         ) AS contains_warning_duplicate_trip_primary_key,
         LOGICAL_OR(
             contains_warning_missing_foreign_key_stop_id
-        ) AS contains_warning_missing_foreign_key_stop_id,
+        ) AS contains_warning_missing_foreign_key_stop_id
     FROM stops_on_day_by_route_and_hour
     GROUP BY 1, 2, 3, 4, 5
 ),
@@ -110,7 +88,7 @@ stop_counts_by_route_type AS (
         feed_key,
         stop_id,
         route_type,
-        COUNT(*) AS arrivals
+        SUM(arrivals) AS arrivals_by_route_type
     FROM stops_on_day_by_route_and_hour
     GROUP BY 1, 2, 3
 ),
@@ -124,11 +102,11 @@ pivot_to_route_type AS (
             feed_key,
             stop_id,
             route_type,
-            arrivals,
+            arrivals_by_route_type
 
         FROM stop_counts_by_route_type)
     PIVOT(
-        SUM(arrivals) AS route_type
+        SUM(arrivals_by_route_type) AS route_type
         FOR route_type IN
         (0, 1, 2, 3, 4, 5, 6, 7, 11, 12, 1000)
     )
@@ -141,7 +119,7 @@ stop_counts_by_time_of_day AS (
         time_of_day,
         {{ generate_time_of_day_hours('time_of_day') }} AS n_hours,
 
-        COUNT(*) AS arrivals
+        SUM(arrivals) AS arrivals_by_time_of_day
     FROM stops_on_day_by_route_and_hour
     GROUP BY 1, 2, 3, 4
 ),
@@ -155,12 +133,12 @@ pivot_to_time_of_day AS (
             feed_key,
             stop_id,
             time_of_day,
-            arrivals,
+            arrivals_by_time_of_day,
             n_hours
 
         FROM stop_counts_by_time_of_day)
     PIVOT(
-        SUM(arrivals) AS arrivals,
+        SUM(arrivals_by_time_of_day) AS arrivals,
         SUM(n_hours) AS n_hours
         FOR time_of_day IN
         ("owl", "early_am", "am_peak", "midday", "pm_peak", "evening")
@@ -233,10 +211,10 @@ fct_daily_scheduled_stops AS (
         stops.stop_desc,
         stops.location_type,
         stops.stop_timezone_coalesced,
-        stops.wheelchair_boarding,
+        stops.wheelchair_boarding
 
     FROM stops_on_day
-    INNER JOIN dim_stops AS stops
+    INNER JOIN {{ ref('dim_stops') }} AS stops
         ON stops_on_day.feed_key = stops.feed_key
         AND stops_on_day.stop_id = stops.stop_id
     LEFT JOIN pivot_to_time_of_day AS p_time


### PR DESCRIPTION
# Description

This PR fixes total number of stops per route type and time of day.
Since the first CTE was grouped, following CTEs need to use `SUM` on `arrival_hour` instead of `COUNT`.

To simplify the code and query plan I merged the three first CTEs where models were really used.

Part of work to fix #5505

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Tested running and validating values on BigQuery.
Use `cal-itp-data-infra-staging.mart_gtfs.fct_daily_scheduled_stops_05_2026` to query and validate.

Also tested locally:
```
❯ uv run dbt run -s fct_daily_scheduled_stops --target staging --full-refresh
21:43:21  Running with dbt=1.10.8
21:43:22  Registered adapter: bigquery=1.10.2
21:43:24  Found 610 models, 218 data tests, 17 seeds, 218 sources, 5 exposures, 1067 macros
21:43:24
21:43:24  Concurrency: 8 threads (target='staging')
21:43:24
21:43:26  1 of 1 START sql incremental model mart_gtfs.fct_daily_scheduled_stops ......... [RUN]
21:43:30  1 of 1 OK created sql incremental model mart_gtfs.fct_daily_scheduled_stops .... [CREATE TABLE (0.0 rows, 755.9 MiB processed) in 4.21s]
21:43:30
21:43:30  Finished running 1 incremental model in 0 hours 0 minutes and 6.67 seconds (6.67s).
21:43:31
21:43:31  Completed successfully
21:43:31
21:43:31  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)

The table `fct_daily_scheduled_stops` is incremental, but merging this PR will execute a full refresh on the table fixing all wrong data.