### PR TITLE
Fix `bridge_gtfs_analysis_name_x_ntd`

### DIFF
--- a/warehouse/models/mart/transit_database/bridge_gtfs_analysis_name_x_ntd.sql
+++ b/warehouse/models/mart/transit_database/bridge_gtfs_analysis_name_x_ntd.sql
@@ -48,8 +48,8 @@ deduped_provider AS (
 
     FROM dim_provider_gtfs_data
     QUALIFY ROW_NUMBER() OVER(
-        PARTITION BY schedule_source_record_id
-        ORDER BY _valid_from DESC
+        PARTITION BY schedule_source_record_id, organization_name
+    ORDER BY _valid_from DESC
     ) = 1
 ),
 
@@ -110,7 +110,7 @@ gtfs_to_orgs AS (
         orgs_with_geog.county_name,
         orgs_with_geog.caltrans_district,
         orgs_with_geog.caltrans_district_name,
-        CONCAT(CAST(caltrans_district AS STRING FORMAT '00'), " - ", caltrans_district_name) AS caltrans_district_full,
+        TRIM(CONCAT(CAST(caltrans_district AS STRING FORMAT '00'), " - ", caltrans_district_name)) AS caltrans_district_full,
         orgs_with_geog.ntd_id,
         orgs_with_geog.ntd_id_2022,
         orgs_with_geog.rtpa_name,


### PR DESCRIPTION
# Description
Allow fanout from `dim_provider_gtfs_data` to select combinations of `schedule_source_record_id (gtfs_dataset_name)` and `organization_name` (allowing us to get the NTD IDs for organization). 

Resolves https://github.com/cal-itp/gtfs-curator/issues/72
Bring the solution that worked in: https://github.com/cal-itp/gtfs-curator/issues/70
* first noticed that Foothill and Duarte were selecting only 1 record, since both share the same `schedule_source_record_id` / `schedule_gtfs_dataset_name`, but we want both organization_names + `ntd_id` to be present
* also fix the leading space present in concatenated `caltrans_district_full` that was fixed for GTFS digest and open data

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

`uv run dbt run -s bridge_gtfs_analysis_name_x_ntd`

## Post-merge follow-ups

- [x] No action required
- [ ] Actions required (specified below)
