### PR TITLE
Staging/airflow alerts payments

### DIFF
--- a/airflow/.production_c3.env
+++ b/airflow/.production_c3.env
@@ -16,3 +16,4 @@ GTFS_RT_VALIDATOR_VERSION=v1.0.0
 AIRTABLE_ISSUE_MANAGEMENT_EMAIL=airtable-issue-alerts@dot.ca.gov
 TRANSIT_DATA_QUALITY_ISSUES=Transit Data Quality Issues
 HUBSPOT_NOTIFICATION_EMAIL=tdq@calitp.org
+AIRFLOW_ALERTS_PAYMENTS_EMAIL=airflow-alerts-payments@dot.ca.gov

--- a/airflow/.staging_c3.env
+++ b/airflow/.staging_c3.env
@@ -16,3 +16,4 @@ GTFS_RT_VALIDATOR_VERSION=v1.0.0
 AIRTABLE_ISSUE_MANAGEMENT_EMAIL=farhad.salemi@dot.ca.gov
 TRANSIT_DATA_QUALITY_ISSUES=Staging Transit Data Quality Issues
 HUBSPOT_NOTIFICATION_EMAIL=farhad.salemi@dot.ca.gov
+AIRFLOW_ALERTS_PAYMENTS_EMAIL=airflow-alerts-payments+staging@dot.ca.gov

--- a/airflow/dags/dbt_daily_dag.py
+++ b/airflow/dags/dbt_daily_dag.py
@@ -132,6 +132,7 @@ with DAG(
         },
         default_args={
             "retries": 1,
+            # Route Payments failures to the Payments alert distribution list.
             "email": os.getenv("AIRFLOW_ALERTS_PAYMENTS_EMAIL"),
         },
     )

--- a/airflow/dags/dbt_daily_dag.py
+++ b/airflow/dags/dbt_daily_dag.py
@@ -132,6 +132,7 @@ with DAG(
         },
         default_args={
             "retries": 1,
+            "email": os.getenv("AIRFLOW_ALERTS_PAYMENTS_EMAIL"),
         },
     )
 


### PR DESCRIPTION
## Description

Adds a Payments-specific email distribution list for Airflow alerts from the `dbt_payments` task group in the `dbt_daily` DAG.

This allows Payments failures to be routed to the personnel responsible for Payments alerts.

The existing Slack notification remains intact, so these failures will continue to appear in the existing Slack alert channel in addition to being sent to the Payments email distribution list.

Adds the environment-specific configuration:

- Production: `airflow-alerts-payments@dot.ca.gov`
- Staging: `airflow-alerts-payments+staging@dot.ca.gov`

The membership of the Payments distribution list is still open for team discussion. Members can be added or removed from the distribution list through Microsoft Outlook without requiring additional Airflow code changes.

Ref #5675

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How is this PR tested?

Tested in staging by clearing and rerunning the failing `dbt_payments.warehouse_test` task in the `dbt_daily` DAG.

Confirmed that:

- The task failed as expected.
- The Airflow failure notification was sent to `airflow-alerts-payments+staging@dot.ca.gov`.
- The email was successfully received through the Payments distribution list.
- The existing Slack failure notification continued to work.

### Staging test evidence
<img width="706" height="526" alt="image" src="https://github.com/user-attachments/assets/699bcc51-a4b8-4b97-bb33-3509843ff738" />


## Post-merge follow-ups

Specify the distribution list memebers 

- [ ] No action required
- [X] Actions required (specified below)
