### PR TITLE
Reduce GTFS-RT archiver log ingestion costs

### DIFF
--- a/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/workflow.tf
+++ b/iac/cal-itp-data-infra-staging/gtfs-rt-archiver/us/workflow.tf
@@ -39,8 +39,8 @@ resource "google_workflows_workflow" "gtfs-rt-archiver-staging-clock" {
   service_account = data.terraform_remote_state.iam.outputs.google_service_account_gtfs-rt-archiver_email
   source_contents = templatefile("${local.source_path}/clock.yaml", {})
 
-  call_log_level          = "LOG_ALL_CALLS"
-  execution_history_level = "EXECUTION_HISTORY_DETAILED"
+  call_log_level          = "LOG_ERRORS_ONLY"
+  execution_history_level = "EXECUTION_HISTORY_BASIC"
 
   user_env_vars = {
     "CALITP_TOPIC__GTFS_RT_ARCHIVER_HEARTBEAT" = google_pubsub_topic.gtfs-rt-archiver-staging-heartbeat.id

--- a/iac/cal-itp-data-infra/gtfs-rt-archiver/us/workflow.tf
+++ b/iac/cal-itp-data-infra/gtfs-rt-archiver/us/workflow.tf
@@ -39,8 +39,8 @@ resource "google_workflows_workflow" "gtfs-rt-archiver-clock" {
   service_account = data.terraform_remote_state.iam.outputs.google_service_account_gtfs-rt-archiver_email
   source_contents = templatefile("${local.source_path}/clock.yaml", {})
 
-  call_log_level          = "LOG_ALL_CALLS"
-  execution_history_level = "EXECUTION_HISTORY_DETAILED"
+  call_log_level          = "LOG_ERRORS_ONLY"
+  execution_history_level = "EXECUTION_HISTORY_BASIC"
 
   user_env_vars = {
     "CALITP_TOPIC__GTFS_RT_ARCHIVER_HEARTBEAT" = google_pubsub_topic.gtfs-rt-archiver-heartbeat.id

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/heartbeat.py
@@ -18,11 +18,11 @@ class Heartbeat:
         self, logger: logging.Logger
     ) -> Callable[[pubsub_v1.publisher.futures.Future], None]:
         def callback(publish_future: pubsub_v1.publisher.futures.Future) -> None:
-            logger.info(
+            logger.debug(
                 json.dumps(
                     {
-                        "severity": "Default",
-                        "message": "Started",
+                        "severity": "Debug",
+                        "message": "Publishing batch",
                         "message_id": self.message_id,
                         "publish_time": self.publish_time.isoformat(),
                         "batch_at": self.batch_at().isoformat(),
@@ -30,18 +30,7 @@ class Heartbeat:
                 )
             )
             try:
-                result = publish_future.result(timeout=PUBLISH_TIMEOUT)
-                logger.info(
-                    json.dumps(
-                        {
-                            "severity": "Default",
-                            "message": f"Finished - {result}",
-                            "message_id": self.message_id,
-                            "publish_time": self.publish_time.isoformat(),
-                            "batch_at": self.batch_at().isoformat(),
-                        }
-                    )
-                )
+                publish_future.result(timeout=PUBLISH_TIMEOUT)
             except Exception as e:
                 logger.error(
                     json.dumps(

--- a/services/gtfs-rt-archiver/gtfs_rt_archiver/service.py
+++ b/services/gtfs-rt-archiver/gtfs_rt_archiver/service.py
@@ -30,11 +30,11 @@ class Service:
         return Archiver(configuration=self.configuration())
 
     def run(self, logger=logging.getLogger(__name__)):
-        logger.info(
+        logger.debug(
             json.dumps(
                 {
-                    "severity": "Default",
-                    "message": f"Started {self.configuration().url}",
+                    "severity": "Debug",
+                    "message": f"Processing {self.configuration().url}",
                     "url": self.configuration().url,
                     "message_id": self.message_id,
                     "publish_time": self.publish_time.isoformat(),
@@ -43,17 +43,6 @@ class Service:
         )
         try:
             self.archiver().save(result=self.downloader().get())
-            logger.info(
-                json.dumps(
-                    {
-                        "severity": "Default",
-                        "message": f"Finished {self.configuration().url}",
-                        "url": self.configuration().url,
-                        "message_id": self.message_id,
-                        "publish_time": self.publish_time.isoformat(),
-                    }
-                )
-            )
         except Exception as e:
             logger.error(
                 json.dumps(


### PR DESCRIPTION
# Description

Convert success logs from INFO to DEBUG level and configure Cloud Workflows to log errors only, reducing daily log volume from ~7 GiB to ~3 GiB.

Changes:
- heartbeat.py: Convert Started/Finished logs to DEBUG, fix unused var
- service.py: Convert Started/Finished logs to DEBUG
- workflow.tf: Set call_log_level to LOG_ERRORS_ONLY
- workflow.tf: Set execution_history_level to EXECUTION_HISTORY_BASIC

All error-level logging preserved for debugging.


Resolves #5572 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Manual code review of log level changes:
- Verified `heartbeat.py`: Changed Started message from INFO to DEBUG (line ~25), removed Finished message
- Verified `service.py`: Changed Started from INFO to DEBUG, Finished removed, changed log message to DEBUG level
- Verified `workflow.tf`: Production config `call_log_level = "LOG_ERRORS_ONLY"`, staging config `call_log_level = "LOG_ERRORS_ONLY"`, `execution_history_level = "EXECUTION_HISTORY_BASIC"`
- Error-level logging (`error()` calls) remains unchanged at ERROR level
- No tests added or modified in this PR

## Post-merge follow-ups

- Yes: Monitor logs after deployment to verify the expected ~7 GiB → ~3 GiB log volume reduction and confirm error logs are only at ERROR level