### PR TITLE
Coerce Airtable specialValue/error sentinel objects to null

### DIFF
--- a/airflow/plugins/src/bigquery_cleaner.py
+++ b/airflow/plugins/src/bigquery_cleaner.py
@@ -17,6 +17,18 @@ class BigQueryValueCleaner:
         """
         result = self.value
 
+        # Airtable returns a sentinel object for computed (formula/rollup)
+        # fields that evaluate to a non-finite number or an error, e.g.
+        # {"specialValue": "NaN"} or {"error": "#ERROR!"}. These are not real
+        # values and break BigQuery's typed JSON parser (autodetect infers the
+        # column numeric, then chokes on the object), so coerce them to null.
+        if (
+            isinstance(result, dict)
+            and result
+            and set(result) <= {"specialValue", "error"}
+        ):
+            return None
+
         if isinstance(result, dict):
             for k, v in result.items():
                 if isinstance(v, dict):

--- a/airflow/tests/src/test_bigquery_cleaner.py
+++ b/airflow/tests/src/test_bigquery_cleaner.py
@@ -26,3 +26,22 @@ class TestBigQueryCleaner:
         assert cleaner.clean() == [
             {"id": 0, "score": -2, "amount": 123.00055556, "total": 0.5}
         ]
+
+    def test_cleaning_airtable_special_value(self):
+        # Airtable emits {"specialValue": "NaN"} for formula fields that
+        # evaluate to a non-finite number; it must not leak into BigQuery.
+        rows = [{"id": "abc123", "days_open": {"specialValue": "NaN"}}]
+        cleaner = BigQueryCleaner(rows)
+        assert cleaner.clean() == [{"id": "abc123", "days_open": None}]
+
+    def test_cleaning_airtable_error_object(self):
+        rows = [{"id": "abc123", "computed": {"error": "#ERROR!"}}]
+        cleaner = BigQueryCleaner(rows)
+        assert cleaner.clean() == [{"id": "abc123", "computed": None}]
+
+    def test_preserves_legitimate_nested_object(self):
+        rows = [{"id": "abc", "user": {"id": "u1", "email": "a@b.c", "name": "A"}}]
+        cleaner = BigQueryCleaner(rows)
+        assert cleaner.clean() == [
+            {"id": "abc", "user": {"id": "u1", "email": "a@b.c", "name": "A"}}
+        ]


### PR DESCRIPTION
# Description

Airtable emits a sentinel object (e.g. `{"specialValue": "NaN"}`) for formula
fields that evaluate to a non-finite number. The loader wrote these verbatim, so
BigQuery's autodetect (which infers the column numeric) failed to parse them —
breaking `create_external_tables` and downstream reads of the TDQI external
table.

Same root cause as #4339, which was only fixed operationally (formula + moving
files) and recurred; this adds the missing code-side guard by coercing sentinel
objects to `null` in `BigQueryValueCleaner`.

Contributes to #5676

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Unit tests in `test_bigquery_cleaner.py` (sentinel → null, real values
untouched). Loader/plugin change only, so no dbt run needed.

## Post-merge follow-ups

- [x] No action required

The poisoned partitions (`dt=2026-08-24/25/26`) were scrubbed in GCS and the
mart re-run separately, so nothing is outstanding from this PR.
