### PR TITLE
Allow New Zealand traffic through the Metabase Cloud Armor geo rule

### DIFF
--- a/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra-staging/metabase/us/cloud_armor.tf
@@ -5,10 +5,10 @@ resource "google_compute_security_policy" "metabase-staging" {
   rule {
     priority    = 500
     action      = "deny(403)"
-    description = "Geo-restrict to US/CA/GB/NL/HU"
+    description = "Geo-restrict to US/CA/GB/NL/HU/NZ"
     match {
       expr {
-        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA' || origin.region_code == 'GB' || origin.region_code == 'NL' || origin.region_code == 'HU')"
+        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA' || origin.region_code == 'GB' || origin.region_code == 'NL' || origin.region_code == 'HU' || origin.region_code == 'NZ')"
       }
     }
   }

--- a/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
+++ b/iac/cal-itp-data-infra/metabase/us/cloud_armor.tf
@@ -5,10 +5,10 @@ resource "google_compute_security_policy" "metabase" {
   rule {
     priority    = 500
     action      = "deny(403)"
-    description = "Geo-restrict to US/CA/GB/NL/HU"
+    description = "Geo-restrict to US/CA/GB/NL/HU/NZ"
     match {
       expr {
-        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA' || origin.region_code == 'GB' || origin.region_code == 'NL' || origin.region_code == 'HU')"
+        expression = "!(origin.region_code == 'US' || origin.region_code == 'CA' || origin.region_code == 'GB' || origin.region_code == 'NL' || origin.region_code == 'HU' || origin.region_code == 'NZ')"
       }
     }
   }


### PR DESCRIPTION
# Description

Adds `NZ` to the Metabase Cloud Armor geo allowlist (priority-500 rule) in both prod and staging. Snapper, an SCMTD contractor based in New Zealand, needs to reach Metabase for API queries and their cards, but NZ traffic was being denied `403` by the geo rule (`US/CA/GB/NL/HU`).

Note: the policy gates by country, not by IP, so this opens Metabase to all NZ traffic — the WAF and per-IP rate-limit rules still apply.

Resolves #5701

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Not tested.

## Post-merge follow-ups

- [x] Actions required (specified below)

- Apply the Terraform for both the prod and staging Metabase Cloud Armor policies.
- Have Snapper retry from NZ to confirm they can authenticate and hit the API.
